### PR TITLE
boot: fix more slices missing types

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -862,11 +862,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"asset-hash", dataHash},
+		"asset": []string{"asset-hash", dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 
 	// verify that managed assets are to be preserved
@@ -936,10 +936,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 
 	// reseal does nothing
@@ -1058,10 +1058,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateRepeatedAssetErr(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"one", "two"},
+			"asset": []string{"one", "two"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"one", "two"},
+			"asset": []string{"one", "two"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1115,10 +1115,10 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 	}
 	err = m.WriteTo("")
@@ -1158,11 +1158,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
 		// original asset is restored, listed first
-		"asset": {beforeHash, dataHash},
+		"asset": []string{beforeHash, dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
 		// same here
-		"asset": {beforeHash, dataHash},
+		"asset": []string{beforeHash, dataHash},
 	})
 }
 
@@ -1220,15 +1220,15 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			// new version added during update
-			"asset": {dataHash, "newhash"},
+			"asset": []string{dataHash, "newhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
 			// no new version added during update
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 			// new version added during update
-			"shim": {shimHash, "newshimhash"},
+			"shim": []string{shimHash, "newshimhash"},
 			// completely new file
-			"other-asset": {"newotherhash"},
+			"other-asset": []string{"newotherhash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1278,11 +1278,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 }
 
@@ -1301,11 +1301,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileValidity(c *C) {
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			// only one hash is listed, indicating it's a new file
-			"asset": {"newhash"},
+			"asset": []string{"newhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
 			// same thing
-			"asset": {"newhash"},
+			"asset": []string{"newhash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1333,11 +1333,11 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileValidity(c *C) {
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			// only one hash is listed, indicating it's a new file
-			"asset": {"newhash", "bogushash"},
+			"asset": []string{"newhash", "bogushash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
 			// same thing
-			"asset": {"newhash", "bogushash"},
+			"asset": []string{"newhash", "bogushash"},
 		},
 	}
 	err = m.WriteTo("")
@@ -1454,11 +1454,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"grubx64.efi": {"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"},
+			"grubx64.efi": []string{"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"grubx64.efi": {"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"},
-			"bootx64.efi": {"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"},
+			"grubx64.efi": []string{"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d"},
+			"bootx64.efi": []string{"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1505,7 +1505,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"grubx64.efi": {
+		"grubx64.efi": []string{
 			// old hash
 			"0d0c6522fcc813770f2bb9ca68ad3b4f0ccc6b4bfbd2e8497030079e6146f92177ad8f6f83d96ab61d7d42f5228a4389",
 			// update
@@ -1513,13 +1513,13 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 		},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"grubx64.efi": {
+		"grubx64.efi": []string{
 			// old hash
 			"6c3e6fc78ade5aadc5f9f0603a127346cc174436eb5e0188e108a376c3ba4d8951c460a8f51674e797c06951f74cb10d",
 			// update
 			"f9554844308e89b565c1cdbcbdb9b09b8210dd2f1a11cb3b361de0a59f780ae3d4bd6941729a60e0f8ce15b2edef605d",
 		},
-		"bootx64.efi": {
+		"bootx64.efi": []string{
 			// old hash
 			"c0437507ac094a7e9c699725cc0a4726cd10799af9eb79bbeaa136c2773163c80432295c2a04d3aa2ddd535ce8f1a12b",
 			// update
@@ -1559,11 +1559,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
-			"shim":  {"shimhash"},
+			"asset": []string{"assethash"},
+			"shim":  []string{"shimhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryhash"},
+			"asset": []string{"recoveryhash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1624,12 +1624,12 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"assethash", dataHash},
-		"shim":  {"shimhash", shimHash},
+		"asset": []string{"assethash", dataHash},
+		"shim":  []string{"shimhash", shimHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"recoveryhash", dataHash},
-		"shim":  {shimHash},
+		"asset": []string{"recoveryhash", dataHash},
+		"shim":  []string{shimHash},
 	})
 	resealCalls := 0
 	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
@@ -1691,11 +1691,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
-			"shim":  {"shimhash"},
+			"asset": []string{"assethash"},
+			"shim":  []string{"shimhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"shim": {shimHash},
+			"shim": []string{shimHash},
 		},
 	}
 	err = m.WriteTo("")
@@ -1726,12 +1726,12 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"assethash", dataHash},
-		"shim":  {"shimhash", shimHash},
+		"asset": []string{"assethash", dataHash},
+		"shim":  []string{"shimhash", shimHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 	// update is canceled
 	err = obs.Canceled()
@@ -1760,11 +1760,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
-			"shim":  {"shimhash"},
+			"asset": []string{"assethash"},
+			"shim":  []string{"shimhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryhash"},
+			"asset": []string{"recoveryhash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1886,10 +1886,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
+			"asset": []string{"assethash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
+			"asset": []string{"assethash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1946,10 +1946,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
+			"asset": []string{"assethash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryhash"},
+			"asset": []string{"recoveryhash"},
 		},
 	}
 	err := m.WriteTo("")
@@ -1991,12 +1991,12 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 	newM, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"assethash"},
-		"shim":  {shimHash},
+		"asset": []string{"assethash"},
+		"shim":  []string{shimHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {"recoveryhash"},
-		"shim":  {shimHash},
+		"asset": []string{"recoveryhash"},
+		"shim":  []string{shimHash},
 	})
 
 	// make cache directory read only and thus cache.Remove() fail
@@ -2039,10 +2039,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootNoAssetsOnDisk(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
+			"asset": []string{"assethash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
+			"asset": []string{"assethash"},
 		},
 	}
 
@@ -2074,11 +2074,11 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash", dataHash},
+			"asset": []string{"assethash", dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryassethash", dataHash},
-			"shim":  {"recoveryshimhash", shimHash},
+			"asset": []string{"recoveryassethash", dataHash},
+			"shim":  []string{"recoveryshimhash", shimHash},
 		},
 	}
 
@@ -2086,11 +2086,11 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 	c.Check(drop, HasLen, 3)
 	for i, en := range []struct {
@@ -2122,10 +2122,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash", dataHash},
+			"asset": []string{"assethash", dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryassethash", dataHash},
+			"asset": []string{"recoveryassethash", dataHash},
 		},
 	}
 
@@ -2164,11 +2164,11 @@ func (s *assetsSuite) TestObserveSuccessfulBootSingleEntries(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
-			"shim":  {shimHash},
+			"asset": []string{dataHash},
+			"shim":  []string{shimHash},
 		},
 	}
 
@@ -2200,10 +2200,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {maybeDropHash},
+			"asset": []string{maybeDropHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {maybeDropHash, dataHash},
+			"asset": []string{maybeDropHash, dataHash},
 		},
 	}
 
@@ -2212,10 +2212,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {maybeDropHash},
+		"asset": []string{maybeDropHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	// nothing get dropped, maybe-drop asset is still used by the
 	// ubuntu-boot bootloader
@@ -2242,11 +2242,11 @@ func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"oldhash", dataHash},
+			"asset": []string{"oldhash", dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"oldhash", dataHash},
-			"shim":  {shimHash},
+			"asset": []string{"oldhash", dataHash},
+			"shim":  []string{shimHash},
 		},
 	}
 
@@ -2254,11 +2254,11 @@ func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(newM, NotNil)
 	c.Check(newM.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 	// asset was updated in parallel on both partition from the same
 	// oldhash that should be dropped now
@@ -2284,10 +2284,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 	m := &boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 	}
 
@@ -2302,10 +2302,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootDifferentMode(c *C) {
 	m := &boot.Modeenv{
 		Mode: "recover",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"hash-1", "hash-2"},
+			"asset": []string{"hash-1", "hash-2"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"hash-3", "hash-4"},
+			"asset": []string{"hash-3", "hash-4"},
 		},
 	}
 
