### PR TITLE
cmd/snap-bootstrap: mount kernel components in /run/mnt

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -2074,6 +2074,20 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 			if err := doSystemdMount(snapPath, filepath.Join(boot.InitramfsRunMntDir, dir), mountReadOnlyOptions); err != nil {
 				return err
 			}
+			if typ == snap.TypeKernel {
+				// Mount kernel components
+				cpis, err := kernelComponentsToMount(sn.InstanceName(), rootfsDir)
+				if err != nil {
+					return fmt.Errorf("while reading kernel components: %w", err)
+				}
+				for _, cpi := range cpis {
+					compPath := filepath.Join(dirs.SnapBlobDirUnder(rootfsDir), cpi.Filename())
+					if err := doSystemdMount(compPath, filepath.Join(boot.InitramfsRunMntDir,
+						"kernel-modules", cpi.ContainerName()), mountReadOnlyOptions); err != nil {
+						return err
+					}
+				}
+			}
 		}
 	}
 

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -42,6 +42,8 @@ var (
 	MountNonDataPartitionMatchingKernelDisk = mountNonDataPartitionMatchingKernelDisk
 
 	GetNonUEFISystemDisk = getNonUEFISystemDisk
+
+	KernelComponentsToMount = kernelComponentsToMount
 )
 
 type SystemdMountOptions = systemdMountOptions

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -233,5 +234,13 @@ func MockEnsureNextBootToRunMode(f func(systemLabel string) error) (restore func
 	bootEnsureNextBootToRunMode = f
 	return func() {
 		bootEnsureNextBootToRunMode = old
+	}
+}
+
+func MockKernelComponentsToMount(f func(kernelName, rootfsDir string) ([]snap.ContainerPlaceInfo, error)) (restore func()) {
+	old := kernelComponentsToMount
+	kernelComponentsToMount = f
+	return func() {
+		kernelComponentsToMount = old
 	}
 }

