### PR TITLE
o/snapstate: test refresh policies for classic are not run at preseed time

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -539,3 +539,7 @@ func MockCgroupMonitorSnapEnded(f func(string, chan<- string) error) func() {
 func SetRestoredMonitoring(snapmgr *SnapManager, value bool) {
 	snapmgr.autoRefresh.restoredMonitoring = value
 }
+
+func SetPreseed(snapmgr *SnapManager, value bool) {
+	snapmgr.preseed = value
+}


### PR DESCRIPTION
Somebody asked a related question and I noticed that no test was exercising this behavior currently
