### PR TITLE
many: move snapstate.Sequence to its own package

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox"
@@ -485,7 +486,7 @@ version: %s
 	var snapst snapstate.SnapState
 	snapstate.Get(st, instanceName, &snapst)
 	snapst.Active = active
-	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(&snapInfo.SideInfo, nil))
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(&snapInfo.SideInfo, nil))
 	snapst.Current = snapInfo.SideInfo.Revision
 	snapst.TrackingChannel = "stable"
 	snapst.InstanceKey = instanceKey

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox"
@@ -378,8 +379,8 @@ func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
 	snapstate.Set(st, "other", &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi, nil)}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi, nil)}),
 		Current: snap.R(1),
 	})
 	st.Unlock()
@@ -414,8 +415,8 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 	snapstate.Set(st, expectedInstanceName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi, nil)}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi, nil)}),
 		Current: snap.R(1),
 	})
 	st.Unlock()

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -66,7 +67,7 @@ func (s *snapFileSuite) TestGetFile(c *check.C) {
 				sideInfo := &snap.SideInfo{Revision: snap.R(-1), RealName: "foo"}
 				snapst.Active = scen.active
 				snapst.Current = sideInfo.Revision
-				snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(sideInfo, nil))
+				snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(sideInfo, nil))
 				if scen.try {
 					snapst.TryMode = true
 				}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -2130,7 +2131,7 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, snapInfo.InstanceName(), &snapst)
 	c.Assert(err, IsNil)
-	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(sideInfo, nil))
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(sideInfo, nil))
 	snapstate.Set(s.state, snapInfo.InstanceName(), &snapst)
 
 	return snapInfo

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -140,8 +141,8 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
-			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
+			sequence.NewRevisionSideInfo(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 
@@ -150,8 +151,8 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI1, nil),
-			snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI1, nil),
+			sequence.NewRevisionSideInfo(kernelSI2, nil)}),
 		Current: snap.R(2),
 	})
 
@@ -277,7 +278,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI2, nil)}),
 		Current:  snap.R(2),
 	})
 
@@ -286,8 +287,8 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
-			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
+			sequence.NewRevisionSideInfo(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 	bs.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/core/1")
@@ -559,8 +560,8 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI1, nil),
-			snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI1, nil),
+			sequence.NewRevisionSideInfo(kernelSI2, nil)}),
 		Current: snap.R(2),
 	})
 	// we have core22 and current is r2
@@ -571,8 +572,8 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "core22", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
-			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
+			sequence.NewRevisionSideInfo(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 	// now pretend that for whatever reason the modeenv reports that

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -151,8 +152,8 @@ func setStateWithOneSnap(st *state.State, snapName string, snapRev snap.Revision
 	snapstate.Set(st, snapName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi, nil)}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi, nil)}),
 		Current: snapRev,
 	})
 }
@@ -170,8 +171,8 @@ func setStateWithComponents(st *state.State, snapName string,
 	snapstate.Set(st, snapName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi, comps)}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi, comps)}),
 		Current: snapRev,
 	})
 }
@@ -265,8 +266,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathForParallelInstall(c *C) {
 	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi, nil)}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi, nil)}),
 		Current:     snapRev,
 		InstanceKey: snapKey,
 	})
@@ -356,9 +357,9 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresentDiffSnapRe
 	snapstate.Set(s.state, snapName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi1, nil),
-				snapstate.NewRevisionSideInfo(ssi2,
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi1, nil),
+				sequence.NewRevisionSideInfo(ssi2,
 					[]*snap.ComponentSideInfo{csi}),
 			}),
 		Current: snapRev1,
@@ -417,8 +418,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathSnapNotActive(c *C) {
 	snapstate.Set(s.state, snapName, &snapstate.SnapState{
 		Active: false,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi,
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi,
 					[]*snap.ComponentSideInfo{csi})}),
 		Current: snapRev,
 	})

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -77,8 +78,8 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 	snapSt := &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi,
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi,
 					[]*snap.ComponentSideInfo{csi2, csi})}),
 		Current: snapRev,
 	}
@@ -100,9 +101,9 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 	snapSt = &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi2, nil),
-				snapstate.NewRevisionSideInfo(ssi, []*snap.ComponentSideInfo{csi}),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi2, nil),
+				sequence.NewRevisionSideInfo(ssi, []*snap.ComponentSideInfo{csi}),
 			}),
 		Current: snapRev2,
 	}
