### PR TITLE
steam_support: generalize pressure-vessel root paths

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -169,15 +169,15 @@ mount options=(rw, rbind) /bindfile* -> /newroot/run/host/font-dirs.xml,
 mount options=(rw, rbind) /oldroot/usr/share/icons/ -> /newroot/run/host/share/icons/,
 mount options=(rw, rbind) /oldroot/home/**/.local/share/icons/ -> /newroot/run/host/user-share/icons/,
 
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/wayland-* -> /newroot/*/pressure-vessel/wayland-*,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/wayland-* -> /newroot/**,
 mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X* -> /newroot/tmp/.X11-unix/X*,
-mount options=(rw, rbind) /bindfile* -> /newroot/*/pressure-vessel/Xauthority,
+mount options=(rw, rbind) /bindfile* -> /newroot/**,
 
-mount options=(rw, rbind) /bindfile* -> /newroot/*/pressure-vessel/pulse/config,
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/pulse/native -> /newroot/*/pressure-vessel/pulse/native,
+mount options=(rw, rbind) /bindfile* -> /newroot/**,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/pulse/native -> /newroot/**,
 mount options=(rw, rbind) /oldroot/dev/snd/ -> /newroot/dev/snd/,
 mount options=(rw, rbind) /bindfile* -> /newroot/etc/asound.conf,
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/bus -> /newroot/*/pressure-vessel/bus,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/bus -> /newroot/**,
 
 mount options=(rw, rbind) /oldroot/run/dbus/system_bus_socket -> /newroot/run/dbus/system_bus_socket,
 mount options=(rw, rbind) /oldroot/run/systemd/resolve/io.systemd.Resolve -> /newroot/run/systemd/resolve/io.systemd.Resolve,
@@ -188,7 +188,7 @@ mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** 
 
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,
-mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/*/pressure-vessel/ldso/,
+mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/**,
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/tmp/.X11-unix/,
 
 # Pivot from the intermediate root to sandbox root

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -138,8 +138,8 @@ mount options=(rw, rbind) /oldroot/home/{,**} -> /newroot/home/{,**},
 mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/** -> /newroot/etc/**,
-mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.cache,
-mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.conf,
+mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/*/pressure-vessel/ldso/runtime-ld.so.cache,
+mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/*/pressure-vessel/ldso/runtime-ld.so.conf,
 
 mount options=(rw, rbind) /oldroot/{home,media,mnt,run/media,opt,srv}/**/steamapps/common/** -> /newroot/**,
 
@@ -169,15 +169,15 @@ mount options=(rw, rbind) /bindfile* -> /newroot/run/host/font-dirs.xml,
 mount options=(rw, rbind) /oldroot/usr/share/icons/ -> /newroot/run/host/share/icons/,
 mount options=(rw, rbind) /oldroot/home/**/.local/share/icons/ -> /newroot/run/host/user-share/icons/,
 
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/wayland-* -> /newroot/run/pressure-vessel/wayland-*,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/wayland-* -> /newroot/*/pressure-vessel/wayland-*,
 mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X* -> /newroot/tmp/.X11-unix/X*,
-mount options=(rw, rbind) /bindfile* -> /newroot/run/pressure-vessel/Xauthority,
+mount options=(rw, rbind) /bindfile* -> /newroot/*/pressure-vessel/Xauthority,
 
-mount options=(rw, rbind) /bindfile* -> /newroot/run/pressure-vessel/pulse/config,
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/pulse/native -> /newroot/run/pressure-vessel/pulse/native,
+mount options=(rw, rbind) /bindfile* -> /newroot/*/pressure-vessel/pulse/config,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/pulse/native -> /newroot/*/pressure-vessel/pulse/native,
 mount options=(rw, rbind) /oldroot/dev/snd/ -> /newroot/dev/snd/,
 mount options=(rw, rbind) /bindfile* -> /newroot/etc/asound.conf,
-mount options=(rw, rbind) /oldroot/run/user/[0-9]*/bus -> /newroot/run/pressure-vessel/bus,
+mount options=(rw, rbind) /oldroot/run/user/[0-9]*/bus -> /newroot/*/pressure-vessel/bus,
 
 mount options=(rw, rbind) /oldroot/run/dbus/system_bus_socket -> /newroot/run/dbus/system_bus_socket,
 mount options=(rw, rbind) /oldroot/run/systemd/resolve/io.systemd.Resolve -> /newroot/run/systemd/resolve/io.systemd.Resolve,
@@ -188,7 +188,7 @@ mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** 
 
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,
-mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/run/pressure-vessel/ldso/,
+mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/*/pressure-vessel/ldso/,
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/tmp/.X11-unix/,
 
 # Pivot from the intermediate root to sandbox root
@@ -201,7 +201,7 @@ umount /,
 /usr/** ixr,
 deny /usr/bin/{chfn,chsh,gpasswd,mount,newgrp,passwd,su,sudo,umount} x,
 /run/host/** mr,
-/run/pressure-vessel/** mrw,
+/*/pressure-vessel/** mrw,
 /run/host/usr/sbin/ldconfig* ixr,
 /run/host/usr/bin/localedef ixr,
 /var/cache/ldconfig/** rw,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -138,8 +138,8 @@ mount options=(rw, rbind) /oldroot/home/{,**} -> /newroot/home/{,**},
 mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/** -> /newroot/etc/**,
-mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/*/pressure-vessel/ldso/runtime-ld.so.cache,
-mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/*/pressure-vessel/ldso/runtime-ld.so.conf,
+mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/**,
+mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/**,
 
 mount options=(rw, rbind) /oldroot/{home,media,mnt,run/media,opt,srv}/**/steamapps/common/** -> /newroot/**,
 

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -187,9 +187,7 @@ mount options=(rw, rbind) /bindfile* -> /newroot/run/host/container-manager,
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/**,
 
 # Allow masking of certain directories in the sandbox
-mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/**,
-mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/tmp/.X11-unix/,
 
 # Pivot from the intermediate root to sandbox root
 mount options in (rw, silent, rprivate) -> /oldroot/,


### PR DESCRIPTION
This PR changes every `pressure-vessel` parent to `*` (previously just `run`).

This fixes https://github.com/canonical/steam-snap/issues/356 in the Steam snap, where users were encountering the error: `bwrap: Can't mount tmpfs on /newroot/var/pressure-vessel/ldso: Permission denied` when running any Proton game, which represents a huge portion of games.

I included every pressure-vessel path (not just the tmpfs one noted in the issue) since pressure-vessel is likely to change at any point, as noted by @smcv here: https://github.com/canonical/steam-snap/issues/356#issuecomment-1893784766. In that comment, Simon recommended something more general and less restrictive (`/newroot/**/`), but for the time being I've opted for a more restrictive approach here.

Security permitting, we could generalize pressure-vessel paths more, e.g. `/newroot/*/pressure-vessel/**,` or even `/newroot/**,`. I'm not sure of the full security implications of these options, so I would love to have a discussion on how this can be improved.

*For reference, [Pressure Vessel](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/main/pressure-vessel) is a containerization tool used by Steam to run games inside. Steam and Pressure Vessel are generally to be considered trusted.*