### PR TITLE
tests: new perf test install-many-snaps

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1067,6 +1067,7 @@ suites:
             CPU_LOAD: '$(HOST: echo "${PERF_CPU_LOAD:-}")'
             LOAD_DURATION: '$(HOST: echo "${PERF_LOAD_DURATION:-1200}")'
             NUM_PARALLEL: '$(HOST: echo "${PERF_NUM_PARALLEL:-10}")'
+            NUM_SNAPS: '$(HOST: echo "${PERF_NUM_SNAPS:-100}")'
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -69,6 +69,12 @@ nested_wait_vm_ready() {
             return 1
         fi
 
+        # Check if ssh connection can be established, and return if it is possible
+        if nested_wait_for_ssh 1 1; then
+            echo "SSH connection ready"
+            return
+        fi
+
         # Check during $limit seconds that the serial log is growing
         # shellcheck disable=SC2016
         if ! retry -n "$log_limit" --wait 1 --env serial_log="$serial_log" --env output_lines="$output_lines" \
@@ -85,12 +91,6 @@ nested_wait_vm_ready() {
             test "$(grep -c -E "Command line:.*snapd_recovery_mode=run" "$serial_log")" -le 1
         elif nested_is_core_16_system || nested_is_core_18_system; then
             test "$(grep -c -E "Command line:.*BOOT_IMAGE=\(loop\)/kernel.img" "$serial_log")" -le 1
-        fi
-
-        # Check if ssh connection can be established, and return if it is possible
-        if nested_wait_for_ssh 1 1; then
-            echo "SSH connection ready"
-            return
         fi
 
         sleep 3

--- a/tests/perf/install-many-snaps/task.yaml
+++ b/tests/perf/install-many-snaps/task.yaml
@@ -1,0 +1,70 @@
+summary: Ensure the system handles properly a big number of different installed snaps
+
+details: |
+    Install different snaps many times based on arch availability.
+    This will help catch performance issues in snapd, AppArmor, etc.
+
+warn-timeout: 5m
+kill-timeout: 90m
+
+execute: |
+    if [ -z "$NUM_SNAPS" ]; then
+        NUM_SNAPS=100
+    fi
+
+    LETTERS="a b c d e f g h i j k l m n o p q r s t u v w x y z"
+    INSTALLED=0
+    CHANNEL='stable'
+
+    # shellcheck disable=SC2086
+    for letter in $LETTERS; do
+        if [ "$INSTALLED" = "$NUM_SNAPS" ]; then
+            echo "already $NUM_SNAPS installed, now check other features"
+            break
+        fi
+
+        snaps="$(snap find --narrow "$letter")"
+        SNAP_NAMES="$(echo "$snaps" | awk '{if($4~/-/){print $1}}' | tail -n+2)"
+        for SNAP in $SNAP_NAMES; do
+            # Get the info from latest/$CHANNEL
+            # shellcheck disable=SC2153
+            if ! CHANNEL_INFO="$(snap info --unicode=never "$SNAP" | grep " latest/$CHANNEL: ")"; then
+                echo "Snap $SNAP not found"
+                continue
+            fi
+            PARAMS=""
+            if echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*-$"; then
+                snap install "$SNAP" "--$CHANNEL"
+            elif echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*classic$"; then
+                if "$TESTSTOOLS"/snaps-state is-confinement-supported classic; then
+                    PARAMS="--classic"
+                else
+                    echo "The snap $SNAP requires classic confinement which is not supported yet"
+                    continue
+                fi
+            elif echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*jailmode$"; then
+                PARAMS="--jailmode"
+            elif echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*devmode$"; then
+                PARAMS="--devmode"
+            else
+                echo "Channel info not proccessed correctly: $CHANNEL_INFO"
+                continue
+            fi
+            
+            if snap install "$SNAP" --$CHANNEL $PARAMS 2> stderr.out; then
+                INSTALLED=$(( INSTALLED + 1 ))
+            else 
+                # this could cause the failure https://bugs.launchpad.net/snapstore-server/+bug/2049071
+                MATCH "error: snap \"$SNAP\" not found' < stderr.out
+            fi
+
+            if [ "$INSTALLED" = "$NUM_SNAPS" ]; then
+                echo "already $NUM_SNAPS installed, now check other features"
+                break
+            fi
+        done        
+    done
+
+    snap refresh
+    snap services
+    snap list

--- a/tests/perf/install-many-snaps/task.yaml
+++ b/tests/perf/install-many-snaps/task.yaml
@@ -55,7 +55,7 @@ execute: |
                 INSTALLED=$(( INSTALLED + 1 ))
             else 
                 # this could cause the failure https://bugs.launchpad.net/snapstore-server/+bug/2049071
-                MATCH "error: snap \"$SNAP\" not found' < stderr.out
+                MATCH "error: snap \"$SNAP\" not found" < stderr.out
             fi
 
             if [ "$INSTALLED" = "$NUM_SNAPS" ]; then


### PR DESCRIPTION
This test installs as many snaps as desired and then checks the snapd status and main functions

The idea of this test is also to use all the disk space and see how snap works under this scenario