### PR TITLE
o/configstate,o/snapstate: configurable refresh inhibition days number

### DIFF
--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -37,6 +37,7 @@ func init() {
 	supportedConfigurations["core.refresh.metered"] = true
 	supportedConfigurations["core.refresh.retain"] = true
 	supportedConfigurations["core.refresh.rate-limit"] = true
+	supportedConfigurations["core.refresh.max-inhibition-days"] = true
 }
 
 func reportOrIgnoreInvalidManageRefreshes(tr RunTransaction, optName string) error {
@@ -53,6 +54,15 @@ func reportOrIgnoreInvalidManageRefreshes(tr RunTransaction, optName string) err
 }
 
 func validateRefreshSchedule(tr RunTransaction) error {
+	maxInhibitionDaysStr, err := coreCfg(tr, "refresh.max-inhibition-days")
+	if err != nil {
+		return err
+	}
+	if maxInhibitionDaysStr != "" {
+		if n, err := strconv.ParseUint(maxInhibitionDaysStr, 10, 8); err != nil || (n < 1 || n > 14) {
+			return fmt.Errorf("max-inhibition-days must be a number between 1 and 14, not %q", maxInhibitionDaysStr)
+		}
+	}
 	refreshRetainStr, err := coreCfg(tr, "refresh.retain")
 	if err != nil {
 		return err

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -30,6 +30,11 @@ import (
 	"github.com/snapcore/snapd/timeutil"
 )
 
+const (
+	minInhibitionDays = 1
+	maxInhibitionDays = 21
+)
+
 func init() {
 	supportedConfigurations["core.refresh.hold"] = true
 	supportedConfigurations["core.refresh.schedule"] = true
@@ -59,8 +64,8 @@ func validateRefreshSchedule(tr RunTransaction) error {
 		return err
 	}
 	if maxInhibitionDaysStr != "" {
-		if n, err := strconv.ParseUint(maxInhibitionDaysStr, 10, 8); err != nil || (n < 1 || n > 14) {
-			return fmt.Errorf("max-inhibition-days must be a number between 1 and 14, not %q", maxInhibitionDaysStr)
+		if n, err := strconv.ParseUint(maxInhibitionDaysStr, 10, 8); err != nil || (n < minInhibitionDays || n > maxInhibitionDays) {
+			return fmt.Errorf("max-inhibition-days must be a number between %d and %d, not %q", minInhibitionDays, maxInhibitionDays, maxInhibitionDaysStr)
 		}
 	}
 	refreshRetainStr, err := coreCfg(tr, "refresh.retain")

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -226,11 +226,11 @@ func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 		val interface{}
 		err string
 	}{
-		{val: "zzz", err: `max-inhibition-days must be a number between 1 and 14, not "zzz"`},
-		{val: "-1", err: `max-inhibition-days must be a number between 1 and 14, not "-1"`},
-		{val: -1, err: `max-inhibition-days must be a number between 1 and 14, not "-1"`},
-		{val: "21", err: `max-inhibition-days must be a number between 1 and 14, not "21"`},
-		{val: 0, err: `max-inhibition-days must be a number between 1 and 14, not "0"`},
+		{val: "zzz", err: `max-inhibition-days must be a number between 1 and 21, not "zzz"`},
+		{val: "-1", err: `max-inhibition-days must be a number between 1 and 21, not "-1"`},
+		{val: -1, err: `max-inhibition-days must be a number between 1 and 21, not "-1"`},
+		{val: "21", err: `max-inhibition-days must be a number between 1 and 21, not "21"`},
+		{val: 0, err: `max-inhibition-days must be a number between 1 and 21, not "0"`},
 		// happy cases
 		{val: nil}, // default value (14 days)
 		{val: ""},  // default value (14 days)

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -220,3 +220,35 @@ func (s *refreshSuite) TestConfigureRefreshRetainInvalid(c *C) {
 	})
 	c.Assert(err, ErrorMatches, `retain must be a number between 2 and 20, not "invalid"`)
 }
+
+func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
+	data := []struct {
+		val interface{}
+		err string
+	}{
+		{val: "zzz", err: `max-inhibition-days must be a number between 1 and 14, not "zzz"`},
+		{val: "-1", err: `max-inhibition-days must be a number between 1 and 14, not "-1"`},
+		{val: -1, err: `max-inhibition-days must be a number between 1 and 14, not "-1"`},
+		{val: "21", err: `max-inhibition-days must be a number between 1 and 14, not "21"`},
+		{val: 0, err: `max-inhibition-days must be a number between 1 and 14, not "0"`},
+		// happy cases
+		{val: nil}, // default value (14 days)
+		{val: ""},  // default value (14 days)
+		{val: 1},
+		{val: "1"},
+		{val: 14},
+	}
+	for _, tc := range data {
+		err := configcore.Run(classicDev, &mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"refresh.max-inhibition-days": tc.val,
+			},
+		})
+		if tc.err != "" {
+			c.Check(err, ErrorMatches, tc.err)
+		} else {
+			c.Check(err, IsNil)
+		}
+	}
+}

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -232,8 +232,8 @@ func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 		{val: "23", err: `max-inhibition-days must be a number between 1 and 21, not "23"`},
 		{val: 0, err: `max-inhibition-days must be a number between 1 and 21, not "0"`},
 		// happy cases
