### PR TITLE
boot: add UnmarkRecoveryCapableSystem function for undoing creation of a recovery system

### DIFF
--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -2066,6 +2066,7 @@ func (s *systemsSuite) TestUnmarkRecoveryCapableSystemHappy(c *C) {
 	rbl := bootloadertest.Mock("recovery", c.MkDir()).RecoveryAware()
 	bootloader.Force(rbl)
 
+	// mark system
 	err := boot.MarkRecoveryCapableSystem("1234")
 	c.Assert(err, IsNil)
 	vars, err := rbl.GetBootVars("snapd_good_recovery_systems")
@@ -2074,6 +2075,7 @@ func (s *systemsSuite) TestUnmarkRecoveryCapableSystemHappy(c *C) {
 		"snapd_good_recovery_systems": "1234",
 	})
 
+	// mark system
 	err = boot.MarkRecoveryCapableSystem("4567")
 	c.Assert(err, IsNil)
 	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
@@ -2082,6 +2084,16 @@ func (s *systemsSuite) TestUnmarkRecoveryCapableSystemHappy(c *C) {
 		"snapd_good_recovery_systems": "1234,4567",
 	})
 
+	// unmark system that is not present, function is idempotent
+	err = boot.UnmarkRecoveryCapableSystem("not-here")
+	c.Assert(err, IsNil)
+	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Check(vars, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "1234,4567",
+	})
+
+	// unmark system
 	err = boot.UnmarkRecoveryCapableSystem("1234")
 	c.Assert(err, IsNil)
 	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
@@ -2090,6 +2102,7 @@ func (s *systemsSuite) TestUnmarkRecoveryCapableSystemHappy(c *C) {
 		"snapd_good_recovery_systems": "4567",
 	})
 
+	// unmark system
 	err = boot.UnmarkRecoveryCapableSystem("4567")
 	c.Assert(err, IsNil)
 	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -2061,3 +2061,40 @@ func (s *initramfsMarkTryRecoverySystemSuite) TestRecoverySystemSuccessDifferent
 	c.Assert(err, IsNil)
 	c.Check(isTry, Equals, false)
 }
+
+func (s *systemsSuite) TestUnmarkRecoveryCapableSystemHappy(c *C) {
+	rbl := bootloadertest.Mock("recovery", c.MkDir()).RecoveryAware()
+	bootloader.Force(rbl)
+
+	err := boot.MarkRecoveryCapableSystem("1234")
+	c.Assert(err, IsNil)
+	vars, err := rbl.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Check(vars, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "1234",
+	})
+
+	err = boot.MarkRecoveryCapableSystem("4567")
+	c.Assert(err, IsNil)
+	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Check(vars, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "1234,4567",
+	})
+
+	err = boot.UnmarkRecoveryCapableSystem("1234")
+	c.Assert(err, IsNil)
+	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Check(vars, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "4567",
+	})
+
+	err = boot.UnmarkRecoveryCapableSystem("4567")
+	c.Assert(err, IsNil)
+	vars, err = rbl.GetBootVars("snapd_good_recovery_systems")
+	c.Assert(err, IsNil)
+	c.Check(vars, DeepEquals, map[string]string{
+		"snapd_good_recovery_systems": "",
+	})
+}


### PR DESCRIPTION
This function will be used during the removal (and the undoing of creating) of a recovery system. It is the inverse of `MarkRecoveryCapableSystem`.