### PR TITLE
boot/grub.go: add new bootchain

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -257,11 +257,15 @@ type TrustedAssetsInstallObserver struct {
 
 	blName        string
 	managedAssets []string
-	trustedAssets []string
+	// trustedAssets records all trusted run asset mapping their
+	// relative path to identifier used in the modeenv
+	trustedAssets map[string]string
 	trackedAssets bootAssetsMap
 
-	recoveryBlName        string
-	trustedRecoveryAssets []string
+	recoveryBlName string
+	// trustedRecoveryAssets records all trusted recovery asset mapping their
+	// relative path to identifier used in the modeenv
+	trustedRecoveryAssets map[string]string
 	trackedRecoveryAssets bootAssetsMap
 
 	dataEncryptionKey keys.EncryptionKey
@@ -284,11 +288,12 @@ func (o *TrustedAssetsInstallObserver) Observe(op gadget.ContentOperation, partR
 		// this asset is managed by bootloader installation
 		return gadget.ChangeIgnore, nil
 	}
-	if len(o.trustedAssets) == 0 || !strutil.ListContains(o.trustedAssets, relativeTarget) {
+	trustedAssetName, isTrustedAsset := o.trustedAssets[relativeTarget]
+	if !isTrustedAsset {
 		// not one of the trusted assets
 		return gadget.ChangeApply, nil
 	}
-	ta, err := o.cache.Add(data.After, o.blName, filepath.Base(relativeTarget))
+	ta, err := o.cache.Add(data.After, o.blName, trustedAssetName)
 	if err != nil {
 		return gadget.ChangeAbort, err
 	}
@@ -314,8 +319,12 @@ func (o *TrustedAssetsInstallObserver) ObserveExistingTrustedRecoveryAssets(reco
 		// not a trusted assets bootloader or has no trusted assets
 		return nil
 	}
-	for _, trustedAsset := range o.trustedRecoveryAssets {
-		ta, err := o.cache.Add(filepath.Join(recoveryRootDir, trustedAsset), o.recoveryBlName, filepath.Base(trustedAsset))
+	for trustedAsset, trustedAssetName := range o.trustedRecoveryAssets {
+		path := filepath.Join(recoveryRootDir, trustedAsset)
+		if !osutil.FileExists(path) {
+			continue
+		}
+		ta, err := o.cache.Add(path, o.recoveryBlName, trustedAssetName)
 		if err != nil {
 			return err
 		}
@@ -420,13 +429,17 @@ type TrustedAssetsUpdateObserver struct {
 	cache *trustedAssetsCache
 	model *asserts.Model
 
-	bootBootloader    bootloader.Bootloader
-	bootTrustedAssets []string
+	bootBootloader bootloader.Bootloader
+	// bootTrustedAssets records all trusted run asset mapping their
+	// relative path to identifier used in the modeenv
+	bootTrustedAssets map[string]string
 	bootManagedAssets []string
 	changedAssets     []*trackedAsset
 
-	seedBootloader    bootloader.Bootloader
-	seedTrustedAssets []string
+	seedBootloader bootloader.Bootloader
+	// seedTrustedAssets records all trusted recovery asset mapping their
+	// relative path to identifier used in the modeenv
+	seedTrustedAssets map[string]string
 	seedManagedAssets []string
 	seedChangedAssets []*trackedAsset
 
@@ -447,7 +460,7 @@ func (o *TrustedAssetsUpdateObserver) modeenvUnlock() {
 	o.modeenvLocked = false
 }
 
-func trustedAndManagedAssetsOfBootloader(bl bootloader.Bootloader) (trustedAssets, managedAssets []string, err error) {
+func trustedAndManagedAssetsOfBootloader(bl bootloader.Bootloader) (trustedAssets map[string]string, managedAssets []string, err error) {
 	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 	if ok {
 		trustedAssets, err = tbl.TrustedAssets()
@@ -459,7 +472,7 @@ func trustedAndManagedAssetsOfBootloader(bl bootloader.Bootloader) (trustedAsset
 	return trustedAssets, managedAssets, nil
 }
 
-func findMaybeTrustedBootloaderAndAssets(rootDir string, opts *bootloader.Options) (foundBl bootloader.Bootloader, trustedAssets []string, err error) {
+func findMaybeTrustedBootloaderAndAssets(rootDir string, opts *bootloader.Options) (foundBl bootloader.Bootloader, trustedAssets map[string]string, err error) {
 	foundBl, err = bootloader.Find(rootDir, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot find bootloader: %v", err)
@@ -468,7 +481,7 @@ func findMaybeTrustedBootloaderAndAssets(rootDir string, opts *bootloader.Option
 	return foundBl, trustedAssets, err
 }
 
-func gadgetMaybeTrustedBootloaderAndAssets(gadgetDir, rootDir string, opts *bootloader.Options) (foundBl bootloader.Bootloader, trustedAssets, managedAssets []string, err error) {
+func gadgetMaybeTrustedBootloaderAndAssets(gadgetDir, rootDir string, opts *bootloader.Options) (foundBl bootloader.Bootloader, trustedAssets map[string]string, managedAssets []string, err error) {
 	foundBl, err = bootloader.ForGadget(gadgetDir, rootDir, opts)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot find bootloader: %v", err)
@@ -485,7 +498,7 @@ func gadgetMaybeTrustedBootloaderAndAssets(gadgetDir, rootDir string, opts *boot
 // Implements gadget.ContentUpdateObserver.
 func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 	var whichBootloader bootloader.Bootloader
-	var whichTrustedAssets []string
+	var whichTrustedAssets map[string]string
 	var whichManagedAssets []string
 	var err error
 	var isRecovery bool
@@ -520,8 +533,9 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, partRo
 		return gadget.ChangeApply, nil
 	}
 
+	trustedAssetName, hasTrustedAsset := whichTrustedAssets[relativeTarget]
 	// maybe an asset that is trusted in the boot process?
-	if !strutil.ListContains(whichTrustedAssets, relativeTarget) {
+	if !hasTrustedAsset {
 		// not one of the trusted assets
 		return gadget.ChangeApply, nil
 	}
@@ -538,16 +552,16 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, partRo
 	}
 	switch op {
 	case gadget.ContentUpdate:
-		return o.observeUpdate(whichBootloader, isRecovery, relativeTarget, data)
+		return o.observeUpdate(whichBootloader, isRecovery, trustedAssetName, data)
 	case gadget.ContentRollback:
-		return o.observeRollback(whichBootloader, isRecovery, root, relativeTarget)
+		return o.observeRollback(whichBootloader, isRecovery, root, relativeTarget, trustedAssetName)
 	default:
 		// we only care about update and rollback actions
 		return gadget.ChangeApply, nil
 	}
 }
 
-func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, relativeTarget string, change *gadget.ContentChange) (gadget.ContentChangeAction, error) {
+func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, recovery bool, trustedAssetName string, change *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 	modeenvBefore, err := o.modeenv.Copy()
 	if err != nil {
 		return gadget.ChangeAbort, fmt.Errorf("cannot copy modeenv: %v", err)
@@ -561,13 +575,13 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	if change.Before != "" {
 		// make sure that the original copy is present in the cache if
 		// it existed
-		taBefore, err = o.cache.Add(change.Before, bl.Name(), filepath.Base(relativeTarget))
+		taBefore, err = o.cache.Add(change.Before, bl.Name(), trustedAssetName)
 		if err != nil {
 			return gadget.ChangeAbort, err
 		}
 	}
 
-	ta, err := o.cache.Add(change.After, bl.Name(), filepath.Base(relativeTarget))
+	ta, err := o.cache.Add(change.After, bl.Name(), trustedAssetName)
 	if err != nil {
 		return gadget.ChangeAbort, err
 	}
@@ -617,7 +631,7 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 	return gadget.ChangeApply, nil
 }
 
-func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, recovery bool, root, relativeTarget string) (gadget.ContentChangeAction, error) {
+func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, recovery bool, root, relativeTarget string, trustedAssetName string) (gadget.ContentChangeAction, error) {
 	trustedAssets := &o.modeenv.CurrentTrustedBootAssets
 	otherTrustedAssets := o.modeenv.CurrentTrustedRecoveryBootAssets
 	if recovery {
@@ -625,8 +639,7 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 		otherTrustedAssets = o.modeenv.CurrentTrustedBootAssets
 	}
 
-	assetName := filepath.Base(relativeTarget)
-	hashList, ok := (*trustedAssets)[assetName]
+	hashList, ok := (*trustedAssets)[trustedAssetName]
 	if !ok || len(hashList) == 0 {
 		// asset not tracked in modeenv
 		return gadget.ChangeApply, nil
@@ -648,7 +661,7 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 			// a previous revision to be restored, but got nothing
 			// instead
 			return gadget.ChangeAbort, fmt.Errorf("tracked asset %q is unexpectedly missing from disk",
-				assetName)
+				trustedAssetName)
 		}
 	} else {
 		if ondiskHash != expectedOldHash {
@@ -665,19 +678,19 @@ func (o *TrustedAssetsUpdateObserver) observeRollback(bl bootloader.Bootloader, 
 	} else {
 		newHash = hashList[1]
 	}
-	if newHash != "" && !isAssetHashTrackedInMap(otherTrustedAssets, assetName, newHash) {
+	if newHash != "" && !isAssetHashTrackedInMap(otherTrustedAssets, trustedAssetName, newHash) {
 		// asset revision is not used used elsewhere, we can remove it from the cache
-		if err := o.cache.Remove(bl.Name(), assetName, newHash); err != nil {
+		if err := o.cache.Remove(bl.Name(), trustedAssetName, newHash); err != nil {
 			// XXX: should this be a log instead?
-			return gadget.ChangeAbort, fmt.Errorf("cannot remove unused boot asset %v:%v: %v", assetName, newHash, err)
+			return gadget.ChangeAbort, fmt.Errorf("cannot remove unused boot asset %v:%v: %v", trustedAssetName, newHash, err)
 		}
 	}
 
 	// update modeenv content
 	if !newlyAdded {
-		(*trustedAssets)[assetName] = hashList[:1]
+		(*trustedAssets)[trustedAssetName] = hashList[:1]
 	} else {
-		delete(*trustedAssets, assetName)
+		delete(*trustedAssets, trustedAssetName)
 	}
 
 	if err := o.modeenv.Write(); err != nil {
@@ -794,20 +807,28 @@ func observeSuccessfulBootAssetsForBootloader(m *Modeenv, root string, opts *boo
 	}
 
 	cache := newTrustedAssetsCache(dirs.SnapBootAssetsDir)
-	for _, trustedAsset := range trustedAssets {
-		assetName := filepath.Base(trustedAsset)
 
-		// find the hash of the file on disk
-		assetHash, err := cache.fileHash(filepath.Join(root, trustedAsset))
-		if err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("cannot calculate the digest of existing trusted asset: %v", err)
+	alreadySeenAssetNames := make(map[string]bool)
+	for trustedAsset, assetName := range trustedAssets {
+		_, alreadySeen := alreadySeenAssetNames[assetName]
+		if alreadySeen {
+			// TrustedAssetsBootloader.TrustedAssets
+			// should not map different paths to the same
+			// name. If it does it is a bug.
+			return nil, fmt.Errorf("internal error: bootloader %s has several asset of the same name %s", whichBootloader, assetName)
 		}
-		if assetHash == "" {
-			// no trusted asset on disk, but we booted nonetheless,
-			// at least log something
+		assetHash, err := cache.fileHash(filepath.Join(root, trustedAsset))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("cannot calculate the digest of existing trusted asset: %v", err)
+			}
 			logger.Noticef("system booted without %v bootloader trusted asset %q", whichBootloader, trustedAsset)
-			// given that asset names cannot be reused, clear the
-			// boot assets map for the current bootloader
+			// Asset names are supposed to be unique, that
+			// is no 2 different paths can used the same
+			// name. If this path is not used, it is safe
+			// to say that asset name will not be used
+			// either. So we can safely removed it from
+			// the trusted asset map.
 			delete(*trustedAssetsMap, assetName)
 			continue
 		}

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -83,10 +83,10 @@ func (s *assetsSuite) uc20UpdateObserver(c *C, gadgetDir string) (*boot.TrustedA
 	return obs, uc20Model
 }
 
-func (s *assetsSuite) bootloaderWithTrustedAssets(trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
+func (s *assetsSuite) bootloaderWithTrustedAssets(trustedAssets map[string]string) *bootloadertest.MockTrustedAssetsBootloader {
 	tab := bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(tab)
-	tab.TrustedAssetsList = trustedAssets
+	tab.TrustedAssetsMap = trustedAssets
 	s.AddCleanup(func() { bootloader.Force(nil) })
 	return tab
 }
@@ -257,8 +257,8 @@ func (s *assetsSuite) TestInstallObserverNew(c *C) {
 	c.Assert(nonUC20obs, IsNil)
 
 	// listing trusted assets fails
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
 	})
 	tab.TrustedAssetsErr = fmt.Errorf("fail")
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, true)
@@ -356,9 +356,9 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/other-asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":              "asset",
+		"nested/other-asset": "other-asset",
 	})
 
 	// we get an observer for UC20
@@ -416,7 +416,9 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedNoEncryption(c *C) {
 	d := c.MkDir()
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 	uc20Model := boottest.MakeMockUC20Model()
 	useEncryption := false
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
@@ -426,7 +428,9 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedNoEncryption(c *
 
 func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedUnencryptedWithManaged(c *C) {
 	d := c.MkDir()
-	tab := s.bootloaderWithTrustedAssets([]string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 	tab.ManagedAssetsList = []string{"managed"}
 	uc20Model := boottest.MakeMockUC20Model()
 	useEncryption := false
@@ -492,9 +496,9 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":        "asset",
+		"nested/asset": "asset",
 	})
 
 	// we get an observer for UC20
@@ -524,10 +528,10 @@ func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/other-asset",
-		"shim",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":              "asset",
+		"nested/other-asset": "other-asset",
+		"shim":               "shim",
 	})
 
 	// we get an observer for UC20
@@ -574,9 +578,9 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *C) {
 	d := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":        "asset",
+		"nested/asset": "asset",
 	})
 	// we get an observer for UC20
 	uc20Model := boottest.MakeMockUC20Model()
@@ -601,25 +605,6 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *
 	c.Check(tab.TrustedAssetsCalls, Equals, 2)
 }
 
-func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryButMissingErr(c *C) {
-	d := c.MkDir()
-
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-	})
-
-	uc20Model := boottest.MakeMockUC20Model()
-	useEncryption := true
-	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
-	c.Assert(err, IsNil)
-	c.Assert(obs, NotNil)
-	c.Check(tab.TrustedAssetsCalls, Equals, 2)
-
-	// trusted asset is missing
-	err = obs.ObserveExistingTrustedRecoveryAssets(d)
-	c.Assert(err, ErrorMatches, "cannot open asset file: .*/asset: no such file or directory")
-}
-
 func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	tab := s.bootloaderWithTrustedAssets(nil)
 
@@ -633,14 +618,14 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	c.Check(obs, IsNil)
 
 	// no managed, some trusted assets, but we are not tracking them
-	tab.TrustedAssetsList = []string{"asset"}
+	tab.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	obs, err = boot.TrustedAssetsUpdateObserverForModel(uc20Model, gadgetDir)
 	c.Assert(err, Equals, boot.ErrObserverNotApplicable)
 	c.Check(obs, IsNil)
 
 	// let's see some managed assets, but not trusted assets
 	tab.ManagedAssetsList = []string{"managed"}
-	tab.TrustedAssetsList = nil
+	tab.TrustedAssetsMap = nil
 	obs, err = boot.TrustedAssetsUpdateObserverForModel(uc20Model, gadgetDir)
 	c.Assert(err, IsNil)
 	c.Check(obs, NotNil)
@@ -648,7 +633,7 @@ func (s *assetsSuite) TestUpdateObserverNew(c *C) {
 	// no managed, some trusted which we need to track
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 	tab.ManagedAssetsList = nil
-	tab.TrustedAssetsList = []string{"asset"}
+	tab.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	obs, err = boot.TrustedAssetsUpdateObserverForModel(uc20Model, gadgetDir)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
@@ -705,10 +690,10 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/other-asset",
-		"shim",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":              "asset",
+		"nested/other-asset": "other-asset",
+		"shim":               "shim",
 	})
 	tab.ManagedAssetsList = []string{
 		"managed-asset",
@@ -791,9 +776,9 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"shim",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
 	})
 	tab.ManagedAssetsList = []string{
 		"managed-asset",
@@ -897,8 +882,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
 	})
 
 	data := []byte("foobar")
@@ -953,8 +938,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateOtherRoleStructMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
 	})
 
 	// modeenv is not set up, but the observer should not care
@@ -1004,7 +989,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateTrivialErr(c *C) {
 	// grab a new bootloader mock
 	bl = bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(bl)
-	bl.TrustedAssetsList = []string{"asset"}
+	bl.TrustedAssetsMap = map[string]string{"asset": "asset"}
 
 	obs, err = boot.TrustedAssetsUpdateObserverForModel(uc20Model, gadgetDir)
 	c.Assert(err, IsNil)
@@ -1050,7 +1035,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRepeatedAssetErr(c *C) {
 	bl := bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(bl)
 	defer bootloader.Force(nil)
-	bl.TrustedAssetsList = []string{"asset"}
+	bl.TrustedAssetsMap = map[string]string{"asset": "asset"}
 
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1124,8 +1109,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets([]string{
-		"asset",
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
 	})
 
 	// we get an observer for UC20
@@ -1172,10 +1157,10 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	d := c.MkDir()
 	backups := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"nested/other-asset",
-		"shim",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset":              "asset",
+		"nested/other-asset": "other-asset",
+		"shim":               "shim",
 	})
 
 	data := []byte("foobar")
@@ -1289,7 +1274,9 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 func (s *assetsSuite) TestUpdateObserverRollbackFileValidity(c *C) {
 	root := c.MkDir()
 
-	tab := s.bootloaderWithTrustedAssets([]string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -1580,7 +1567,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -1662,7 +1652,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	d := c.MkDir()
 	root := c.MkDir()
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1781,7 +1774,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1840,7 +1836,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1895,7 +1894,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -1965,7 +1967,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 		c.Assert(err, IsNil)
 	}
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 	// we get an observer for UC20
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
@@ -2034,7 +2039,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoTrusted(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 	// call to observe successful boot, but assets do not exist on disk
 
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2057,7 +2064,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2093,21 +2103,27 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 		"shim":  []string{shimHash},
 	})
 	c.Check(drop, HasLen, 3)
-	for i, en := range []struct {
+	byHash := make(map[string]*boot.TrackedAsset)
+	for _, dropElement := range drop {
+		byHash[dropElement.GetHash()] = dropElement
+	}
+	for _, en := range []struct {
 		assetName, hash string
 	}{
 		{"asset", "assethash"},
 		{"asset", "recoveryassethash"},
 		{"shim", "recoveryshimhash"},
 	} {
-		c.Check(drop[i].Equals("trusted", en.assetName, en.hash), IsNil)
+		c.Check(byHash[en.hash].Equals("trusted", en.assetName, en.hash), IsNil)
 	}
 }
 
 func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 	// call to observe successful boot, but the asset we booted with is unexpected
 
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
@@ -2147,7 +2163,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 func (s *assetsSuite) TestObserveSuccessfulBootSingleEntries(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2185,7 +2204,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	// bootloader is used by the ubuntu-boot bootloader, so it cannot be
 	// dropped from cache
 
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	maybeDrop := []byte("maybe-drop")
 	maybeDropHash := "08a99ce3af529ebbfb9a82df690007ac650635b165c3d1b416d471907fa3843270dce9cc001ea26f4afb4e0c5af05209"
@@ -2225,7 +2246,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	// call to observe successful boot
 
-	s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2273,7 +2297,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 		c.Skip("the test cannot be executed by the root user")
 	}
 
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
@@ -2297,7 +2323,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 }
 
 func (s *assetsSuite) TestObserveSuccessfulBootDifferentMode(c *C) {
-	s.bootloaderWithTrustedAssets([]string{"asset"})
+	s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+	})
 
 	m := &boot.Modeenv{
 		Mode: "recover",
@@ -2430,9 +2458,9 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
-		"shim",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
 	})
 
 	// we get an observer for UC20
