### PR TITLE
tests: move nested tests to a different google location

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -219,7 +219,7 @@ backends:
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/us-central1-b
         halt-timeout: 2h
         systems:
             - ubuntu-18.04-64:
@@ -234,7 +234,7 @@ backends:
     google-nested:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/us-central1-b
         plan: n2-standard-2
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"
@@ -271,7 +271,7 @@ backends:
     google-nested-dev:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/us-central1-b
         plan: n2-standard-4
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"

--- a/spread.yaml
+++ b/spread.yaml
@@ -219,7 +219,7 @@ backends:
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-central1-b
+        location: snapd-spread/us-central1-a
         halt-timeout: 2h
         systems:
             - ubuntu-18.04-64:
@@ -234,7 +234,7 @@ backends:
     google-nested:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-central1-b
+        location: snapd-spread/us-central1-a
         plan: n2-standard-2
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"
@@ -271,7 +271,7 @@ backends:
     google-nested-dev:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-central1-b
+        location: snapd-spread/us-central1-a
         plan: n2-standard-4
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"


### PR DESCRIPTION
In google cloud the instance quotas are defined by datacenter.

This change is to improve a bit how instances are grouped in different datacenters.