@@ -2441,10 +2441,10 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {beforeHash},
+			"asset": []string{beforeHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {beforeHash},
+			"asset": []string{beforeHash},
 		},
 		CurrentRecoverySystems: []string{"recovery-system-label"},
 		CurrentKernels:         []string{"pc-kernel_500.snap"},
@@ -2581,12 +2581,12 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	m := boot.Modeenv{
 		Mode: "run",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
-			"shim":  {"shimhash"},
+			"asset": []string{"assethash"},
+			"shim":  []string{"shimhash"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash"},
-			"shim":  {"shimhash"},
+			"asset": []string{"assethash"},
+			"shim":  []string{"shimhash"},
 		},
 		CurrentRecoverySystems:    []string{"system"},
 		CurrentKernels:            []string{"pc-kernel_1.snap"},

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1096,7 +1096,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		Model:          model.Model(),
 		BrandID:        model.BrandID(),
@@ -1214,7 +1214,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		Model:          uc20Model.Model(),
 		BrandID:        uc20Model.BrandID(),
@@ -1328,7 +1328,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
 
@@ -1446,7 +1446,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
 
@@ -1847,7 +1847,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 
 		Model:          model.Model(),
@@ -2165,7 +2165,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename(), s.kern2.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		Model:          model.Model(),
 		BrandID:        model.BrandID(),
@@ -2416,11 +2416,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"assethash", dataHash},
+			"asset": []string{"assethash", dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"recoveryassethash", dataHash},
-			"shim":  {"recoveryshimhash", shimHash},
+			"asset": []string{"recoveryassethash", dataHash},
+			"shim":  []string{"recoveryshimhash", shimHash},
 		},
 		CurrentRecoverySystems: []string{"system"},
 
