### PR TITLE
cmd: snap-bootstrap: fix unpreseeded single boot install

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -376,7 +376,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 		return err
 	}
 	preseedSeed, ok := currentSeed.(seed.PreseedCapable)
-	if ok {
+	if ok && preseedSeed.HasArtifact("preseed.tgz") {
 		runMode := false
 		if err := installApplyPreseededData(preseedSeed, boot.InitramfsWritableDir(model, runMode)); err != nil {
 			return err


### PR DESCRIPTION
When using single boot install mode, it is wrongly assumed that preseed capable system is always preseeded.
Improve conditions so attempt to apply pressed data is only made if `preseed.tgz` is present.