### PR TITLE
i/builtin: add new Google Titan key ProductID to u2f_devices.go

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -115,7 +115,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "Google Titan U2F",
 		VendorIDPattern:  "18d1",
-		ProductIDPattern: "5026",
+		ProductIDPattern: "5026|9470",
 	},
 	{
 		Name:             "Tomu board + chopstx U2F + SoloKeys + Flipper zero",


### PR DESCRIPTION
This PR adds the ProductID for the Google Titan Security Key v2. Below the line from my `lsusb` output where I extracted the ProductID from. I verified that this ID is correct for both the USB A and the USB C version of the key.
```
Bus 003 Device 023: ID 18d1:9470 Google Inc. Titan Security Key v2
```

This change is necessary to make the keys compatible with browsers installed through snap. This PR is inspired by [this issue](https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1919268) and [this PR fixing it](https://github.com/snapcore/snapd/pull/10080).