@@ -119,9 +120,9 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 	snapSt = &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
-			[]*snapstate.RevisionSideState{
-				snapstate.NewRevisionSideInfo(ssi2, nil),
-				snapstate.NewRevisionSideInfo(ssi, nil),
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideInfo(ssi2, nil),
+				sequence.NewRevisionSideInfo(ssi, nil),
 			}),
 		Current: snapRev2,
 	}

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -342,7 +343,7 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 			var snapst snapstate.SnapState
 			snapstate.Get(st, snapsup.InstanceName(), &snapst)
 			snapst.Current = snapsup.Revision()
-			snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(snapsup.SideInfo, nil))
+			snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(snapsup.SideInfo, nil))
 			snapstate.Set(st, snapsup.InstanceName(), &snapst)
 
 			// check that prerequisites task is not done yet, it must wait for core.

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package sequence contains types representing a sequence of snap
+// revisions (with components) that describe current and past states
+// of the snap in the system.
+package sequence
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+// RevisionSideState contains the side information for a snap and related components
+// installed in the system.
+type RevisionSideState struct {
+	Snap       *snap.SideInfo
+	Components []*snap.ComponentSideInfo
+}
+
+// revisionSideInfoMarshal is an ancillary structure used exclusively to
+// help marshaling of RevisionSideInfo.
+type revisionSideInfoMarshal struct {
+	// SideInfo is included for compatibility with older snapd state files
+	*snap.SideInfo
+	CompSideInfo []*snap.ComponentSideInfo `yaml:"components,omitempty" json:"components,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (bsi RevisionSideState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&revisionSideInfoMarshal{bsi.Snap, bsi.Components})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (bsi *RevisionSideState) UnmarshalJSON(in []byte) error {
+	var aux revisionSideInfoMarshal
+	if err := json.Unmarshal(in, &aux); err != nil {
+		return err
+	}
+	bsi.Snap = aux.SideInfo
+	bsi.Components = aux.CompSideInfo
+	return nil
+}
+
+// FindComponent returns the snap.ComponentSideInfo if cref is found in the sequence point.
+func (rss *RevisionSideState) FindComponent(cref naming.ComponentRef) *snap.ComponentSideInfo {
+	for _, csi := range rss.Components {
+		if csi.Component == cref {
+			return csi
+		}
+	}
+	return nil
+}
+
+// NewRevisionSideInfo creates a RevisionSideInfo from snap and
+// related components side information.
+func NewRevisionSideInfo(snapSideInfo *snap.SideInfo, compSideInfo []*snap.ComponentSideInfo) *RevisionSideState {
+	return &RevisionSideState{Snap: snapSideInfo, Components: compSideInfo}
+}
+
+// SnapSequence is a container for a slice containing revisions of
+// snaps plus related components.
+// TODO add methods to access Revisions (length, copy, append) and
+// use them in handlers.go and snapstate.go.
+type SnapSequence struct {
+	// Revisions contains information for a snap revision and
+	// components SideInfo.
+	Revisions []*RevisionSideState
+}
+
+// MarshalJSON implements the json.Marshaler interface. We override the default
+// so serialization of the SnapState.Sequence field is compatible to what was
+// produced when it was defined as a []*snap.SideInfo. This is also the reason
+// to have SnapSequence.UnmarshalJSON and MarshalJSON/UnmarshalJSON for
+// RevisionSideState.
+func (snapSeq SnapSequence) MarshalJSON() ([]byte, error) {
+	return json.Marshal(snapSeq.Revisions)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (snapSeq *SnapSequence) UnmarshalJSON(in []byte) error {
+	aux := []*RevisionSideState{}
+	if err := json.Unmarshal(in, &aux); err != nil {
+		return err
+	}
+	snapSeq.Revisions = aux
+	return nil
+}
+
+// SideInfos returns a slice with all the SideInfos for the snap sequence.
+func (snapSeq SnapSequence) SideInfos() []*snap.SideInfo {
+	sis := make([]*snap.SideInfo, len(snapSeq.Revisions))
+	for i, rev := range snapSeq.Revisions {
+		sis[i] = rev.Snap
+	}
+	return sis
+}
+
+// LastIndex returns the last index of the given revision in snapSeq,
+// or -1 if the revision was not found.
+func (snapSeq *SnapSequence) LastIndex(revision snap.Revision) int {
+	for i := len(snapSeq.Revisions) - 1; i >= 0; i-- {
+		if snapSeq.Revisions[i].Snap.Revision == revision {
+			return i
+		}
+	}
+	return -1
+}
+
+var ErrSnapRevNotInSequence = errors.New("snap is not in the sequence")
+
+// AddComponentForRevision adds a component to the last instance of snapRev in
+// the sequence.
+func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, csi *snap.ComponentSideInfo) error {
+	snapIdx := snapSeq.LastIndex(snapRev)
+	if snapIdx == -1 {
+		return ErrSnapRevNotInSequence
+	}
+	revSt := snapSeq.Revisions[snapIdx]
+
+	if revSt.FindComponent(csi.Component) != nil {
+		// Component already present
+		return nil
+	}
+
+	// Append new component to components of the current snap
+	revSt.Components = append(revSt.Components, csi)
+	return nil
+}
+
+// RemoveComponentForRevision removes the cref component for the last instance
+// of snapRev in the sequence and returns a pointer to it, which might be nil
+// if not found.
+func (snapSeq *SnapSequence) RemoveComponentForRevision(snapRev snap.Revision, cref naming.ComponentRef) (unlinkedComp *snap.ComponentSideInfo) {
+	snapIdx := snapSeq.LastIndex(snapRev)
+	if snapIdx == -1 {
+		return nil
+	}
+
+	revSt := snapSeq.Revisions[snapIdx]
+	var leftComp []*snap.ComponentSideInfo
+	for _, csi := range revSt.Components {
+		if csi.Component == cref {
+			unlinkedComp = csi
+			continue
+		}
+		leftComp = append(leftComp, csi)
+	}
+	revSt.Components = leftComp
+	// might be nil
+	return unlinkedComp
+}

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -1,0 +1,152 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sequence_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type sequenceTestSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&sequenceTestSuite{})
+
+func (s *sequenceTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *sequenceTestSuite) TestSequenceSerialize(c *C) {
+	si1 := &snap.SideInfo{RealName: "mysnap", SnapID: "snapid", Revision: snap.R(7)}
+	si2 := &snap.SideInfo{RealName: "othersnap", SnapID: "otherid", Revision: snap.R(11)}
+
+	// Without components
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+		si1, si2,
+	})
+	marshaled, err := json.Marshal(seq)
+	c.Assert(err, IsNil)
+	c.Check(string(marshaled), Equals, `[{"name":"mysnap","snap-id":"snapid","revision":"7"},{"name":"othersnap","snap-id":"otherid","revision":"11"}]`)
+
+	// Now check that unmarshaling is as expected
+	var readSeq sequence.SnapSequence
+	c.Check(json.Unmarshal(marshaled, &readSeq), IsNil)
+	c.Check(readSeq, DeepEquals, seq)
+
+	// With components
+	seq = snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
+		sequence.NewRevisionSideInfo(si1, []*snap.ComponentSideInfo{
+			snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"),
+				snap.R(7)),
+		}),
+		sequence.NewRevisionSideInfo(si2, []*snap.ComponentSideInfo{
+			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"),
+				snap.R(11)),
+			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)),
+		}),
+	})
+	marshaled, err = json.Marshal(seq)
+	c.Assert(err, IsNil)
+	c.Check(string(marshaled), Equals, `[{"name":"mysnap","snap-id":"snapid","revision":"7","components":[{"component":{"snap-name":"mysnap","component-name":"mycomp"},"revision":"7"}]},{"name":"othersnap","snap-id":"otherid","revision":"11","components":[{"component":{"snap-name":"othersnap","component-name":"othercomp1"},"revision":"11"},{"component":{"snap-name":"othersnap","component-name":"othercomp2"},"revision":"14"}]}]`)
+
+	// Now check that unmarshaling is as expected
+	c.Check(json.Unmarshal(marshaled, &readSeq), IsNil)
+	c.Check(readSeq, DeepEquals, seq)
+}
+
+func (s *sequenceTestSuite) TestSideInfos(c *C) {
+	ssi := &snap.SideInfo{RealName: "foo", Revision: snap.R(1),
+		SnapID: "some-snap-id"}
+	ssi2 := &snap.SideInfo{RealName: "foo", Revision: snap.R(2),
+		SnapID: "some-snap-id"}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef("foo", "comp"), snap.R(11))
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideInfo(ssi, []*snap.ComponentSideInfo{csi}),
+			sequence.NewRevisionSideInfo(ssi2, nil)})
+
+	c.Check(seq.SideInfos(), DeepEquals, []*snap.SideInfo{ssi, ssi2})
+}
+
+func (s *sequenceTestSuite) TestAddComponentForRevision(c *C) {
+	const snapName = "foo"
+	snapRev := snap.R(1)
+	const compName1 = "comp1"
+	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(2))
+	csi2 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(3))
+
+	ssi := &snap.SideInfo{RealName: snapName,
+		Revision: snap.R(1), SnapID: "some-snap-id"}
+	comps := []*snap.ComponentSideInfo{csi1, csi2}
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(ssi, comps)})
+	c.Assert(seq.AddComponentForRevision(snapRev, csi1), IsNil)
+	// Not re-appended
+	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
+
+	csi3 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, "other-comp"), snap.R(1))
+	c.Assert(seq.AddComponentForRevision(snapRev, csi3), IsNil)
+	comps = []*snap.ComponentSideInfo{csi1, csi2, csi3}
+	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
+
+	c.Assert(seq.AddComponentForRevision(snap.R(2), csi3), Equals, sequence.ErrSnapRevNotInSequence)
+}
+
+func (s *sequenceTestSuite) TestRemoveComponentForRevision(c *C) {
+	const snapName = "foo"
+	snapRev := snap.R(1)
+	const compName1 = "comp1"
+	const compName2 = "comp2"
+	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(2))
+	csi2 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName2), snap.R(3))
+
+	ssi := &snap.SideInfo{RealName: snapName,
+		Revision: snap.R(1), SnapID: "some-snap-id"}
+	comps := []*snap.ComponentSideInfo{csi1, csi2}
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(ssi, comps)})
+
+	// component not in sequence point
+	removed := seq.RemoveComponentForRevision(snapRev, naming.NewComponentRef(snapName, "other-comp"))
+	c.Assert(removed, IsNil)
+	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
+
+	// snap revision not in sequence
+	removed = seq.RemoveComponentForRevision(snap.R(2), naming.NewComponentRef(snapName, compName1))
+	c.Assert(removed, IsNil)
+	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
+
+	// component is removed
+	removed = seq.RemoveComponentForRevision(snapRev, naming.NewComponentRef(snapName, compName1))
+	c.Assert(removed, DeepEquals, csi1)
+	c.Assert(seq.Revisions[0].Components, DeepEquals, []*snap.ComponentSideInfo{csi2})
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -21,7 +21,6 @@ package snapstate
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/release"
@@ -215,152 +215,12 @@ const (
 	NotBlocked
 )
 
-// RevisionSideState contains the side information for a snap and related components
-// installed in the system.
-type RevisionSideState struct {
-	Snap       *snap.SideInfo
-	Components []*snap.ComponentSideInfo
-}
-
-// revisionSideInfoMarshal is an ancillary structure used exclusively to
-// help marshaling of RevisionSideInfo.
-type revisionSideInfoMarshal struct {
-	// SideInfo is included for compatibility with older snapd state files
-	*snap.SideInfo
-	CompSideInfo []*snap.ComponentSideInfo `yaml:"components,omitempty" json:"components,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaler interface
-func (bsi RevisionSideState) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&revisionSideInfoMarshal{bsi.Snap, bsi.Components})
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface
-func (bsi *RevisionSideState) UnmarshalJSON(in []byte) error {
-	var aux revisionSideInfoMarshal
-	if err := json.Unmarshal(in, &aux); err != nil {
-		return err
-	}
-	bsi.Snap = aux.SideInfo
-	bsi.Components = aux.CompSideInfo
-	return nil
-}
-
-// FindComponent returns the snap.ComponentSideInfo if cref is found in the sequence point.
-func (rss *RevisionSideState) FindComponent(cref naming.ComponentRef) *snap.ComponentSideInfo {
-	for _, csi := range rss.Components {
-		if csi.Component == cref {
-			return csi
-		}
-	}
-	return nil
-}
-
-// NewRevisionSideInfo creates a RevisionSideInfo from snap and
-// related components side information.
-func NewRevisionSideInfo(snapSideInfo *snap.SideInfo, compSideInfo []*snap.ComponentSideInfo) *RevisionSideState {
-	return &RevisionSideState{Snap: snapSideInfo, Components: compSideInfo}
-}
-
-// SnapSequence is a container for a slice containing revisions of
-// snaps plus related components.
-// TODO add methods to access Revisions (length, copy, append) and
-// use them in handlers.go and snapstate.go.
-type SnapSequence struct {
-	// Revisions contains information for a snap revision and
-	// components SideInfo.
-	Revisions []*RevisionSideState
-}
-
-// MarshalJSON implements the json.Marshaler interface. We override the default
-// so serialization of the SnapState.Sequence field is compatible to what was
-// produced when it was defined as a []*snap.SideInfo. This is also the reason
-// to have SnapSequence.UnmarshalJSON and MarshalJSON/UnmarshalJSON for
-// RevisionSideState.
-func (snapSeq SnapSequence) MarshalJSON() ([]byte, error) {
-	return json.Marshal(snapSeq.Revisions)
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface
-func (snapSeq *SnapSequence) UnmarshalJSON(in []byte) error {
-	aux := []*RevisionSideState{}
-	if err := json.Unmarshal(in, &aux); err != nil {
-		return err
-	}
-	snapSeq.Revisions = aux
-	return nil
-}
-
-// SideInfos returns a slice with all the SideInfos for the snap sequence.
-func (snapSeq SnapSequence) SideInfos() []*snap.SideInfo {
-	sis := make([]*snap.SideInfo, len(snapSeq.Revisions))
-	for i, rev := range snapSeq.Revisions {
-		sis[i] = rev.Snap
-	}
-	return sis
-}
-
-// LastIndex returns the last index of the given revision in snapSeq,
-// or -1 if the revision was not found.
-func (snapSeq *SnapSequence) LastIndex(revision snap.Revision) int {
-	for i := len(snapSeq.Revisions) - 1; i >= 0; i-- {
-		if snapSeq.Revisions[i].Snap.Revision == revision {
-			return i
-		}
-	}
-	return -1
-}
-
-var ErrSnapRevNotInSequence = errors.New("snap is not in the sequence")
-
-// AddComponentForRevision adds a component to the last instance of snapRev in
-// the sequence.
-func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, csi *snap.ComponentSideInfo) error {
-	snapIdx := snapSeq.LastIndex(snapRev)
-	if snapIdx == -1 {
-		return ErrSnapRevNotInSequence
-	}
-	revSt := snapSeq.Revisions[snapIdx]
-
-	if revSt.FindComponent(csi.Component) != nil {
-		// Component already present
-		return nil
-	}
-
-	// Append new component to components of the current snap
-	revSt.Components = append(revSt.Components, csi)
-	return nil
-}
-
-// RemoveComponentForRevision removes the cref component for the last instance
-// of snapRev in the sequence and returns a pointer to it, which might be nil
-// if not found.
-func (snapSeq *SnapSequence) RemoveComponentForRevision(snapRev snap.Revision, cref naming.ComponentRef) (unlinkedComp *snap.ComponentSideInfo) {
-	snapIdx := snapSeq.LastIndex(snapRev)
-	if snapIdx == -1 {
-		return nil
-	}
-
-	revSt := snapSeq.Revisions[snapIdx]
-	leftComp := []*snap.ComponentSideInfo{}
-	for _, csi := range revSt.Components {
-		if csi.Component == cref {
-			unlinkedComp = csi
-			continue
-		}
-		leftComp = append(leftComp, csi)
-	}
-	revSt.Components = leftComp
-	// might be nil
-	return unlinkedComp
-}
-
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
 	SnapType string `json:"type"` // Use Type and SetType
 	// Sequence contains installation side state for a snap revision and
 	// related components.
