### PR TITLE
.github: update golangci-lint version to v1.55.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.51.2
+        version: v1.55.2
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work


### PR DESCRIPTION
Master is failing with some new typecheck failure in very old code but it's not reproducible locally. Let's try to bump up the version. Related https://github.com/snapcore/snapd/pull/13419 and https://github.com/snapcore/snapd/pull/13421