### PR TITLE
cmd/snap/inhibit.go: refactor inhibit notification flows

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -259,12 +260,12 @@ func (x *cmdRun) Execute(args []string) error {
 	return x.snapRunApp(snapApp, args)
 }
 
-func maybeWaitWhileInhibited(snapName string) error {
+func maybeWaitWhileInhibited(ctx context.Context, snapName string) error {
 	// If the snap is inhibited from being used then postpone running it until
 	// that condition passes. Inhibition UI can be dismissed by the user, in
 	// which case we don't run the application at all.
 	if features.RefreshAppAwareness.IsEnabled() {
-		return waitWhileInhibited(snapName)
+		return waitWhileInhibited(ctx, snapName)
 	}
 	return nil
 }
@@ -509,7 +510,8 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 	}
 
 	if !app.IsService() {
-		if err := maybeWaitWhileInhibited(snapName); err != nil {
+		// TODO: use signal.NotifyContext as context when snap-run flow is finalized
+		if err := maybeWaitWhileInhibited(context.Background(), snapName); err != nil {
 			return err
 		}
 	}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -238,15 +239,28 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called++
-		return false, nil
+		c.Check(snapName, check.Equals, "snapname")
+		c.Check(ctx, check.NotNil)
+
+		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+		c.Assert(err, check.IsNil)
+		// non-service apps should keep waiting
+		c.Check(cont, check.Equals, false)
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
+		}
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
 	})
 	defer restore()
 
 	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
 	c.Assert(err, check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Check(called, check.Equals, 1)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -277,10 +291,10 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 	defer restorer()
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called = true
-		c.Errorf("WaitInhibitUnlock should not have been called")
-		return false, nil
+		c.Errorf("runinhibit.WaitWhileInhibited should not have been called")
+		return nil, nil
 	})
 	defer restore()
 
@@ -323,10 +337,10 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called = true
-		c.Errorf("WaitInhibitUnlock should not have been called")
-		return false, nil
+		c.Errorf("runinhibit.WaitWhileInhibited should not have been called")
+		return nil, nil
 	})
 	defer restore()
 
@@ -1831,106 +1845,191 @@ func (s *RunSuite) TestRunGdbserverNoGdbserver(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "please install gdbserver on your system")
 }
 
-func (s *RunSuite) TestWaitInhibitUnlock(c *check.C) {
-	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		called++
-		if called < 5 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
-		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
-	})
-	defer restore()
-
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintNotInhibited)
-	c.Assert(err, check.IsNil)
-	c.Check(notInhibited, check.Equals, true)
-	c.Check(called, check.Equals, 5)
+func openHintFileLock(snapName string) (*osutil.FileLock, error) {
+	return osutil.NewFileLockWithMode(runinhibit.HintFile(snapName), 0644)
 }
 
-func (s *RunSuite) TestWaitInhibitUnlockWaitsForSpecificHint(c *check.C) {
-	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		called++
-		if called < 5 {
-			return runinhibit.HintInhibitedGateRefresh, runinhibit.InhibitInfo{}, nil
-		}
-		return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
-	})
-	defer restore()
-
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintInhibitedForRefresh)
+func checkHintFileNotLocked(c *check.C, snapName string) {
+	flock, err := openHintFileLock(snapName)
 	c.Assert(err, check.IsNil)
-	c.Check(notInhibited, check.Equals, false)
-	c.Check(called, check.Equals, 5)
+	c.Check(flock.TryLock(), check.IsNil)
+	flock.Close()
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
+
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called++
-		if called < 2 {
-			return runinhibit.HintInhibitedGateRefresh, runinhibit.InhibitInfo{}, nil
+
+		c.Check(snapName, check.Equals, "some-snap")
+		c.Check(ctx, check.NotNil)
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedGateRefresh, nil)
+			c.Assert(err, check.IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, check.Equals, false)
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
+		}
+
+		flock, err := openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
 	})
 	defer restore()
 
 	meter := &progresstest.Meter{}
 	defer progress.MockMeter(meter)()
 
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
+	c.Check(called, check.Equals, 1)
 
 	c.Check(meter.Values, check.HasLen, 0)
 	c.Check(meter.Written, check.HasLen, 0)
 	c.Check(meter.Finishes, check.Equals, 0)
 	c.Check(meter.Labels, check.HasLen, 0)
 	c.Check(meter.Labels, check.HasLen, 0)