-		{val: nil}, // default value (14 days)
-		{val: ""},  // default value (14 days)
+		{val: nil}, // default value (21 days)
+		{val: ""},  // default value (21 days)
 		{val: 1},
 		{val: "1"},
 		{val: 14},

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -232,8 +232,8 @@ func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 		{val: "23", err: `max-inhibition-days must be a number between 1 and 21, not "23"`},
 		{val: 0, err: `max-inhibition-days must be a number between 1 and 21, not "0"`},
 		// happy cases
-		{val: nil}, // default value (21 days)
-		{val: ""},  // default value (21 days)
+		{val: nil}, // default value (14 days)
+		{val: ""},  // default value (14 days)
 		{val: 1},
 		{val: "1"},
 		{val: 14},

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -229,7 +229,7 @@ func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 		{val: "zzz", err: `max-inhibition-days must be a number between 1 and 21, not "zzz"`},
 		{val: "-1", err: `max-inhibition-days must be a number between 1 and 21, not "-1"`},
 		{val: -1, err: `max-inhibition-days must be a number between 1 and 21, not "-1"`},
-		{val: "21", err: `max-inhibition-days must be a number between 1 and 21, not "21"`},
+		{val: "23", err: `max-inhibition-days must be a number between 1 and 21, not "23"`},
 		{val: 0, err: `max-inhibition-days must be a number between 1 and 21, not "0"`},
 		// happy cases
 		{val: nil}, // default value (14 days)

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -815,7 +815,7 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 	// inhibition time.
 	now := time.Now()
 	// cannot inhibit refreshes for more than maxInhibitionDuration
