### PR TITLE
i/builtin: Added RSA DS100 authenticator

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -177,6 +177,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "1370",
 		ProductIDPattern: "0911",
 	},
+	{
+		Name:             "RSA DS100",
+		VendorIDPattern:  "15e1",
+		ProductIDPattern: "2019",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 28)
+	c.Assert(spec.Snippets(), HasLen, 29)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Added RSA DS100 authenticator to the whitelist. RSA Security is the vendor and the authenticator is certified by the FIDO Alliance (certificate no. FIDO20020230501001).