### PR TITLE
tests: update the snap used to install in parallel-installs perf test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1068,6 +1068,8 @@ suites:
             LOAD_DURATION: '$(HOST: echo "${PERF_LOAD_DURATION:-1200}")'
             NUM_PARALLEL: '$(HOST: echo "${PERF_NUM_PARALLEL:-10}")'
         manual: true
+        warn-timeout: 10m
+        kill-timeout: 60m
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -1299,6 +1301,8 @@ suites:
             SPREAD_URL: https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz
 
         manual: true
+        warn-timeout: 10m
+        kill-timeout: 60m
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh

--- a/tests/perf/parallel-installs/task.yaml
+++ b/tests/perf/parallel-installs/task.yaml
@@ -5,7 +5,7 @@ details: |
     interfaces. This will help catch performance issues in snapd, AppArmor, etc.
 
 environment:
-    SNAPS: jq snap-store gh
+    SNAPS: jq snap-store test-snapd-tools
 
 prepare: |
     snap set system experimental.parallel-instances=true


### PR DESCRIPTION
This is required because gh is not available for arm64 devices
