### PR TITLE
o/devicestate: make sure we do not remodel to UC16 from UC18+

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1239,6 +1239,12 @@ func Remodel(st *state.State, new *asserts.Model, localSnaps []*snap.SideInfo, p
 		return nil, fmt.Errorf("cannot remodel from grade %v to grade %v", current.Grade(), new.Grade())
 	}
 
+	if new.Base() == "" || new.Base() == "core" {
+		if current.Base() != "" && current.Base() != "core" {
+			return nil, errors.New("cannot remodel from snapd based system to core based system")
+		}
+	}
+
 	// TODO: we need dedicated assertion language to permit for
 	// model transitions before we allow cross vault
 	// transitions.

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1239,10 +1239,8 @@ func Remodel(st *state.State, new *asserts.Model, localSnaps []*snap.SideInfo, p
 		return nil, fmt.Errorf("cannot remodel from grade %v to grade %v", current.Grade(), new.Grade())
 	}
 
-	if new.Base() == "" || new.Base() == "core" {
-		if current.Base() != "" && current.Base() != "core" {
-			return nil, errors.New("cannot remodel from snapd based system to core based system")
-		}
+	if new.Base() == "" && current.Base() != "" {
+		return nil, errors.New("cannot remodel from snapd based system to core based system")
 	}
 
 	// TODO: we need dedicated assertion language to permit for

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1240,7 +1240,7 @@ func Remodel(st *state.State, new *asserts.Model, localSnaps []*snap.SideInfo, p
 	}
 
 	if new.Base() == "" && current.Base() != "" {
-		return nil, errors.New("cannot remodel from snapd based system to core based system")
+		return nil, errors.New("cannot remodel from UC18+ (using snapd snap) system back to UC16 system (using core snap)")
 	}
 
 	// TODO: we need dedicated assertion language to permit for

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -111,7 +111,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelSnapdBasedToCoreBased(c *C) {
 	})
 
 	chg, err := devicestate.Remodel(st, newModel, nil, nil)
-	c.Assert(err, ErrorMatches, "cannot remodel from snapd based system to core based system")
+	c.Assert(err, ErrorMatches, `cannot remodel from UC18\+ \(using snapd snap\) system back to UC16 system \(using core snap\)`)
 	c.Assert(chg, IsNil)
 }
 


### PR DESCRIPTION
We should not support remodeling from UC18+ to UC16. This change explicitly prevents that from happening.