### PR TITLE
o/snapstate: skip aliases removal during refresh for RAA UX flow

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3500,12 +3500,65 @@ func (m *SnapManager) doSetAutoAliases(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	if !snapst.AliasesPending {
+		// set-auto-aliases can be invoked in both install and update, and
+		// at least in the update case, remove-aliases may not run based
+		// on a check, and as such old aliases need to be pruned later
+		// in setup-aliases.
+		//
+		// set this flag to let setup-aliases know that it should
+		// prune old aliases.
+		//
+		// NOTE: this will also trigger for first installs since
+		// AliasesPending will also be false for a new install but
+		// it is fine since prunning without without existing aliases
+		// is basically a no-op.
+		t.Set("prune-old-aliases", true)
+	}
+
 	t.Set("old-aliases-v2", curAliases)
-	// noop, except on first install where we need to set this here
 	snapst.AliasesPending = true
 	snapst.Aliases = newAliases
 	Set(st, snapName, snapst)
 	return nil
+}
+
+type removeAliasesReason string
+
+const (
+	removeAliasesReasonRefresh removeAliasesReason = "refresh"
+	removeAliasesReasonDisable removeAliasesReason = "disable"
+	removeAliasesReasonRemove  removeAliasesReason = "remove"
+)
+
+// shouldSkipRemoveAliases checks if we should skip removal of aliases for
+// experimental RAA UX features, where the app is perceived to be present
+// during a refresh.
+func shouldSkipRemoveAliases(st *state.State, removeReason removeAliasesReason, snapType snap.Type) (skip bool, err error) {
+	tr := config.NewTransaction(st)
+	experimentalRefreshAppAwareness, err := features.Flag(tr, features.RefreshAppAwareness)
+	if err != nil && !config.IsNoOption(err) {
+		return false, err
+	}
+	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
+	if err != nil && !config.IsNoOption(err) {
+		return false, err
+	}
+
+	if removeReason != removeAliasesReasonRefresh {
+		return false, nil
+	}
+	if !experimentalRefreshAppAwarenessUX {
+		return false, nil
+	}
+	if !experimentalRefreshAppAwareness {
+		return false, nil
+	}
+	if excludeFromRefreshAppAwareness(snapType) {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (m *SnapManager) doRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
@@ -3518,6 +3571,20 @@ func (m *SnapManager) doRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
 	}
 	snapName := snapsup.InstanceName()
 
+	var removeReason removeAliasesReason
+	if err := t.Get("remove-reason", &removeReason); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	skip, err := shouldSkipRemoveAliases(st, removeReason, snapsup.Type)
+	if err != nil {
+		return err
+	}
+	if skip {
+		// skip removing aliases, setup-aliases will prune old aliases later.
+		return nil
+	}
+
 	err = m.backend.RemoveSnapAliases(snapName)
 	if err != nil {
 		return err
@@ -3526,6 +3593,73 @@ func (m *SnapManager) doRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
 	snapst.AliasesPending = true
 	Set(st, snapName, snapst)
 	return nil
+}
+
+func (m *SnapManager) undoRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+	snapsup, snapst, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	if !snapst.AliasesPending {
+		// do nothing
+		return nil
+	}
+
+	snapName := snapsup.InstanceName()
+	curAliases := snapst.Aliases
+	_, _, err = applyAliasesChange(snapName, autoDis, nil, snapst.AutoAliasesDisabled, curAliases, m.backend, doApply)
+	if err != nil {
+		return err
+	}
+
+	snapst.AliasesPending = false
+	Set(st, snapName, snapst)
+	return nil
+}
+
+func shouldPruneOldAliases(t *state.Task, snapst *SnapState) (prune bool, oldAliases map[string]*AliasTarget, oldAutoDisabled bool, err error) {
+	for _, t := range t.WaitTasks() {
+		if t.Kind() != "set-auto-aliases" || !t.Status().Ready() {
+			continue
+		}
+
+		taskSetup, err := TaskSnapSetup(t)
+		if err != nil {
+			return false, nil, false, err
+		}
+
+		if taskSetup.InstanceName() != snapst.InstanceName() {
+			continue
+		}
+
+		var pruneOldAliases bool
+		if err := t.Get("prune-old-aliases", &pruneOldAliases); err != nil && !errors.Is(err, state.ErrNoState) {
+			return false, nil, false, err
+		}
+
+		if !pruneOldAliases {
+			// don't prune
+			return false, nil, autoDis, nil
+		}
+
+		var oldAliases map[string]*AliasTarget
+		if err := t.Get("old-aliases-v2", &oldAliases); err != nil && !errors.Is(err, state.ErrNoState) {
+			return false, nil, false, err
+		}
+
+		oldAutoDisabled := snapst.AutoAliasesDisabled
+		if err := t.Get("old-auto-aliases-disabled", &oldAutoDisabled); err != nil && !errors.Is(err, state.ErrNoState) {
+			return false, nil, false, err
+		}
+
+		return true, oldAliases, oldAutoDisabled, nil
+	}
+
+	return false, nil, autoDis, nil
 }
 
 func (m *SnapManager) doSetupAliases(t *state.Task, _ *tomb.Tomb) error {
@@ -3538,13 +3672,55 @@ func (m *SnapManager) doSetupAliases(t *state.Task, _ *tomb.Tomb) error {
 	}
 	snapName := snapsup.InstanceName()
 	curAliases := snapst.Aliases
+	autoDisabled := snapst.AutoAliasesDisabled
 
-	_, _, err = applyAliasesChange(snapName, autoDis, nil, snapst.AutoAliasesDisabled, curAliases, m.backend, doApply)
+	prune, oldAliases, oldAutoDisabled, err := shouldPruneOldAliases(t, snapst)
 	if err != nil {
 		return err
 	}
 
+	// no need to check for conflicts as it was already checked in `set-auto-aliases`
+	_, _, err = applyAliasesChange(snapName, oldAutoDisabled, oldAliases, autoDisabled, curAliases, m.backend, doApply)
+	if err != nil {
+		// the undo for set-auto-aliases must revert aliases on disk since
+		// applyAliasesChange could have failed mid-way leaving disk in an
+		// inconsistent state.
+		return err
+	}
+
+	t.Set("old-aliases-pruned", prune)
+
 	snapst.AliasesPending = false
+	Set(st, snapName, snapst)
+	return nil
+}
+
+func (m *SnapManager) undoSetupAliases(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+	snapsup, snapst, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+	snapName := snapsup.InstanceName()
+
+	var oldAliasesPruned bool
+	if err := t.Get("old-aliases-pruned", &oldAliasesPruned); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if oldAliasesPruned {
+		// keep AliasesPending set to false so that the undo for set-auto-aliases
+		// can revert aliases on disk.
+		return nil
+	}
+
+	// remove added aliases
+	err = m.backend.RemoveSnapAliases(snapName)
+	if err != nil {
+		return err
+	}
+	snapst.AliasesPending = true
 	Set(st, snapName, snapst)
 	return nil
 }
