### PR TITLE
aspects: set can write to multiple paths

### DIFF
--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -125,6 +125,9 @@ func toAPIError(err error) *apiError {
 	case errors.Is(err, &aspects.NotFoundError{}):
 		return NotFound(err.Error())
 
+	case errors.Is(err, &aspects.BadRequestError{}):
+		return BadRequest(err.Error())
+
 	case errors.Is(err, &aspects.InvalidAccessError{}):
 		return &apiError{
 			Status:  403,


### PR DESCRIPTION
Per the spec, we should allow writes to match several entries with the same request but different paths so the storage can change while supporting old and new paths. The matching should also work on prefixes so we may write to paths nested in other matching paths and therefore have to take care to write to them in order of parentage to prevent overwriting more nested values.