### PR TITLE
packaging: require xdelta on Fedora and EPEL9

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -141,6 +141,11 @@ Requires:       fuse
 Requires:       ((squashfuse and fuse) or kmod(squashfs.ko))
 %endif
 
+# Require xdelta for delta updates of snap packages.
+%if 0%{?fedora} || ( 0%{?rhel} && 0%{?rhel} > 8 )
+Requires:       xdelta
+%endif
+
 # bash-completion owns /usr/share/bash-completion/completions
 Requires:       bash-completion
 


### PR DESCRIPTION
This is a sync from Fedora, it was released as a part of: https://bodhi.fedoraproject.org/updates/FEDORA-2024-9699b795ca
