### PR TITLE
o/devicestate: fix panic when requesting a serial when device-service.access=offline

### DIFF
--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -853,6 +853,35 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialNoReachableDNS(c *C) {
 	s.testDoRequestSerialKeepsRetrying(c, &simulateNoDNSRoundTripper{})
 }
 
+func (s *deviceMgrSerialSuite) TestDoRequestSerialOffline(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	err := tr.Set("pc", "device-service.access", "offline")
+	c.Assert(err, IsNil)
+	tr.Commit()
+
+	s.state.Unlock()
+
+	chg, _ := s.makeRequestChangeWithTransport(c, http.DefaultTransport)
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	// task will appear done, since we don't want to pollute system with retries
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Assert(chg.Err(), IsNil)
+
+	device, err := devicestatetest.Device(s.state)
+	c.Assert(err, IsNil)
+
+	// but the serial will not be there
+	c.Check(device.Serial, Equals, "")
+}
+
 func (s *deviceMgrSerialSuite) testDoRequestSerialKeepsRetrying(c *C, rt http.RoundTripper) {
 	chg, t := s.makeRequestChangeWithTransport(c, rt)
 

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -496,7 +496,7 @@ func submitSerialRequest(t *state.Task, serialRequest string, client *http.Clien
 
 var httputilNewHTTPClient = httputil.NewHTTPClient
 
-var errStoreOffline = errors.New("store is offline")
+var errStoreOffline = errors.New("snap store is marked offline")
 
 func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.PrivateKey, device *auth.DeviceState, tm timings.Measurer) (serial *asserts.Serial, ancillaryBatch *asserts.Batch, err error) {
 	var serialSup serialSetup

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -496,6 +496,8 @@ func submitSerialRequest(t *state.Task, serialRequest string, client *http.Clien
 
 var httputilNewHTTPClient = httputil.NewHTTPClient
 
+var errStoreOffline = errors.New("store is offline")
+
 func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.PrivateKey, device *auth.DeviceState, tm timings.Measurer) (serial *asserts.Serial, ancillaryBatch *asserts.Batch, err error) {
 	var serialSup serialSetup
 	err = t.Get("serial-setup", &serialSup)
@@ -520,8 +522,7 @@ func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.Privat
 	}
 
 	if !shouldRequest {
-		t.Logf("skipping getting serial, store is marked as offline")
-		return nil, nil, nil
+		return nil, nil, errStoreOffline
 	}
 
 	proxyConf := proxyconf.New(st)
@@ -819,8 +820,11 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 		return &state.Retry{After: retryInterval}
 	}
 	if err != nil { // errors & retries
+		if errors.Is(err, errStoreOffline) {
+			t.Logf("skipping getting serial, store is marked as offline")
+			return nil
+		}
 		return err
-
 	}
 
 	// TODO: the accept* helpers put the serial directly in the


### PR DESCRIPTION
This fixes a panic that was reported when requesting a serial when `device-service.access=offline` is set.