### PR TITLE
snap: fix unit test on Arch

### DIFF
--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -284,7 +284,7 @@ func (s *componentSuite) TestComponentContainerPlaceInfoImpl(c *C) {
 	c.Check(contPi.ContainerName(), Equals, "mysnap_instance+test-info")
 	c.Check(contPi.Filename(), Equals, "mysnap_instance+test-info_25.comp")
 	c.Check(contPi.MountDir(), Equals,
-		filepath.Join(dirs.GlobalRootDir, "snap/mysnap_instance/components/11/test-info"))
+		filepath.Join(dirs.SnapMountDir, "mysnap_instance/components/11/test-info"))
 	c.Check(contPi.MountFile(), Equals,
 		filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap_instance+test-info_25.comp"))
 	c.Check(contPi.MountDescription(), Equals, "Mount unit for mysnap_instance+test-info, revision 25")


### PR DESCRIPTION
Arch does not use /snap as the snap mount dir. Use the appropriate values from dirs to fix that.