+
+	// lock must be released
+	checkHintFileNotLocked(c, "some-snap")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
+
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called++
-		if called < 2 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+
+		c.Check(snapName, check.Equals, "some-snap")
+		cont, err := inhibited(ctx, runinhibit.HintInhibitedGateRefresh, nil)
+		c.Assert(err, check.IsNil)
+		// non-service apps should keep waiting
+		c.Check(cont, check.Equals, false)
+		cont, err = inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+		c.Assert(err, check.IsNil)
+		// non-service apps should keep waiting
+		c.Check(cont, check.Equals, false)
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
 	})
 	defer restore()
 
-	meter := &progresstest.Meter{}
-	defer progress.MockMeter(meter)()
+	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
+	c.Check(called, check.Equals, 1)
+
+	c.Check(s.Stdout(), check.Equals, "snap package \"some-snap\" is being refreshed, please wait\n")
+
+	// lock must be released
+	checkHintFileNotLocked(c, "some-snap")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedDesktopIntegrationFlow(c *check.C) {
+	_, r := logger.MockLogger()
+	defer r()
+
+	var dbusCalled int
+	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
+		dbusCalled++
+		return []*dbus.Message{makeDBusMethodAvailableMessage(c, msg)}, nil
+	})
+	c.Assert(err, check.IsNil)
+
+	restore := dbusutil.MockOnlySessionBusAvailable(conn)
+	defer restore()
+
+	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
+	defer restoreIsGraphicalSession()
+
+	var pendingRefreshNotificationCalled int
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		pendingRefreshNotificationCalled++
+		c.Error("this should never be reached")
+		return nil
+	})
+	defer restorePendingRefreshNotification()
+
+	var finishRefreshNotificationCalled int
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		finishRefreshNotificationCalled++
+		c.Error("this should never be reached")
+		return nil
+	})
+	defer restoreFinishRefreshNotification()
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
 
-	c.Check(s.Stdout(), check.Equals, "snap package cannot be used now: gate-refresh\n")
-	c.Check(meter.Values, check.HasLen, 0)
-	c.Check(meter.Written, check.HasLen, 0)
-	c.Check(meter.Finishes, check.Equals, 1)
-	c.Check(meter.Labels, check.DeepEquals, []string{"please wait..."})
+	var called int
+	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		called++
+
+		c.Check(snapName, check.Equals, "some-snap")
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+			c.Assert(err, check.IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, check.Equals, false)
+		}
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
+		}
+
+		flock, err := openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
+	})
+	defer restore()
+
+	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
+	c.Check(called, check.Equals, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+
+	// snapd-desktop-integration snap monitors inhibit file
+	// flow.Finish is a no-op, so it's only called once
+	c.Check(dbusCalled, check.Equals, 1)
+	// session flow was not called
+	c.Check(pendingRefreshNotificationCalled, check.Equals, 0)
+	c.Check(finishRefreshNotificationCalled, check.Equals, 0)
+
+	// lock must be released
+	checkHintFileNotLocked(c, "some-snap")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	_, r := logger.MockLogger()
 	defer r()
 
+	originalCtx := context.Background()
+
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		// check context is propagated properly
+		c.Assert(ctx, check.Equals, originalCtx)
+		c.Check(ctx.Err(), check.IsNil)
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+	var pendingRefreshNotificationCalled int
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		pendingRefreshNotificationCalled++
+		// check context is propagated properly
+		c.Assert(ctx, check.Equals, originalCtx)
+		c.Check(ctx.Err(), check.IsNil)
 		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
 			InstanceName:  "some-snap",
 			TimeRemaining: 0,
@@ -1939,7 +2038,12 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	})
 	defer restorePendingRefreshNotification()
 
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+	var finishRefreshNotificationCalled int
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		finishRefreshNotificationCalled++
+		// check context is propagated properly
+		c.Assert(ctx, check.Equals, originalCtx)
+		c.Check(ctx.Err(), check.IsNil)
 		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.FinishedSnapRefreshInfo{
 			InstanceName: "some-snap",
 		})