-	Sequence SnapSequence `json:"sequence"`
+	Sequence sequence.SnapSequence `json:"sequence"`
 
 	// RevertStatus maps revisions to RevertStatus for revisions that
 	// need special handling in Block().

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -1331,7 +1332,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -1514,7 +1515,7 @@ func (s *snapmgrTestSuite) testParallelInstanceInstallRunThrough(c *C, inputFlag
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -1878,7 +1879,7 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "scurries")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(666),
@@ -2043,7 +2044,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
@@ -2207,7 +2208,7 @@ version: 1.0`)
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "mock",
 		Channel:  "",
 		Revision: snap.R(-1),
@@ -2517,7 +2518,7 @@ version: 1.0`)
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(si, nil))
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(si, nil))
 	c.Assert(snapst.LocalRevision().Unset(), Equals, true)
 	c.Assert(snapst.Required, Equals, true)
 }
@@ -2765,7 +2766,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		Channel:  "stable",
 		SnapID:   "core-id",
@@ -2879,7 +2880,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		c.Assert(err, IsNil)
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: "core",
 			SnapID:   "core-id",
 			Channel:  "stable",
@@ -2891,7 +2892,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		c.Assert(err, IsNil)
 		c.Assert(snapst2.Active, Equals, true)
 		c.Assert(snapst2.Sequence.Revisions, HasLen, 1)
