### PR TITLE
systemd: add mount unit templates for kernel-modules

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -301,7 +301,20 @@ func MockJournalctl(f func(svcs []string, n int, follow, namespaces bool) (io.Re
 	}
 }
 
+// MountUnitType is an enum for the supported mount unit types.
+type MountUnitType int
+
+const (
+	// RegularMountUnit is a mount with the usual dependencies
+	RegularMountUnit MountUnitType = iota
+	// BeforeDriversLoadMountUnit mounts things before kernel modules are
+	// loaded either by udevd or by systemd-modules-load.service.
+	BeforeDriversLoadMountUnit
+)
+
 type MountUnitOptions struct {
+	// MountUnitType is the type of mount unit we want
+	MountUnitType MountUnitType
 	// Whether the unit is transient or persistent across reboots
 	Lifetime    UnitLifetime
 	Description string
@@ -1368,7 +1381,7 @@ var squashfsFsType = squashfs.FsType
 
 // Note that WantedBy=multi-user.target and Before=local-fs.target are
 // only used to allow downgrading to an older version of snapd.
-const mountUnitTemplate = `[Unit]
+const regularMountUnitTmpl = `[Unit]
 Description={{.Description}}
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
@@ -1389,8 +1402,33 @@ X-SnapdOrigin={{.}}
 {{- end}}
 `
 
+// We want kernel-modules components to be mounted before modules are
+// loaded (that is before systemd-{udevd,modules-load}).
+const beforeDriversLoadUnitTmpl = `[Unit]
+Description={{.Description}}
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=sysinit.target
+Before=systemd-udevd.service systemd-modules-load.service
+Before=umount.target
+Conflicts=umount.target
+
+[Mount]
+What={{.What}}
+Where={{.Where}}
+Type={{.Fstype}}
+Options={{join .Options ","}}
+
+[Install]
+WantedBy=sysinit.target
+{{- with .Origin}}
+X-SnapdOrigin={{.}}
+{{- end}}
+`
+
 var templateFuncs = template.FuncMap{"join": strings.Join}
-var parsedMountUnitTemplate = template.Must(template.New("unit").Funcs(templateFuncs).Parse(mountUnitTemplate))
+var parsedRegularMountUnitTmpl = template.Must(template.New("unit").Funcs(templateFuncs).Parse(regularMountUnitTmpl))
+var parsedKernelDriversMountUnitTmpl = template.Must(template.New("unit").Funcs(templateFuncs).Parse(beforeDriversLoadUnitTmpl))
 
 const (
 	snappyOriginModule = "X-SnapdOrigin"
@@ -1404,7 +1442,17 @@ func ensureMountUnitFile(u *MountUnitOptions) (mountUnitName string, modified mo
 	mu := MountUnitPathWithLifetime(u.Lifetime, u.Where)
 	var unitContent bytes.Buffer
 
-	if err := parsedMountUnitTemplate.Execute(&unitContent, &u); err != nil {
+	var mntUnitTmpl *template.Template
+	switch u.MountUnitType {
+	case RegularMountUnit:
+		mntUnitTmpl = parsedRegularMountUnitTmpl
+	case BeforeDriversLoadMountUnit:
+		mntUnitTmpl = parsedKernelDriversMountUnitTmpl
+	default:
+		return "", mountUnchanged, fmt.Errorf("internal error: unknown mount unit type")
+	}
+
+	if err := mntUnitTmpl.Execute(&unitContent, &u); err != nil {
 		return "", mountUnchanged, fmt.Errorf("cannot generate mount unit: %v", err)
 	}
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1398,6 +1398,103 @@ X-SnapdOrigin=bar
 	})
 }
 
+func (s *SystemdTestSuite) TestAddKernelModulesMountUnit(c *C) {
+	rootDir := dirs.GlobalRootDir
+
+	restore := squashfs.MockNeedsFuse(false)
+	defer restore()
+
+	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snapd/snaps/mykernel+mykmod_11.comp")
+	makeMockFile(c, mockSnapPath)
+
+	addMountUnitOptions := &MountUnitOptions{
+		MountUnitType: BeforeDriversLoadMountUnit,
+		Lifetime:      Persistent,
+		Description:   "Mount unit for wifi kernel modules component",
+		What:          mockSnapPath,
+		Where:         "/run/mnt/kernel-modules/5.15.0-91-generic/mykmod/",
+		Fstype:        "squashfs",
+		Options:       []string{"nodev,ro,x-gdu.hide,x-gvfs-hide"},
+		Origin:        "",
+	}
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFileWithOptions(addMountUnitOptions)
+	c.Assert(err, IsNil)
+	defer os.Remove(mountUnitName)
+
+	c.Assert(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`[Unit]
+Description=Mount unit for wifi kernel modules component
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=sysinit.target
+Before=systemd-udevd.service systemd-modules-load.service
+Before=umount.target
+Conflicts=umount.target
+
+[Mount]
+What=%s
+Where=/run/mnt/kernel-modules/5.15.0-91-generic/mykmod/
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
+
+[Install]
+WantedBy=sysinit.target
+`, mockSnapPath))
+	escapedUnit := "run-mnt-kernel\\x2dmodules-5.15.0\\x2d91\\x2dgeneric-mykmod.mount"
+	c.Assert(s.argses, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--root", rootDir, "enable", escapedUnit},
+		{"reload-or-restart", escapedUnit},
+	})
+}
+
+func (s *SystemdTestSuite) TestAddKernelTreeMountUnit(c *C) {
+	rootDir := dirs.GlobalRootDir
+
+	restore := squashfs.MockNeedsFuse(false)
+	defer restore()
+
+	// systemd would automatically add a dependency for this unit on the mount unit for
+	// /run/mnt/kernel-modules/5.15.0-91-generic/mykmod
+	addMountUnitOptions := &MountUnitOptions{
+		MountUnitType: BeforeDriversLoadMountUnit,
+		Lifetime:      Persistent,
+		Description:   "Mount unit for kernel modules in kernel tree",
+		What:          "/run/mnt/kernel-modules/5.15.0-91-generic/mykmod/modules/5.15.0-91-generic",
+		Where:         "/usr/lib/modules/5.15.0-91-generic/updates/mykmod/",
+		Fstype:        "none",
+		Options:       []string{"bind"},
+		Origin:        "",
+	}
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFileWithOptions(addMountUnitOptions)
+	c.Assert(err, IsNil)
+	defer os.Remove(mountUnitName)
+
+	c.Assert(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`[Unit]
+Description=Mount unit for kernel modules in kernel tree
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=sysinit.target
+Before=systemd-udevd.service systemd-modules-load.service
+Before=umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/run/mnt/kernel-modules/5.15.0-91-generic/mykmod/modules/5.15.0-91-generic
+Where=/usr/lib/modules/5.15.0-91-generic/updates/mykmod/
+Type=none
+Options=bind
+
+[Install]
+WantedBy=sysinit.target
+`))
+	escapedUnit := "usr-lib-modules-5.15.0\\x2d91\\x2dgeneric-updates-mykmod.mount"
+	c.Assert(s.argses, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--root", rootDir, "enable", escapedUnit},
+		{"reload-or-restart", escapedUnit},
+	})
+}
+
 func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer restore()


### PR DESCRIPTION
We define specific mount unit templates for kernel-modules components,
as we need to mount them before any service that loads kernel modules.
These units are of two types:

1. Units to mount the kernel-modules component containers.
2. Units that mount bits of these containers under
   /usr/lib/{modules,firmware}.
