### PR TITLE
o/state,daemon: add per-user notices

### DIFF
--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -31,13 +31,13 @@ var (
 	noticesCmd = &Command{
 		Path:       "/v2/notices",
 		GET:        getNotices,
-		ReadAccess: authenticatedAccess{},
+		ReadAccess: openAccess{},
 	}
 
 	noticeCmd = &Command{
 		Path:       "/v2/notices/{id}",
 		GET:        getNotice,
-		ReadAccess: authenticatedAccess{},
+		ReadAccess: openAccess{},
 	}
 )
 

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -40,24 +40,7 @@ func (s *noticesSuite) expectNoticesAccess() {
 	s.expectReadAccess(daemon.AuthenticatedAccess{})
 }
 
-func fakeSysGetuid(fakeUID uint32) (restore func()) {
-	/*
-		old := sysGetuid
-		sysGetuid = func() sys.UserID {
-			return sys.UserID(fakeUid)
-		}
-		restore = func() {
-			sysGetuid = old
-		}
-	*/
-	_ = fakeUID
-	restore = func() {}
-	return restore
-}
-
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
-	restore := fakeSysGetuid(0)
-	defer restore()
 	// A bit hacky... filter by user ID which doesn't have any notices to just
 	// get public notices (those with nil user ID)
 	s.expectNoticesAccess()
