### PR TITLE
tests: add new ubuntu-core-24-arm-64 system to spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -535,6 +535,9 @@ backends:
             - ubuntu-core-24-64:
                   username: external
                   password: ubuntu
+            - ubuntu-core-24-arm-64:
+                  username: external
+                  password: ubuntu
 
 path: /home/gopath/src/github.com/snapcore/snapd
 


### PR DESCRIPTION
This new system is needed to uc24 validation