@@ -3624,6 +3800,25 @@ func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 		autoDisabled = true
 	} else if err != nil {
 		return err
+	}
+
+	var setAutoAliasesInPruneMode bool
+	if t.Kind() == "set-auto-aliases" {
+		if err := t.Get("prune-old-aliases", &setAutoAliasesInPruneMode); err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+	}
+
+	// AliasesPending needs to be fixed if `setup-aliases` failed in prune mode.
+	//
+	// the following sequence triggers the edge-case:
+	//	1. `remove-aliases` skips removing aliases for refresh-app-awareness
+	//	    keeping AliasesPending as false
+	//	2. `set-auto-aliases` sets AliasesPending to true
+	//	3. `setup-aliases` fails mid-way before setting AliasesPending to false
+	if snapst.AliasesPending && setAutoAliasesInPruneMode {
+		// aliases on disk and state should now be fixed with applyAliasesChange below.
+		snapst.AliasesPending = false
 	}
 
 	if !snapst.AliasesPending {

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -20,15 +20,365 @@
 package snapstate_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
+
+func (s *snapmgrTestSuite) TestDoRemoveAliasesRefreshAppAwarenessDisabled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// With refresh-app-awareness disabled
+	tr = config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness", false)
+	tr.Commit()
+
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestDoUndoRemoveAliasesRefreshAppAwarenessDisabled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// With refresh-app-awareness disabled
+	tr = config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness", false)
+	tr.Commit()
+
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
+		},
+		{
+			op:      "update-aliases",
+			aliases: []*backend.Alias{{Name: "manual1", Target: "alias-snap.cmd1"}},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestDoRemoveAliasesExcludeFromRefreshAppAwareness(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// With excluded from refresh-app-awareness
+	restore := snapstate.MockExcludeFromRefreshAppAwareness(func(t snap.Type) bool {
+		return true
+	})
+	defer restore()
+
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestDoRemoveAliasesRemoveReasonNotRefresh(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "not-refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestDoRemoveAliasesSkipped(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// refresh-app-awareness should be enabled by default
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	// no actual removal is done
+	c.Assert(len(s.fakeBackend.ops), Equals, 0)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	// no aliases were removed, check AliasesPending is false
+	c.Check(snapst.AliasesPending, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestDoUndoRemoveAliasesSkipped(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: true,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"manual1": {Manual: "cmd1"},
+		},
+	})
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// refresh-app-awareness should be enabled by default
+	t := s.state.NewTask("remove-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	t.Set("remove-reason", "refresh")
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	// no actual removal is done so no removal is undone
+	c.Assert(len(s.fakeBackend.ops), Equals, 0)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, false)
+}
 
 func (s *snapmgrTestSuite) TestDoSetAutoAliases(c *C) {
 	s.state.Lock()
@@ -418,8 +768,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallUnaliased(c *C) {
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
 		}),
-		Current: snap.R(11),
-		Active:  true,
+		Current:        snap.R(11),
+		Active:         true,
+		AliasesPending: false,
 	})
 
 	t := s.state.NewTask("set-auto-aliases", "test")
