### PR TITLE
cmd/snaplock/runinhibit: fix nil dereference in WaitWhileInhibited

### DIFF
--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -324,9 +324,11 @@ var WaitWhileInhibited = func(snapName string, notInhibited func() error, inhibi
 		flock, err = osutil.OpenExistingLockForReading(HintFile(snapName))
 		// We must return flock alongside errors so that cleanup defer can close it.
 		if os.IsNotExist(err) {
-			if err := notInhibited(); err != nil {
-				// No flock opened, it is okay to return nil here
-				return nil, err
+			if notInhibited != nil {
+				if err := notInhibited(); err != nil {
+					// No flock opened, it is okay to return nil here
+					return nil, err
+				}
 			}
 			return nil, nil
 		}

--- a/cmd/snaplock/runinhibit/inhibit_test.go
+++ b/cmd/snaplock/runinhibit/inhibit_test.go
@@ -386,3 +386,20 @@ func (s *runInhibitSuite) TestWaitWhileInhibitedHintFileNotExist(c *C) {
 	c.Check(notInhibitedCalled, Equals, 1)
 	c.Check(inhibitedCalled, Equals, 0)
 }
+
+func (s *runInhibitSuite) TestWaitWhileInhibitedHintFileNotExistNilCallback(c *C) {
+	c.Assert(os.RemoveAll(runinhibit.HintFile("pkg")), IsNil)
+
+	inhibited := func(hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error) {
+		c.Error("this should never be called")
+		return false, nil
+	}
+
+	// check that we don't panic when notInhibited is nil
+	flock, err := runinhibit.WaitWhileInhibited("pkg", nil, inhibited, 1*time.Millisecond)
+	c.Assert(err, IsNil)
+	// hint file still does not exist
+	c.Check(runinhibit.HintFile("pkg"), testutil.FileAbsent)
+	// flock is nil because lock file does not exist
+	c.Check(flock, IsNil)
+}


### PR DESCRIPTION
This fixes a nil dereference bug that was introduced in https://github.com/snapcore/snapd/pull/13435. Nothing is  breaking because no part of snapd is using WaitWhileInhibited yet.