### PR TITLE
o/snapstate: add component type to sequence points and ComponentSetup

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -486,7 +486,7 @@ version: %s
 	var snapst snapstate.SnapState
 	snapstate.Get(st, instanceName, &snapst)
 	snapst.Active = active
-	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(&snapInfo.SideInfo, nil))
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideState(&snapInfo.SideInfo, nil))
 	snapst.Current = snapInfo.SideInfo.Revision
 	snapst.TrackingChannel = "stable"
 	snapst.InstanceKey = instanceKey

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -380,7 +380,7 @@ func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi, nil)}),
+				sequence.NewRevisionSideState(ssi, nil)}),
 		Current: snap.R(1),
 	})
 	st.Unlock()
@@ -416,7 +416,7 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi, nil)}),
+				sequence.NewRevisionSideState(ssi, nil)}),
 		Current: snap.R(1),
 	})
 	st.Unlock()

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -67,7 +67,7 @@ func (s *snapFileSuite) TestGetFile(c *check.C) {
 				sideInfo := &snap.SideInfo{Revision: snap.R(-1), RealName: "foo"}
 				snapst.Active = scen.active
 				snapst.Current = sideInfo.Revision
-				snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(sideInfo, nil))
+				snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideState(sideInfo, nil))
 				if scen.try {
 					snapst.TryMode = true
 				}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2131,7 +2131,7 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, snapInfo.InstanceName(), &snapst)
 	c.Assert(err, IsNil)
-	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(sideInfo, nil))
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideState(sideInfo, nil))
 	snapstate.Set(s.state, snapInfo.InstanceName(), &snapst)
 
 	return snapInfo

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -141,8 +141,8 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
-			sequence.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(osSI1, nil),
+			sequence.NewRevisionSideState(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 
@@ -151,8 +151,8 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI1, nil),
-			sequence.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(kernelSI1, nil),
+			sequence.NewRevisionSideState(kernelSI2, nil)}),
 		Current: snap.R(2),
 	})
 
@@ -278,7 +278,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(kernelSI2, nil)}),
 		Current:  snap.R(2),
 	})
 
@@ -287,8 +287,8 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
-			sequence.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(osSI1, nil),
+			sequence.NewRevisionSideState(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 	bs.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/core/1")
@@ -560,8 +560,8 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(kernelSI1, nil),
-			sequence.NewRevisionSideInfo(kernelSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(kernelSI1, nil),
+			sequence.NewRevisionSideState(kernelSI2, nil)}),
 		Current: snap.R(2),
 	})
 	// we have core22 and current is r2
@@ -572,8 +572,8 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "core22", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(osSI1, nil),
-			sequence.NewRevisionSideInfo(osSI2, nil)}),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{sequence.NewRevisionSideState(osSI1, nil),
+			sequence.NewRevisionSideState(osSI2, nil)}),
 		Current: snap.R(2),
 	})
 	// now pretend that for whatever reason the modeenv reports that

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -87,6 +87,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	}
 	compSetup := &ComponentSetup{
 		CompSideInfo: csi,
+		CompType:     compInfo.Type,
 		CompPath:     path,
 	}
 	// The file passed around is temporary, make sure it gets removed.

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -153,7 +153,7 @@ func setStateWithOneSnap(st *state.State, snapName string, snapRev snap.Revision
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi, nil)}),
+				sequence.NewRevisionSideState(ssi, nil)}),
 		Current: snapRev,
 	})
 }
@@ -173,7 +173,7 @@ func setStateWithComponents(st *state.State, snapName string,
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi, comps)}),
+				sequence.NewRevisionSideState(ssi, comps)}),
 		Current: snapRev,
 	})
 }
@@ -268,7 +268,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathForParallelInstall(c *C) {
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi, nil)}),
+				sequence.NewRevisionSideState(ssi, nil)}),
 		Current:     snapRev,
 		InstanceKey: snapKey,
 	})
