### PR TITLE
aspects: pre-check writes for schema mismatches

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -128,7 +128,37 @@ type DataBag interface {
 // be committed.
 type Schema interface {
 	Validate(data []byte) error
+
+	// SchemaAt returns the schemas (e.g., string, int, etc) that may be at the
+	// provided path. If the path cannot be followed, an error is returned.
+	SchemaAt(path []string) ([]Schema, error)
+
+	// Type returns the SchemaType corresponding to the Schema.
+	Type() SchemaType
 }
+
+type SchemaType uint
+
+func (v SchemaType) String() string {
+	if int(v) >= len(typeStrings) {
+		panic("unknown schema type")
+	}
+
+	return typeStrings[v]
+}
+
+const (
+	Int SchemaType = iota
+	Number
+	String
+	Bool
+	Map
+	Array
+	Any
+	Alt
+)
+
+var typeStrings = [...]string{"int", "number", "string", "bool", "map", "array", "any", "alt"}
 
 // Bundle holds a series of related aspects.
 type Bundle struct {
@@ -1002,4 +1032,13 @@ func (s JSONSchema) Validate(jsonData []byte) error {
 	// the top-level is always an object
 	var data map[string]json.RawMessage
 	return json.Unmarshal(jsonData, &data)
+}
+
+// SchemaAt always returns the JSONSchema.
+func (v JSONSchema) SchemaAt(path []string) ([]Schema, error) {
+	return []Schema{v}, nil
+}
+
+func (v JSONSchema) Type() SchemaType {
+	return Any
 }

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -115,6 +115,14 @@ func (f *failingSchema) Validate([]byte) error {
 	return f.err
 }
 
+func (f *failingSchema) SchemaAt(path []string) ([]aspects.Schema, error) {
+	return []aspects.Schema{f}, nil
+}
+
+func (f *failingSchema) Type() aspects.SchemaType {
+	return aspects.Any
+}
+
 func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {
 	databag := aspects.NewJSONDataBag()
 	witness := &witnessReadWriter{bag: databag}


### PR DESCRIPTION
Add a TypeAtPath function to the schema interface that returns the schema types that can be stored at that path. Then use that for a pre-write check that compares the allowed types at the storage paths of matching rules. If the paths require different types, fail early. TypeAtPath could also be used in the future to validate that the aspect-bundle assertion and its schema make sense (i.e., no writable path defines constraint that can't be met).