### PR TITLE
packaging/ubuntu-16.04/control: depend on `fuse3 | fuse`

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -69,6 +69,7 @@ Architecture: any
 Depends: adduser,
          apparmor (>= 2.10.95-0ubuntu2.2),
          ca-certificates,
+         fuse3 (>= 3.10.5-1) | fuse,
          openssh-client,
          squashfs-tools,
          systemd,
@@ -78,8 +79,7 @@ Depends: adduser,
          ${dbussession:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
-Recommends: gnupg,
-            fuse3 (>= 3.10.5-1) | fuse
+Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${Built-Using} ${misc:Built-Using}


### PR DESCRIPTION
This fixes [LP: #2046379](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2046379).

As mentioned in the above LP bug, it's not enough to recommend `fuse3`, it needs to be a depends otherwise it won't be possible to install snaps on minimal images:

```
$ lxc launch ubuntu-minimal-daily:24.04 c1
$ lxc exec c1 -- systemctl is-system-running --wait --quiet
$ lxc exec c1 -- snap install lxd
error: system does not fully support snapd: The "fuse" filesystem is required on this system but
       not available. Please try to install the fuse package.
```

This also provide a proper fix for [LP: #1792656](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1792656)