### PR TITLE
overlord/systemd: remove unused variable from MountUnitOptions

### DIFF
--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -189,7 +189,6 @@ func (m *mountCommand) ensureMount(sysd systemd.Systemd) (string, error) {
 	}
 	unitName, err := sysd.EnsureMountUnitFileWithOptions(&systemd.MountUnitOptions{
 		Lifetime:    lifetime,
-		SnapName:    snapName,
 		Description: fmt.Sprintf("Mount unit for %s, revision %s via mount-control", snapName, revision),
 		What:        m.Positional.What,
 		Where:       m.Positional.Where,

--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -282,7 +282,6 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Transient,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/src",
 			Where:       "/dest",
@@ -302,7 +301,6 @@ func (s *mountSuite) TestHappy(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Persistent,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/src",
 			Where:       "/dest",
@@ -326,7 +324,6 @@ func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Transient,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/media/me/data",
 			Where:       where,
@@ -347,7 +344,6 @@ func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Transient,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/dev/dma_heap/qcom,qseecom",
 			Where:       "/dest,with,commas",
@@ -367,7 +363,6 @@ func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Persistent,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/src",
 			Where:       "/dest",
@@ -391,7 +386,6 @@ func (s *mountSuite) TestEnsureMountUnitFailedRemoveFailed(c *C) {
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime:    systemd.Persistent,
-			SnapName:    "snap1",
 			Description: "Mount unit for snap1, revision 1 via mount-control",
 			What:        "/src",
 			Where:       "/dest",

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -36,7 +36,7 @@ func addMountUnit(c snap.ContainerPlaceInfo, preseed bool, meter progress.Meter)
 	} else {
 		sysd = systemd.New(systemd.SystemMode, meter)
 	}
-	_, err := sysd.EnsureMountUnitFile(c.ContainerName(), c.MountDescription(), squashfsPath, whereDir, "squashfs")
+	_, err := sysd.EnsureMountUnitFile(c.MountDescription(), squashfsPath, whereDir, "squashfs")
 	return err
 }
 

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 type ParamsForEnsureMountUnitFile struct {
-	name, description, what, where, fstype string
+	description, what, where, fstype string
 }
 
 type ResultForEnsureMountUnitFile struct {
@@ -55,9 +55,9 @@ type FakeSystemd struct {
 	ListMountUnitsResult ResultForListMountUnits
 }
 
-func (s *FakeSystemd) EnsureMountUnitFile(name, description, what, where, fstype string) (string, error) {
+func (s *FakeSystemd) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
 	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls,
-		ParamsForEnsureMountUnitFile{name, description, what, where, fstype})
+		ParamsForEnsureMountUnitFile{description, what, where, fstype})
 	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err
 }
 
@@ -119,7 +119,6 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 
 	// ensure correct parameters
 	expectedParameters := ParamsForEnsureMountUnitFile{
-		name:        "foo",
 		description: "Mount unit for foo, revision 13",
 		what:        "/var/lib/snapd/snaps/foo_13.snap",
 		where:       fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1240,7 +1240,7 @@ func (m *SnapManager) ensureMountsUpdated() error {
 			}
 			squashfsPath := dirs.StripRootDir(info.MountFile())
 			whereDir := dirs.StripRootDir(info.MountDir())
-			if _, err = sysd.EnsureMountUnitFile(info.InstanceName(), info.MountDescription(), squashfsPath, whereDir, "squashfs"); err != nil {
+			if _, err = sysd.EnsureMountUnitFile(info.MountDescription(), squashfsPath, whereDir, "squashfs"); err != nil {
 				return err
 			}
 		}

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -124,7 +124,7 @@ func (s *emulation) LogReader(services []string, n int, follow, namespaces bool)
 	return nil, fmt.Errorf("LogReader")
 }
 
-func (s *emulation) EnsureMountUnitFile(snapName, description, what, where, fstype string) (string, error) {
+func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
 	if osutil.IsDirectory(what) {
 		return "", fmt.Errorf("bind-mounted directory is not supported in emulation mode")
 	}
@@ -136,7 +136,6 @@ func (s *emulation) EnsureMountUnitFile(snapName, description, what, where, fsty
 	mountUnitOptions := append(fsMountOptions(fstype), squashfs.StandardOptions()...)
 	mountUnitName, modified, err := ensureMountUnitFile(&MountUnitOptions{
 		Lifetime:    Persistent,
-		SnapName:    snapName,
 		Description: description,
 		What:        what,
 		Where:       where,

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -304,7 +304,6 @@ func MockJournalctl(f func(svcs []string, n int, follow, namespaces bool) (io.Re
 type MountUnitOptions struct {
 	// Whether the unit is transient or persistent across reboots
 	Lifetime    UnitLifetime
-	SnapName    string
 	Description string
 	What        string
 	Where       string
@@ -387,7 +386,7 @@ type Systemd interface {
 	// logs, and is required to get logs for services which are in journal namespaces.
 	LogReader(services []string, n int, follow, namespaces bool) (io.ReadCloser, error)
 	// EnsureMountUnitFile adds/enables/starts a mount unit.
-	EnsureMountUnitFile(name, description, what, where, fstype string) (string, error)
+	EnsureMountUnitFile(description, what, where, fstype string) (string, error)
 	// EnsureMountUnitFileWithOptions adds/enables/starts a mount unit with options.
 	EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error)
 	// RemoveMountUnitFile unmounts/stops/disables/removes a mount unit.
@@ -1459,7 +1458,7 @@ func hostFsTypeAndMountOptions(fstype string) (hostFsType string, options []stri
 	return hostFsType, options
 }
 
-func (s *systemd) EnsureMountUnitFile(snapName, description, what, where, fstype string) (string, error) {
+func (s *systemd) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
 	hostFsType, options := hostFsTypeAndMountOptions(fstype)
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
@@ -1467,7 +1466,6 @@ func (s *systemd) EnsureMountUnitFile(snapName, description, what, where, fstype
 	}
 	return s.EnsureMountUnitFileWithOptions(&MountUnitOptions{
 		Lifetime:    Persistent,
-		SnapName:    snapName,
 		Description: description,
 		What:        what,
 		Where:       where,

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1159,7 +1159,7 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1222,7 +1222,7 @@ WantedBy=multi-user.target
 	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// Should still be the same file
@@ -1282,7 +1282,7 @@ WantedBy=multi-user.target
 	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// Should still be the same file
@@ -1319,7 +1319,7 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foodir", "Mount unit for foodir, revision x1", snapDir, "/snap/snapname/x1", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("Mount unit for foodir, revision x1", snapDir, "/snap/snapname/x1", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1360,7 +1360,6 @@ func (s *SystemdTestSuite) TestAddMountUnitTransient(c *C) {
 
 	addMountUnitOptions := &MountUnitOptions{
 		Lifetime:    Transient,
-		SnapName:    "foo",
 		Description: "Mount unit for foo via bar",
 		What:        mockSnapPath,
 		Where:       "/snap/snapname/345",
@@ -1413,7 +1412,7 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1459,7 +1458,7 @@ exit 0
 	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1501,7 +1500,7 @@ exit 0
 	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "Mount unit for foo, revision x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("Mount unit for foo, revision x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1682,7 +1681,7 @@ func (s *SystemdTestSuite) testDaemonOpWithMutex(c *C, testFunc func(Systemd) er
 	// daemon-reload. This will be serialized, if not this would
 	// panic because systemd.daemonReloadNoLock ensures the lock is
 	// taken when this happens.
-	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/foo/42", "squashfs")
+	_, err := sysd.EnsureMountUnitFile("42", mockSnapPath, "/snap/foo/42", "squashfs")
 	c.Assert(err, IsNil)
 	close(stopCh)
 	<-stoppedCh
@@ -1802,7 +1801,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1847,7 +1846,7 @@ WantedBy=multi-user.target
 	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = sysd.EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	_, err = sysd.EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// systemd was not called
@@ -1892,7 +1891,7 @@ WantedBy=multi-user.target
 	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", dirs.GlobalRootDir, "enable", "snap-snapname-123.mount"}})
@@ -1913,7 +1912,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("Mount unit for foo, revision 42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1933,7 +1932,7 @@ func (s *SystemdTestSuite) TestPreseedModeMountError(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	_, err := sysd.EnsureMountUnitFile("42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, ErrorMatches, `cannot mount .*/var/lib/snappy/snaps/foo_1.0.snap \(squashfs\) at /snap/snapname/123 in preseed mode: exit status 1; some failure\n`)
 }
 
@@ -1999,7 +1998,7 @@ func (s *SystemdTestSuite) TestPreseedModeBindmountNotSupported(c *C) {
 
 	mockSnapPath := c.MkDir()
 
-	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "")
+	_, err := sysd.EnsureMountUnitFile("42", mockSnapPath, "/snap/snapname/123", "")
 	c.Assert(err, ErrorMatches, `bind-mounted directory is not supported in emulation mode`)
 }
 
@@ -2428,6 +2427,6 @@ func (s *systemdErrorSuite) TestEnsureMountUnitFileEnsureFileStateErr(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap-snapname-123.mount"), 0755)
 	c.Assert(err, IsNil)
 
-	_, err = New(SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	_, err = New(SystemMode, nil).EnsureMountUnitFile("42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, ErrorMatches, fmt.Sprintf("internal error: only regular files are supported, got %q instead", os.ModeDir))
 }


### PR DESCRIPTION
Remove SnapName from systemd.MountUnitOptions, as it was not used anymore (instead, the mount unit description already has the container name). Remove it from the EnsureMountUnitFile method as well.