-	maxInhibitionTimeValue := maxInhibitionDuration(st)
+	maxInhibitionDurationValue := maxInhibitionDuration(st)
 	switch {
 	case snapst.RefreshInhibitedTime == nil:
 		// If the snap did not have inhibited refresh yet then commence a new
@@ -823,14 +823,14 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 		// time in the snap state's RefreshInhibitedTime field. This field is
 		// reset to nil on successful refresh.
 		snapst.RefreshInhibitedTime = &now
-		busyErr.timeRemaining = (maxInhibitionTimeValue - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
+		busyErr.timeRemaining = (maxInhibitionDurationValue - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
 		Set(st, info.InstanceName(), snapst)
-	case now.Sub(*snapst.RefreshInhibitedTime) < maxInhibitionTimeValue:
+	case now.Sub(*snapst.RefreshInhibitedTime) < maxInhibitionDurationValue:
 		// If we are still in the allowed window then just return the error but
 		// don't change the snap state again.
 		// TODO: as time left shrinks, send additional notifications with
 		// increasing frequency, allowing the user to understand the urgency.
-		busyErr.timeRemaining = (maxInhibitionTimeValue - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
+		busyErr.timeRemaining = (maxInhibitionDurationValue - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
 	default:
 		// XXX: should we drop this notification?
 		// if the refresh inhibition window has ended, notify the user that the

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -55,6 +55,9 @@ const maxPostponementBuffer = 5 * 24 * time.Hour
 // maxDuration is used to represent "forever" internally (it's 290 years).
 const maxDuration = time.Duration(1<<63 - 1)
 
+// time in days by default to wait until a pending refresh is forced by the system
+const defaultMaxInhibitionDays = 14
+
 // hooks setup by devicestate
 var (
 	CanAutoRefresh        func(st *state.State) (bool, error)

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -794,7 +794,7 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 	// Decide on what to do depending on the state of the snap and the remaining
 	// inhibition time.
 	now := time.Now()
-	// cannot inhibit refreshes for more than maxInhibitionTime seconds;
+	// cannot inhibit refreshes for more than maxInhibitionTime
 	maxInhibitionTimeValue := maxInhibitionTime(st)
 	switch {
 	case snapst.RefreshInhibitedTime == nil:

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1031,7 +1031,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	defer restore()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibitionTime(s.state) / 2) // In the middle of the allowed window
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) / 2) // In the middle of the allowed window
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
@@ -1075,7 +1075,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	defer restore()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibitionTime(s.state) * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
@@ -1106,7 +1106,7 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	})
 	defer restore()
 
-	pastInstant := time.Now().Add(-snapstate.MaxInhibitionTime(s.state))
+	pastInstant := time.Now().Add(-snapstate.MaxInhibitionDuration(s.state))
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1031,7 +1031,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	defer restore()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition / 2) // In the middle of the allowed window
+	pastInstant := instant.Add(-snapstate.MaxInhibitionTime(s.state) / 2) // In the middle of the allowed window
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
@@ -1075,7 +1075,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	defer restore()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionTime(s.state) * 2)
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
@@ -1106,7 +1106,7 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	})
 	defer restore()
 