@@ -359,8 +359,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresentDiffSnapRe
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi1, nil),
-				sequence.NewRevisionSideInfo(ssi2,
+				sequence.NewRevisionSideState(ssi1, nil),
+				sequence.NewRevisionSideState(ssi2,
 					[]*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
 			}),
 		Current: snapRev1,
@@ -420,7 +420,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathSnapNotActive(c *C) {
 		Active: false,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi,
+				sequence.NewRevisionSideState(ssi,
 					[]*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)})}),
 		Current: snapRev,
 	})

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -161,11 +161,12 @@ func setStateWithOneSnap(st *state.State, snapName string, snapRev snap.Revision
 func setStateWithOneComponent(st *state.State, snapName string,
 	snapRev snap.Revision, compName string, compRev snap.Revision) {
 	csi := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), compRev)
-	setStateWithComponents(st, snapName, snapRev, []*snap.ComponentSideInfo{csi})
+	setStateWithComponents(st, snapName, snapRev,
+		[]*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)})
 }
 
 func setStateWithComponents(st *state.State, snapName string,
-	snapRev snap.Revision, comps []*snap.ComponentSideInfo) {
+	snapRev snap.Revision, comps []*sequence.ComponentState) {
 	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev,
 		SnapID: "some-snap-id"}
 	snapstate.Set(st, snapName, &snapstate.SnapState{
@@ -360,7 +361,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresentDiffSnapRe
 			[]*sequence.RevisionSideState{
 				sequence.NewRevisionSideInfo(ssi1, nil),
 				sequence.NewRevisionSideInfo(ssi2,
-					[]*snap.ComponentSideInfo{csi}),
+					[]*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
 			}),
 		Current: snapRev1,
 	})
@@ -420,7 +421,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathSnapNotActive(c *C) {
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
 				sequence.NewRevisionSideInfo(ssi,
-					[]*snap.ComponentSideInfo{csi})}),
+					[]*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)})}),
 		Current: snapRev,
 	})
 

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -79,7 +79,7 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi,
+				sequence.NewRevisionSideState(ssi,
 					[]*sequence.ComponentState{sequence.NewComponentState(csi2, snap.TestComponent), sequence.NewComponentState(csi, snap.TestComponent)})}),
 		Current: snapRev,
 	}
@@ -102,8 +102,8 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi2, nil),
-				sequence.NewRevisionSideInfo(ssi, []*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
+				sequence.NewRevisionSideState(ssi2, nil),
+				sequence.NewRevisionSideState(ssi, []*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
 			}),
 		Current: snapRev2,
 	}
@@ -121,8 +121,8 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
-				sequence.NewRevisionSideInfo(ssi2, nil),
-				sequence.NewRevisionSideInfo(ssi, nil),
+				sequence.NewRevisionSideState(ssi2, nil),
+				sequence.NewRevisionSideState(ssi, nil),
 			}),
 		Current: snapRev2,
 	}

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -80,7 +80,7 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
 				sequence.NewRevisionSideInfo(ssi,
-					[]*snap.ComponentSideInfo{csi2, csi})}),
+					[]*sequence.ComponentState{sequence.NewComponentState(csi2, snap.TestComponent), sequence.NewComponentState(csi, snap.TestComponent)})}),
 		Current: snapRev,
 	}
 	snapstate.Set(s.state, snapName, snapSt)
@@ -103,7 +103,7 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
 			[]*sequence.RevisionSideState{
 				sequence.NewRevisionSideInfo(ssi2, nil),
-				sequence.NewRevisionSideInfo(ssi, []*snap.ComponentSideInfo{csi}),
+				sequence.NewRevisionSideInfo(ssi, []*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
 			}),
 		Current: snapRev2,
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2003,7 +2003,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// find if the snap is already installed before we modify snapst below
 	isInstalled := snapst.IsInstalled()
 