@@ -2573,7 +2601,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	tab := s.bootloaderWithTrustedAssets([]string{"asset", "shim"})
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	// we get an observer for UC20
 	obs, uc20model := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -2714,8 +2745,8 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 	err = m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	tab := s.bootloaderWithTrustedAssets([]string{
-		"asset",
+	tab := s.bootloaderWithTrustedAssets(map[string]string{
+		"asset": "asset",
 	})
 	tab.ManagedAssetsList = []string{
 		"managed-asset",

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1061,7 +1061,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1179,7 +1181,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1296,7 +1300,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1414,7 +1420,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -1794,7 +1802,9 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
 	// set up all the bits required for an encrypted system
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
@@ -2133,7 +2143,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2347,13 +2359,13 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BaseUpdate(c *C) {
 	c.Assert(m3.BaseStatus, Equals, "")
 }
 
-func (s *bootenv20Suite) bootloaderWithTrustedAssets(c *C, trustedAssets []string) *bootloadertest.MockTrustedAssetsBootloader {
+func (s *bootenv20Suite) bootloaderWithTrustedAssets(c *C, trustedAssets map[string]string) *bootloadertest.MockTrustedAssetsBootloader {
 	// TODO:UC20: this should be an ExtractedRecoveryKernelImageBootloader
 	// because that would reflect our main currently supported
 	// trusted assets bootloader (grub)
 	tab := bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(tab)
-	tab.TrustedAssetsList = trustedAssets
+	tab.TrustedAssetsMap = trustedAssets
 	s.AddCleanup(func() { bootloader.Force(nil) })
 	return tab
 }
@@ -2362,7 +2374,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset", "shim"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+		"shim":  "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2503,7 +2518,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"nested/asset", "shim"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"nested/asset": "asset",
+		"shim":         "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2530,12 +2548,12 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 
 	tab.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "nested/asset", bootloader.RoleRecovery),
 		runKernelBf,
 	}
 	tab.RecoveryBootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "nested/asset", bootloader.RoleRecovery),
 		recoveryKernelBf,
 	}
 
