### PR TITLE
gadget: fix matching of devices on ICE method

### DIFF
--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -5217,3 +5217,25 @@ func (s *gadgetYamlTestSuite) TestGadgetToLinuxFilesystem(c *C) {
 		c.Check(tc.vs.LinuxFilesystem(), Equals, tc.linFs)
 	}
 }
+
+func (s *gadgetYamlTestSuite) TestLayoutCompatibilityWithICEEncryptedPartitions(c *C) {
+	gadgetVolume, err := gadgettest.VolumeFromYaml(c.MkDir(), mockSimpleGadgetYaml+mockExtraStructure, nil)
+	c.Assert(err, IsNil)
+	deviceLayout := mockEncDeviceLayout
+
+	// if we set the EncryptedPartitions and assume partitions are already
+	// created then they match
+
+	encParams := gadget.StructureEncryptionParameters{Method: gadget.EncryptionICE}
+	encParams.SetUnknownKeys(map[string]string{"foo": "secret-foo"})
+
+	encOpts := &gadget.VolumeCompatibilityOptions{
+		AssumeCreatablePartitionsCreated: true,
+		ExpectedStructureEncryption: map[string]gadget.StructureEncryptionParameters{
+			"Writable": encParams,
+		},
+	}
+
+	_, err = gadget.EnsureVolumeCompatibility(gadgetVolume, &deviceLayout, encOpts)
+	c.Assert(err, IsNil)
+}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -387,6 +387,11 @@ func EnsureVolumeCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolume, o
 				}
 
 				switch encTypeParams.Method {
+				case EncryptionICE:
+					// Old ICE method, we don't check anything else as
+					// there is no "-enc" label and the filesystem
+					// type is not identified by the kernel.
+					return true, ""
 				case EncryptionLUKS:
 					// then this partition is expected to have been encrypted, the
 					// filesystem label on disk will need "-enc" appended
@@ -630,6 +635,9 @@ const (
 	// standard LUKS as it is used for automatic FDE using SecureBoot and TPM
 	// 2.0 in UC20+
 	EncryptionLUKS DiskEncryptionMethod = "LUKS"
+	// This is for compatibility with disk-mapping.json generated in old
+	// images that might use "ICE" on some device.
+	EncryptionICE DiskEncryptionMethod = "ICE"
 )
 
 // DiskVolumeValidationOptions is a set of options on how to validate a disk to

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -5216,8 +5216,6 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingPreUC20NonFatalError(
 }
 
 func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingPreUC20CannotMap(c *C) {
-	fmt.Println("TestBuildNewVolumeToDeviceMappingPreUC20CannotMap")
-	defer fmt.Println("TestBuildNewVolumeToDeviceMappingPreUC20CannotMap")
 	mockLogBuf, restore := logger.MockLogger()
 	defer restore()
 


### PR DESCRIPTION
Some older snapd could create disk-mapping.json files with encryption
method "ICE". Make sure that these systems still update. Fixes LP#2046338.