@@ -67,8 +50,6 @@ func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"types": {"change-update"}}
@@ -76,8 +57,6 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"keys": {"123"}}
@@ -85,8 +64,6 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"after": {after.UTC().Format(time.RFC3339Nano)}}
@@ -94,8 +71,6 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterAll(c *C) {
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{
@@ -161,8 +136,6 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -189,8 +162,6 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -219,8 +190,6 @@ func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
 func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -259,8 +228,6 @@ func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 func (s *noticesSuite) TestNoticesUserIDAdminDefault(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -297,8 +264,6 @@ func (s *noticesSuite) TestNoticesUserIDAdminDefault(c *C) {
 func (s *noticesSuite) TestNoticesUserIDAdminFilter(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -338,8 +303,6 @@ func (s *noticesSuite) TestNoticesUserIDAdminFilter(c *C) {
 func (s *noticesSuite) TestNoticesUserIDNonAdminDefault(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -376,8 +339,6 @@ func (s *noticesSuite) TestNoticesUserIDNonAdminDefault(c *C) {
 func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -397,8 +358,6 @@ func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
 func (s *noticesSuite) TestNoticesUnknownRequestUID(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -416,8 +375,6 @@ func (s *noticesSuite) TestNoticesUnknownRequestUID(c *C) {
 func (s *noticesSuite) TestNoticesWait(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	go func() {
@@ -446,8 +403,6 @@ func (s *noticesSuite) TestNoticesWait(c *C) {
 func (s *noticesSuite) TestNoticesTimeout(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	req, err := http.NewRequest("GET", "/v2/notices?timeout=1ms", nil)
 	c.Assert(err, IsNil)
@@ -463,8 +418,6 @@ func (s *noticesSuite) TestNoticesTimeout(c *C) {
 func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -493,29 +446,21 @@ func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 
 func (s *noticesSuite) TestNoticesInvalidUserID(c *C) {
 	s.expectNoticesAccess()
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.testNoticesBadRequest(c, "user-id=foo", `invalid "user-id" filter:.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidSelect(c *C) {
 	s.expectNoticesAccess()
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.testNoticesBadRequest(c, "select=foo", `invalid "select" filter:.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidAfter(c *C) {
 	s.expectNoticesAccess()
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.testNoticesBadRequest(c, "after=foo", `invalid "after" timestamp.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidTimeout(c *C) {
 	s.expectNoticesAccess()
-	restore := fakeSysGetuid(0)
-	defer restore()
 	s.testNoticesBadRequest(c, "timeout=foo", "invalid timeout.*")
 }
 
@@ -533,8 +478,6 @@ func (s *noticesSuite) testNoticesBadRequest(c *C, query, errorMatch string) {
 func (s *noticesSuite) TestNotice(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -577,8 +520,6 @@ func (s *noticesSuite) TestNotice(c *C) {
 func (s *noticesSuite) TestNoticeNotFound(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
 	c.Assert(err, IsNil)
@@ -590,8 +531,6 @@ func (s *noticesSuite) TestNoticeNotFound(c *C) {
 func (s *noticesSuite) TestNoticeUnknownRequestUID(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
 	c.Assert(err, IsNil)
@@ -603,8 +542,6 @@ func (s *noticesSuite) TestNoticeUnknownRequestUID(c *C) {
 func (s *noticesSuite) TestNoticeNotAllowed(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
-	restore := fakeSysGetuid(0)
-	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -17,8 +17,10 @@ package daemon_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -38,7 +40,35 @@ func (s *noticesSuite) expectNoticesAccess() {
 	s.expectReadAccess(daemon.AuthenticatedAccess{})
 }
 
+func fakeSysGetuid(fakeUID uint32) (restore func()) {
+	/*
+		old := sysGetuid
+		sysGetuid = func() sys.UserID {
+			return sys.UserID(fakeUid)
+		}
+		restore = func() {
+			sysGetuid = old
+		}
+	*/
+	_ = fakeUID
+	restore = func() {}
+	return restore
+}
+
+func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
+	restore := fakeSysGetuid(0)
+	defer restore()
+	// A bit hacky... filter by user ID which doesn't have any notices to just
+	// get public notices (those with nil user ID)
+	s.expectNoticesAccess()
+	s.testNoticesFilter(c, func(after time.Time) url.Values {
+		return url.Values{"user-id": {"1000"}}
+	})
+}
+
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"types": {"change-update"}}
@@ -46,6 +76,8 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"keys": {"123"}}
@@ -53,6 +85,8 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"after": {after.UTC().Format(time.RFC3339Nano)}}
@@ -60,12 +94,15 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterAll(c *C) {
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{
-			"types": {"change-update"},
-			"keys":  {"123"},
-			"after": {after.UTC().Format(time.RFC3339Nano)},
+			"user-id": {"1000"},
+			"types":   {"change-update"},
+			"keys":    {"123"},
+			"after":   {after.UTC().Format(time.RFC3339Nano)},
 		}
 	})
 }
@@ -75,10 +112,11 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	addNotice(c, st, state.WarningNotice, "warning", nil)
+	uid := uint32(123)
+	addNotice(c, st, &uid, state.WarningNotice, "warning", nil)
 	after := time.Now()
 	time.Sleep(time.Microsecond)
-	noticeId, err := st.AddNotice(state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
+	noticeID, err := st.AddNotice(nil, state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
 		Data: map[string]string{"k": "v"},
 	})
 	c.Assert(err, IsNil)
@@ -87,6 +125,7 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 	query := makeQuery(after)
 	req, err := http.NewRequest("GET", "/v2/notices?"+query.Encode(), nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -109,7 +148,8 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 	delete(n, "last-occurred")
 	delete(n, "last-repeated")
 	c.Assert(n, DeepEquals, map[string]any{
-		"id":           noticeId,
+		"id":           noticeID,
+		"user-id":      nil,
 		"type":         "change-update",
 		"key":          "123",
 		"occurrences":  1.0,
@@ -121,16 +161,19 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "danger", nil)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
 	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/notices?types=change-update&types=warning", nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -146,18 +189,21 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.ChangeUpdateNotice, "456", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "456", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "danger", nil)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
 	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/notices?keys=456&keys=danger", nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -173,18 +219,21 @@ func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
 func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "danger", nil)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
 	st.Unlock()
 
 	// Check that invalid types are discarded, and notices with remaining
 	// types are requested as expected, without error.
 	req, err := http.NewRequest("GET", "/v2/notices?types=foo&types=warning&types=bar,baz", nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -198,6 +247,7 @@ func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 	// is no error.
 	req, err = http.NewRequest("GET", "/v2/notices?types=foo&types=bar,baz", nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp = s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -206,21 +256,181 @@ func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 	c.Assert(notices, HasLen, 0)
 }
 
+func (s *noticesSuite) TestNoticesUserIDAdminDefault(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	admin := uint32(0)
+	nonAdmin := uint32(1000)
+	otherNonAdmin := uint32(123)
+	addNotice(c, st, &admin, state.ChangeUpdateNotice, "123", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &nonAdmin, state.WarningNotice, "error1", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &otherNonAdmin, state.ChangeUpdateNotice, "456", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	st.Unlock()
+
+	// Test that admin user sees their own and all public notices if no filter is specified
+	req, err := http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 200)
+
+	notices, ok := rsp.Result.([]*state.Notice)
+	c.Assert(ok, Equals, true)
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["user-id"], Equals, float64(admin))
+	c.Assert(n["key"], Equals, "123")
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["user-id"], Equals, nil)
+	c.Assert(n["key"], Equals, "danger")
+}
+
+func (s *noticesSuite) TestNoticesUserIDAdminFilter(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	admin := uint32(0)
+	nonAdmin := uint32(1000)
+	otherNonAdmin := uint32(123)
+	addNotice(c, st, &admin, state.ChangeUpdateNotice, "123", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &nonAdmin, state.WarningNotice, "error1", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &otherNonAdmin, state.ChangeUpdateNotice, "456", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	st.Unlock()
+
+	// Test that admin can filter on any user IDs, and always gets public notices too
+	for _, uid := range []uint32{0, 1000, 123} {
+		userIDValues := url.Values{}
+		userIDValues.Add("user-id", strconv.FormatUint(uint64(uid), 10))
+		reqUrl := fmt.Sprintf("/v2/notices?%s", userIDValues.Encode())
+		req, err := http.NewRequest("GET", reqUrl, nil)
+		c.Assert(err, IsNil)
+		req.RemoteAddr = "pid=100;uid=0;socket=;"
+		rsp := s.syncReq(c, req, nil)
+		c.Check(rsp.Status, Equals, 200)
+
+		notices, ok := rsp.Result.([]*state.Notice)
+		c.Assert(ok, Equals, true)
+		c.Assert(notices, HasLen, 2)
+		n := noticeToMap(c, notices[0])
+		c.Assert(n["user-id"], Equals, float64(uid))
+		n = noticeToMap(c, notices[1])
+		c.Assert(n["user-id"], Equals, nil)
+	}
+}
+
+func (s *noticesSuite) TestNoticesUserIDNonAdminDefault(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	admin := uint32(0)
+	nonAdmin := uint32(1000)
+	otherNonAdmin := uint32(123)
+	addNotice(c, st, &admin, state.ChangeUpdateNotice, "123", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &nonAdmin, state.WarningNotice, "error1", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &otherNonAdmin, state.ChangeUpdateNotice, "456", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	st.Unlock()
+
+	// Test that non-admin user by default only sees their notices and public notices.
+	req, err := http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 200)
+
+	notices, ok := rsp.Result.([]*state.Notice)
+	c.Assert(ok, Equals, true)
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["user-id"], Equals, float64(nonAdmin))
+	c.Assert(n["key"], Equals, "error1")
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["user-id"], Equals, nil)
+	c.Assert(n["key"], Equals, "danger")
+}
+
+func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	nonAdmin := uint32(1000)
+	addNotice(c, st, &nonAdmin, state.WarningNotice, "error1", nil)
+	st.Unlock()
+
+	// Test that non-admin user may not use --user-id filter
+	reqUrl := "/v2/notices?user-id=1000"
+	req, err := http.NewRequest("GET", reqUrl, nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 403)
+}
+
+func (s *noticesSuite) TestNoticesUnknownRequestUID(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	st.Unlock()
+
+	// Test that a connection with unknown UID is forbidden from receiving notices
+	req, err := http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=;socket=;"
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 403)
+}
+
 func (s *noticesSuite) TestNoticesWait(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	st := s.d.Overlord().State()
 	go func() {
 		time.Sleep(testutil.HostScaledTimeout(50 * time.Millisecond))
 		st.Lock()
-		addNotice(c, st, state.WarningNotice, "foo", nil)
+		addNotice(c, st, nil, state.WarningNotice, "foo", nil)
 		st.Unlock()
 	}()
 
 	timeout := testutil.HostScaledTimeout(5 * time.Second).String()
 	req, err := http.NewRequest("GET", "/v2/notices?timeout="+timeout, nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -228,6 +438,7 @@ func (s *noticesSuite) TestNoticesWait(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo")
 }
@@ -235,9 +446,12 @@ func (s *noticesSuite) TestNoticesWait(c *C) {
 func (s *noticesSuite) TestNoticesTimeout(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	req, err := http.NewRequest("GET", "/v2/notices?timeout=1ms", nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
@@ -249,6 +463,8 @@ func (s *noticesSuite) TestNoticesTimeout(c *C) {
 func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -265,6 +481,7 @@ func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", "/v2/notices?timeout="+reqTimeout.String(), nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 400)
 	c.Check(rsp.Message, Matches, "request canceled")
@@ -274,13 +491,31 @@ func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 	c.Check(elapsed < reqTimeout, Equals, true)
 }
 
+func (s *noticesSuite) TestNoticesInvalidUserID(c *C) {
+	s.expectNoticesAccess()
+	restore := fakeSysGetuid(0)
+	defer restore()
+	s.testNoticesBadRequest(c, "user-id=foo", `invalid "user-id" filter:.*`)
+}
+
+func (s *noticesSuite) TestNoticesInvalidSelect(c *C) {
+	s.expectNoticesAccess()
+	restore := fakeSysGetuid(0)
+	defer restore()
+	s.testNoticesBadRequest(c, "select=foo", `invalid "select" filter:.*`)
+}
+
 func (s *noticesSuite) TestNoticesInvalidAfter(c *C) {
 	s.expectNoticesAccess()
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.testNoticesBadRequest(c, "after=foo", `invalid "after" timestamp.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidTimeout(c *C) {
 	s.expectNoticesAccess()
+	restore := fakeSysGetuid(0)
+	defer restore()
 	s.testNoticesBadRequest(c, "timeout=foo", "invalid timeout.*")
 }
 
@@ -289,6 +524,7 @@ func (s *noticesSuite) testNoticesBadRequest(c *C, query, errorMatch string) {
 
 	req, err := http.NewRequest("GET", "/v2/notices?"+query, nil)
 	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 400)
 	c.Assert(rsp.Message, Matches, errorMatch)
@@ -297,38 +533,91 @@ func (s *noticesSuite) testNoticesBadRequest(c *C, query, errorMatch string) {
 func (s *noticesSuite) TestNotice(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	addNotice(c, st, state.WarningNotice, "foo", nil)
-	noticeId, err := st.AddNotice(state.WarningNotice, "bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo", nil)
+	noticeIDPublic, err := st.AddNotice(nil, state.WarningNotice, "bar", nil)
 	c.Assert(err, IsNil)
-	addNotice(c, st, state.WarningNotice, "baz", nil)
+	uid := uint32(1000)
+	noticeIDPrivate, err := st.AddNotice(&uid, state.WarningNotice, "fizz", nil)
+	c.Assert(err, IsNil)
+	addNotice(c, st, &uid, state.WarningNotice, "baz", nil)
 	st.Unlock()
 
-	req, err := http.NewRequest("GET", "/v2/notices/"+noticeId, nil)
+	req, err := http.NewRequest("GET", "/v2/notices/"+noticeIDPublic, nil)
 	c.Assert(err, IsNil)
-	s.vars = map[string]string{"id": noticeId}
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 200)
 
 	notice, ok := rsp.Result.(*state.Notice)
 	c.Assert(ok, Equals, true)
 	n := noticeToMap(c, notice)
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "bar")
+
+	req, err = http.NewRequest("GET", "/v2/notices/"+noticeIDPrivate, nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
+	rsp = s.syncReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 200)
+
+	notice, ok = rsp.Result.(*state.Notice)
+	c.Assert(ok, Equals, true)
+	n = noticeToMap(c, notice)
+	c.Check(n["user-id"], Equals, 1000.0)
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "fizz")
 }
 
 func (s *noticesSuite) TestNoticeNotFound(c *C) {
 	s.expectNoticesAccess()
 	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
 
 	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
 	c.Assert(err, IsNil)
-	s.vars = map[string]string{"id": "1234"}
+	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 404)
-	c.Check(rsp.Message, Matches, `cannot find notice with id "1234"`)
+}
+
+func (s *noticesSuite) TestNoticeUnknownRequestUID(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid-100;uid=;socket=;"
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 403)
+}
+
+func (s *noticesSuite) TestNoticeNotAllowed(c *C) {
+	s.expectNoticesAccess()
+	s.daemon(c)
+	restore := fakeSysGetuid(0)
+	defer restore()
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	uid := uint32(1000)
+	noticeID, err := st.AddNotice(&uid, state.WarningNotice, "danger", nil)
+	c.Assert(err, IsNil)
+	st.Unlock()
+
+	req, err := http.NewRequest("GET", "/v2/notices/"+noticeID, nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid-100;uid=1001;socket=;"
+	rsp := s.errorReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 403)
 }
 
 func noticeToMap(c *C, notice *state.Notice) map[string]any {
@@ -340,7 +629,7 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 	return n
 }
 
-func addNotice(c *C, st *state.State, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
-	_, err := st.AddNotice(noticeType, key, options)
+func addNotice(c *C, st *state.State, userID *uint32, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
+	_, err := st.AddNotice(userID, noticeType, key, options)
 	c.Assert(err, IsNil)
 }

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -36,42 +35,33 @@ type noticesSuite struct {
 	apiBaseSuite
 }
 
-func (s *noticesSuite) expectNoticesAccess() {
-	s.expectReadAccess(daemon.AuthenticatedAccess{})
-}
-
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
 	// A bit hacky... filter by user ID which doesn't have any notices to just
 	// get public notices (those with nil user ID)
-	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"user-id": {"1000"}}
 	})
 }
 
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"types": {"change-update"}}
 	})
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"keys": {"123"}}
 	})
 }
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{"after": {after.UTC().Format(time.RFC3339Nano)}}
 	})
 }
 
 func (s *noticesSuite) TestNoticesFilterAll(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesFilter(c, func(after time.Time) url.Values {
 		return url.Values{
 			"user-id": {"1000"},
@@ -134,7 +124,6 @@ func (s *noticesSuite) testNoticesFilter(c *C, makeQuery func(after time.Time) u
 }
 
 func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -160,7 +149,6 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -188,7 +176,6 @@ func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -226,7 +213,6 @@ func (s *noticesSuite) TestNoticesFilterInvalidTypes(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesUserIDAdminDefault(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -262,7 +248,6 @@ func (s *noticesSuite) TestNoticesUserIDAdminDefault(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesUserIDAdminFilter(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -301,7 +286,6 @@ func (s *noticesSuite) TestNoticesUserIDAdminFilter(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesUserIDNonAdminDefault(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -337,7 +321,6 @@ func (s *noticesSuite) TestNoticesUserIDNonAdminDefault(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -356,7 +339,6 @@ func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesUnknownRequestUID(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -373,7 +355,6 @@ func (s *noticesSuite) TestNoticesUnknownRequestUID(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesWait(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -401,7 +382,6 @@ func (s *noticesSuite) TestNoticesWait(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesTimeout(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/notices?timeout=1ms", nil)
@@ -416,7 +396,6 @@ func (s *noticesSuite) TestNoticesTimeout(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -445,22 +424,18 @@ func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 }
 
 func (s *noticesSuite) TestNoticesInvalidUserID(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesBadRequest(c, "user-id=foo", `invalid "user-id" filter:.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidSelect(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesBadRequest(c, "select=foo", `invalid "select" filter:.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidAfter(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesBadRequest(c, "after=foo", `invalid "after" timestamp.*`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidTimeout(c *C) {
-	s.expectNoticesAccess()
 	s.testNoticesBadRequest(c, "timeout=foo", "invalid timeout.*")
 }
 
@@ -476,7 +451,6 @@ func (s *noticesSuite) testNoticesBadRequest(c *C, query, errorMatch string) {
 }
 
 func (s *noticesSuite) TestNotice(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -518,7 +492,6 @@ func (s *noticesSuite) TestNotice(c *C) {
 }
 
 func (s *noticesSuite) TestNoticeNotFound(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
@@ -529,7 +502,6 @@ func (s *noticesSuite) TestNoticeNotFound(c *C) {
 }
 
 func (s *noticesSuite) TestNoticeUnknownRequestUID(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/notices/1234", nil)
@@ -540,7 +512,6 @@ func (s *noticesSuite) TestNoticeUnknownRequestUID(c *C) {
 }
 
 func (s *noticesSuite) TestNoticeNotAllowed(c *C) {
-	s.expectNoticesAccess()
 	s.daemon(c)
 
 	st := s.d.Overlord().State()

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -38,9 +38,10 @@ func (s *noticesSuite) TestMarshal(c *C) {
 	defer st.Unlock()
 
 	start := time.Now()
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	uid := uint32(1000)
+	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
-	addNotice(c, st, state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
+	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
 		Data: map[string]string{"k": "v"},
 	})
 
@@ -66,6 +67,7 @@ func (s *noticesSuite) TestMarshal(c *C) {
 	delete(n, "last-repeated")
 	c.Assert(n, DeepEquals, map[string]any{
 		"id":           "1",
+		"user-id":      1000.0,
 		"type":         "change-update",
 		"key":          "123",
 		"occurrences":  2.0,
@@ -77,6 +79,7 @@ func (s *noticesSuite) TestMarshal(c *C) {
 func (s *noticesSuite) TestUnmarshal(c *C) {
 	noticeJSON := []byte(`{
 		"id": "1",
+		"user-id": 1000,
 		"type": "change-update",
 		"key": "123",
 		"first-occurred": "2023-09-01T05:23:01Z",
@@ -96,6 +99,7 @@ func (s *noticesSuite) TestUnmarshal(c *C) {
 	n := noticeToMap(c, notice)
 	c.Assert(n, DeepEquals, map[string]any{
 		"id":             "1",
+		"user-id":        1000.0,
 		"type":           "change-update",
 		"key":            "123",
 		"first-occurred": "2023-09-01T05:23:01Z",
@@ -108,16 +112,49 @@ func (s *noticesSuite) TestUnmarshal(c *C) {
 	})
 }
 
+func (s *noticesSuite) TestString(c *C) {
+	noticeJSON := []byte(`{
+		"id": "1",
+		"user-id": 1000,
+		"type": "change-update",
+		"key": "123",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred": "2023-09-01T07:23:02Z",
+		"last-repeated": "2023-09-01T06:23:03.123456789Z",
+		"occurrences": 2
+	}`)
+	var notice *state.Notice
+	err := json.Unmarshal(noticeJSON, &notice)
+	c.Assert(err, IsNil)
+
+	c.Assert(notice.String(), Equals, "Notice 1 (1000:change-update:123)")
+
+	noticeJSON = []byte(`{
+		"id": "2",
+		"user-id": null,
+		"type": "warning",
+		"key": "scary",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred": "2023-09-01T07:23:02Z",
+		"last-repeated": "2023-09-01T06:23:03.123456789Z",
+		"occurrences": 2
+	}`)
+	err = json.Unmarshal(noticeJSON, &notice)
+	c.Assert(err, IsNil)
+
+	c.Assert(notice.String(), Equals, "Notice 2 (public:warning:scary)")
+}
+
 func (s *noticesSuite) TestOccurrences(c *C) {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 2)
@@ -146,7 +183,7 @@ func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration)
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
 		RepeatAfter: first,
 	})
 	time.Sleep(time.Microsecond)
@@ -164,7 +201,7 @@ func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration)
 
 	// Add a notice (with faked time) after a long time and ensure it has repeated
 	future := time.Now().Add(delay)
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
 		RepeatAfter: second,
 		Time:        future,
 	})
@@ -176,30 +213,75 @@ func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration)
 	c.Assert(newLastRepeated.After(lastRepeated), Equals, true)
 }
 
+func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	uid1 := uint32(1000)
+	uid2 := uint32(0)
+	addNotice(c, st, &uid1, state.ChangeUpdateNotice, "443", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &uid2, state.ChangeUpdateNotice, "123", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, &uid2, state.WarningNotice, "Warning 1!", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
+
+	// No filter
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 4)
+
+	// User ID unset
+	notices = st.Notices(&state.NoticeFilter{})
+	c.Assert(notices, HasLen, 4)
+
+	// User ID set
+	notices = st.Notices(&state.NoticeFilter{UserID: &uid2})
+	c.Assert(notices, HasLen, 3)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, float64(uid2))
+	c.Check(n["type"], Equals, "change-update")
+	c.Check(n["key"], Equals, "123")
+	n = noticeToMap(c, notices[1])
+	c.Check(n["user-id"], Equals, float64(uid2))
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 1!")
+	n = noticeToMap(c, notices[2])
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 2!")
+}
+
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.ChangeUpdateNotice, "443", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "443", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "Warning 1!", nil)
+	addNotice(c, st, nil, state.WarningNotice, "Warning 1!", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "Warning 2!", nil)
+	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
+
+	// No filter
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 4)
 
 	// No types
-	notices := st.Notices(nil)
+	notices = st.Notices(&state.NoticeFilter{})
 	c.Assert(notices, HasLen, 4)
 
 	// One type
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}})
 	c.Assert(notices, HasLen, 2)
 	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 1!")
 	n = noticeToMap(c, notices[1])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 2!")
 
@@ -207,9 +289,11 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
 	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "443")
 	n = noticeToMap(c, notices[1])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
 
@@ -220,15 +304,19 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	}})
 	c.Assert(notices, HasLen, 4)
 	n = noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "443")
 	n = noticeToMap(c, notices[1])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
 	n = noticeToMap(c, notices[2])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 1!")
 	n = noticeToMap(c, notices[3])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 2!")
 }
@@ -238,20 +326,25 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "example.com/x", nil)
+	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "foo.com/baz", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
+
+	// No filter
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 3)
 
 	// No keys
-	notices := st.Notices(nil)
+	notices = st.Notices(&state.NoticeFilter{})
 	c.Assert(notices, HasLen, 3)
 
 	// One key
 	notices = st.Notices(&state.NoticeFilter{Keys: []string{"example.com/x"}})
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "example.com/x")
 
@@ -262,9 +355,11 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 	}})
 	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/bar")
 	n = noticeToMap(c, notices[1])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/baz")
 }
@@ -274,7 +369,7 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/x", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", nil)
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
@@ -282,11 +377,17 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 	c.Assert(err, IsNil)
 
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/y", nil)
 
+	// After unset
+	notices = st.Notices(nil)
+	c.Assert(notices, HasLen, 2)
+
+	// After set
 	notices = st.Notices(&state.NoticeFilter{After: lastRepeated})
 	c.Assert(notices, HasLen, 1)
 	n = noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/y")
 }
@@ -296,11 +397,14 @@ func (s *noticesSuite) TestNotice(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/x", nil)
+	uid1 := uint32(0)
+	uid2 := uint32(123)
+	uid3 := uint32(1000)
+	addNotice(c, st, &uid1, state.WarningNotice, "foo.com/x", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, st, &uid2, state.WarningNotice, "foo.com/y", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "foo.com/z", nil)
+	addNotice(c, st, &uid3, state.WarningNotice, "foo.com/z", nil)
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 3)
@@ -311,6 +415,7 @@ func (s *noticesSuite) TestNotice(c *C) {
 	notice := st.Notice(noticeId)
 	c.Assert(notice, NotNil)
 	n = noticeToMap(c, notice)
+	c.Check(n["user-id"], Equals, 123.0)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/y")
 }
@@ -328,7 +433,7 @@ func (s *noticesSuite) TestCheckpoint(c *C) {
 	backend := &fakeStateBackend{}
 	st := state.New(backend)
 	st.Lock()
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	st.Unlock()
 	c.Assert(backend.checkpoints, HasLen, 1)
 
@@ -340,6 +445,7 @@ func (s *noticesSuite) TestCheckpoint(c *C) {
 	notices := st2.Notices(nil)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/bar")
 }
@@ -350,15 +456,15 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 	defer st.Unlock()
 
 	old := time.Now().Add(-8 * 24 * time.Hour)
-	addNotice(c, st, state.WarningNotice, "foo.com/w", &state.AddNoticeOptions{
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/w", &state.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, state.WarningNotice, "foo.com/x", &state.AddNoticeOptions{
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", &state.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/y", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, state.WarningNotice, "foo.com/z", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/z", nil)
 
 	c.Assert(st.NumNotices(), Equals, 4)
 	st.Prune(time.Now(), 0, 0, 0)
@@ -377,9 +483,9 @@ func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, state.WarningNotice, "example.com/x", nil)
-	addNotice(c, st, state.WarningNotice, "foo.com/baz", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
+	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -387,6 +493,7 @@ func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "example.com/x")
 }
@@ -398,8 +505,8 @@ func (s *noticesSuite) TestWaitNoticesNew(c *C) {
 		time.Sleep(10 * time.Millisecond)
 		st.Lock()
 		defer st.Unlock()
-		addNotice(c, st, state.WarningNotice, "example.com/x", nil)
-		addNotice(c, st, state.WarningNotice, "example.com/y", nil)
+		addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
+		addNotice(c, st, nil, state.WarningNotice, "example.com/y", nil)
 	}()
 
 	st.Lock()
@@ -453,7 +560,7 @@ func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 	go func() {
 		for i := 0; i < 10; i++ {
 			st.Lock()
-			addNotice(c, st, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
+			addNotice(c, st, nil, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
 			st.Unlock()
 			time.Sleep(time.Millisecond)
 		}
@@ -499,7 +606,7 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 
 	for i := 0; i < numWaiters; i++ {
 		st.Lock()
-		addNotice(c, st, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
+		addNotice(c, st, nil, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
 		st.Unlock()
 		time.Sleep(time.Microsecond)
 	}
@@ -527,7 +634,7 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 	return n
 }
 
-func addNotice(c *C, st *state.State, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
-	_, err := st.AddNotice(noticeType, key, options)
+func addNotice(c *C, st *state.State, userID *uint32, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
+	_, err := st.AddNotice(userID, noticeType, key, options)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Add per-user notices. This is a backport of the following PR from pebble: https://github.com/canonical/pebble/pull/323