@@ -2664,7 +2682,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"nested/asset", "shim"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"nested/asset": "asset",
+		"shim":         "shim",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2691,12 +2712,12 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 
 	tab.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "nested/asset", bootloader.RoleRecovery),
 		runKernelBf,
 	}
 	tab.RecoveryBootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "shim", bootloader.RoleRecovery),
-		bootloader.NewBootFile("", "asset", bootloader.RoleRecovery),
+		bootloader.NewBootFile("", "nested/asset", bootloader.RoleRecovery),
 		recoveryKernelBf,
 	}
 
@@ -2824,7 +2845,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 }
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset(c *C) {
-	tab := s.bootloaderWithTrustedAssets(c, []string{"EFI/asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"EFI/asset": "efi:asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -2917,7 +2940,9 @@ func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, model *asser
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedHappy(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run candidate panic=-1")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 	m := s.setupMarkBootSuccessful20CommandLine(c, coreDev.Model(), "run", boot.BootCommandLines{
@@ -2950,7 +2975,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedHappy(c *C) {
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedOld(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run panic=-1")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 	m := s.setupMarkBootSuccessful20CommandLine(c, coreDev.Model(), "run", boot.BootCommandLines{
@@ -2983,7 +3010,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedOld(c *C) {
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedMismatch(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run different")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 	m := s.setupMarkBootSuccessful20CommandLine(c, coreDev.Model(), "run", boot.BootCommandLines{
@@ -3008,7 +3037,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedMismatch(c *C
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedFallbackOnBootSuccessful(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run panic=-1")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	tab.StaticCommandLine = "panic=-1"
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
@@ -3039,7 +3070,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedFallbackOnBoo
 
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedFallbackOnBootMismatch(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run panic=-1 unexpected")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	tab.StaticCommandLine = "panic=-1"
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
@@ -3063,7 +3096,9 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineUpdatedFallbackOnBoo
 func (s *bootenv20Suite) TestMarkBootSuccessful20CommandLineNonRunMode(c *C) {
 	// recover mode
 	s.mockCmdline(c, "snapd_recovery_mode=recover snapd_recovery_system=1234 panic=-1")
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	tab.StaticCommandLine = "panic=-1"
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
@@ -3427,7 +3462,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 		"asset-hash-1",
 	})
 
-	s.bootloader.TrustedAssetsList = []string{"asset"}
+	s.bootloader.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	s.bootloader.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
 		runKernelBf,
@@ -3645,7 +3680,7 @@ volumes:
 		"asset-hash-1",
 	})
 
-	s.bootloader.TrustedAssetsList = []string{"asset"}
+	s.bootloader.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	s.bootloader.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
 		runKernelBf,
@@ -3715,7 +3750,7 @@ volumes:
 
 	// a minimal bootloader and modeenv setup that works because reseal is
 	// not executed
-	s.bootloader.TrustedAssetsList = []string{"asset"}
+	s.bootloader.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentKernelCommandLines: boot.BootCommandLines{
@@ -3778,7 +3813,7 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	s.bootloader = bootloadertest.Mock("trusted", c.MkDir()).WithTrustedAssets()
-	s.bootloader.TrustedAssetsList = []string{"asset"}
+	s.bootloader.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	s.bootloader.StaticCommandLine = "static mocked panic=-1"
 	s.bootloader.CandidateStaticCommandLine = "mocked candidate panic=-1"
 	s.forceBootloader(s.bootloader)
@@ -4762,7 +4797,9 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -4876,7 +4913,9 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -4987,7 +5026,9 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -5105,7 +5146,9 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 	// checked by resealKeyToModeenv
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -5299,7 +5342,9 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
 	// set up all the bits required for an encrypted system
-	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	tab := s.bootloaderWithTrustedAssets(c, map[string]string{
+		"asset": "asset",
+	})
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -89,6 +89,10 @@ func (t *TrackedAsset) Equals(blName, name, hash string) error {
 	return nil
 }
 
+func (t *TrackedAsset) GetHash() string {
+	return t.hash
+}
+
 func (o *TrustedAssetsInstallObserver) CurrentTrustedBootAssetsMap() BootAssetsMap {
 	return o.currentTrustedBootAssetsMap()
 }

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -68,6 +68,7 @@ var (
 	SealKeyToModeenv                = sealKeyToModeenvImpl
 	ResealKeyToModeenv              = resealKeyToModeenv
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
+	RunModeBootChains               = runModeBootChains
 	SealKeyModelParams              = sealKeyModelParams
 
 	BootVarsForTrustedCommandLineFromGadget = bootVarsForTrustedCommandLineFromGadget

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -132,7 +132,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 	})
 
 	mtbl := bootloadertest.Mock("trusted", s.bootdir).WithTrustedAssets()
-	mtbl.TrustedAssetsList = []string{"asset-1"}
+	mtbl.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	mtbl.StaticCommandLine = "static cmdline"
 	mtbl.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -736,6 +736,10 @@ func recoveryBootChainsForSystems(systems []string, modesForSystems map[string][
 					return err
 				}
 				if assetChain == nil {
+					// This chain is not used as
+					// it is not in the modeenv,
+					// we expect another chain to
+					// work.
 					continue
 				}
 
@@ -814,6 +818,10 @@ func runModeBootChains(rbl, bl bootloader.Bootloader, modeenv *Modeenv, cmdlines
 					return err
 				}
 				if assetChain == nil {
+					// This chain is not used as
+					// it is not in the modeenv,
+					// we expect another chain to
+					// work.
 					continue
 				}
 				var kernelRev string
@@ -870,7 +878,7 @@ func buildBootAssets(bootFiles []bootloader.BootFile, modeenv *Modeenv, trustedA
 		path := bf.Path
 		name, ok := trustedAssets[path]
 		if !ok {
-			return nil, kernel, nil
+			return nil, kernel, fmt.Errorf("internal error: asset '%s' is not considered a trusted asset for the bootloader", path)
 		}
 		var hashes []string
 		if bf.Role == bootloader.RoleRecovery {
@@ -879,6 +887,12 @@ func buildBootAssets(bootFiles []bootloader.BootFile, modeenv *Modeenv, trustedA
 			hashes, ok = modeenv.CurrentTrustedBootAssets[name]
 		}
 		if !ok {
+			// We have not found an asset for this
+			// chain. There are chains expected to not
+			// exist. So we return without error.
+			// recoveryBootChainsForSystems and
+			// runModeBootChains will fail if no chain is
+			// found
 			return nil, kernel, nil
 		}
 		assets[i] = bootAsset{

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 
 	. "gopkg.in/check.v1"
@@ -1116,7 +1117,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 	bootdir := c.MkDir()
 	mtbl := bootloadertest.Mock("trusted", bootdir).WithTrustedAssets()
-	mtbl.TrustedAssetsList = []string{"asset-1"}
+	mtbl.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	mtbl.StaticCommandLine = "static cmdline"
 	mtbl.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
@@ -1219,7 +1220,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 		modesForSystems         map[string][]string
 		undefinedKernel         bool
 		gadgetFilesForSystem    map[string][][]string
-		expectedAssets          []boot.BootAsset
+		expectedAssets          [][]boot.BootAsset
 		expectedKernelRevs      []int
 		expectedBootChainsCount int
 		// in the order of boot chains
@@ -1234,10 +1235,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1", "grub-hash-2"}},
-			},
+			}},
 			expectedKernelRevs: []int{1},
 			expectedCmdlines: [][]string{{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -1255,10 +1256,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1", "grub-hash-2"}},
-			},
+			}},
 			expectedKernelRevs: []int{1, 3},
 			expectedCmdlines: [][]string{{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -1276,10 +1277,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1"}},
-			},
+			}},
 			expectedKernelRevs: []int{1},
 			expectedCmdlines: [][]string{{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -1297,10 +1298,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1", "grub-hash-2"}},
-			},
+			}},
 			gadgetFilesForSystem: map[string][][]string{
 				"20200825": {
 					{"cmdline.extra", "extra for 20200825"},
@@ -1331,10 +1332,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1", "grub-hash-2"}},
-			},
+			}},
 			expectedKernelRevs: []int{1, 3},
 			expectedCmdlines: [][]string{{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -1356,10 +1357,10 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
 				"bootx64.efi": []string{"shim-hash-1"},
 			},
-			expectedAssets: []boot.BootAsset{
+			expectedAssets: [][]boot.BootAsset{{
 				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
 				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1", "grub-hash-2"}},
-			},
+			}},
 			expectedKernelRevs: []int{1, 3},
 			expectedCmdlines: [][]string{{
 				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
@@ -1380,6 +1381,43 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 			recoverySystems: []string{"20200825"},
 			modesForSystems: map[string][]string{"other": {boot.ModeRecover}},
 			err:             `internal error: no modes for system "20200825"`,
+		},
+		{
+			desc:            "no matching boot chains",
+			recoverySystems: []string{"20200825"},
+			modesForSystems: map[string][]string{"20200825": {boot.ModeRecover, boot.ModeFactoryReset}},
+			assetsMap: boot.BootAssetsMap{
+				"grubx64.efi": []string{"grub-hash-1", "grub-hash-2"},
+				"shimx64.efi": []string{"shim-hash-1"}, // it should be bootx64.efi
+			},
+			err: `could not find any valid chain for this model`,
+		},
+		{
+			desc:            "udpate to new layout",
+			recoverySystems: []string{"20200825"},
+			modesForSystems: map[string][]string{"20200825": {boot.ModeRecover, boot.ModeFactoryReset}},
+			assetsMap: boot.BootAssetsMap{
+				"grubx64.efi":        []string{"grub-hash-1"},
+				"bootx64.efi":        []string{"shim-hash-1"},
+				"ubuntu:grubx64.efi": []string{"grub-hash-2"},
+				"ubuntu:shimx64.efi": []string{"shim-hash-2"},
+			},
+			expectedAssets: [][]boot.BootAsset{{
+				{Role: bootloader.RoleRecovery, Name: "bootx64.efi", Hashes: []string{"shim-hash-1"}},
+				{Role: bootloader.RoleRecovery, Name: "grubx64.efi", Hashes: []string{"grub-hash-1"}},
+			}, {
+				{Role: bootloader.RoleRecovery, Name: "ubuntu:shimx64.efi", Hashes: []string{"shim-hash-2"}},
+				{Role: bootloader.RoleRecovery, Name: "ubuntu:grubx64.efi", Hashes: []string{"grub-hash-2"}},
+			}},
+			expectedKernelRevs: []int{1, 1},
+			expectedCmdlines: [][]string{{
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=factory-reset snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+			}, {
+				"snapd_recovery_mode=recover snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+				"snapd_recovery_mode=factory-reset snapd_recovery_system=20200825 console=ttyS0 console=tty1 panic=-1",
+			}},
+			expectedBootChainsCount: 2,
 		},
 	} {
 		c.Logf("tc: %q", tc.desc)
@@ -1438,8 +1476,17 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 				c.Assert(bc, HasLen, tc.expectedBootChainsCount)
 			}
 			c.Assert(tc.expectedCmdlines, HasLen, len(bc), Commentf("broken test, expected command lines must be of the same length as recovery systems and recovery boot chains"))
+			foundChains := make(map[int]bool)
 			for i, chain := range bc {
-				c.Assert(chain.AssetChain, DeepEquals, tc.expectedAssets)
+				foundChain := false
+				for j, expectedAssets := range tc.expectedAssets {
+					if reflect.DeepEqual(chain.AssetChain, expectedAssets) {
+						foundChains[j] = true
+						foundChain = true
+						continue
+					}
+				}
+				c.Assert(foundChain, Equals, true)
 				c.Assert(chain.Kernel, Equals, "pc-kernel")
 				expectedKernelRev := tc.expectedKernelRevs[i]
 				c.Assert(chain.KernelRevision, Equals, fmt.Sprintf("%d", expectedKernelRev))
@@ -1449,6 +1496,9 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 					Role: bootloader.RoleRecovery,
 				})
 				c.Assert(chain.KernelCmdlines, DeepEquals, tc.expectedCmdlines[i])
+			}
+			for j := range tc.expectedAssets {
+				c.Assert(foundChains[j], Equals, true)
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.err)

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -67,7 +67,7 @@ func (s *systemsSuite) mockTrustedBootloaderWithAssetAndChains(c *C, runKernelBf
 	})
 
 	mtbl := bootloadertest.Mock("trusted", s.bootdir).WithTrustedAssets()
-	mtbl.TrustedAssetsList = []string{"asset-1"}
+	mtbl.TrustedAssetsMap = map[string]string{"asset": "asset"}
 	mtbl.StaticCommandLine = "static cmdline"
 	mtbl.BootChainList = []bootloader.BootFile{
 		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -219,19 +219,23 @@ type TrustedAssetsBootloader interface {
 	// system parameters.
 	DefaultCommandLine(candidate bool) (string, error)
 
-	// TrustedAssets returns the list of relative paths to assets inside the
-	// bootloader's rootdir that are measured in the boot process in the
-	// order of loading during the boot. Does not require rootdir to be set.
-	TrustedAssets() ([]string, error)
+	// TrustedAssets returns a map of relative paths to asset
+	// identifers. The paths are inside the bootloader's rootdir
+	// that are measured in the boot process. The asset
+	// identifiers correspond to the backward compatible names in
+	// the modeenv (CurrentTrustedBootAssets and
+	// CurrentTrustedRecoveryBootAssets).
+	TrustedAssets() (map[string]string, error)
 
-	// RecoveryBootChain returns the load chain for recovery modes.
-	// It should be called on a RoleRecovery bootloader.
-	RecoveryBootChain(kernelPath string) ([]BootFile, error)
+	// RecoveryBootChains returns the possible load chains for
+	// recovery modes.  It should be called on a RoleRecovery
+	// bootloader.
+	RecoveryBootChains(kernelPath string) ([][]BootFile, error)
 
-	// BootChain returns the load chain for run mode.
-	// It should be called on a RoleRecovery bootloader passing the
-	// RoleRunMode bootloader.
-	BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error)
+	// BootChains returns the possible load chains for run mode.
+	// It should be called on a RoleRecovery bootloader passing
+	// the RoleRunMode bootloader.
+	BootChains(runBl Bootloader, kernelPath string) ([][]BootFile, error)
 }
 
 // NotScriptableBootloader cannot change the bootloader environment

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -222,8 +222,8 @@ type TrustedAssetsBootloader interface {
 	// TrustedAssets returns a map of relative paths to asset
 	// identifers. The paths are inside the bootloader's rootdir
 	// that are measured in the boot process. The asset
-	// identifiers correspond to the backward compatible names in
-	// the modeenv (CurrentTrustedBootAssets and
+	// identifiers correspond to the backward compatible names
+	// recorded in the modeenv (CurrentTrustedBootAssets and
 	// CurrentTrustedRecoveryBootAssets).
 	TrustedAssets() (map[string]string, error)
 

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -413,7 +413,7 @@ func (b *MockExtractedRunKernelImageMixin) DisableTryKernel() error {
 // MockTrustedAssetsMixin implements the bootloader.TrustedAssetsBootloader
 // interface.
 type MockTrustedAssetsMixin struct {
-	TrustedAssetsList  []string
+	TrustedAssetsMap   map[string]string
 	TrustedAssetsErr   error
 	TrustedAssetsCalls int
 
@@ -501,20 +501,20 @@ func (b *MockTrustedAssetsMixin) DefaultCommandLine(candidate bool) (string, err
 	return b.StaticCommandLine, nil
 }
 
-func (b *MockTrustedAssetsMixin) TrustedAssets() ([]string, error) {
+func (b *MockTrustedAssetsMixin) TrustedAssets() (map[string]string, error) {
 	b.TrustedAssetsCalls++
-	return b.TrustedAssetsList, b.TrustedAssetsErr
+	return b.TrustedAssetsMap, b.TrustedAssetsErr
 }
 
-func (b *MockTrustedAssetsMixin) RecoveryBootChain(kernelPath string) ([]bootloader.BootFile, error) {
+func (b *MockTrustedAssetsMixin) RecoveryBootChains(kernelPath string) ([][]bootloader.BootFile, error) {
 	b.RecoveryBootChainCalls = append(b.RecoveryBootChainCalls, kernelPath)
-	return b.RecoveryBootChainList, b.RecoveryBootChainErr
+	return [][]bootloader.BootFile{b.RecoveryBootChainList}, b.RecoveryBootChainErr
 }
 
-func (b *MockTrustedAssetsMixin) BootChain(runBl bootloader.Bootloader, kernelPath string) ([]bootloader.BootFile, error) {
+func (b *MockTrustedAssetsMixin) BootChains(runBl bootloader.Bootloader, kernelPath string) ([][]bootloader.BootFile, error) {
 	b.BootChainRunBl = append(b.BootChainRunBl, runBl)
 	b.BootChainKernelPath = append(b.BootChainKernelPath, kernelPath)
-	return b.BootChainList, b.BootChainErr
+	return [][]bootloader.BootFile{b.BootChainList}, b.BootChainErr
 }
 
 // MockRecoveryAwareTrustedAssetsBootloader implements the

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -525,65 +525,85 @@ func (g *grub) getGrubBootAssetsForArch() (*grubBootAssetPath, error) {
 	return &assets, nil
 }
 
-// getGrubRecoveryModeTrustedAssets returns the assets for recovery mode,
-// which are shim and grub from the seed partition.
-func (g *grub) getGrubRecoveryModeTrustedAssets() ([]string, error) {
+// getGrubRecoveryModeTrustedAssets returns the list of ordered asset
+// chain for recovery mode, which are shim and grub from the seed
+// partition.
+func (g *grub) getGrubRecoveryModeTrustedAssets() ([][]string, error) {
 	assets, err := g.getGrubBootAssetsForArch()
 	if err != nil {
 		return nil, err
 	}
-	return []string{assets.shimBinary, assets.grubBinary}, nil
+	return [][]string{{assets.shimBinary, assets.grubBinary}}, nil
 }
 
-// getGrubRunModeTrustedAssets returns the assets for run mode, which is
-// grub from the boot partition.
-func (g *grub) getGrubRunModeTrustedAssets() ([]string, error) {
+// getGrubRunModeTrustedAssets returns the list of ordered asset
+// chains for run mode, which is grub from the boot partition.
+func (g *grub) getGrubRunModeTrustedAssets() ([][]string, error) {
 	assets, err := g.getGrubBootAssetsForArch()
 	if err != nil {
 		return nil, err
 	}
-	return []string{assets.grubBinary}, nil
+	return [][]string{{assets.grubBinary}}, nil
 }
 
-// TrustedAssets returns the list of relative paths to assets inside
-// the bootloader's rootdir that are measured in the boot process in the
-// order of loading during the boot.
-func (g *grub) TrustedAssets() ([]string, error) {
+// TrustedAssets returns the map of relative paths to asset
+// identifers. The relative paths are relative to the bootloader's
+// rootdir. The asset identifiers correspond to the backward
+// compatible names in the modeenv (CurrentTrustedBootAssets and
+// CurrentTrustedRecoveryBootAssets).
+func (g *grub) TrustedAssets() (map[string]string, error) {
 	if !g.nativePartitionLayout {
 		return nil, fmt.Errorf("internal error: trusted assets called without native host-partition layout")
 	}
+	ret := make(map[string]string)
+	var chains [][]string
+	var err error
 	if g.recovery {
-		return g.getGrubRecoveryModeTrustedAssets()
+		chains, err = g.getGrubRecoveryModeTrustedAssets()
+	} else {
+		chains, err = g.getGrubRunModeTrustedAssets()
 	}
-	return g.getGrubRunModeTrustedAssets()
+	if err != nil {
+		return nil, err
+	}
+	for _, chain := range chains {
+		for _, asset := range chain {
+			ret[asset] = filepath.Base(asset)
+		}
+	}
+	return ret, nil
 }
 
-// RecoveryBootChain returns the load chain for recovery modes.
+// RecoveryBootChains returns the list of load chains for recovery modes.
 // It should be called on a RoleRecovery bootloader.
-func (g *grub) RecoveryBootChain(kernelPath string) ([]BootFile, error) {
+func (g *grub) RecoveryBootChains(kernelPath string) ([][]BootFile, error) {
 	if !g.recovery {
 		return nil, fmt.Errorf("not a recovery bootloader")
 	}
 
 	// add trusted assets to the recovery chain
-	assets, err := g.getGrubRecoveryModeTrustedAssets()
+	assetsSet, err := g.getGrubRecoveryModeTrustedAssets()
 	if err != nil {
 		return nil, err
 	}
-	chain := make([]BootFile, 0, len(assets)+1)
-	for _, ta := range assets {
-		chain = append(chain, NewBootFile("", ta, RoleRecovery))
+	chains := make([][]BootFile, 0, len(assetsSet))
+	for _, assets := range assetsSet {
+		chain := make([]BootFile, 0, len(assets)+1)
+		for _, ta := range assets {
+			chain = append(chain, NewBootFile("", filepath.Base(ta), RoleRecovery))
+		}
+		// add recovery kernel to the recovery chain
+		chain = append(chain, NewBootFile(kernelPath, "kernel.efi", RoleRecovery))
+		chains = append(chains, chain)
 	}
-	// add recovery kernel to the recovery chain
-	chain = append(chain, NewBootFile(kernelPath, "kernel.efi", RoleRecovery))
 
-	return chain, nil
+	return chains, nil
 }
 
-// BootChain returns the load chain for run mode.
+// BootChains returns the list of load chains for run mode.
 // It should be called on a RoleRecovery bootloader passing the
 // RoleRunMode bootloader.
-func (g *grub) BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error) {
+func (g *grub) BootChains(runBl Bootloader, kernelPath string) ([][]BootFile, error) {
 	if !g.recovery {
 		return nil, fmt.Errorf("not a recovery bootloader")
 	}
@@ -592,23 +612,29 @@ func (g *grub) BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error
 	}
 
 	// add trusted assets to the recovery chain
-	recoveryModeAssets, err := g.getGrubRecoveryModeTrustedAssets()
+	recoveryModeAssetsSet, err := g.getGrubRecoveryModeTrustedAssets()
 	if err != nil {
 		return nil, err
 	}
-	runModeAssets, err := g.getGrubRunModeTrustedAssets()
+	runModeAssetsSet, err := g.getGrubRunModeTrustedAssets()
 	if err != nil {
 		return nil, err
 	}
-	chain := make([]BootFile, 0, len(recoveryModeAssets)+len(runModeAssets)+1)
-	for _, ta := range recoveryModeAssets {
-		chain = append(chain, NewBootFile("", ta, RoleRecovery))
+	chains := make([][]BootFile, 0, len(recoveryModeAssetsSet)*len(runModeAssetsSet))
+	for _, recoveryModeAssets := range recoveryModeAssetsSet {
+		for _, runModeAssets := range runModeAssetsSet {
+			chain := make([]BootFile, 0, len(recoveryModeAssets)+len(runModeAssets)+1)
+			for _, ta := range recoveryModeAssets {
+				chain = append(chain, NewBootFile("", filepath.Base(ta), RoleRecovery))
+			}
+			for _, ta := range runModeAssets {
+				chain = append(chain, NewBootFile("", filepath.Base(ta), RoleRunMode))
+			}
+			// add kernel to the boot chain
+			chain = append(chain, NewBootFile(kernelPath, "kernel.efi", RoleRunMode))
+			chains = append(chains, chain)
+		}
 	}
-	for _, ta := range runModeAssets {
-		chain = append(chain, NewBootFile("", ta, RoleRunMode))
-	}
-	// add kernel to the boot chain
-	chain = append(chain, NewBootFile(kernelPath, "kernel.efi", RoleRunMode))
 
-	return chain, nil
+	return chains, nil
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -256,6 +256,15 @@ func (s *grubTestSuite) makeFakeGrubEFINativeEnv(c *C, content []byte) {
 	c.Assert(err, IsNil)
 }
 
+func (s *grubTestSuite) makeFakeShimFallback(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootdir, "/EFI/boot"), 0755)
+	c.Assert(err, IsNil)
+	_, err = os.Create(filepath.Join(s.rootdir, "/EFI/boot/fbx64.efi"))
+	c.Assert(err, IsNil)
+	_, err = os.Create(filepath.Join(s.rootdir, "/EFI/boot/fbaa64.efi"))
+	c.Assert(err, IsNil)
+}
+
 func (s *grubTestSuite) TestNewGrubWithOptionRecovery(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
@@ -1190,8 +1199,24 @@ func (s *grubTestSuite) TestTrustedAssetsNativePartitionLayout(c *C) {
 	ta, err = tarb.TrustedAssets()
 	c.Assert(err, IsNil)
 	c.Check(ta, DeepEquals, map[string]string{
-		"EFI/boot/bootx64.efi": "bootx64.efi",
-		"EFI/boot/grubx64.efi": "grubx64.efi",
+		"EFI/boot/bootx64.efi":   "bootx64.efi",
+		"EFI/boot/grubx64.efi":   "grubx64.efi",
+		"EFI/ubuntu/shimx64.efi": "ubuntu:shimx64.efi",
+		"EFI/ubuntu/grubx64.efi": "ubuntu:grubx64.efi",
+	})
+
+	// recovery bootloader, with fallback implemented
+	s.makeFakeShimFallback(c)
+	tarb = bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
+	c.Assert(tarb, NotNil)
+
+	ta, err = tarb.TrustedAssets()
+	c.Assert(err, IsNil)
+	c.Check(ta, DeepEquals, map[string]string{
+		"EFI/ubuntu/shimx64.efi": "ubuntu:shimx64.efi",
+		"EFI/ubuntu/grubx64.efi": "ubuntu:grubx64.efi",
+		"EFI/boot/bootx64.efi":   "bootx64.efi",
+		"EFI/boot/grubx64.efi":   "grubx64.efi",
 	})
 }
 
@@ -1234,8 +1259,35 @@ func (s *grubTestSuite) TestRecoveryBootChains(c *C) {
 
 	chains, err := tab.RecoveryBootChains("kernel.snap")
 	c.Assert(err, IsNil)
-	c.Assert(chains, HasLen, 1)
+	c.Assert(chains, HasLen, 2)
 	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
+	})
+}
+
+func (s *grubTestSuite) TestRecoveryBootChainsWithFallback(c *C) {
+	s.makeFakeShimFallback(c)
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	chains, err := tab.RecoveryBootChains("kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chains, HasLen, 2)
+	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
 		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
 		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
@@ -1262,8 +1314,40 @@ func (s *grubTestSuite) TestBootChains(c *C) {
 
 	chains, err := tab.BootChains(g2, "kernel.snap")
 	c.Assert(err, IsNil)
-	c.Assert(chains, HasLen, 1)
+	c.Assert(chains, HasLen, 2)
 	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+}
+
+func (s *grubTestSuite) TestBootChainsWithFallback(c *C) {
+	s.makeFakeShimFallback(c)
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+
+	chains, err := tab.BootChains(g2, "kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chains, HasLen, 2)
+	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
 		{Path: "EFI/boot/bootx64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
@@ -1283,8 +1367,42 @@ func (s *grubTestSuite) TestBootChainsArm64(c *C) {
 
 	chains, err := tab.BootChains(g2, "kernel.snap")
 	c.Assert(err, IsNil)
-	c.Assert(chains, HasLen, 1)
+	c.Assert(chains, HasLen, 2)
 	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/boot/bootaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+}
+
+func (s *grubTestSuite) TestBootChainsArm64WithFallback(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	s.makeFakeShimFallback(c)
+	r := archtest.MockArchitecture("arm64")
+	defer r()
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+
+	chains, err := tab.BootChains(g2, "kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chains, HasLen, 2)
+	c.Assert(chains[0], DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+	c.Assert(chains[1], DeepEquals, []bootloader.BootFile{
 		{Path: "EFI/boot/bootaa64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -297,7 +297,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetSimple(c *C, grade string, encryp
 	if grade != "" {
 		bootDir := c.MkDir()
 		tbl := bootloadertest.Mock("trusted", bootDir).WithTrustedAssets()
-		tbl.TrustedAssetsList = []string{"trusted-asset"}
+		tbl.TrustedAssetsMap = map[string]string{"trusted-asset": "trusted-asset"}
 		tbl.ManagedAssetsList = []string{"managed-asset"}
 		bootloader.Force(tbl)
 		defer func() { bootloader.Force(nil) }()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -277,7 +277,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 
 	if tc.trustedBootloader {
 		tab := bootloadertest.Mock("trusted", bootloaderRootdir).WithTrustedAssets()
-		tab.TrustedAssetsList = []string{"trusted-asset"}
+		tab.TrustedAssetsMap = map[string]string{"trusted-asset": "trusted-asset"}
 		bootloader.Force(tab)
 		s.AddCleanup(func() { bootloader.Force(nil) })
 
@@ -1597,7 +1597,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 
 	if tc.trustedBootloader {
 		tab := bootloadertest.Mock("trusted", bootloaderRootdir).WithTrustedAssets()
-		tab.TrustedAssetsList = []string{"trusted-asset"}
+		tab.TrustedAssetsMap = map[string]string{"trusted-asset": "trusted-asset"}
 		bootloader.Force(tab)
 		s.AddCleanup(func() { bootloader.Force(nil) })
 

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -142,7 +142,7 @@ func validateCore20Seed(c *C, name string, expectedModel *asserts.Model, trusted
 func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 	bl := bootloadertest.Mock("trusted", c.MkDir()).WithRecoveryAwareTrustedAssets()
 	// make it simple for now, no assets
-	bl.TrustedAssetsList = nil
+	bl.TrustedAssetsMap = nil
 	bl.StaticCommandLine = "mock static"
 	bl.CandidateStaticCommandLine = "unused"
 	bootloader.Force(bl)
@@ -261,7 +261,7 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 func (s *createSystemSuite) TestCreateSystemFromUnassertedSnaps(c *C) {
 	bl := bootloadertest.Mock("trusted", c.MkDir()).WithRecoveryAwareTrustedAssets()
 	// make it simple for now, no assets
-	bl.TrustedAssetsList = nil
+	bl.TrustedAssetsMap = nil
 	bl.StaticCommandLine = "mock static"
 	bl.CandidateStaticCommandLine = "unused"
 	bootloader.Force(bl)

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -814,7 +814,7 @@ func (s *installSuite) mockBootloader(c *C, trustedAssets bool, managedAssets bo
 	if trustedAssets || managedAssets {
 		tab := bootloadertest.Mock("trusted", bootloaderRootdir).WithTrustedAssets()
 		if trustedAssets {
-			tab.TrustedAssetsList = []string{"trusted-asset"}
+			tab.TrustedAssetsMap = map[string]string{"trusted-asset": "trusted-asset"}
 		}
 		if managedAssets {
 			tab.ManagedAssetsList = []string{"managed-asset"}

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -406,6 +406,9 @@ nested_secboot_sign_gadget() {
     local GADGET_DIR="$1"
     local KEY="$2"
     local CERT="$3"
+    if [ -f "$GADGET_DIR/fb.efi" ]; then
+        nested_secboot_sign_file "$GADGET_DIR/fb.efi" "$KEY" "$CERT"
+    fi
     nested_secboot_sign_file "$GADGET_DIR/shim.efi.signed" "$KEY" "$CERT"
 }
 

--- a/tests/nested/manual/uc-grub-boot-chains/modify-gadget.py
+++ b/tests/nested/manual/uc-grub-boot-chains/modify-gadget.py
@@ -1,0 +1,56 @@
+import argparse
+import yaml
+
+parser = argparse.ArgumentParser()
+parser.add_argument('edition_bump', type=int)
+# Type of media:
+# * A bootable removable media will have boot/bootx64.efi and boot/grubx64.efi.
+#   It will not register boot entries in UEFI variables.
+# * A bootable installed system (boot_entry) will have boot/bootx64.efi and boot/fbx64.efi as fallback.
+#   It will also have <distro>/shimx64.efi and <distro>/grubx64.efi.
+#   This will work with UEFI variables for boot entries.
+# For more information see:
+# See https://github.com/rhboot/shim/blob/66e6579dbf921152f647a0c16da1d3b2f40861ca/README.fallback
+parser.add_argument('type', choices=['removable', 'boot_entry'])
+parser.add_argument('gadget_yaml', type=argparse.FileType('r', encoding='utf-8'))
+parser.add_argument('output', type=argparse.FileType('w', encoding='utf-8'))
+args = parser.parse_args()
+
+content = yaml.safe_load(args.gadget_yaml)
+for partition in content['volumes']['pc']['structure']:
+    if partition.get('role') == 'system-seed':
+        partition['update']['edition'] += args.edition_bump
+        if args.type == 'removable':
+            partition['content'] = [
+                {'source': 'grubx64.efi',
+                'target': 'EFI/boot/grubx64.efi'},
+                {'source': 'shim.efi.signed',
+                 'target': 'EFI/boot/bootx64.efi'},
+            ]
+        elif args.type == 'boot_entry':
+            partition['content'] = [
+                {'source': 'grubx64.efi',
+                 'target': 'EFI/ubuntu/grubx64.efi'},
+                {'source': 'shim.efi.signed',
+                 'target': 'EFI/ubuntu/shimx64.efi'},
+                {'source': 'boot.csv',
+                 'target': 'EFI/ubuntu/bootx64.csv'},
+                {'source': 'fb.efi',
+                 'target': 'EFI/boot/fbx64.efi'},
+                {'source': 'shim.efi.signed',
+                 'target': 'EFI/boot/bootx64.efi'},
+            ]
+    elif partition.get('role') == 'system-boot':
+        partition['update']['edition'] += args.edition_bump
+        if args.type == 'removable':
+            partition['content'] = [
+                {'source': 'grubx64.efi',
+                 'target': 'EFI/boot/grubx64.efi'},
+            ]
+        elif args.type == 'boot_entry':
+            partition['content'] = [
+                {'source': 'grubx64.efi',
+                 'target': 'EFI/ubuntu/grubx64.efi'},
+            ]
+
+yaml.safe_dump(content, stream=args.output)

--- a/tests/nested/manual/uc-grub-boot-chains/task.yaml
+++ b/tests/nested/manual/uc-grub-boot-chains/task.yaml
@@ -1,0 +1,101 @@
+summary: Grub boot chain can be provided with different boot chains
+
+details: |
+  Older pc gadget use a layout for removable media. The new pc
+  gadget will use a proper layout with fallback and boot entries. This
+  tests that we support both layouts and that we can update.
+
+systems:
+  - ubuntu-24.04-64
+  - ubuntu-22.04-64
+  - ubuntu-20.04-64
+
+prepare: |
+  # snappy-dev:image ppa contains some weird version of shim-signed.
+  # snappy-dev:image ppa is possibly enabled by some other tests.
+  cat >/etc/apt/preferences.d/ppa-disable-shim-signed <<EOF
+  Package: shim-signed
+  Pin: release o=LP-PPA-snappy-dev-image
+  Pin-Priority: -1
+  EOF
+  apt update
+
+  VERSION=$(tests.nested show version)
+  snap download --basename=pc --channel="${VERSION}/${NESTED_GADGET_CHANNEL}" pc
+  unsquashfs -d pc pc.snap
+  apt download shim-signed
+  dpkg-deb -x shim-signed_*.deb ./shim-signed
+  shim="${PWD}/shim-signed/usr/lib/shim/shimx64.efi.dualsigned"
+  fb="${PWD}/shim-signed/usr/lib/shim/fbx64.efi"
+  csv="${PWD}/shim-signed/usr/lib/shim/BOOTX64.CSV"
+
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+  python3 modify-gadget.py 0 removable pc/meta/gadget.yaml gadget.yaml.old
+  python3 modify-gadget.py 1 boot_entry pc/meta/gadget.yaml gadget.yaml.new
+  python3 modify-gadget.py 2 removable pc/meta/gadget.yaml gadget.yaml.old-again
+
+  cp "${shim}" pc/shim.efi.signed
+  rm -f pc/boot.csv
+  rm -f pc/fb.efi
+  cp gadget.yaml.old pc/meta/gadget.yaml
+
+  tests.nested secboot-sign gadget pc "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  snap pack pc "$(tests.nested get extra-snaps-path)"
+
+  cp "${fb}" pc/fb.efi
+  cp "${csv}" pc/boot.csv
+  cp gadget.yaml.new pc/meta/gadget.yaml
+  tests.nested secboot-sign gadget pc "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  snap pack pc --filename=pc_x2.snap
+
+  rm -f pc/fb.efi
+  rm -f pc/boot.csv
+  cp gadget.yaml.old-again pc/meta/gadget.yaml
+  tests.nested secboot-sign gadget pc "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  snap pack pc --filename=pc_x3.snap
+
+  tests.nested build-image core
+  tests.nested create-vm core
+
+restore: |
+  rm -f /etc/apt/preferences.d/ppa-disable-shim-signed
+  apt update
+
+execute: |
+  remote.exec "! [ -f /boot/efi/EFI/ubuntu/grubx64.efi ]"
+  remote.exec "[ -f /boot/efi/EFI/boot/grubx64.efi ]"
+  remote.push pc_x2.snap
+  boot_id=$(tests.nested boot-id)
+  install_change=$(remote.exec sudo snap install --dangerous pc_x2.snap --no-wait)
+  remote.wait-for reboot "$boot_id"
+  remote.exec sudo snap watch "${install_change}"
+
+  remote.exec "[ -f /boot/efi/EFI/ubuntu/grubx64.efi ]"
+  remote.exec "[ -f /boot/efi/EFI/ubuntu/shimx64.efi ]"
+  remote.exec "[ -f /boot/efi/EFI/ubuntu/bootx64.csv ]"
+
+  #FIXME: We do not remove old assets yet
+  #remote.exec "! [ -f /boot/efi/EFI/boot/grubx64.efi ]"
+  remote.exec "sudo rm -f /boot/efi/EFI/boot/grubx64.efi"
+
+  # Make sure we can still boot
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
+  remote.wait-for reboot "$boot_id"
+
+  remote.exec "! [ -f /boot/efi/EFI/boot/grubx64.efi ]"
+
+  # Let's "downgrade"!
+  remote.push pc_x3.snap
+  boot_id=$(tests.nested boot-id)
+  # FIXME: this does not work yet since we do not delete yet content
+  # that are not on newly installed gadget snap while defined in
+  # previous gadget snap. As a work-around we remove the files
+  # manually.
+  remote.exec sudo systemd-inhibit --what=shutdown bash -c "'snap install --dangerous pc_x3.snap; rm -f /boot/efi/EFI/ubuntu/grubx64.efi /boot/efi/EFI/boot/fbx64.efi /boot/efi/EFI/ubuntu/shimx64.efi'"
+  remote.wait-for reboot "$boot_id"
+  remote.exec "[ -f /boot/efi/EFI/boot/grubx64.efi ]"
+  retry --wait 4 -n 100 sh -c 'remote.exec "! [ -f /boot/efi/EFI/ubuntu/grubx64.efi ]"'


### PR DESCRIPTION
We need to resolve the boot chains another place based on the trusted assets we encountered to be installed. At this point it could be any chain. We will need to discover later what the correct chain is.

Also make TrustedAssets return an unsorted data structure to make sure we do not use the order like the comments claimed.