-		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: "snap2",
 			SnapID:   "snap2-id",
 			Channel:  "",
@@ -3020,7 +3021,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		Revision: snap.R(1),
 	}, nil))
@@ -3028,7 +3029,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	snapst = snaps["some-snap"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -3793,7 +3794,7 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		SnapID:   "core-id",
 		Revision: snap.R(11),
@@ -3805,7 +3806,7 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 		snapst = snaps[s]
 		c.Assert(snapst, NotNil)
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: s,
 			SnapID:   s + "-id",
 			Channel:  "stable",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -611,12 +612,12 @@ func (s *snapmgrTestSuite) TestSequenceSerialize(c *C) {
 	c.Check(string(marshaled), Equals, `{"type":"","sequence":[{"name":"mysnap","snap-id":"snapid","revision":"7"},{"name":"othersnap","snap-id":"otherid","revision":"11"}],"current":"unset"}`)
 
 	// With components
-	snapst = &snapstate.SnapState{Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{
-		snapstate.NewRevisionSideInfo(si1, []*snap.ComponentSideInfo{
+	snapst = &snapstate.SnapState{Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
+		sequence.NewRevisionSideInfo(si1, []*snap.ComponentSideInfo{
 			snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"),
 				snap.R(7)),
 		}),
-		snapstate.NewRevisionSideInfo(si2, []*snap.ComponentSideInfo{
+		sequence.NewRevisionSideInfo(si2, []*snap.ComponentSideInfo{
 			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"),
 				snap.R(11)),
 			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)),
@@ -1638,12 +1639,12 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),
@@ -1690,12 +1691,12 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlocked(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),
@@ -1946,12 +1947,12 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),
@@ -9587,8 +9588,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsSequences(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}},
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}},
 			},
@@ -9618,8 +9619,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsRefreshHint(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}},
 			},
 		},