--- a/cmd/snap-bootstrap/kernel_components.go
+++ b/cmd/snap-bootstrap/kernel_components.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type readOnlyBackend struct{}
+
+func (b *readOnlyBackend) Checkpoint(data []byte) error {
+	// We do not try to write the state
+	return nil
+}
+
+func (b *readOnlyBackend) EnsureBefore(d time.Duration) {
+	panic("cannot use EnsureBefore in readOnlyBackend")
+}
+
+var _ state.Backend = &readOnlyBackend{}
+
+func kernelComponentsToMount(kernelName, rootfsDir string) ([]snap.ContainerPlaceInfo, error) {
+	statePath := dirs.SnapStateFileUnder(rootfsDir)
+	f, err := os.Open(statePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open state file %q: %s", statePath, err)
+	}
+	defer f.Close()
+
+	st, err := state.ReadState(&readOnlyBackend{}, f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading state file %q: %s", statePath, err)
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	var kernelst snapstate.SnapState
+	if err := snapstate.Get(st, kernelName, &kernelst); err != nil {
+		return nil, fmt.Errorf("error reading state for snap %q: %s", kernelName, err)
+	}
+
+	// Finally, get components
+	idx := kernelst.LastIndex(kernelst.Current)
+	if idx == -1 {
+		return nil, fmt.Errorf("inconsistent state file, current is not in sequence")
+	}
+	revSideState := kernelst.Sequence.Revisions[idx]
+	cpis := make([]snap.ContainerPlaceInfo, len(revSideState.Components))
+	for i, comp := range revSideState.Components {
+		cpis[i] = snap.MinimalComponentContainerPlaceInfo(
+			comp.Component.ComponentName, comp.Revision,
+			kernelName, revSideState.Snap.Revision)
+	}
+	return cpis, nil
+}

--- a/cmd/snap-bootstrap/kernel_components.go
+++ b/cmd/snap-bootstrap/kernel_components.go
@@ -43,7 +43,10 @@ func (b *readOnlyBackend) EnsureBefore(d time.Duration) {
 
 var _ state.Backend = &readOnlyBackend{}
 
-func kernelComponentsToMount(kernelName, rootfsDir string) ([]snap.ContainerPlaceInfo, error) {
+// To allow mocking in tests
+var kernelComponentsToMount = kernelComponentsToMountImpl
+
+func kernelComponentsToMountImpl(kernelName, rootfsDir string) ([]snap.ContainerPlaceInfo, error) {
 	statePath := dirs.SnapStateFileUnder(rootfsDir)
 	f, err := os.Open(statePath)
 	if err != nil {

--- a/cmd/snap-bootstrap/kernel_components_test.go
+++ b/cmd/snap-bootstrap/kernel_components_test.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"os"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type kernelCompSuite struct {
+	testutil.BaseTest
+
+	tmpDir string
+}
+
+var _ = Suite(&kernelCompSuite{})
+
+func (s *kernelCompSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	_, r := logger.MockLogger()
+	s.AddCleanup(r)
+
+	// mock /run/mnt
+	s.tmpDir = c.MkDir()
+	dirs.SetRootDir(s.tmpDir)
+	r = func() { dirs.SetRootDir("") }
+	s.AddCleanup(r)
+}
+
+type testReadStateBackend struct {
+	path string
+}
+
+func (b *testReadStateBackend) EnsureBefore(d time.Duration) {
+	panic("cannot use EnsureBefore in testReadStateBackend")
+}
+
+func (b *testReadStateBackend) Checkpoint(data []byte) error {
+	return osutil.AtomicWriteFile(b.path, data, 0600, 0)
+}
+
+var _ state.Backend = &testReadStateBackend{}
+
+func (s *kernelCompSuite) TestReadState(c *C) {
+	// make <root>/var/lib/snapd/
+	snapdStateDir := dirs.SnapdStateDir(s.tmpDir)
+	c.Assert(os.MkdirAll(snapdStateDir, 0755), IsNil)
+	// Write state with components
+	st := state.New(&testReadStateBackend{path: dirs.SnapStateFile})
+	st.Lock()
+	const snapName = "mykernel"
+	const compName = "mycomp"
+	const compName2 = "mycomp2"
+	snapRev := snap.R(1)
+	compRev := snap.R(33)
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev,
+		SnapID: "some-snap-id"}
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	cref2 := naming.NewComponentRef(snapName, compName2)
+	csi2 := snap.NewComponentSideInfo(cref2, compRev)
+
+	snapSt := &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*snapstate.RevisionSideState{
+				snapstate.NewRevisionSideInfo(ssi,
+					[]*snap.ComponentSideInfo{csi, csi2})}),
+		Current: snapRev,
+	}
+	snapstate.Set(st, snapName, snapSt)
+	st.Unlock()
+
+	conts, err := main.KernelComponentsToMount(snapName, s.tmpDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(conts), Equals, 2)
+	c.Check(conts[0].Filename(), Equals, "mykernel+mycomp_33.comp")
+	c.Check(conts[0].MountDir(), testutil.Contains, "snap/mykernel/components/1/mycomp")
+	c.Check(conts[1].Filename(), Equals, "mykernel+mycomp2_33.comp")
+	c.Check(conts[1].MountDir(), testutil.Contains, "snap/mykernel/components/1/mycomp2")
+}
+
+func (s *kernelCompSuite) TestReadStateNoState(c *C) {
+	conts, err := main.KernelComponentsToMount("mykernel", s.tmpDir)
+	c.Assert(err, ErrorMatches, `cannot open state file .*`)
+	c.Assert(conts, IsNil)
+}
+
+func (s *kernelCompSuite) TestReadStateBadState(c *C) {
+	snapdStateDir := dirs.SnapdStateDir(s.tmpDir)
+	c.Assert(os.MkdirAll(snapdStateDir, 0755), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapStateFileUnder(s.tmpDir), []byte{}, 0644), IsNil)
+
+	conts, err := main.KernelComponentsToMount("mykernel", s.tmpDir)
+	c.Assert(err, ErrorMatches, `error reading state file .*`)
+	c.Assert(conts, IsNil)
+}
+
+func (s *kernelCompSuite) TestReadStateNoSnapInState(c *C) {
+	// make <root>/var/lib/snapd/
+	snapdStateDir := dirs.SnapdStateDir(s.tmpDir)
+	c.Assert(os.MkdirAll(snapdStateDir, 0755), IsNil)
+	// Write state with components
+	st := state.New(&testReadStateBackend{path: dirs.SnapStateFile})
+	st.Lock()
+	st.Unlock()
+
+	conts, err := main.KernelComponentsToMount("mykernel", s.tmpDir)
+	c.Assert(err, ErrorMatches, `error reading state for snap "mykernel".*`)
+	c.Assert(conts, IsNil)
+}

--- a/snap/types.go
+++ b/snap/types.go
@@ -188,12 +188,14 @@ type ComponentType string
 
 const (
 	// TestComponent is just for testing purposes.
-	// TODO add here new component when there is more progress on the
-	// components implementation.
 	TestComponent ComponentType = "test"
+	// KernelModulesComp is the type for a component carrying kernel
+	// modules and firmware, and it is valid only for components belonging
+	// to a kernel snap.
+	KernelModulesComp ComponentType = "kernel-modules"
 )
 
-var validComponentTypes = [...]ComponentType{TestComponent}
+var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesComp}
 
 // Component represents a snap component.
 type Component struct {


### PR DESCRIPTION
These mount will be used to generate the modules/fw tree finally exposed to the rootfs.