@@ -1947,22 +2051,39 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	})
 	defer restoreFinishRefreshNotification()
 
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
+
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		c.Check(snapName, check.Equals, "some-snap")
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		called++
-		if called < 2 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+
+		c.Check(snapName, check.Equals, "some-snap")
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+			c.Assert(err, check.IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, check.Equals, false)
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
+		}
+
+		flock, err := openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
 	})
 	defer restore()
 
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Assert(snaprun.WaitWhileInhibited(originalCtx, "some-snap"), check.IsNil)
+	c.Check(called, check.Equals, 1)
 	c.Check(s.Stdout(), check.Equals, "")
+
+	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
+	c.Check(finishRefreshNotificationCalled, check.Equals, 1)
+
+	// lock must be released
+	checkHintFileNotLocked(c, "some-snap")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
@@ -1972,13 +2093,15 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+	var pendingRefreshNotificationCalled int
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		pendingRefreshNotificationCalled++
 		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
 			InstanceName:  "some-snap",
 			TimeRemaining: 0,
@@ -1987,15 +2110,27 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
 	})
 	defer restorePendingRefreshNotification()
 
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		c.Errorf("this should never be reached")
+		return nil
+	})
+	defer restoreFinishRefreshNotification()
+
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		c.Check(snapName, check.Equals, "some-snap")
-		return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+
+		_, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+		c.Assert(err, check.ErrorMatches, "boom")
+		return nil, err
 	})
 	defer restore()
 
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.ErrorMatches, "boom")
+	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.ErrorMatches, "boom")
+
+	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *check.C) {
@@ -2005,13 +2140,15 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+	var pendingRefreshNotificationCalled int
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		pendingRefreshNotificationCalled++
 		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
 			InstanceName:  "some-snap",
 			TimeRemaining: 0,
@@ -2020,7 +2157,9 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 	})
 	defer restorePendingRefreshNotification()
 
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+	var finishRefreshNotificationCalled int
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		finishRefreshNotificationCalled++
 		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.FinishedSnapRefreshInfo{
 			InstanceName: "some-snap",
 		})
@@ -2030,18 +2169,56 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	n := 0
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		c.Check(snapName, check.Equals, "some-snap")
-		n++
-		if n == 1 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+
+		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
+		c.Assert(err, check.IsNil)
+		// non-service apps should keep waiting
+		c.Check(cont, check.Equals, false)
+		if notInhibited != nil {
+			c.Errorf("this should never be reached")
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		return flock, nil
 	})
 	defer restore()
 
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.ErrorMatches, "boom")
+	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.ErrorMatches, "boom")
+
+	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
+	c.Check(finishRefreshNotificationCalled, check.Equals, 1)
+
+	// lock must be released
+	checkHintFileNotLocked(c, "some-snap")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *check.C) {
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
+
+	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
+	defer restoreIsGraphicalSession()
+
+	originalCtx, cancel := context.WithCancel(context.Background())
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
+		c.Check(snapName, check.Equals, "some-snap")
+		// check context is propagated properly
+		c.Assert(ctx, check.Equals, originalCtx)
+		c.Check(ctx.Err(), check.IsNil)
+		// cancel context to trigger cancellation error
+		cancel()
+		return true
+	})
+	defer restoreTryNotifyRefresh()
+
+	err := snaprun.WaitWhileInhibited(originalCtx, "some-snap")
+	c.Assert(err, check.ErrorMatches, "context canceled")
+	c.Assert(errors.Is(err, context.Canceled), check.Equals, true)
+	c.Assert(errors.Is(originalCtx.Err(), context.Canceled), check.Equals, true)
 }
 
 func (s *RunSuite) TestCreateSnapDirPermissions(c *check.C) {
@@ -2140,9 +2317,8 @@ func (s *RunSuite) TestDesktopIntegrationNoDBus(c *check.C) {
 	restore := dbusutil.MockConnections(noDBus, noDBus)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("Test")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "Test")
 	c.Assert(sent, check.Equals, false)
-	c.Assert(err, check.IsNil)
 }
 
 func makeDBusMethodNotAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