@@ -9662,8 +9663,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsOngoingChange(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}},
 			},
 		},
@@ -9715,8 +9716,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsLocalRevisions(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R("x2")}},
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R("x3")}},
 			},
@@ -9749,8 +9750,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsParallelInstalls(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)}},
 			},
 		},
@@ -9774,8 +9775,8 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsKeepsNewDownloads(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}},
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}},
 			},
@@ -9826,8 +9827,8 @@ func (s *snapmgrTestSuite) TestCleanDownloads(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}},
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}},
 			},
@@ -9862,8 +9863,8 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}},
 				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}},
 			},
@@ -9898,58 +9899,4 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 	// revisions in sequence should be kept
 	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
 	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
-}
-
-func (s *snapmgrTestSuite) TestAddComponentForRevision(c *C) {
-	const snapName = "foo"
-	snapRev := snap.R(1)
-	const compName1 = "comp1"
-	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(2))
-	csi2 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(3))
-
-	ssi := &snap.SideInfo{RealName: snapName,
-		Revision: snap.R(1), SnapID: "some-snap-id"}
-	comps := []*snap.ComponentSideInfo{csi1, csi2}
-	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
-		[]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(ssi, comps)})
-	c.Assert(seq.AddComponentForRevision(snapRev, csi1), IsNil)
-	// Not re-appended
-	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
-
-	csi3 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, "other-comp"), snap.R(1))
-	c.Assert(seq.AddComponentForRevision(snapRev, csi3), IsNil)
-	comps = []*snap.ComponentSideInfo{csi1, csi2, csi3}
-	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
-
-	c.Assert(seq.AddComponentForRevision(snap.R(2), csi3), Equals, snapstate.ErrSnapRevNotInSequence)
-}
-
-func (s *snapmgrTestSuite) TestRemoveComponentForRevision(c *C) {
-	const snapName = "foo"
-	snapRev := snap.R(1)
-	const compName1 = "comp1"
-	const compName2 = "comp2"
-	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName1), snap.R(2))
-	csi2 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName2), snap.R(3))
-
-	ssi := &snap.SideInfo{RealName: snapName,
-		Revision: snap.R(1), SnapID: "some-snap-id"}
-	comps := []*snap.ComponentSideInfo{csi1, csi2}
-	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
-		[]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(ssi, comps)})
-
-	// component not in sequence point
-	removed := seq.RemoveComponentForRevision(snapRev, naming.NewComponentRef(snapName, "other-comp"))
-	c.Assert(removed, IsNil)
-	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
-
-	// snap revision not in sequence
-	removed = seq.RemoveComponentForRevision(snap.R(2), naming.NewComponentRef(snapName, compName1))
-	c.Assert(removed, IsNil)
-	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
-
-	// component is removed
-	removed = seq.RemoveComponentForRevision(snapRev, naming.NewComponentRef(snapName, compName1))
-	c.Assert(removed, DeepEquals, csi1)
-	c.Assert(seq.Revisions[0].Components, DeepEquals, []*snap.ComponentSideInfo{csi2})
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -421,7 +422,7 @@ func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 }
 