@@ -450,7 +801,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallUnaliased(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.AutoAliasesDisabled, Equals, false)
-	c.Check(snapst.AliasesPending, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, false)
 	c.Check(snapst.Aliases, HasLen, 0)
 }
 
@@ -772,6 +1123,525 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesNothing(c *C) {
 
 	c.Check(snapst.AutoAliasesDisabled, Equals, false)
 	c.Check(snapst.AliasesPending, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestDoSetupAliasesAutoPruneOldAliases(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
+		c.Check(info.InstanceName(), Equals, "alias-snap")
+		return map[string]string{
+			"alias1": "cmd1",
+			"alias2": "cmd2",
+			"alias4": "cmd4",
+		}, nil
+	}
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: false,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"alias1": {Auto: "cmd1"},
+			"alias2": {Auto: "cmd2x"},
+			"alias3": {Auto: "cmd3"},
+		},
+	})
+
+	snapsup := snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	}
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// remove-aliases + refresh-app-awareness task triggers pruning
+	// refresh-app-awareness should be enabled by default
+	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
+	removeAliasesTask.Set("snap-setup", &snapsup)
+	removeAliasesTask.Set("remove-reason", "refresh")
+
+	setAutoAliasesTask := s.state.NewTask("set-auto-aliases", "test")
+	setAutoAliasesTask.Set("snap-setup", &snapsup)
+	setAutoAliasesTask.WaitFor(removeAliasesTask)
+
+	setupAliasesTask := s.state.NewTask("setup-aliases", "test")
+	setupAliasesTask.Set("snap-setup", &snapsup)
+	setupAliasesTask.WaitFor(setAutoAliasesTask)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(removeAliasesTask)
+	chg.AddTask(setAutoAliasesTask)
+	chg.AddTask(setupAliasesTask)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(removeAliasesTask.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setAutoAliasesTask.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setupAliasesTask.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
+
+	expected := fakeOps{
+		{
+			// notice no "remove-snap-aliases" op because it was skipped
+			// setup-aliases prunes old aliases and only updates changed aliases
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, false)
+	c.Check(snapst.AliasesPending, Equals, false)
+	c.Check(snapst.Aliases, DeepEquals, map[string]*snapstate.AliasTarget{
+		"alias1": {Auto: "cmd1"},
+		"alias2": {Auto: "cmd2"},
+		"alias4": {Auto: "cmd4"},
+	})
+}
+
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoPruneOldAliases(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
+		c.Check(info.InstanceName(), Equals, "alias-snap")
+		return map[string]string{
+			"alias1": "cmd1",
+			"alias2": "cmd2",
+			"alias4": "cmd4",
+		}, nil
+	}
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: false,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"alias1": {Auto: "cmd1"},
+			"alias2": {Auto: "cmd2x"},
+			"alias3": {Auto: "cmd3"},
+		},
+	})
+
+	snapsup := snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	}
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// remove-aliases + refresh-app-awareness task triggers pruning
+	// refresh-app-awareness should be enabled by default
+	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
+	removeAliasesTask.Set("snap-setup", &snapsup)
+	removeAliasesTask.Set("remove-reason", "refresh")
+
+	setAutoAliasesTask := s.state.NewTask("set-auto-aliases", "test")
+	setAutoAliasesTask.Set("snap-setup", &snapsup)
+	setAutoAliasesTask.WaitFor(removeAliasesTask)
+
+	setupAliasesTask := s.state.NewTask("setup-aliases", "test")
+	setupAliasesTask.Set("snap-setup", &snapsup)
+	setupAliasesTask.WaitFor(setAutoAliasesTask)
+
+	errTask := s.state.NewTask("error-trigger", "provoking total undo")
+	errTask.WaitFor(setupAliasesTask)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(removeAliasesTask)
+	chg.AddTask(setAutoAliasesTask)
+	chg.AddTask(setupAliasesTask)
+	chg.AddTask(errTask)
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(removeAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setAutoAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setupAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+
+	expected := fakeOps{
+		{
+			// notice no "remove-snap-aliases" op because it was skipped
+			// setup-aliases prunes old aliases and only updates changed aliases
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+		},
+		{
+			// notice no "remove-snap-aliases" op because it was skipped
+			// undo
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, false)
+	c.Check(snapst.AliasesPending, Equals, false)
+	c.Check(snapst.Aliases, DeepEquals, map[string]*snapstate.AliasTarget{
+		"alias1": {Auto: "cmd1"},
+		"alias2": {Auto: "cmd2x"},
+		"alias3": {Auto: "cmd3"},
+	})
+}
+
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoErrorMidwayPruneOldAliases(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
+		c.Check(info.InstanceName(), Equals, "alias-snap")
+		return map[string]string{
+			"alias1": "cmd1",
+			"alias2": "cmd2",
+			"alias4": "cmd4",
+		}, nil
+	}
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: false,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"alias1": {Auto: "cmd1"},
+			"alias2": {Auto: "cmd2x"},
+			"alias3": {Auto: "cmd3"},
+		},
+	})
+
+	snapsup := snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	}
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// remove-aliases + refresh-app-awareness task triggers pruning
+	// refresh-app-awareness should be enabled by default
+	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
+	removeAliasesTask.Set("snap-setup", &snapsup)
+	removeAliasesTask.Set("remove-reason", "refresh")
+
+	setAutoAliasesTask := s.state.NewTask("set-auto-aliases", "test")
+	setAutoAliasesTask.Set("snap-setup", &snapsup)
+	setAutoAliasesTask.WaitFor(removeAliasesTask)
+
+	setupAliasesTask := s.state.NewTask("setup-aliases", "test")
+	setupAliasesTask.Set("snap-setup", &snapsup)
+	setupAliasesTask.WaitFor(setAutoAliasesTask)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(removeAliasesTask)
+	chg.AddTask(setAutoAliasesTask)
+	chg.AddTask(setupAliasesTask)
+
+	expected := fakeOps{
+		{
+			// notice no "remove-snap-aliases" op because it was skipped
+			// setup-aliases prunes old aliases and only updates changed aliases
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+		},
+		{
+			// notice no "remove-snap-aliases" op because it was skipped
+			// undo
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+		},
+	}
+
+	var backendCalledFromSetupAliases int
+	var backendCalledFromSetAutoAliases int
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		var currentTask *state.Task
+		for _, t := range chg.Tasks() {
+			if t.Status() == state.DoingStatus || t.Status() == state.UndoingStatus {
+				currentTask = t
+				break
+			}
+		}
+		if currentTask == nil {
+			c.Errorf("unexpected nil task")
+		}
+
+		switch currentTask.Kind() {
+		case "setup-aliases":
+			backendCalledFromSetupAliases++
+			// double-check setup-aliases do did the correct op
+			c.Check(currentTask.Status(), Equals, state.DoingStatus)
+			c.Check(op, DeepEquals, &expected[0])
+			// trigger error in the middle of setup-aliases
+			return fmt.Errorf("setup-aliases failed in the middle")
+		case "set-auto-aliases":
+			backendCalledFromSetAutoAliases++
+			// double-check set-auto-aliases undo did the correct op
+			c.Check(currentTask.Status(), Equals, state.UndoingStatus)
+			c.Check(op, DeepEquals, &expected[1])
+		default:
+			c.Errorf("unexpected task: %s", currentTask.Kind())
+		}
+
+		return nil
+	}
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(removeAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setAutoAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setupAliasesTask.Status(), Equals, state.ErrorStatus, Commentf("%v", chg.Err()))
+
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	c.Assert(backendCalledFromSetupAliases, Equals, 1)
+	c.Assert(backendCalledFromSetAutoAliases, Equals, 1)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, false)
+	c.Check(snapst.AliasesPending, Equals, false)
+	c.Check(snapst.Aliases, DeepEquals, map[string]*snapstate.AliasTarget{
+		"alias1": {Auto: "cmd1"},
+		"alias2": {Auto: "cmd2x"},
+		"alias3": {Auto: "cmd3"},
+	})
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*setup-aliases failed in the middle.*`)
+}
+
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoPruneOldAliasesConflict(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
+		c.Check(info.InstanceName(), Equals, "alias-snap")
+		return map[string]string{
+			"alias1": "cmd1",
+			"alias2": "cmd2",
+			"alias4": "cmd4",
+		}, nil
+	}
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
+		Current:             snap.R(11),
+		Active:              true,
+		AutoAliasesDisabled: false,
+		AliasesPending:      false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"alias1": {Auto: "cmd1"},
+			"alias2": {Auto: "cmd2x"},
+			"alias3": {Auto: "cmd3"},
+		},
+	})
+
+	otherSnapState := &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "other-snap", Revision: snap.R(3)},
+		}),
+		Current:             snap.R(3),
+		Active:              true,
+		AutoAliasesDisabled: false,
+		Aliases: map[string]*snapstate.AliasTarget{
+			"alias5": {Auto: "cmd5"},
+		},
+	}
+	snapstate.Set(s.state, "other-snap", otherSnapState)
+
+	grabAlias3 := func(t *state.Task, _ *tomb.Tomb) error {
+		st := t.State()
+		st.Lock()
+		defer st.Unlock()
+
+		otherSnapState.Aliases = map[string]*snapstate.AliasTarget{
+			"alias3": {Auto: "cmd3"},
+			"alias5": {Auto: "cmd5"},
+		}
+		snapstate.Set(s.state, "other-snap", otherSnapState)
+
+		return nil
+	}
+
+	s.o.TaskRunner().AddHandler("grab-alias3", grabAlias3, nil)
+
+	snapsup := snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	}
+
+	// enable experimental refresh-app-awareness-ux
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	// remove-aliases + refresh-app-awareness task triggers pruning
+	// refresh-app-awareness should be enabled by default
+	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
+	removeAliasesTask.Set("snap-setup", &snapsup)
+	removeAliasesTask.Set("remove-reason", "refresh")
+
+	setAutoAliasesTask := s.state.NewTask("set-auto-aliases", "test")
+	setAutoAliasesTask.Set("snap-setup", &snapsup)
+	setAutoAliasesTask.WaitFor(removeAliasesTask)
+
+	setupAliasesTask := s.state.NewTask("setup-aliases", "test")
+	setupAliasesTask.Set("snap-setup", &snapsup)
+	setupAliasesTask.WaitFor(setAutoAliasesTask)
+
+	grab3Task := s.state.NewTask("grab-alias3", "grab alias3 for other-snap")
+	grab3Task.WaitFor(setupAliasesTask)
+
+	errTask := s.state.NewTask("error-trigger", "provoking total undo")
+	errTask.WaitFor(setupAliasesTask)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(removeAliasesTask)
+	chg.AddTask(setAutoAliasesTask)
+	chg.AddTask(setupAliasesTask)
+	chg.AddTask(grab3Task)
+	chg.AddTask(errTask)
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(removeAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setAutoAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	c.Check(setupAliasesTask.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+
+	expected := fakeOps{
+		{
+			// setup-aliases prunes old aliases and only updates changed aliases
+			op: "update-aliases",
+			aliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+			rmAliases: []*backend.Alias{
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
+			},
+		},
+		{
+			// undo
+			op: "update-aliases",
+			rmAliases: []*backend.Alias{
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
+			},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "alias-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst.AutoAliasesDisabled, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, false)
+	c.Check(snapst.Aliases, DeepEquals, map[string]*snapstate.AliasTarget{
+		"alias1": {Auto: "cmd1"},
+		"alias2": {Auto: "cmd2x"},
+		"alias3": {Auto: "cmd3"},
+	})
+
+	c.Assert(setupAliasesTask.Log(), HasLen, 0)
+	// set-auto-aliases undo should handle alias conflict
+	c.Assert(setAutoAliasesTask.Log(), HasLen, 1)
+	c.Check(setAutoAliasesTask.Log()[0], Matches, `.* ERROR cannot reinstate alias state because of conflicts, disabling: cannot enable alias "alias3" for "alias-snap", already enabled for "other-snap".*`)
 }
 
 func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAuto(c *C) {
@@ -2020,8 +2890,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallPrefer(c *C) {
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
 		}),
-		Current: snap.R(11),
-		Active:  true,
+		Current:        snap.R(11),
+		Active:         true,
+		AliasesPending: false,
 	})
 
 	t := s.state.NewTask("set-auto-aliases", "test")
@@ -2052,6 +2923,6 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallPrefer(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.AutoAliasesDisabled, Equals, false)
-	c.Check(snapst.AliasesPending, Equals, true)
+	c.Check(snapst.AliasesPending, Equals, false)
 	c.Check(snapst.Aliases, HasLen, 0)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -260,7 +260,9 @@ type SnapState struct {
 	// aliases, see aliasesv2.go
 	Aliases             map[string]*AliasTarget `json:"aliases,omitempty"`
 	AutoAliasesDisabled bool                    `json:"auto-aliases-disabled,omitempty"`
-	AliasesPending      bool                    `json:"aliases-pending,omitempty"`
+	// AliasesPending when true indicates that aliases in internal state
+	// and on disk might not match.
+	AliasesPending bool `json:"aliases-pending,omitempty"`
 
 	// UserID of the user requesting the install
 	UserID int `json:"user-id,omitempty"`
@@ -636,10 +638,10 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	// FIXME: drop the task entirely after a while
 	runner.AddHandler("clear-aliases", func(*state.Task, *tomb.Tomb) error { return nil }, nil)
 	runner.AddHandler("set-auto-aliases", m.doSetAutoAliases, m.undoRefreshAliases)
-	runner.AddHandler("setup-aliases", m.doSetupAliases, m.doRemoveAliases)
+	runner.AddHandler("setup-aliases", m.doSetupAliases, m.undoSetupAliases)
 	runner.AddHandler("refresh-aliases", m.doRefreshAliases, m.undoRefreshAliases)
 	runner.AddHandler("prune-auto-aliases", m.doPruneAutoAliases, m.undoRefreshAliases)
-	runner.AddHandler("remove-aliases", m.doRemoveAliases, m.doSetupAliases)
+	runner.AddHandler("remove-aliases", m.doRemoveAliases, m.undoRemoveAliases)
 	runner.AddHandler("alias", m.doAlias, m.undoRefreshAliases)
 	runner.AddHandler("unalias", m.doUnalias, m.undoRefreshAliases)
 	runner.AddHandler("disable-aliases", m.doDisableAliases, m.undoRefreshAliases)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -533,6 +533,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		prev = stop
 
 		removeAliases := st.NewTask("remove-aliases", fmt.Sprintf(i18n.G("Remove aliases for snap %q"), snapsup.InstanceName()))
+		removeAliases.Set("remove-reason", removeAliasesReasonRefresh)
 		addTask(removeAliases)
 		prev = removeAliases
 
@@ -3285,6 +3286,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 
 	removeAliases := st.NewTask("remove-aliases", fmt.Sprintf(i18n.G("Remove aliases for snap %q"), snapsup.InstanceName()))
 	removeAliases.Set("snap-setup-task", stopSnapServices.ID())
+	removeAliases.Set("remove-reason", removeAliasesReasonDisable)
 	removeAliases.WaitFor(stopSnapServices)
 
 	unlinkSnap := st.NewTask("unlink-snap", fmt.Sprintf(i18n.G("Make snap %q (%s) unavailable to the system"), snapsup.InstanceName(), snapst.Current))
@@ -3524,6 +3526,7 @@ func removeTasks(st *state.State, name string, revision snap.Revision, flags *Re
 		removeAliases := st.NewTask("remove-aliases", fmt.Sprintf(i18n.G("Remove aliases for snap %q"), name))
 		removeAliases.WaitFor(prev) // prev is not needed beyond here
 		removeAliases.Set("snap-setup-task", stopSnapServices.ID())
+		removeAliases.Set("remove-reason", removeAliasesReasonRemove)
 
 		unlink := st.NewTask("unlink-snap", fmt.Sprintf(i18n.G("Make snap %q unavailable to the system"), name))
 		unlink.Set("snap-setup-task", stopSnapServices.ID())

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1663,8 +1663,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 			op: "update-aliases",
 		},
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
+			op: "update-aliases",
 		},
 		{
 			op:    "auto-connect:Undoing",


### PR DESCRIPTION
This PR is a building block towards refresh app awareness UX improvements. It allows skipping aliases removal during refresh for the refresh-app-awareness UX flow. This is similar to what is done to binaries https://github.com/snapcore/snapd/pull/13374 but for aliases.

For context: https://github.com/snapcore/snapd/pull/13066