### PR TITLE
aspects: unmatched placeholder returns all values

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -735,12 +735,12 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 	// read the final value
 	if index == len(subKeys)-1 {
 		if matchAll {
-			// request ends in placeholder so return map to all values (but unmarshal first)
+			// request ends in placeholder so return map to all values (but unmarshal the rest first)
 			level := make(map[string]interface{}, len(node))
 			for k, v := range node {
 				var deser interface{}
 				if err := json.Unmarshal(v, &deser); err != nil {
-					return err
+					return fmt.Errorf(`internal error: %w`, err)
 				}
 				level[k] = deser
 			}
@@ -749,13 +749,11 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 			return nil
 		}
 
-		err := json.Unmarshal(rawLevel, result)
-		if uErr, ok := err.(*json.UnmarshalTypeError); ok {
-			path := strings.Join(subKeys, ".")
-			return pathErrorf("cannot read value of %q into %T: maps to %s", path, result, uErr.Value)
+		if err := json.Unmarshal(rawLevel, result); err != nil {
+			return fmt.Errorf(`internal error: %w`, err)
 		}
 
-		return err
+		return nil
 	}
 
 	if matchAll {

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -284,7 +284,7 @@ func getPlaceholders(aspectStr string) map[string]bool {
 
 	subkeys := strings.Split(aspectStr, ".")
 	for _, subkey := range subkeys {
-		if subkey[0] == '{' && subkey[len(subkey)-1] == '}' {
+		if isPlaceholder(subkey) {
 			if placeholders == nil {
 				placeholders = make(map[string]bool)
 			}
@@ -356,7 +356,7 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 	// check if the part is an unmatched placeholder which should have been filled
 	// by the databag with all possible values
 	part := suffixParts[0]
-	if part[0] == '{' && part[len(part)-1] == '}' {
+	if isPlaceholder(part) {
 		values, ok := res.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("internal error: expected databag to return map for unmatched placeholder")
@@ -724,7 +724,7 @@ func (s JSONDataBag) Get(path string) (interface{}, error) {
 // any sub-path that matched the request path are then merged in a map and returned.
 func get(subKeys []string, index int, node map[string]json.RawMessage, result *interface{}) error {
 	key := subKeys[index]
-	matchAll := key[0] == '{' && key[len(key)-1] == '}'
+	matchAll := isPlaceholder(key)
 
 	rawLevel, ok := node[key]
 	if !matchAll && !ok {

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -353,6 +353,8 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 		return res, nil
 	}
 
+	// check if the part is an unmatched placeholder which should have been filled
+	// by the databag with all possible values
 	part := suffixParts[0]
 	if part[0] == '{' && part[len(part)-1] == '}' {
 		values, ok := res.(map[string]interface{})

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -706,11 +706,14 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 	// read the final value
 	if index == len(subKeys)-1 {
 		if matchAll {
-			// request ends in placeholder so return the entire object (convert to
-			// interface{} so caller always gets map[string]interface{} for placeholders)
+			// request ends in placeholder so return map to all values (but unmarshal first)
 			level := make(map[string]interface{}, len(node))
 			for k, v := range node {
-				level[k] = interface{}(v)
+				var deser interface{}
+				if err := json.Unmarshal(v, &deser); err != nil {
+					return err
+				}
+				level[k] = deser
 			}
 
 			*result = level

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -930,6 +930,7 @@ func (s *aspectSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 				// the request can be fulfilled here
 				"d1": map[string]interface{}{
 					"e": "end",
+					"f": "not-included",
 				},
 				"d2": "f",
 			},

--- a/aspects/transaction.go
+++ b/aspects/transaction.go
@@ -64,7 +64,7 @@ func (t *Transaction) Set(path string, value interface{}) error {
 }
 
 // Get reads a value from the transaction's databag including uncommitted changes.
-func (t *Transaction) Get(path string, value interface{}) error {
+func (t *Transaction) Get(path string, value *interface{}) error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 

--- a/aspects/transaction.go
+++ b/aspects/transaction.go
@@ -64,13 +64,13 @@ func (t *Transaction) Set(path string, value interface{}) error {
 }
 
 // Get reads a value from the transaction's databag including uncommitted changes.
-func (t *Transaction) Get(path string, value *interface{}) error {
+func (t *Transaction) Get(path string) (interface{}, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	// if there aren't any changes, just use the pristine bag
 	if len(t.deltas) == 0 {
-		return t.pristine.Get(path, value)
+		return t.pristine.Get(path)
 	}
 
 	// if there are changes, use a cached bag with modifications to do the Get
@@ -83,11 +83,11 @@ func (t *Transaction) Get(path string, value *interface{}) error {
 	if err := applyDeltas(t.modified, t.deltas[t.appliedDeltas:]); err != nil {
 		t.modified = nil
 		t.appliedDeltas = 0
-		return err
+		return nil, err
 	}
 	t.appliedDeltas = len(t.deltas)
 
-	return t.modified.Get(path, value)
+	return t.modified.Get(path)
 }
 
 // Commit applies the previous writes and validates the final databag. If any

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -62,7 +62,7 @@ func (s *transactionTestSuite) TestSet(c *C) {
 
 	var value interface{}
 	err = witness.writtenDatabag.Get("foo", &value)
-	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
+	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 }
 
 func (s *transactionTestSuite) TestCommit(c *C) {
@@ -105,7 +105,7 @@ func (s *transactionTestSuite) TestGetReadsUncommitted(c *C) {
 	c.Assert(witness.writeCalled, Equals, 0)
 	c.Assert(txData(c, tx), Equals, "{}")
 
-	var val string
+	var val interface{}
 	err = tx.Get("foo", &val)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "baz")
@@ -137,7 +137,7 @@ func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {
 	c.Assert(txData(c, tx), Equals, "{}")
 
 	// but subsequent Gets still read the uncommitted values
-	var val string
+	var val interface{}
 	err = tx.Get("foo", &val)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "bar")
@@ -236,7 +236,7 @@ func (s *transactionTestSuite) TestCommittedIncludesPreviousCommit(c *C) {
 	c.Assert(value, Equals, "bar")
 
 	err = databag.Get("bar", &value)
-	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
+	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 
 	err = txTwo.Commit()
 	c.Assert(err, IsNil)
@@ -311,7 +311,7 @@ func (s *transactionTestSuite) TestTransactionReadsIsolated(c *C) {
 
 	var value interface{}
 	err = tx.Get("foo", &value)
-	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
+	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 }
 
 func (s *transactionTestSuite) TestReadDatabagsAreCopiedForIsolation(c *C) {

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -60,8 +60,7 @@ func (s *transactionTestSuite) TestSet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(witness.writeCalled, Equals, 0)
 
-	var value interface{}
-	err = witness.writtenDatabag.Get("foo", &value)
+	_, err = witness.writtenDatabag.Get("foo")
 	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 }
 
@@ -81,10 +80,8 @@ func (s *transactionTestSuite) TestCommit(c *C) {
 	err = tx.Commit()
 	c.Assert(err, IsNil)
 
-	var value interface{}
-	err = witness.writtenDatabag.Get("foo", &value)
+	value, err := witness.writtenDatabag.Get("foo")
 	c.Assert(err, IsNil)
-
 	c.Assert(value, Equals, "bar")
 	c.Assert(witness.writeCalled, Equals, 1)
 }
@@ -105,8 +102,7 @@ func (s *transactionTestSuite) TestGetReadsUncommitted(c *C) {
 	c.Assert(witness.writeCalled, Equals, 0)
 	c.Assert(txData(c, tx), Equals, "{}")
 
-	var val interface{}
-	err = tx.Get("foo", &val)
+	val, err := tx.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "baz")
 }
@@ -137,8 +133,7 @@ func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {
 	c.Assert(txData(c, tx), Equals, "{}")
 
 	// but subsequent Gets still read the uncommitted values
-	var val interface{}
-	err = tx.Get("foo", &val)
+	val, err := tx.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "bar")
 }
@@ -162,8 +157,7 @@ func (s *transactionTestSuite) TestManyWrites(c *C) {
 	// writes are applied in chronological order
 	c.Assert(txData(c, tx), Equals, `{"foo":"baz"}`)
 
-	var value interface{}
-	err = witness.writtenDatabag.Get("foo", &value)
+	value, err := witness.writtenDatabag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "baz")
 }
@@ -189,13 +183,12 @@ func (s *transactionTestSuite) TestCommittedIncludesRecentWrites(c *C) {
 	c.Assert(witness.writeCalled, Equals, 1)
 
 	// writes are applied in chronological order
-	var value interface{}
-	err = witness.writtenDatabag.Get("foo", &value)
+	value, err := witness.writtenDatabag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 
 	// contains recent values not written by the transaction
-	err = witness.writtenDatabag.Get("bar", &value)
+	value, err = witness.writtenDatabag.Get("bar")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "baz")
 }
@@ -230,23 +223,22 @@ func (s *transactionTestSuite) TestCommittedIncludesPreviousCommit(c *C) {
 	err = txOne.Commit()
 	c.Assert(err, IsNil)
 
-	var value interface{}
-	err = databag.Get("foo", &value)
+	value, err := databag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 
-	err = databag.Get("bar", &value)
+	value, err = databag.Get("bar")
 	c.Assert(err, FitsTypeOf, aspects.PathError(""))
+	c.Assert(value, IsNil)
 
 	err = txTwo.Commit()
 	c.Assert(err, IsNil)
 
-	value = nil
-	err = databag.Get("foo", &value)
+	value, err = databag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 
-	err = databag.Get("bar", &value)
+	value, err = databag.Get("bar")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "baz")
 }
@@ -309,8 +301,7 @@ func (s *transactionTestSuite) TestTransactionReadsIsolated(c *C) {
 	err = databag.Set("foo", "bar")
 	c.Assert(err, IsNil)
 
-	var value interface{}
-	err = tx.Get("foo", &value)
+	_, err = tx.Get("foo")
 	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 }
 
@@ -329,8 +320,7 @@ func (s *transactionTestSuite) TestReadDatabagsAreCopiedForIsolation(c *C) {
 	err = tx.Set("foo", "baz")
 	c.Assert(err, IsNil)
 
-	var value interface{}
-	err = witness.writtenDatabag.Get("foo", &value)
+	value, err := witness.writtenDatabag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 
@@ -338,7 +328,7 @@ func (s *transactionTestSuite) TestReadDatabagsAreCopiedForIsolation(c *C) {
 	err = tx.Commit()
 	c.Assert(err, ErrorMatches, "expected error")
 
-	err = witness.writtenDatabag.Get("foo", &value)
+	value, err = witness.writtenDatabag.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 }

--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -60,8 +60,7 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 
 	for _, field := range fields {
-		var value interface{}
-		err := aspectstateGetAspect(tx, account, bundleName, aspect, field, &value)
+		result, err := aspectstateGetAspect(tx, account, bundleName, aspect, field)
 		if err != nil {
 			if errors.Is(err, &aspects.NotFoundError{}) && len(fields) > 1 {
 				// keep looking; return partial result if only some fields are found
@@ -71,7 +70,7 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 			}
 		}
 
-		results[field] = value
+		results[field] = result
 	}
 
 	// no results were found, return 404

--- a/daemon/api_aspects_test.go
+++ b/daemon/api_aspects_test.go
@@ -283,7 +283,7 @@ func (s *aspectsSuite) testAspectSetMany(c *C) {
 	c.Assert(value, Equals, "foo")
 
 	err = databags["system"]["network"].Get("wifi.psk", &value)
-	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
+	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 }
 
 func (s *aspectsSuite) TestGetAspectError(c *C) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -335,7 +335,7 @@ var (
 	MaxReadBuflen = maxReadBuflen
 )
 
-func MockAspectstateGet(f func(databag aspects.DataBag, account, bundleName, aspect, field string, value *interface{}) error) (restore func()) {
+func MockAspectstateGet(f func(databag aspects.DataBag, account, bundleName, aspect, field string) (interface{}, error)) (restore func()) {
 	old := aspectstateGetAspect
 	aspectstateGetAspect = f
 	return func() {

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -58,18 +58,18 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 // GetAspect finds the aspect identified by the account, bundleName and aspect
 // and returns the specified field value from the provided matching databag
 // through the value output parameter.
-func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field string, value *interface{}) error {
+func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field string) (interface{}, error) {
 	accPatterns := aspecttest.MockWifiSetupAspect()
 	schema := aspects.NewJSONSchema()
 
 	aspectBundle, err := aspects.NewAspectBundle(account, bundleName, accPatterns, schema)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	asp := aspectBundle.Aspect(aspect)
 	if asp == nil {
-		return &aspects.NotFoundError{
+		return nil, &aspects.NotFoundError{
 			Account:    account,
 			BundleName: bundleName,
 			Aspect:     aspect,
@@ -78,11 +78,12 @@ func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 		}
 	}
 
-	if err := asp.Get(databag, field, value); err != nil {
-		return err
+	result, err := asp.Get(databag, field)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return result, nil
 }
 
 // NewTransaction returns a transaction configured to read and write databags

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -108,10 +108,10 @@ func (s *aspectTestSuite) TestUnsetAspect(c *C) {
 	err = aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", nil)
 	c.Assert(err, IsNil)
 
-	var val string
+	var val interface{}
 	err = databag.Get("wifi.ssid", &val)
-	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
-	c.Assert(val, Equals, "")
+	c.Assert(err, FitsTypeOf, aspects.PathError(""))
+	c.Assert(val, Equals, nil)
 }
 
 func (s *aspectTestSuite) TestNewTransactionExistingState(c *C) {

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -46,8 +46,7 @@ func (s *aspectTestSuite) TestGetAspect(c *C) {
 	err := databag.Set("wifi.ssid", "foo")
 	c.Assert(err, IsNil)
 
-	var res interface{}
-	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
+	res, err := aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid")
 	c.Assert(err, IsNil)
 	c.Assert(res, DeepEquals, map[string]interface{}{"ssid": "foo"})
 }
@@ -55,18 +54,17 @@ func (s *aspectTestSuite) TestGetAspect(c *C) {
 func (s *aspectTestSuite) TestGetNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
 
-	var res interface{}
-	err := aspectstate.GetAspect(databag, "system", "network", "other-aspect", "ssid", &res)
+	res, err := aspectstate.GetAspect(databag, "system", "network", "other-aspect", "ssid")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
 	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/other-aspect: aspect not found`)
 	c.Check(res, IsNil)
 
-	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
+	res, err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
 	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: matching rules don't map to any values`)
 	c.Check(res, IsNil)
 
-	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field", &res)
+	res, err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
 	c.Assert(err, ErrorMatches, `cannot find value for "other-field" in aspect system/network/wifi-setup: no matching read rule`)
 	c.Check(res, IsNil)
@@ -77,8 +75,7 @@ func (s *aspectTestSuite) TestSetAspect(c *C) {
 	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", "foo")
 	c.Assert(err, IsNil)
 
-	var val interface{}
-	err = databag.Get("wifi.ssid", &val)
+	val, err := databag.Get("wifi.ssid")
 	c.Assert(err, IsNil)
 	c.Assert(val, DeepEquals, "foo")
 }
@@ -108,8 +105,7 @@ func (s *aspectTestSuite) TestUnsetAspect(c *C) {
 	err = aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", nil)
 	c.Assert(err, IsNil)
 
-	var val interface{}
-	err = databag.Get("wifi.ssid", &val)
+	val, err := databag.Get("wifi.ssid")
 	c.Assert(err, FitsTypeOf, aspects.PathError(""))
 	c.Assert(val, Equals, nil)
 }
@@ -129,8 +125,7 @@ func (s *aspectTestSuite) TestNewTransactionExistingState(c *C) {
 	tx, err := aspectstate.NewTransaction(s.state, "system", "network")
 	c.Assert(err, IsNil)
 
-	var value interface{}
-	err = tx.Get("foo", &value)
+	value, err := tx.Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "bar")
 
@@ -142,7 +137,7 @@ func (s *aspectTestSuite) TestNewTransactionExistingState(c *C) {
 
 	err = s.state.Get("aspect-databags", &databags)
 	c.Assert(err, IsNil)
-	err = databags["system"]["network"].Get("foo", &value)
+	value, err = databags["system"]["network"].Get("foo")
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, "baz")
 }
@@ -189,8 +184,7 @@ func (s *aspectTestSuite) TestNewTransactionNoState(c *C) {
 		err = s.state.Get("aspect-databags", &databags)
 		c.Assert(err, IsNil)
 
-		var value interface{}
-		err = databags["system"]["network"].Get("foo", &value)
+		value, err := databags["system"]["network"].Get("foo")
 		c.Assert(err, IsNil)
 		c.Assert(value, Equals, "bar")
 	}


### PR DESCRIPTION
A Get() with a request that matches a rule without filling some of its placeholders gets the results from all possible placeholder values. The namespace in which the result in inserted takes these values into account instead of the unmatched placeholder.