-func revs(seq []*snapstate.RevisionSideState) []int {
+func revs(seq []*sequence.RevisionSideState) []int {
 	revs := make([]int, len(seq))
 	for i, si := range seq {
 		revs[i] = si.Snap.Revision.N
@@ -840,12 +841,12 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(-42),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "some-channel",
 		SnapID:   "some-snap-id",
@@ -1088,13 +1089,13 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	c.Check(snapst.LastRefreshTime.Equal(now), Equals, true)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1151,13 +1152,13 @@ func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(11))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1443,13 +1444,13 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1772,13 +1773,13 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "18/edge")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "kernel",
 		SnapID:   "kernel-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "kernel",
 		Channel:  "18/edge",
 		SnapID:   "kernel-id",
@@ -2301,7 +2302,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
@@ -2641,7 +2642,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
@@ -2910,7 +2911,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7/stable",
@@ -3020,7 +3021,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Sequence.Revisions, HasLen, 1)
-	c.Check(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+	c.Check(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7",
@@ -8361,13 +8362,13 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -8551,13 +8552,13 @@ func (s *snapmgrTestSuite) TestUpdateGadgetKernelSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -8740,13 +8741,13 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -9004,7 +9005,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -10941,8 +10942,8 @@ func (s *snapmgrTestSuite) TestPreDownloadCleansSnapDownloads(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: snapstate.SnapSequence{
-			Revisions: []*snapstate.RevisionSideState{{Snap: si}},
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{{Snap: si}},
 		},
 		Current: si.Revision,
 	})

--- a/overlord/snapstate/snapstatetest/snapstate.go
+++ b/overlord/snapstate/snapstatetest/snapstate.go
@@ -20,18 +20,18 @@
 package snapstatetest
 
 import (
-	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/snap"
 )
 
-func NewSequenceFromSnapSideInfos(snapSideInfo []*snap.SideInfo) snapstate.SnapSequence {
-	revSis := make([]*snapstate.RevisionSideState, len(snapSideInfo))
+func NewSequenceFromSnapSideInfos(snapSideInfo []*snap.SideInfo) sequence.SnapSequence {
+	revSis := make([]*sequence.RevisionSideState, len(snapSideInfo))
 	for i, si := range snapSideInfo {
-		revSis[i] = snapstate.NewRevisionSideInfo(si, nil)
+		revSis[i] = sequence.NewRevisionSideInfo(si, nil)
 	}
-	return snapstate.SnapSequence{Revisions: revSis}
+	return sequence.SnapSequence{Revisions: revSis}
 }
 
-func NewSequenceFromRevisionSideInfos(revsSideInfo []*snapstate.RevisionSideState) snapstate.SnapSequence {
-	return snapstate.SnapSequence{Revisions: revsSideInfo}
+func NewSequenceFromRevisionSideInfos(revsSideInfo []*sequence.RevisionSideState) sequence.SnapSequence {
+	return sequence.SnapSequence{Revisions: revsSideInfo}
 }


### PR DESCRIPTION
This will allow accessing the sequence in the state without using snapstate.