### PR TITLE
aspects: consider access when matching rules

### DIFF
--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -128,12 +128,6 @@ func toAPIError(err error) *apiError {
 	case errors.Is(err, &aspects.BadRequestError{}):
 		return BadRequest(err.Error())
 
-	case errors.Is(err, &aspects.InvalidAccessError{}):
-		return &apiError{
-			Status:  403,
-			Message: err.Error(),
-		}
-
 	default:
 		return InternalError(err.Error())
 	}

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -43,6 +43,7 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 			Account:    account,
 			BundleName: bundleName,
 			Aspect:     aspect,
+			Operation:  "set",
 			Request:    field,
 			Cause:      "aspect not found",
 		}
@@ -73,6 +74,7 @@ func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 			Account:    account,
 			BundleName: bundleName,
 			Aspect:     aspect,
+			Operation:  "get",
 			Request:    field,
 			Cause:      "aspect not found",
 		}

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -56,17 +56,17 @@ func (s *aspectTestSuite) TestGetNotFound(c *C) {
 
 	res, err := aspectstate.GetAspect(databag, "system", "network", "other-aspect", "ssid")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/other-aspect: aspect not found`)
+	c.Assert(err, ErrorMatches, `cannot get "ssid" in aspect system/network/other-aspect: aspect not found`)
 	c.Check(res, IsNil)
 
 	res, err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get "ssid" in aspect system/network/wifi-setup: matching rules don't map to any values`)
 	c.Check(res, IsNil)
 
 	res, err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "other-field" in aspect system/network/wifi-setup: no matching read rule`)
+	c.Assert(err, ErrorMatches, `cannot get "other-field" in aspect system/network/wifi-setup: no matching read rule`)
 	c.Check(res, IsNil)
 }
 
@@ -84,17 +84,11 @@ func (s *aspectTestSuite) TestSetNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
 	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/wifi-setup: no matching write rule`)
+	c.Assert(err, ErrorMatches, `cannot set "foo" in aspect system/network/wifi-setup: no matching write rule`)
 
 	err = aspectstate.SetAspect(databag, "system", "network", "other-aspect", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/other-aspect: aspect not found`)
-}
-
-func (s *aspectTestSuite) TestSetAccessError(c *C) {
-	databag := aspects.NewJSONDataBag()
-	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "status", "foo")
-	c.Assert(err, ErrorMatches, `cannot write field "status": only supports read access`)
+	c.Assert(err, ErrorMatches, `cannot set "foo" in aspect system/network/other-aspect: aspect not found`)
 }
 
 func (s *aspectTestSuite) TestUnsetAspect(c *C) {

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -38,7 +38,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH $'cannot find value for "ssid" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
+  jq -r '.result.message' < response.txt | MATCH $'cannot get "ssid" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
 
   # write values using a placeholder access
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
@@ -58,7 +58,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH $'cannot find value for "private.my-company" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
+  jq -r '.result.message' < response.txt | MATCH $'cannot get "private.my-company" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
 
   # check second value remains
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt
@@ -80,8 +80,8 @@ execute: |
   # check read-only access control works
   calc_expected_change
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"status": "foo"}' > response.txt
-  jq -r '."status-code"' < response.txt | MATCH 403
-  jq -r '.result.message' < response.txt | MATCH 'cannot write field "status": only supports read access'
+  jq -r '."status-code"' < response.txt | MATCH 404
+  jq -r '.result.message' < response.txt | MATCH 'cannot set "status" in aspect system/network/wifi-setup: no matching write rule'
 
   # check write-only access control works
   calc_expected_change
@@ -90,5 +90,5 @@ execute: |
   jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
 
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=password -X GET > response.txt
-  jq -r '."status-code"' < response.txt | MATCH 403
-  jq -r '.result.message' < response.txt | MATCH 'cannot read field "password": only supports write access'
+  jq -r '."status-code"' < response.txt | MATCH 404
+  jq -r '.result.message' < response.txt | MATCH 'cannot get "password" in aspect system/network/wifi-setup: no matching read rule'


### PR DESCRIPTION
Instead of matching a request to rules and failing if those rules support the requested operation, ignore rules that don't and get/set those that do. If no rule matches the request string and the required access type, return the usual "no matching (read|write) rule".
Depends on https://github.com/snapcore/snapd/pull/13446, first relevant commit is 7919c287e8caea575395563fa4066193ad1e24f4