@@ -2169,9 +2345,8 @@ func (s *RunSuite) TestDesktopIntegrationDBusAvailableNoMethod(c *check.C) {
 	restore := dbusutil.MockOnlySessionBusAvailable(conn)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "some-snap")
 	c.Assert(sent, check.Equals, false)
-	c.Assert(err, check.IsNil)
 }
 
 func makeDBusMethodAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
@@ -2185,9 +2360,9 @@ func makeDBusMethodAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message
 		dbus.FieldMember:      dbus.MakeVariant("ApplicationIsBeingRefreshed"),
 		dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("", "", make(map[string]dbus.Variant))),
 	})
-	c.Check(msg.Body[0], check.Equals, "SnapTest")
+	c.Check(msg.Body[0], check.Equals, "some-snap")
 	param2 := fmt.Sprintf("%s", msg.Body[1])
-	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/SnapTest.lock"), check.Equals, true)
+	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/some-snap.lock"), check.Equals, true)
 	return &dbus.Message{
 		Type: dbus.TypeMethodReply,
 		Headers: map[dbus.HeaderField]dbus.Variant{
@@ -2209,7 +2384,6 @@ func (s *RunSuite) TestDesktopIntegrationDBusAvailableMethodWorks(c *check.C) {
 	restore := dbusutil.MockOnlySessionBusAvailable(conn)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "some-snap")
 	c.Assert(sent, check.Equals, true)
-	c.Assert(err, check.IsNil)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/user"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/image"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/selinux"
 	"github.com/snapcore/snapd/seed/seedwriter"
@@ -149,10 +151,9 @@ var (
 	MaybePrintCohortKey                           = (*infoWriter).maybePrintCohortKey
 	MaybePrintHealth                              = (*infoWriter).maybePrintHealth
 	MaybePrintRefreshInfo                         = (*infoWriter).maybePrintRefreshInfo
-	WaitInhibitUnlock                             = waitInhibitUnlock
 	WaitWhileInhibited                            = waitWhileInhibited
-	IsLocked                                      = isLocked
 	TryNotifyRefreshViaSnapDesktopIntegrationFlow = tryNotifyRefreshViaSnapDesktopIntegrationFlow
+	NewInhibitionFlow                             = newInhibitionFlow
 )
 
 func MockPollTime(d time.Duration) (restore func()) {
@@ -420,20 +421,10 @@ func MockOsChmod(f func(string, os.FileMode) error) (restore func()) {
 	}
 }
 
-func MockWaitInhibitUnlock(f func(snapName string, waitFor runinhibit.Hint) (bool, error)) (restore func()) {
-	old := waitInhibitUnlock
-	waitInhibitUnlock = f
-	return func() {
-		waitInhibitUnlock = old
-	}
-}
-
-func MockIsLocked(f func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error)) (restore func()) {
-	old := isLocked
-	isLocked = f
-	return func() {
-		isLocked = old
-	}
+func MockWaitWhileInhibited(f func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error)) (restore func()) {
+	restore = testutil.Backup(&runinhibitWaitWhileInhibited)
+	runinhibitWaitWhileInhibited = f
+	return restore
 }
 
 func MockIsGraphicalSession(graphical bool) (restore func()) {
@@ -446,7 +437,7 @@ func MockIsGraphicalSession(graphical bool) (restore func()) {
 	}
 }
 
-func MockPendingRefreshNotification(f func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error) (restore func()) {
+func MockPendingRefreshNotification(f func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error) (restore func()) {
 	old := pendingRefreshNotification
 	pendingRefreshNotification = f
 	return func() {
@@ -454,7 +445,7 @@ func MockPendingRefreshNotification(f func(refreshInfo *usersessionclient.Pendin
 	}
 }
 
-func MockFinishRefreshNotification(f func(refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error) (restore func()) {
+func MockFinishRefreshNotification(f func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error) (restore func()) {
 	old := finishRefreshNotification
 	finishRefreshNotification = f
 	return func() {
@@ -462,7 +453,7 @@ func MockFinishRefreshNotification(f func(refreshInfo *usersessionclient.Finishe
 	}
 }
 
-func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(snapName string) (bool, error)) (restore func()) {
+func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(ctx context.Context, snapName string) bool) (restore func()) {
 	old := tryNotifyRefreshViaSnapDesktopIntegrationFlow
 	tryNotifyRefreshViaSnapDesktopIntegrationFlow = f
 	return func() {

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -30,53 +30,129 @@ import (
 	"github.com/snapcore/snapd/dbusutil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/usersession/client"
 )
 
-func waitWhileInhibited(snapName string) error {
-	hint, _, err := runinhibit.IsLocked(snapName)
-	if err != nil {
-		return err
-	}
-	if hint == runinhibit.HintNotInhibited {
-		return nil
+var runinhibitWaitWhileInhibited = runinhibit.WaitWhileInhibited
+
+func waitWhileInhibited(ctx context.Context, snapName string) error {
+	flow := newInhibitionFlow(snapName)
+	notified := false
+	inhibited := func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error) {
+		if !notified {
+			// wait for HintInhibitedForRefresh set by gate-auto-refresh hook handler
+			// when it has finished; the hook starts with HintInhibitedGateRefresh lock
+			// and then either unlocks it or changes to HintInhibitedForRefresh (see
+			// gateAutoRefreshHookHandler in hooks.go).
+			if hint != runinhibit.HintInhibitedForRefresh {
+				return false, nil
+			}
+			// Start notification flow.
+			if err := flow.StartInhibitionNotification(ctx); err != nil {
+				return true, err
+			}
+			// Make sure we call notification flow only once.
+			notified = true
+		}
+		return false, nil
 	}
 
-	// wait for HintInhibitedForRefresh set by gate-auto-refresh hook handler
-	// when it has finished; the hook starts with HintInhibitedGateRefresh lock
-	// and then either unlocks it or changes to HintInhibitedForRefresh (see
-	// gateAutoRefreshHookHandler in hooks.go).
-	// waitInhibitUnlock will return also on HintNotInhibited.
-	notInhibited, err := waitInhibitUnlock(snapName, runinhibit.HintInhibitedForRefresh)
+	hintFlock, err := runinhibitWaitWhileInhibited(ctx, snapName, nil, inhibited, 500*time.Millisecond)
 	if err != nil {
+		// It is fine to return an error here without finishing the notification
+		// flow because we either failed because of it or before it, so it
+		// should not have started in the first place.
 		return err
 	}
-	if notInhibited {
-		return nil
+
+	// XXX: closing as we don't need it for now, this lock will be used in a later iteration
+	if hintFlock != nil {
+		hintFlock.Close()
 	}
 
-	if isGraphicalSession() {
-		notifiedDesktopIntegration, err := tryNotifyRefreshViaSnapDesktopIntegrationFlow(snapName)
-		if err != nil {
+	if notified {
+		if err := flow.FinishInhibitionNotification(ctx); err != nil {
 			return err
 		}
-		if notifiedDesktopIntegration {
-			return nil
-		}
-		return graphicalSessionFlow(snapName, hint)
 	}
-	// terminal and headless
-	return textFlow(snapName, hint)
+
+	return nil
 }
 
-func inhibitMessage(snapName string, hint runinhibit.Hint) string {
-	switch hint {
-	case runinhibit.HintInhibitedForRefresh:
-		return fmt.Sprintf(i18n.G("snap package %q is being refreshed, please wait"), snapName)
-	default:
-		return fmt.Sprintf(i18n.G("snap package cannot be used now: %s"), string(hint))
+type inhibitionFlow interface {
+	StartInhibitionNotification(ctx context.Context) error
+	FinishInhibitionNotification(ctx context.Context) error
+}
+
+var newInhibitionFlow = func(instanceName string) inhibitionFlow {
+	if isGraphicalSession() {
+		return &graphicalFlow{instanceName: instanceName}
 	}
+	return &textFlow{instanceName: instanceName}
+}
+
+type textFlow struct {
+	instanceName string
+}
+
+func (tf *textFlow) StartInhibitionNotification(ctx context.Context) error {
+	_, err := fmt.Fprintf(Stdout, i18n.G("snap package %q is being refreshed, please wait\n"), tf.instanceName)
+	// TODO: add proper progress spinner
+	return err
+}
+
+func (tf *textFlow) FinishInhibitionNotification(ctx context.Context) error {
+	return nil
+}
+
+type graphicalFlow struct {
+	instanceName string
+
+	notifiedDesktopIntegration bool
+}
+
+func (gf *graphicalFlow) StartInhibitionNotification(ctx context.Context) error {
+	gf.notifiedDesktopIntegration = tryNotifyRefreshViaSnapDesktopIntegrationFlow(ctx, gf.instanceName)
+	if gf.notifiedDesktopIntegration {
+		return nil
+	}
+
+	// unable to use snapd-desktop-integration, let's fall back to graphical session flow
+	refreshInfo := client.PendingSnapRefreshInfo{
+		InstanceName: gf.instanceName,
+		// remaining time = 0 results in "Snap .. is refreshing now" message from
+		// usersession agent.
+		TimeRemaining: 0,
+	}
+	return pendingRefreshNotification(ctx, &refreshInfo)
+}
+
+func (gf *graphicalFlow) FinishInhibitionNotification(ctx context.Context) error {
+	if gf.notifiedDesktopIntegration {
+		// snapd-desktop-integration detects inhibit unlock itself, do nothing
+		return nil
+	}
+
+	// finish graphical session flow
+	finishRefreshInfo := client.FinishedSnapRefreshInfo{InstanceName: gf.instanceName}
+	return finishRefreshNotification(ctx, &finishRefreshInfo)
+}
+
+var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(ctx context.Context, snapName string) (notified bool) {
+	// Check if Snapd-Desktop-Integration is available
+	conn, err := dbusutil.SessionBus()
+	if err != nil {
+		logger.Noticef("unable to connect dbus session: %v", err)
+		return false
+	}
+	obj := conn.Object("io.snapcraft.SnapDesktopIntegration", "/io/snapcraft/SnapDesktopIntegration")
+	extraParams := make(map[string]dbus.Variant)
+	err = obj.CallWithContext(ctx, "io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, runinhibit.HintFile(snapName), extraParams).Store()
+	if err != nil {
+		logger.Noticef("unable to successfully call io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed: %v", err)
+		return false
+	}
+	return true
 }
 
 var isGraphicalSession = func() bool {
@@ -85,92 +161,18 @@ var isGraphicalSession = func() bool {
 	return false
 }
 
-var pendingRefreshNotification = func(refreshInfo *client.PendingSnapRefreshInfo) error {
+var pendingRefreshNotification = func(ctx context.Context, refreshInfo *client.PendingSnapRefreshInfo) error {
 	userclient := client.NewForUids(os.Getuid())
-	if err := userclient.PendingRefreshNotification(context.TODO(), refreshInfo); err != nil {
+	if err := userclient.PendingRefreshNotification(ctx, refreshInfo); err != nil {
 		return err
 	}
 	return nil
 }
 
-var finishRefreshNotification = func(refreshInfo *client.FinishedSnapRefreshInfo) error {
+var finishRefreshNotification = func(ctx context.Context, refreshInfo *client.FinishedSnapRefreshInfo) error {
 	userclient := client.NewForUids(os.Getuid())
-	if err := userclient.FinishRefreshNotification(context.TODO(), refreshInfo); err != nil {
+	if err := userclient.FinishRefreshNotification(ctx, refreshInfo); err != nil {
 		return err
 	}
 	return nil
-}
-
-var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string) (bool, error) {
-	// Check if Snapd-Desktop-Integration is available
-	conn, err := dbusutil.SessionBus()
-	if err != nil {
-		logger.Noticef("unable to connect dbus session: %v", err)
-		return false, nil
-	}
-	obj := conn.Object("io.snapcraft.SnapDesktopIntegration", "/io/snapcraft/SnapDesktopIntegration")
-	extraParams := make(map[string]dbus.Variant)
-	err = obj.Call("io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, runinhibit.HintFile(snapName), extraParams).Store()
-	if err != nil {
-		logger.Noticef("unable to successfully call io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed: %v", err)
-		return false, nil
-	}
-	if _, err := waitInhibitUnlock(snapName, runinhibit.HintNotInhibited); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func graphicalSessionFlow(snapName string, hint runinhibit.Hint) error {
-	refreshInfo := client.PendingSnapRefreshInfo{
-		InstanceName: snapName,
-		// Remaining time = 0 results in "Snap .. is refreshing now" message from
-		// usersession agent.
-		TimeRemaining: 0,
-	}
-
-	if err := pendingRefreshNotification(&refreshInfo); err != nil {
-		return err
-	}
-	if _, err := waitInhibitUnlock(snapName, runinhibit.HintNotInhibited); err != nil {
-		return err
-	}
-
-	finishRefreshInfo := client.FinishedSnapRefreshInfo{InstanceName: snapName}
-	return finishRefreshNotification(&finishRefreshInfo)
-}
-
-func textFlow(snapName string, hint runinhibit.Hint) error {
-	fmt.Fprintf(Stdout, "%s\n", inhibitMessage(snapName, hint))
-	pb := progress.MakeProgressBar(Stdout)
-	pb.Spin(i18n.G("please wait..."))
-	_, err := waitInhibitUnlock(snapName, runinhibit.HintNotInhibited)
-	pb.Finished()
-	return err
-}
-
-var isLocked = runinhibit.IsLocked
-
-// waitInhibitUnlock waits until the runinhibit lock hint has a specific waitFor value
-// or isn't inhibited anymore.
-var waitInhibitUnlock = func(snapName string, waitFor runinhibit.Hint) (notInhibited bool, err error) {
-	// Every 0.5s check if the inhibition file is still present.
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			// Half a second has elapsed, let's check again.
-			hint, _, err := isLocked(snapName)
-			if err != nil {
-				return false, err
-			}
-			if hint == runinhibit.HintNotInhibited {
-				return true, nil
-			}
-			if hint == waitFor {
-				return false, nil
-			}
-		}
-	}
 }

--- a/cmd/snaplock/runinhibit/export_test.go
+++ b/cmd/snaplock/runinhibit/export_test.go
@@ -3,16 +3,17 @@ package runinhibit
 import "time"
 
 type fakeTicker struct {
-	wait func()
+	wait func() <-chan time.Time
 }
 
-func (t *fakeTicker) Wait() {
+func (t *fakeTicker) Wait() <-chan time.Time {
 	if t.wait != nil {
-		t.wait()
+		return t.wait()
 	}
+	return nil
 }
 
-func MockNewTicker(wait func()) (restore func()) {
+func MockNewTicker(wait func() <-chan time.Time) (restore func()) {
 	old := newTicker
 	newTicker = func(interval time.Duration) ticker {
 		return &fakeTicker{wait}


### PR DESCRIPTION
This work extracts inhibition notification flows into separate structs to avoid entanglement with current inhibition waiting logic.

This PR is a building block for https://github.com/snapcore/snapd/pull/13411 in an attempt to split it into smaller chunks.
This will be later used in "snap run" to make it aware of inhibited snaps.