### PR TITLE
interfaces/builtin: fix distro mocking in font dirs mount spec test

### DIFF
--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -164,10 +164,13 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/local/share/fonts"), 0777), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/cache/fontconfig"), 0777), IsNil)
 
+	// mock an Ubuntu Core like system
 	restore := release.MockOnClassic(false)
 	defer restore()
+	restore = release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer restore()
 
-	// On all-snaps systems, the mounts are present
+	// On all-snaps systems like Ubuntu Core, the mounts are present
 	spec := &mount.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.appSlot), IsNil)
 	c.Check(spec.MountEntries(), HasLen, 3)
@@ -177,8 +180,8 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 	// are bind mounted from the host system if they exist.
 	restore = release.MockOnClassic(true)
 	defer restore()
-	restore = release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
-	defer restore()
+	// distro is already mocked to be Ubuntu
+
 	spec = &mount.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 


### PR DESCRIPTION
Make sure that when checking Ubuntu Core scenario, the release info is mocked to indicate Ubuntu.

Fixes a unit test failure on Arch:
```
maciek@galeon:snapd/interfaces/builtin (git)-[bboozzoo/fix-component-location-test] go test

----------------------------------------------------------------------
FAIL: desktop_test.go:160: DesktopInterfaceSuite.TestMountSpec

desktop_test.go:173:
    c.Check(spec.MountEntries(), HasLen, 3)
... obtained []osutil.MountEntry = []osutil.MountEntry{osutil.MountEntry{Name:"/var/lib/snapd/hostfs/tmp/check-3094481031/3/usr/share/fonts", Dir:"/usr/share/fonts", Type:"", Options:[]string{"bind", "ro"}, DumpFrequency:0, CheckPassNumber:0}, osutil.MountEntry{Name:"/var/lib/snapd/hostfs/tmp/check-3094481031/3/usr/local/share/fonts", Dir:"/usr/local/share/fonts", Type:"", Options:[]string{"bind", "ro"}, DumpFrequency:0, CheckPassNumber:0}}
... n int = 3

OOPS: 1506 passed, 1 FAILED
```


Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
