### PR TITLE
s/apparmor/notify/listener: fix concurrency test on slow single-core machines

### DIFF
--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -122,6 +122,10 @@ func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte,
 	return recvChanRW, sendChanRW, restore
 }
 
+func (l *Listener) Dead() <-chan struct{} {
+	return l.tomb.Dead()
+}
+
 func (l *Listener) Dying() <-chan struct{} {
 	return l.tomb.Dying()
 }


### PR DESCRIPTION
Thanks @ZeyadYasser for spotting the failure on https://github.com/snapcore/snapd/actions/runs/7486097781/job/20376253469?pr=13469