-	cand := sequence.NewRevisionSideInfo(snapsup.SideInfo, nil)
+	cand := sequence.NewRevisionSideState(snapsup.SideInfo, nil)
 	m.backend.Candidate(cand.Snap)
 
 	oldCandidateIndex := snapst.LastIndex(cand.Snap.Revision)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -121,7 +121,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	// component types (see checkSnap and checkSnapCallbacks slice)
 
 	csi := compSetup.CompSideInfo
-	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
+	cpi := snap.MinimalComponentContainerPlaceInfo(compSetup.ComponentName(),
 		csi.Revision, snapsup.InstanceName(), snapsup.Revision())
 
 	defer func() {
@@ -228,7 +228,7 @@ func (m *SnapManager) undoMountComponent(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	csi := compSetup.CompSideInfo
-	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
+	cpi := snap.MinimalComponentContainerPlaceInfo(compSetup.ComponentName(),
 		csi.Revision, snapsup.InstanceName(), snapsup.Revision())
 
 	pm := NewTaskProgressAdapterUnlocked(t)
@@ -278,7 +278,7 @@ func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	if snapSt.LastCompRefreshTime == nil {
 		snapSt.LastCompRefreshTime = make(map[string]time.Time)
 	}
-	snapSt.LastCompRefreshTime[compSetup.CompSideInfo.Component.ComponentName] = timeNow()
+	snapSt.LastCompRefreshTime[compSetup.ComponentName()] = timeNow()
 
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)

--- a/overlord/snapstate/handlers_components_mount_test.go
+++ b/overlord/snapstate/handlers_components_mount_test.go
@@ -59,7 +59,7 @@ func (s *mountCompSnapSuite) TestDoMountComponent(c *C) {
 	t := s.state.NewTask("mount-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, compPath))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -102,7 +102,7 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponent(c *C) {
 	t := s.state.NewTask("mount-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, compPath))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
 	t.Set("snap-setup", ssu)
 
 	chg := s.state.NewChange("sample", "...")
@@ -158,7 +158,7 @@ func (s *mountCompSnapSuite) TestDoMountComponentSetupFails(c *C) {
 	t := s.state.NewTask("mount-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, compPath))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
 	t.Set("snap-setup", ssu)
 
 	chg := s.state.NewChange("sample", "...")
@@ -205,7 +205,7 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponentFails(c *C) {
 	t := s.state.NewTask("mount-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, compPath))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
 	t.Set("snap-setup", ssu)
 
 	chg := s.state.NewChange("sample", "...")
@@ -258,7 +258,7 @@ func (s *mountCompSnapSuite) TestDoMountComponentMountFails(c *C) {
 	t := s.state.NewTask("mount-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, compPath))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
 	t.Set("snap-setup", ssu)
 
 	chg := s.state.NewChange("sample", "...")

--- a/overlord/snapstate/handlers_components_prepare_test.go
+++ b/overlord/snapstate/handlers_components_prepare_test.go
@@ -47,7 +47,7 @@ func (s *prepareSnapSuite) TestDoPrepareComponentSimple(c *C) {
 	t := s.state.NewTask("prepare-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, "path-to-component"))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, "path-to-component"))
 	t.Set("snap-setup", ssu)
 
 	s.state.NewChange("test change", "change desc").AddTask(t)

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -343,7 +343,7 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 			var snapst snapstate.SnapState
 			snapstate.Get(st, snapsup.InstanceName(), &snapst)
 			snapst.Current = snapsup.Revision()
-			snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideInfo(snapsup.SideInfo, nil))
+			snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideState(snapsup.SideInfo, nil))
 			snapstate.Set(st, snapsup.InstanceName(), &snapst)
 
 			// check that prerequisites task is not done yet, it must wait for core.

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -53,7 +53,7 @@ type RevisionSideState struct {
 type revisionSideInfoMarshal struct {
 	// SideInfo is included for compatibility with older snapd state files
 	*snap.SideInfo
-	CompSideInfo []*ComponentState `json:"components,omitempty"`
+	Components []*ComponentState `json:"components,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface
@@ -68,7 +68,7 @@ func (bsi *RevisionSideState) UnmarshalJSON(in []byte) error {
 		return err
 	}
 	bsi.Snap = aux.SideInfo
-	bsi.Components = aux.CompSideInfo
+	bsi.Components = aux.Components
 	return nil
 }
 
@@ -179,4 +179,29 @@ func (snapSeq *SnapSequence) RemoveComponentForRevision(snapRev snap.Revision, c
 	revSt.Components = leftComp
 	// might be nil
 	return unlinkedComp
+}
+
+// ComponentSideInfoForRev returns cref's component side info for the revision
+// (sequence point) indicated by revIdx if there is one.
+func (snapSeq *SnapSequence) ComponentSideInfoForRev(revIdx int, cref naming.ComponentRef) *snap.ComponentSideInfo {
+	for _, comp := range snapSeq.Revisions[revIdx].Components {
+		if comp.SideInfo.Component == cref {
+			return comp.SideInfo
+		}
+	}
+	// component not found
+	return nil
+}
+
+// IsComponentRevPresent tells us if a given component revision is
+// present in the system for this snap.
+func (snapSeq *SnapSequence) IsComponentRevPresent(compSi *snap.ComponentSideInfo) bool {
+	for _, rev := range snapSeq.Revisions {
+		for _, cs := range rev.Components {
+			if cs.SideInfo.Equal(compSi) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -82,9 +82,9 @@ func (rss *RevisionSideState) FindComponent(cref naming.ComponentRef) *Component
 	return nil
 }
 
-// NewRevisionSideInfo creates a RevisionSideInfo from snap and
+// NewRevisionSideState creates a RevisionSideInfo from snap and
 // related components side information.
-func NewRevisionSideInfo(snapSideInfo *snap.SideInfo, compSideInfo []*ComponentState) *RevisionSideState {
+func NewRevisionSideState(snapSideInfo *snap.SideInfo, compSideInfo []*ComponentState) *RevisionSideState {
 	return &RevisionSideState{Snap: snapSideInfo, Components: compSideInfo}
 }
 

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -64,10 +64,10 @@ func (s *sequenceTestSuite) TestSequenceSerialize(c *C) {
 
 	// With components
 	seq = snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
-		sequence.NewRevisionSideInfo(si1, []*sequence.ComponentState{
+		sequence.NewRevisionSideState(si1, []*sequence.ComponentState{
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"), snap.R(7)), snap.TestComponent),
 		}),
-		sequence.NewRevisionSideInfo(si2, []*sequence.ComponentState{
+		sequence.NewRevisionSideState(si2, []*sequence.ComponentState{
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"), snap.R(11)), snap.TestComponent),
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)), snap.TestComponent),
 		}),
@@ -90,8 +90,8 @@ func (s *sequenceTestSuite) TestSideInfos(c *C) {
 	cs := sequence.NewComponentState(csi, snap.TestComponent)
 	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
 		[]*sequence.RevisionSideState{
-			sequence.NewRevisionSideInfo(ssi, []*sequence.ComponentState{cs}),
-			sequence.NewRevisionSideInfo(ssi2, nil)})
+			sequence.NewRevisionSideState(ssi, []*sequence.ComponentState{cs}),
+			sequence.NewRevisionSideState(ssi2, nil)})
 
 	c.Check(seq.SideInfos(), DeepEquals, []*snap.SideInfo{ssi, ssi2})
 }
@@ -109,7 +109,7 @@ func (s *sequenceTestSuite) TestAddComponentForRevision(c *C) {
 		Revision: snap.R(1), SnapID: "some-snap-id"}
 	comps := []*sequence.ComponentState{cs1, cs2}
 	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
-		[]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(ssi, comps)})
+		[]*sequence.RevisionSideState{sequence.NewRevisionSideState(ssi, comps)})
 	c.Assert(seq.AddComponentForRevision(snapRev, cs1), IsNil)
 	// Not re-appended
 	c.Assert(seq.Revisions[0].Components, DeepEquals, comps)
@@ -137,7 +137,7 @@ func (s *sequenceTestSuite) TestRemoveComponentForRevision(c *C) {
 		Revision: snap.R(1), SnapID: "some-snap-id"}
 	comps := []*sequence.ComponentState{cs1, cs2}
 	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
-		[]*sequence.RevisionSideState{sequence.NewRevisionSideInfo(ssi, comps)})
+		[]*sequence.RevisionSideState{sequence.NewRevisionSideState(ssi, comps)})
 
 	// component not in sequence point
 	removed := seq.RemoveComponentForRevision(snapRev, naming.NewComponentRef(snapName, "other-comp"))

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -347,13 +347,7 @@ func (snapst *SnapState) IsComponentInCurrentSeq(cref naming.ComponentRef) bool 
 	}
 
 	idx := snapst.LastIndex(snapst.Current)
-	for _, seqComp := range snapst.Sequence.Revisions[idx].Components {
-		if seqComp.SideInfo.Component == cref {
-			return true
-		}
-	}
-
-	return false
+	return snapst.Sequence.ComponentSideInfoForRev(idx, cref) != nil
 }
 
 // LocalRevision returns the "latest" local revision. Local revisions
@@ -387,13 +381,7 @@ func (snapst *SnapState) CurrentComponentSideInfo(cref naming.ComponentRef) *sna
 	}
 
 	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {
-		for _, comp := range snapst.Sequence.Revisions[idx].Components {
-			if comp.SideInfo.Component == cref {
-				return comp.SideInfo
-			}
-		}
-		// component not found
-		return nil
+		return snapst.Sequence.ComponentSideInfoForRev(idx, cref)
 	}
 
 	// should not really happen as the method checks if the snap is installed
@@ -422,14 +410,7 @@ func (snapst *SnapState) LastIndex(revision snap.Revision) int {
 // IsComponentRevPresent tells us if a given component revision is
 // present in the system for this snap.
 func (snapst *SnapState) IsComponentRevPresent(compSi *snap.ComponentSideInfo) bool {
-	for _, rev := range snapst.Sequence.Revisions {
-		for _, cs := range rev.Components {
-			if cs.SideInfo.Equal(compSi) {
-				return true
-			}
-		}
-	}
-	return false
+	return snapst.Sequence.IsComponentRevPresent(compSi)
 }
 
 // Block returns revisions that should be blocked on refreshes,

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -204,6 +204,11 @@ func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType,
 	}
 }
 
+// ComponentName returns the component name for compsu.
+func (compsu *ComponentSetup) ComponentName() string {
+	return compsu.CompSideInfo.Component.ComponentName
+}
+
 func (compsu *ComponentSetup) Revision() snap.Revision {
 	return compsu.CompSideInfo.Revision
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -190,13 +190,16 @@ func (snapsup *SnapSetup) MountFile() string {
 type ComponentSetup struct {
 	// CompSideInfo for metadata not coming from the component
 	CompSideInfo *snap.ComponentSideInfo `json:"comp-side-info,omitempty"`
+	// CompType is needed as some types need special handling
+	CompType snap.ComponentType
 	// CompPath is the path to the file
 	CompPath string `json:"comp-path,omitempty"`
 }
 
-func NewComponentSetup(csi *snap.ComponentSideInfo, compPath string) *ComponentSetup {
+func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType, compPath string) *ComponentSetup {
 	return &ComponentSetup{
 		CompSideInfo: csi,
+		CompType:     compType,
 		CompPath:     compPath,
 	}
 }
@@ -340,7 +343,7 @@ func (snapst *SnapState) IsComponentInCurrentSeq(cref naming.ComponentRef) bool 
 
 	idx := snapst.LastIndex(snapst.Current)
 	for _, seqComp := range snapst.Sequence.Revisions[idx].Components {
-		if seqComp.Component == cref {
+		if seqComp.SideInfo.Component == cref {
 			return true
 		}
 	}
@@ -380,8 +383,8 @@ func (snapst *SnapState) CurrentComponentSideInfo(cref naming.ComponentRef) *sna
 
 	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {
 		for _, comp := range snapst.Sequence.Revisions[idx].Components {
-			if comp.Component == cref {
-				return comp
+			if comp.SideInfo.Component == cref {
+				return comp.SideInfo
 			}
 		}
 		// component not found
@@ -415,8 +418,8 @@ func (snapst *SnapState) LastIndex(revision snap.Revision) int {
 // present in the system for this snap.
 func (snapst *SnapState) IsComponentRevPresent(compSi *snap.ComponentSideInfo) bool {
 	for _, rev := range snapst.Sequence.Revisions {
-		for _, csi := range rev.Components {
-			if csi.Equal(compSi) {
+		for _, cs := range rev.Components {
+			if cs.SideInfo.Equal(compSi) {
 				return true
 			}
 		}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1332,7 +1332,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -1515,7 +1515,7 @@ func (s *snapmgrTestSuite) testParallelInstanceInstallRunThrough(c *C, inputFlag
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -1879,7 +1879,7 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "scurries")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(666),
@@ -2044,7 +2044,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
@@ -2208,7 +2208,7 @@ version: 1.0`)
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "mock",
 		Channel:  "",
 		Revision: snap.R(-1),
@@ -2518,7 +2518,7 @@ version: 1.0`)
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(si, nil))
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(si, nil))
 	c.Assert(snapst.LocalRevision().Unset(), Equals, true)
 	c.Assert(snapst.Required, Equals, true)
 }
@@ -2766,7 +2766,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "core",
 		Channel:  "stable",
 		SnapID:   "core-id",
@@ -2880,7 +2880,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		c.Assert(err, IsNil)
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: "core",
 			SnapID:   "core-id",
 			Channel:  "stable",
@@ -2892,7 +2892,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		c.Assert(err, IsNil)
 		c.Assert(snapst2.Active, Equals, true)
 		c.Assert(snapst2.Sequence.Revisions, HasLen, 1)
-		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: "snap2",
 			SnapID:   "snap2-id",
 			Channel:  "",
@@ -3021,7 +3021,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "core",
 		Revision: snap.R(1),
 	}, nil))
@@ -3029,7 +3029,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	snapst = snaps["some-snap"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
@@ -3794,7 +3794,7 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "core",
 		SnapID:   "core-id",
 		Revision: snap.R(11),
@@ -3806,7 +3806,7 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 		snapst = snaps[s]
 		c.Assert(snapst, NotNil)
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: s,
 			SnapID:   s + "-id",
 			Channel:  "stable",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -613,10 +613,10 @@ func (s *snapmgrTestSuite) TestSequenceSerialize(c *C) {
 
 	// With components
 	snapst = &snapstate.SnapState{Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
-		sequence.NewRevisionSideInfo(si1, []*sequence.ComponentState{
+		sequence.NewRevisionSideState(si1, []*sequence.ComponentState{
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"), snap.R(7)), snap.TestComponent),
 		}),
-		sequence.NewRevisionSideInfo(si2, []*sequence.ComponentState{
+		sequence.NewRevisionSideState(si2, []*sequence.ComponentState{
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"), snap.R(11)), snap.TestComponent),
 			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)), snap.TestComponent),
 		}),
@@ -1637,12 +1637,12 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),
@@ -1689,12 +1689,12 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlocked(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),
@@ -1945,12 +1945,12 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 	c.Assert(snapst.Current, Equals, snap.R(2))
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(2),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(7),

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -613,19 +613,17 @@ func (s *snapmgrTestSuite) TestSequenceSerialize(c *C) {
 
 	// With components
 	snapst = &snapstate.SnapState{Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
-		sequence.NewRevisionSideInfo(si1, []*snap.ComponentSideInfo{
-			snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"),
-				snap.R(7)),
+		sequence.NewRevisionSideInfo(si1, []*sequence.ComponentState{
+			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("mysnap", "mycomp"), snap.R(7)), snap.TestComponent),
 		}),
-		sequence.NewRevisionSideInfo(si2, []*snap.ComponentSideInfo{
-			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"),
-				snap.R(11)),
-			snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)),
+		sequence.NewRevisionSideInfo(si2, []*sequence.ComponentState{
+			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp1"), snap.R(11)), snap.TestComponent),
+			sequence.NewComponentState(snap.NewComponentSideInfo(naming.NewComponentRef("othersnap", "othercomp2"), snap.R(14)), snap.TestComponent),
 		}),
 	})}
 	marshaled, err = json.Marshal(snapst)
 	c.Assert(err, IsNil)
-	c.Check(string(marshaled), Equals, `{"type":"","sequence":[{"name":"mysnap","snap-id":"snapid","revision":"7","components":[{"component":{"snap-name":"mysnap","component-name":"mycomp"},"revision":"7"}]},{"name":"othersnap","snap-id":"otherid","revision":"11","components":[{"component":{"snap-name":"othersnap","component-name":"othercomp1"},"revision":"11"},{"component":{"snap-name":"othersnap","component-name":"othercomp2"},"revision":"14"}]}],"current":"unset"}`)
+	c.Check(string(marshaled), Equals, `{"type":"","sequence":[{"name":"mysnap","snap-id":"snapid","revision":"7","components":[{"side-info":{"component":{"snap-name":"mysnap","component-name":"mycomp"},"revision":"7"},"type":"test"}]},{"name":"othersnap","snap-id":"otherid","revision":"11","components":[{"side-info":{"component":{"snap-name":"othersnap","component-name":"othercomp1"},"revision":"11"},"type":"test"},{"side-info":{"component":{"snap-name":"othersnap","component-name":"othercomp2"},"revision":"14"},"type":"test"}]}],"current":"unset"}`)
 }
 
 func maybeMockClassicSupport(c *C) (restore func()) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -841,12 +841,12 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(-42),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "some-channel",
 		SnapID:   "some-snap-id",
@@ -1089,13 +1089,13 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	c.Check(snapst.LastRefreshTime.Equal(now), Equals, true)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1152,13 +1152,13 @@ func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(11))
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1444,13 +1444,13 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
@@ -1773,13 +1773,13 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "18/edge")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "kernel",
 		SnapID:   "kernel-id",
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "kernel",
 		Channel:  "18/edge",
 		SnapID:   "kernel-id",
@@ -2302,7 +2302,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
@@ -2642,7 +2642,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
@@ -2911,7 +2911,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7/stable",
@@ -3021,7 +3021,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Sequence.Revisions, HasLen, 1)
-	c.Check(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+	c.Check(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7",
@@ -8362,13 +8362,13 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -8552,13 +8552,13 @@ func (s *snapmgrTestSuite) TestUpdateGadgetKernelSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -8741,13 +8741,13 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetSingleRebootHappy(c *C) {
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
 		}, nil))
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
@@ -9005,7 +9005,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 
 		c.Assert(snapst.Active, Equals, true)
 		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
-		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideInfo(&snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,

--- a/overlord/snapstate/snapstatetest/snapstate.go
+++ b/overlord/snapstate/snapstatetest/snapstate.go
@@ -27,7 +27,7 @@ import (
 func NewSequenceFromSnapSideInfos(snapSideInfo []*snap.SideInfo) sequence.SnapSequence {
 	revSis := make([]*sequence.RevisionSideState, len(snapSideInfo))
 	for i, si := range snapSideInfo {
-		revSis[i] = sequence.NewRevisionSideInfo(si, nil)
+		revSis[i] = sequence.NewRevisionSideState(si, nil)
 	}
 	return sequence.SnapSequence{Revisions: revSis}
 }


### PR DESCRIPTION
Storing the component type in the state is necessary so kernel-modules
type can be properly handled by the initramfs.