### PR TITLE
asserts: add Model.AllSnaps method

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -613,10 +613,11 @@ func (mod *Model) SnapsWithoutEssential() []*ModelSnap {
 	return mod.allSnaps[mod.numEssentialSnaps:]
 }
 
-// AllSnaps returns all the snaps listed by the model. Essential snaps are at
-// the front of the slice, followed by the non-essential snaps. The essential
-// snaps follow the same order as returned by EssentialSnaps. The non-essential
-// snaps are returned in the order they are mentioned in the model.
+// AllSnaps returns all the snaps listed by the model, across all modes.
+// Essential snaps are at the front of the slice, followed by the non-essential
+// snaps. The essential snaps follow the same order as returned by
+// EssentialSnaps. The non-essential snaps are returned in the order they are
+// mentioned in the model.
 func (mod *Model) AllSnaps() []*ModelSnap {
 	return mod.allSnaps
 }

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -613,6 +613,14 @@ func (mod *Model) SnapsWithoutEssential() []*ModelSnap {
 	return mod.allSnaps[mod.numEssentialSnaps:]
 }
 
+// AllSnaps returns all the snaps listed by the model. Essential snaps are at
+// the front of the slice, followed by the non-essential snaps. The essential
+// snaps follow the same order as returned by EssentialSnaps. The non-essential
+// snaps are returned in the order they are mentioned in the model.
+func (mod *Model) AllSnaps() []*ModelSnap {
+	return mod.allSnaps
+}
+
 // ValidationSets returns all the validation-sets listed by the model.
 func (mod *Model) ValidationSets() []*ModelValidationSet {
 	return mod.validationSets

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1407,3 +1407,19 @@ func (mods *modelSuite) TestModelValidationSetSequenceKey(c *C) {
 
 	c.Check(mvs.SequenceKey(), Equals, "16/test/set")
 }
+
+func (mods *modelSuite) TestAllSnaps(c *C) {
+	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "OTHER", "", 1)
+
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.ModelType)
+
+	model := a.(*asserts.Model)
+
+	allSnaps := append([]*asserts.ModelSnap(nil), model.EssentialSnaps()...)
+	allSnaps = append(allSnaps, model.SnapsWithoutEssential()...)
+
+	c.Check(model.AllSnaps(), DeepEquals, allSnaps)
+}

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type modelSuite struct {
@@ -1419,7 +1420,16 @@ func (mods *modelSuite) TestAllSnaps(c *C) {
 	model := a.(*asserts.Model)
 
 	allSnaps := append([]*asserts.ModelSnap(nil), model.EssentialSnaps()...)
+
+	// make sure that we have essential snaps to compare to
+	c.Assert(len(allSnaps), testutil.IntGreaterThan, 0)
+
+	essentialLen := len(allSnaps)
+
 	allSnaps = append(allSnaps, model.SnapsWithoutEssential()...)
+
+	// same here, make sure that we have non-essential snaps to compare to
+	c.Assert(len(allSnaps), testutil.IntGreaterThan, essentialLen)
 
 	c.Check(model.AllSnaps(), DeepEquals, allSnaps)
 }

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1171,10 +1171,7 @@ func checkForRequiredSnapsNotInModel(model *asserts.Model, vSets *snapasserts.Va
 }
 
 func checkForInvalidSnapsInModel(model *asserts.Model, vSets *snapasserts.ValidationSets) error {
-	snaps := append([]*asserts.ModelSnap(nil), model.EssentialSnaps()...)
-	snaps = append(snaps, model.SnapsWithoutEssential()...)
-
-	for _, sn := range snaps {
+	for _, sn := range model.AllSnaps() {
 		if !vSets.CanBePresent(sn) {
 			return fmt.Errorf("snap presence is invalid: %s", sn.SnapName())
 		}


### PR DESCRIPTION
This method is a small helper that will be used during the creation of recovery systems. It also simplifies another case during remodeling a little bit.