@@ -2485,11 +2485,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(err, IsNil)
 	// update assets are in the list
 	c.Check(m2.CurrentTrustedBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
+		"asset": []string{dataHash},
 	})
 	c.Check(m2.CurrentTrustedRecoveryBootAssets, DeepEquals, boot.BootAssetsMap{
-		"asset": {dataHash},
-		"shim":  {shimHash},
+		"asset": []string{dataHash},
+		"shim":  []string{shimHash},
 	})
 	// unused files were dropped from cache
 	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDir, "trusted", "*"), []string{
@@ -2552,11 +2552,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
-			"shim":  {shimHash},
+			"asset": []string{dataHash},
+			"shim":  []string{shimHash},
 		},
 		CurrentRecoverySystems:    []string{"system"},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
@@ -2713,11 +2713,11 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
-			"shim":  {shimHash},
+			"asset": []string{dataHash},
+			"shim":  []string{shimHash},
 		},
 		CurrentRecoverySystems:    []string{"system"},
 		GoodRecoverySystems:       []string{"system"},
@@ -2851,10 +2851,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
 			// hash will not match
-			"asset": {"one", "two"},
+			"asset": []string{"one", "two"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"one", "two"},
+			"asset": []string{"one", "two"},
 		},
 		Model:          model.Model(),
 		BrandID:        model.BrandID(),
@@ -2900,10 +2900,10 @@ func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, model *asser
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {"one"},
+			"asset": []string{"one"},
 		},
 		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
-			"asset": {"one"},
+			"asset": []string{"one"},
 		},
 		CurrentKernelCommandLines: cmdlines,
 
@@ -4799,7 +4799,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		Model:          model.Model(),
 		BrandID:        model.BrandID(),
@@ -4911,7 +4911,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		Model:          uc20Model.Model(),
 		BrandID:        uc20Model.BrandID(),
@@ -5019,7 +5019,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
 
@@ -5137,7 +5137,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.ukern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
 
@@ -5352,7 +5352,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 		Base:           s.base1.Filename(),
 		CurrentKernels: []string{s.kern1.Filename()},
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"asset": {dataHash},
+			"asset": []string{dataHash},
 		},
 
 		Model:          model.Model(),

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -160,8 +160,8 @@ current_kernel_command_lines=["foo", "bar"]
 		TryBase:        "core20_124.snap",
 		BaseStatus:     "try",
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"thing1": {"hash1", "hash2"},
-			"thing2": {"hash3"},
+			"thing1": []string{"hash1", "hash2"},
+			"thing2": []string{"hash3"},
 		},
 		CurrentKernelCommandLines: boot.BootCommandLines{
 			"foo", "bar",
@@ -252,8 +252,8 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BootFlags: []string{"foo", "factory"},
 
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"thing1": {"hash1", "hash2"},
-			"thing2": {"hash3"},
+			"thing1": []string{"hash1", "hash2"},
+			"thing2": []string{"hash3"},
 		},
 
 		CurrentKernelCommandLines: boot.BootCommandLines{
@@ -281,8 +281,8 @@ func (s *modeenvSuite) TestDeepEquals(c *C) {
 		BootFlags: []string{"foo", "factory"},
 
 		CurrentTrustedBootAssets: boot.BootAssetsMap{
-			"thing1": {"hash1", "hash2"},
-			"thing2": {"hash3"},
+			"thing1": []string{"hash1", "hash2"},
+			"thing2": []string{"hash3"},
 		},
 
 		CurrentKernelCommandLines: boot.BootCommandLines{


### PR DESCRIPTION
Follow-up to https://github.com/snapcore/snapd/pull/13419. The original error message was a bit lacking so I missed that there were other similar errors. This adds types to the remaining missing slices. There's quite a few usages of `BootAssetsMap` and while some have types, others don't. I used this: 
```
grep --no-messages --no-group-separator -R -n -A 3 BootAssetsMap{ . | awk 'NR%4{printf "%s ",$0;next;}1' | grep -v "\[\]string"
``` 
to find usages of `BootAssetMap` that don't use types in the map values. It could miss things if any usage put the map values inline and there happened to be an unrelated `[]string` below it but a quick grep shows that's never the case.

Unfortunately, I haven't been able to reproduce the golangci failures locally, even with the same version run in the same way, so I'm not sure there won't be other issues