-	pastInstant := time.Now().Add(-snapstate.MaxInhibition)
+	pastInstant := time.Now().Add(-snapstate.MaxInhibitionTime(s.state))
 
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -404,7 +404,7 @@ var (
 var (
 	InhibitRefresh                       = inhibitRefresh
 	MaxDuration                          = maxDuration
-	MaxInhibitionTime                    = maxInhibitionTime
+	MaxInhibitionDuration                = maxInhibitionDuration
 	MaybeAddRefreshInhibitNotice         = maybeAddRefreshInhibitNotice
 	MaybeAsyncPendingRefreshNotification = maybeAsyncPendingRefreshNotification
 )

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -404,6 +404,7 @@ var (
 var (
 	InhibitRefresh                       = inhibitRefresh
 	MaxDuration                          = maxDuration
+	MaxInhibitionTime                    = maxInhibitionTime
 	MaybeAddRefreshInhibitNotice         = maybeAddRefreshInhibitNotice
 	MaybeAsyncPendingRefreshNotification = maybeAsyncPendingRefreshNotification
 )

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -403,7 +403,6 @@ var (
 // autorefresh
 var (
 	InhibitRefresh                       = inhibitRefresh
-	MaxInhibition                        = maxInhibition
 	MaxDuration                          = maxDuration
 	MaybeAddRefreshInhibitNotice         = maybeAddRefreshInhibitNotice
 	MaybeAsyncPendingRefreshNotification = maybeAsyncPendingRefreshNotification

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -504,7 +504,7 @@ func (s *linkSnapSuite) TestDoUnlinkCurrentSnapSnapLockUnlocked(c *C) {
 	tr.Commit()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 	// Add test snap
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(42)}
 	snaptest.MockSnap(c, `name: pkg`, si)

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -273,7 +273,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshInhibitionTimeout(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 	// Pretend its refresh inhibition timed out.
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 	snapst.RefreshInhibitedTime = &pastInstant
 	snapstate.Set(s.state, snapst.InstanceName(), snapst)
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -632,8 +632,6 @@ func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {
 		// Zero time, no pending refreshes.
 		return time.Time{}
 	}
-	// TODO: state is needed for when configurable max inhibition
-	// is introduced (i.e. "core.refresh.max-inhibition-days").
 	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibitionDuration(st))
 	return proceedTime
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -624,7 +624,7 @@ func (snapst *SnapState) InstanceName() string {
 
 // RefreshInhibitProceedTime is the time after which a pending refresh is forced
 // for a running snap in the next auto-refresh. Zero time indicates that there
-// are no pending refreshes. St must be locked.
+// are no pending refreshes. st must be locked.
 //
 // The provided state must be locked by the caller.
 func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -624,7 +624,7 @@ func (snapst *SnapState) InstanceName() string {
 
 // RefreshInhibitProceedTime is the time after which a pending refresh is forced
 // for a running snap in the next auto-refresh. Zero time indicates that there
-// are no pending refreshes.
+// are no pending refreshes. St must be locked.
 //
 // The provided state must be locked by the caller.
 func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {
@@ -634,7 +634,7 @@ func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {
 	}
 	// TODO: state is needed for when configurable max inhibition
 	// is introduced (i.e. "core.refresh.max-inhibition-days").
-	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibition)
+	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibitionTime(st))
 	return proceedTime
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -634,7 +634,7 @@ func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {
 	}
 	// TODO: state is needed for when configurable max inhibition
 	// is introduced (i.e. "core.refresh.max-inhibition-days").
-	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibitionTime(st))
+	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibitionDuration(st))
 	return proceedTime
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -350,14 +350,12 @@ func MaxInhibitionTime(st *state.State) time.Duration {
 }
 
 // maxInhibitionDays returns refresh.max-inhibition-days value if set, or the default value (14 days).
-// It deals with potentially wrong type due to lax validation.
 func maxInhibitionDays(st *state.State) int {
-	var maxInhibitionDays int
+	var maxInhibitionDays int = 0
 	err := config.NewTransaction(st).Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		logger.Noticef("internal error: refresh.max-inhibition-days system option is not valid: %v", err)
-		return 0
 	}
 
 	// not set, use default value

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -87,6 +87,8 @@ const (
 	snapdDesktopIntegrationSnapID = "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
 )
 
+const defaultMaxInhibitionDays = 14
+
 var ErrNothingToDo = errors.New("nothing to do")
 
 var osutilCheckFreeSpace = osutil.CheckFreeSpace
@@ -342,9 +344,8 @@ func refreshRetain(st *state.State) int {
 	return retain
 }
 
-// maxInhibitionTime returns the value of the maximum inhibition time, in seconds
+// maxInhibitionTime returns the value of the maximum inhibition time
 func maxInhibitionTime(st *state.State) time.Duration {
-
 	var maxInhibitionDays int
 	err := config.NewTransaction(st).Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 
@@ -354,7 +355,7 @@ func maxInhibitionTime(st *state.State) time.Duration {
 
 	// not set, use default value
 	if maxInhibitionDays == 0 {
-		maxInhibitionDays = 14
+		maxInhibitionDays = defaultMaxInhibitionDays
 	}
 
 	// deduct 1s so it doesn't look confusing initially when two notifications

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -344,26 +344,6 @@ func refreshRetain(st *state.State) int {
 	return retain
 }
 
-// maxInhibitionTime returns the value of the maximum inhibition time
-func maxInhibitionTime(st *state.State) time.Duration {
-	var maxInhibitionDays int
-	err := config.NewTransaction(st).Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
-
-	if err != nil && !config.IsNoOption(err) {
-		logger.Noticef("internal error: refresh.max-inhibition-days system option is not valid: %v", err)
-	}
-
-	// not set, use default value
-	if maxInhibitionDays == 0 {
-		maxInhibitionDays = defaultMaxInhibitionDays
-	}
-
-	// deduct 1s so it doesn't look confusing initially when two notifications
-	// get displayed in short period of time and it immediately goes from "14 days"
-	// to "13 days" left.
-	return time.Duration(maxInhibitionDays)*24*time.Hour - time.Second
-}
-
 var excludeFromRefreshAppAwareness = func(t snap.Type) bool {
 	return t == snap.TypeSnapd || t == snap.TypeOS
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -342,16 +342,10 @@ func refreshRetain(st *state.State) int {
 	return retain
 }
 
-func MaxInhibitionTime(st *state.State) time.Duration {
-	// deduct 1s so it doesn't look confusing initially when two notifications
-	// get displayed in short period of time and it immediately goes from "14 days"
-	// to "13 days" left.
-	return time.Duration(maxInhibitionDays(st))*24*time.Hour - time.Second
-}
+// maxInhibitionTime returns the value of the maximum inhibition time, in seconds
+func maxInhibitionTime(st *state.State) time.Duration {
 
-// maxInhibitionDays returns refresh.max-inhibition-days value if set, or the default value (14 days).
-func maxInhibitionDays(st *state.State) int {
-	var maxInhibitionDays int = 0
+	var maxInhibitionDays int
 	err := config.NewTransaction(st).Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 
 	if err != nil && !config.IsNoOption(err) {
@@ -362,7 +356,11 @@ func maxInhibitionDays(st *state.State) int {
 	if maxInhibitionDays == 0 {
 		maxInhibitionDays = 14
 	}
-	return maxInhibitionDays
+
+	// deduct 1s so it doesn't look confusing initially when two notifications
+	// get displayed in short period of time and it immediately goes from "14 days"
+	// to "13 days" left.
+	return time.Duration(maxInhibitionDays)*24*time.Hour - time.Second
 }
 
 var excludeFromRefreshAppAwareness = func(t snap.Type) bool {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -354,7 +354,7 @@ func maxInhibitionDays(st *state.State) int {
 	var maxInhibitionDays int = 0
 	err := config.NewTransaction(st).Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	if err != nil && !config.IsNoOption(err) {
 		logger.Noticef("internal error: refresh.max-inhibition-days system option is not valid: %v", err)
 	}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -87,8 +87,6 @@ const (
 	snapdDesktopIntegrationSnapID = "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
 )
 
-const defaultMaxInhibitionDays = 14
-
 var ErrNothingToDo = errors.New("nothing to do")
 
 var osutilCheckFreeSpace = osutil.CheckFreeSpace

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10219,13 +10219,13 @@ func (s *refreshSuite) TestSetMaxInhibitionDays(c *C) {
 	var maxInhibitionDays int
 	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 	c.Assert(maxInhibitionDays, Equals, 0)
-	maxInhibitionTime := snapstate.MaxInhibitionTime(st)
+	maxInhibitionTime := snapstate.MaxInhibitionDuration(st)
 	c.Assert(maxInhibitionTime, Equals, 14*24*time.Hour-time.Second)
 	err := tr.Set("core", "refresh.max-inhibition-days", 10)
 	c.Assert(err, IsNil)
 	tr.Commit()
 	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 	c.Assert(maxInhibitionDays, Equals, 10)
-	maxInhibitionTime = snapstate.MaxInhibitionTime(st)
+	maxInhibitionTime = snapstate.MaxInhibitionDuration(st)
 	c.Assert(maxInhibitionTime, Equals, 10*24*time.Hour-time.Second)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10219,13 +10219,13 @@ func (s *refreshSuite) TestSetMaxInhibitionDays(c *C) {
 	var maxInhibitionDays int
 	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 	c.Assert(maxInhibitionDays, Equals, 0)
-	maxInhibitionTime := snapstate.MaxInhibitionDuration(st)
-	c.Assert(maxInhibitionTime, Equals, 14*24*time.Hour-time.Second)
+	maxInhibitionDuration := snapstate.MaxInhibitionDuration(st)
+	c.Assert(maxInhibitionDuration, Equals, 14*24*time.Hour-time.Second)
 	err := tr.Set("core", "refresh.max-inhibition-days", 10)
 	c.Assert(err, IsNil)
 	tr.Commit()
 	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
 	c.Assert(maxInhibitionDays, Equals, 10)
-	maxInhibitionTime = snapstate.MaxInhibitionDuration(st)
-	c.Assert(maxInhibitionTime, Equals, 10*24*time.Hour-time.Second)
+	maxInhibitionDuration = snapstate.MaxInhibitionDuration(st)
+	c.Assert(maxInhibitionDuration, Equals, 10*24*time.Hour-time.Second)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10002,7 +10002,7 @@ func (s *snapmgrTestSuite) TestRefreshInhibitProceedTime(c *C) {
 	// Refresh inhibited
 	refreshInhibitedTime := time.Date(2024, 2, 12, 18, 36, 56, 0, time.UTC)
 	snapst.RefreshInhibitedTime = &refreshInhibitedTime
-	expectedRefreshInhibitProceedTime := refreshInhibitedTime.Add(snapstate.MaxInhibitionTime(st))
+	expectedRefreshInhibitProceedTime := refreshInhibitedTime.Add(snapstate.MaxInhibitionDuration(st))
 	c.Check(snapst.RefreshInhibitProceedTime(s.state), Equals, expectedRefreshInhibitProceedTime)
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10096,6 +10096,10 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 func (s *snapmgrTestSuite) TestCheckExpectedRestartNoEnv(c *C) {
 	os.Unsetenv("SNAPD_REVERT_TO_REV")
 
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
 	// no snapd related change in the state
 	err := snapstate.CheckExpectedRestart(st)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9992,17 +9992,22 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 
 func (s *snapmgrTestSuite) TestRefreshInhibitProceedTime(c *C) {
 	snapst := snapstate.SnapState{}
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
 	// No pending refresh
 	c.Check(snapst.RefreshInhibitProceedTime(s.state).IsZero(), Equals, true)
 
 	// Refresh inhibited
 	refreshInhibitedTime := time.Date(2024, 2, 12, 18, 36, 56, 0, time.UTC)
 	snapst.RefreshInhibitedTime = &refreshInhibitedTime
-	expectedRefreshInhibitProceedTime := refreshInhibitedTime.Add(snapstate.MaxInhibition)
+	expectedRefreshInhibitProceedTime := refreshInhibitedTime.Add(snapstate.MaxInhibitionTime(st))
 	c.Check(snapst.RefreshInhibitProceedTime(s.state), Equals, expectedRefreshInhibitProceedTime)
 }
 
 func (s *snapmgrTestSuite) TestChangeStatusRecordsChangeUpdateNotice(c *C) {
+
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -10090,10 +10095,6 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 
 func (s *snapmgrTestSuite) TestCheckExpectedRestartNoEnv(c *C) {
 	os.Unsetenv("SNAPD_REVERT_TO_REV")
-
-	st := s.state
-	st.Lock()
-	defer st.Unlock()
 
 	// no snapd related change in the state
 	err := snapstate.CheckExpectedRestart(st)
@@ -10207,4 +10208,24 @@ func (s *snapmgrTestSuite) TestCheckExpectedRestartFromStartUpRequestsStop(c *C)
 	// startup asserts the runtime failure state
 	err = s.snapmgr.StartUp()
 	c.Check(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
+}
+
+func (s *refreshSuite) TestSetMaxInhibitionDays(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	tr := config.NewTransaction(st)
+	var maxInhibitionDays int
+	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
+	c.Assert(maxInhibitionDays, Equals, 0)
+	maxInhibitionTime := snapstate.MaxInhibitionTime(st)
+	c.Assert(maxInhibitionTime, Equals, 14*24*time.Hour-time.Second)
+	err := tr.Set("core", "refresh.max-inhibition-days", 10)
+	c.Assert(err, IsNil)
+	tr.Commit()
+	tr.Get("core", "refresh.max-inhibition-days", &maxInhibitionDays)
+	c.Assert(maxInhibitionDays, Equals, 10)
+	maxInhibitionTime = snapstate.MaxInhibitionTime(st)
+	c.Assert(maxInhibitionTime, Equals, 10*24*time.Hour-time.Second)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -11203,7 +11203,7 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 	defer s.state.Unlock()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 	// Add first snap
 	si1 := &snap.SideInfo{
 		RealName: "some-snap",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -10228,7 +10228,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 	refreshInfo := busyErr.PendingSnapRefreshInfo()
 	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
 		InstanceName:  "some-snap",
-		TimeRemaining: snapstate.MaxInhibitionTime(s.state),
+		TimeRemaining: snapstate.MaxInhibitionDuration(s.state),
 	})
 
 	tasks := ts.Tasks()
@@ -10656,7 +10656,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 		refreshInfo := busyErr.PendingSnapRefreshInfo()
 		c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
 			InstanceName:  "some-snap",
-			TimeRemaining: snapstate.MaxInhibitionTime(s.state),
+			TimeRemaining: snapstate.MaxInhibitionDuration(s.state),
 		})
 		c.Assert(ts, IsNil)
 
@@ -11137,7 +11137,7 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	var notified bool
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(_ context.Context, pendingInfo *userclient.PendingSnapRefreshInfo) {
 		c.Check(pendingInfo.InstanceName, Equals, "some-snap")
-		c.Check(pendingInfo.TimeRemaining, Equals, snapstate.MaxInhibitionTime(s.state))
+		c.Check(pendingInfo.TimeRemaining, Equals, snapstate.MaxInhibitionDuration(s.state))
 		notified = true
 	})
 	defer restore()

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -11312,7 +11312,7 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeoutError(c *C
 	defer s.state.Unlock()
 
 	instant := time.Now()
-	pastInstant := instant.Add(-snapstate.MaxInhibition * 2)
+	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 	// Add snap
 	si1 := &snap.SideInfo{
 		RealName: "some-snap",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -10228,7 +10228,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 	refreshInfo := busyErr.PendingSnapRefreshInfo()
 	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
 		InstanceName:  "some-snap",
-		TimeRemaining: snapstate.MaxInhibition,
+		TimeRemaining: snapstate.MaxInhibitionTime(s.state),
 	})
 
 	tasks := ts.Tasks()
@@ -10656,7 +10656,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 		refreshInfo := busyErr.PendingSnapRefreshInfo()
 		c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
 			InstanceName:  "some-snap",
-			TimeRemaining: snapstate.MaxInhibition,
+			TimeRemaining: snapstate.MaxInhibitionTime(s.state),
 		})
 		c.Assert(ts, IsNil)
 
@@ -11137,7 +11137,7 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	var notified bool
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(_ context.Context, pendingInfo *userclient.PendingSnapRefreshInfo) {
 		c.Check(pendingInfo.InstanceName, Equals, "some-snap")
-		c.Check(pendingInfo.TimeRemaining, Equals, snapstate.MaxInhibition)
+		c.Check(pendingInfo.TimeRemaining, Equals, snapstate.MaxInhibitionTime(s.state))
 		notified = true
 	})
 	defer restore()


### PR DESCRIPTION
This patch allows to configure the number of days refresh is inhibited, between 1 and the current 14 days.

This patch implements proposal SD165. The rationale behind this is that 14 days is a reasonable value for a server, but not for a desktop, where users are, usually, less experienced than sysadmins, and so it is a good idea to keep updated the snaps faster.

The proposal is available at https://docs.google.com/document/d/1ZdKwvu-WRyAKLahFD7Tq_gEAwdt38VBu4KU6w31TZjo/edit?usp=sharing

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
