### PR TITLE
cmd/snap-bootstrap: relax fde-setup restrictions for single-boot install

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -249,7 +249,7 @@ func canInstallAndRunAtOnce(mst *initramfsMountsState) (bool, error) {
 	// TODO: when install in initrd is finished and it is tested
 	// without fde hook, turn the return into...
 	// return true, nil
-	return kernelHasFdeSetup, nil
+	return true, nil
 }
 
 func readSnapInfo(sysSnaps map[snap.Type]*seed.Snap, snapType snap.Type) (*snap.Info, error) {


### PR DESCRIPTION
This is a draft to see what nested tests break when relaxing single-boot install restrictions.