### PR TITLE
tests/main/postrm-purge: account for snap services which may have failed

### DIFF
--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -95,7 +95,11 @@ execute: |
 
     # XXX: use retry instead
     sleep 5
-    systemctl --no-legend --full > output.txt
+    # snap services may have failed and systemd will keep their 'state' in
+    # memory even after it's reloaded, since the purge does not run reset-failed
+    # to allow the user to inspect them as need we need to account for those
+    # entries in the output
+    systemctl --plain --no-legend --full |grep -v ' not-found failed ' > output.txt
     if grep -E "snap\..*\.(service|timer|socket)" < output.txt; then
         echo "found unexpected leftovers"
         exit 1

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -1,5 +1,7 @@
 summary: Check that package remove and purge removes everything related to snaps
-
+details: |
+  Ensure that the purge we do when removing the snapd package really removes all
+  snap related files from the host system.
 systems: [-ubuntu-core-*]
 
 prepare: |


### PR DESCRIPTION
It is possible that snap services may have refused to stop or failed when purging the snapd package data, in which case such services will appear in the output like so:

    snap.test-snapd-dbus-provider.system-provider.service not-found failed failed snap.test-snapd-dbus-provider.system-provider.service

Since we do not reset such service in order to allow the user to inspect their state, the test needs to account for this.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
