### PR TITLE
tests: fix snap-run test work on ubuntu 24.04

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -55,7 +55,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
-    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora; then
+    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora || os.query is-ubuntu-ge 24.04; then
         MATCH "Cannot find executable 'invalid'" < stderr
     else
         MATCH "Can't stat 'invalid': No such file or directory" < stderr


### PR DESCRIPTION
fix the test following the same pattern than other systems