### PR TITLE
many: add CLI support for getting and setting aspects

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -424,7 +424,7 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 
 // Get returns the aspect value identified by the request. If either the named
 // aspect or the corresponding value can't be found, a NotFoundError is returned.
-func (a *Aspect) Get(databag DataBag, request string) (map[string]interface{}, error) {
+func (a *Aspect) Get(databag DataBag, request string) (interface{}, error) {
 	if err := validateAspectDottedPath(request, nil); err != nil {
 		return nil, badRequestErrorFrom(a, "get", request, err.Error())
 	}
@@ -461,8 +461,7 @@ func (a *Aspect) Get(databag DataBag, request string) (map[string]interface{}, e
 		return nil, notFoundErrorFrom(a, "get", request, "matching rules don't map to any values")
 	}
 
-	// the top level maps the request to the remaining namespace
-	return map[string]interface{}{request: merged}, nil
+	return merged, nil
 }
 
 func mergeNamespaces(old, new interface{}) (interface{}, error) {

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -152,7 +152,7 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 
 	ssid, err := wsAspect.Get(databag, "ssid")
 	c.Assert(err, IsNil)
-	c.Check(ssid, DeepEquals, map[string]interface{}{"ssid": "my-ssid"})
+	c.Check(ssid, DeepEquals, "my-ssid")
 
 	// nested list value
 	err = wsAspect.Set(databag, "ssids", []string{"one", "two"})
@@ -160,7 +160,7 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 
 	ssids, err := wsAspect.Get(databag, "ssids")
 	c.Assert(err, IsNil)
-	c.Check(ssids, DeepEquals, map[string]interface{}{"ssids": []interface{}{"one", "two"}})
+	c.Check(ssids, DeepEquals, []interface{}{"one", "two"})
 
 	// top-level string
 	err = wsAspect.Set(databag, "top-level", "randomValue")
@@ -168,7 +168,7 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 
 	topLevel, err := wsAspect.Get(databag, "top-level")
 	c.Assert(err, IsNil)
-	c.Check(topLevel, DeepEquals, map[string]interface{}{"top-level": "randomValue"})
+	c.Check(topLevel, DeepEquals, "randomValue")
 
 	// dotted request paths are permitted
 	err = wsAspect.Set(databag, "dotted.path", 3)
@@ -176,7 +176,7 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 
 	num, err := wsAspect.Get(databag, "dotted.path")
 	c.Assert(err, IsNil)
-	c.Check(num, DeepEquals, map[string]interface{}{"dotted.path": float64(3)})
+	c.Check(num, DeepEquals, float64(3))
 }
 
 func (s *aspectSuite) TestAspectNotFound(c *C) {
@@ -369,7 +369,7 @@ func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
 
 		value, err := aspect.Get(databag, t.request)
 		c.Assert(err, IsNil, cmt)
-		c.Assert(value, DeepEquals, map[string]interface{}{t.request: "expectedValue"}, cmt)
+		c.Assert(value, DeepEquals, "expectedValue", cmt)
 
 		getPath, setPath := databag.getLastPaths()
 		c.Assert(getPath, Equals, t.storage, cmt)
@@ -476,7 +476,7 @@ func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 
 	value, err := aspect.Get(databag, "bar")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"bar": "bval"})
+	c.Assert(value, DeepEquals, "bval")
 }
 
 func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
@@ -505,7 +505,7 @@ func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 	// doesn't affect the other leaf entry under "foo"
 	value, err := aspect.Get(databag, "baz")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"baz": "bazVal"})
+	c.Assert(value, DeepEquals, "bazVal")
 }
 
 func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
@@ -624,16 +624,16 @@ func (s *aspectSuite) TestAspectGetResultNamespaceMatchesRequest(c *C) {
 
 	value, err := aspect.Get(databag, "one.two")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"one.two": "value"})
+	c.Assert(value, DeepEquals, "value")
 
 	value, err = aspect.Get(databag, "onetwo")
 	c.Assert(err, IsNil)
 	// the key matches the request, not the storage storage
-	c.Assert(value, DeepEquals, map[string]interface{}{"onetwo": "value"})
+	c.Assert(value, DeepEquals, "value")
 
 	value, err = aspect.Get(databag, "one")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"one": map[string]interface{}{"two": "value"}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"two": "value"})
 }
 
 func (s *aspectSuite) TestAspectGetMatchesOnPrefix(c *C) {
@@ -655,11 +655,11 @@ func (s *aspectSuite) TestAspectGetMatchesOnPrefix(c *C) {
 
 	value, err := aspect.Get(databag, "snapd.status")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snapd.status": "active"})
+	c.Assert(value, DeepEquals, "active")
 
 	value, err = aspect.Get(databag, "snapd")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": map[string]interface{}{"status": "active"}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"status": "active"})
 }
 
 func (s *aspectSuite) TestAspectGetNoMatchRequestLongerThanPattern(c *C) {
@@ -700,12 +700,11 @@ func (s *aspectSuite) TestAspectManyPrefixMatches(c *C) {
 
 	value, err := aspect.Get(databag, "status")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{
-		"status": map[string]interface{}{
+	c.Assert(value, DeepEquals,
+		map[string]interface{}{
 			"snapd":   "disabled",
 			"firefox": "active",
-		},
-	})
+		})
 }
 
 func (s *aspectSuite) TestAspectCombineNamespacesInPrefixMatches(c *C) {
@@ -732,16 +731,15 @@ func (s *aspectSuite) TestAspectCombineNamespacesInPrefixMatches(c *C) {
 
 	value, err := aspect.Get(databag, "status")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{
-		"status": map[string]interface{}{
+	c.Assert(value, DeepEquals,
+		map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": map[string]interface{}{
 					"firefox": "active",
 				},
 				"snapd": "disabled",
 			},
-		},
-	})
+		})
 }
 
 func (s *aspectSuite) TestGetScalarOverwritesLeafOfMapValue(c *C) {
@@ -770,7 +768,7 @@ func (s *aspectSuite) TestGetScalarOverwritesLeafOfMapValue(c *C) {
 
 	value, err := aspect.Get(databag, "motors")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"motors": map[string]interface{}{"a": map[string]interface{}{"speed": 101.5}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"a": map[string]interface{}{"speed": 101.5}})
 }
 
 func (s *aspectSuite) TestGetSingleScalarOk(c *C) {
@@ -789,7 +787,7 @@ func (s *aspectSuite) TestGetSingleScalarOk(c *C) {
 
 	value, err := aspect.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(value, DeepEquals, "bar")
 }
 
 func (s *aspectSuite) TestGetMatchScalarAndMapError(c *C) {
@@ -831,7 +829,7 @@ func (s *aspectSuite) TestGetRulesAreSortedByParentage(c *C) {
 	value, err := aspect.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// returned the value read by entry "foo"
-	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}})
 
 	err = databag.Set("second", map[string]interface{}{"baz": "second"})
 	c.Assert(err, IsNil)
@@ -839,7 +837,7 @@ func (s *aspectSuite) TestGetRulesAreSortedByParentage(c *C) {
 	value, err = aspect.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// the leaf is replaced by a value read from a rule that is nested
-	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "second"}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "second"}})
 
 	err = databag.Set("third", "third")
 	c.Assert(err, IsNil)
@@ -847,7 +845,7 @@ func (s *aspectSuite) TestGetRulesAreSortedByParentage(c *C) {
 	value, err = aspect.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// lastly, it reads the value from "foo.bar.baz" the most nested entry
-	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "third"}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "third"}})
 }
 
 func (s *aspectSuite) TestGetUnmatchedPlaceholderReturnsAll(c *C) {
@@ -871,7 +869,7 @@ func (s *aspectSuite) TestGetUnmatchedPlaceholderReturnsAll(c *C) {
 
 	value, err := aspect.Get(databag, "snaps")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snaps": map[string]interface{}{"snapd": float64(1), "foo": map[string]interface{}{"bar": float64(2)}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": float64(1), "foo": map[string]interface{}{"bar": float64(2)}})
 }
 
 func (s *aspectSuite) TestGetUnmatchedPlaceholdersWithNestedValues(c *C) {
@@ -897,7 +895,7 @@ func (s *aspectSuite) TestGetUnmatchedPlaceholdersWithNestedValues(c *C) {
 
 	value, err := asp.Get(databag, "snaps")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snaps": map[string]interface{}{"snapd": map[string]interface{}{"status": "active"}}})
+	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": map[string]interface{}{"status": "active"}})
 }
 
 func (s *aspectSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
@@ -937,12 +935,10 @@ func (s *aspectSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 	value, err := asp.Get(databag, "a")
 	c.Assert(err, IsNil)
 	expected := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b1": map[string]interface{}{
-				"c": map[string]interface{}{
-					"d1": map[string]interface{}{
-						"e": "end",
-					},
+		"b1": map[string]interface{}{
+			"c": map[string]interface{}{
+				"d1": map[string]interface{}{
+					"e": "end",
 				},
 			},
 		},
@@ -978,12 +974,10 @@ func (s *aspectSuite) TestGetMergeAtDifferentLevels(c *C) {
 	value, err := asp.Get(databag, "a")
 	c.Assert(err, IsNil)
 	expected := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b": map[string]interface{}{
-				"c": map[string]interface{}{
-					"d": map[string]interface{}{
-						"e": "end",
-					},
+		"b": map[string]interface{}{
+			"c": map[string]interface{}{
+				"d": map[string]interface{}{
+					"e": "end",
 				},
 			},
 		},
@@ -1137,19 +1131,14 @@ func (s *aspectSuite) TestReadWriteRead(c *C) {
 
 	data, err := asp.Get(databag, "a")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"a": initData,
-	})
+	c.Assert(data, DeepEquals, initData)
 
-	// we return the data in a map keyed the request so unwrap before setting
-	err = asp.Set(databag, "a", data["a"])
+	err = asp.Set(databag, "a", data)
 	c.Assert(err, IsNil)
 
 	data, err = asp.Get(databag, "a")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"a": initData,
-	})
+	c.Assert(data, DeepEquals, initData)
 }
 
 func (s *aspectSuite) TestReadWriteSameDataAtDifferentLevels(c *C) {
@@ -1172,11 +1161,9 @@ func (s *aspectSuite) TestReadWriteSameDataAtDifferentLevels(c *C) {
 	c.Assert(err, IsNil)
 
 	for _, req := range []string{"a", "a.b", "a.b.c"} {
-		namespacedVal, err := asp.Get(databag, req)
+		val, err := asp.Get(databag, req)
 		c.Assert(err, IsNil)
 
-		// Get returns the data in a collapsed top-level namespace so we must remove it before setting back
-		val := namespacedVal[req]
 		err = asp.Set(databag, req, val)
 		c.Assert(err, IsNil)
 	}
@@ -1249,10 +1236,8 @@ func (s *aspectSuite) TestGetReadsStorageLessNestedNamespaceBefore(c *C) {
 	data, err := asp.Get(databag, "snaps")
 	c.Assert(err, IsNil)
 	c.Assert(data, DeepEquals, map[string]interface{}{
-		"snaps": map[string]interface{}{
-			"snapd": map[string]interface{}{
-				"version": float64(2),
-			},
+		"snapd": map[string]interface{}{
+			"version": float64(2),
 		},
 	})
 }

--- a/client/aspects.go
+++ b/client/aspects.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func (c *Client) AspectGet(aspectID string, requests []string) (result map[string]interface{}, err error) {
+	query := url.Values{}
+	query.Add("fields", strings.Join(requests, ","))
+
+	endpoint := fmt.Sprintf("/v2/aspects/%s", aspectID)
+	_, err = c.doSync("GET", endpoint, query, nil, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *Client) AspectSet(aspectID string, requestValues map[string]interface{}) (changeID string, err error) {
+	body, err := json.Marshal(requestValues)
+	if err != nil {
+		return "", err
+	}
+
+	headers := make(map[string]string)
+	headers["Content-Type"] = "application/json"
+
+	endpoint := fmt.Sprintf("/v2/aspects/%s", aspectID)
+	return c.doAsync("PUT", endpoint, nil, headers, bytes.NewReader(body))
+}

--- a/client/aspects_test.go
+++ b/client/aspects_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/url"
+
+	. "gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestAspectGet(c *C) {
+	cs.rsp = `{"type": "sync", "result":{"foo":"baz","bar":1}}`
+
+	res, err := cs.cli.AspectGet("a/b/c", []string{"foo", "bar"})
+	c.Check(err, IsNil)
+	c.Check(res, DeepEquals, map[string]interface{}{"foo": "baz", "bar": json.Number("1")})
+	c.Assert(cs.reqs, HasLen, 1)
+	c.Check(cs.reqs[0].Method, Equals, "GET")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/aspects/a/b/c")
+	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"fields": []string{"foo,bar"}})
+}
+
+func (cs *clientSuite) TestAspectSet(c *C) {
+	cs.status = 202
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "123"}`
+
+	chgID, err := cs.cli.AspectSet("a/b/c", map[string]interface{}{"foo": "bar", "baz": json.Number("1")})
+	c.Check(err, IsNil)
+	c.Check(chgID, Equals, "123")
+	c.Assert(cs.reqs, HasLen, 1)
+	c.Check(cs.reqs[0].Method, Equals, "PUT")
+	c.Check(cs.reqs[0].Header.Get("Content-Type"), Equals, "application/json")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/aspects/a/b/c")
+	data, err := ioutil.ReadAll(cs.reqs[0].Body)
+	c.Assert(err, IsNil)
+
+	// need to decode because entries may have been encoded in any order
+	res := make(map[string]interface{})
+	err = json.Unmarshal(data, &res)
+	c.Assert(err, IsNil)
+	c.Check(res, DeepEquals, map[string]interface{}{"foo": "bar", "baz": float64(1)})
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -35,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
@@ -681,7 +680,7 @@ func (cs *clientSuite) TestClientSystemRecoveryKeys(c *C) {
 	c.Check(key.RecoveryKey, Equals, "42")
 }
 
-func (cs *clientSuite) TestClientDebugEnvVar(c *check.C) {
+func (cs *clientSuite) TestClientDebugEnvVar(c *C) {
 	buf, restore := logger.MockLogger()
 	defer restore()
 
@@ -702,9 +701,9 @@ func (cs *clientSuite) TestClientDebugEnvVar(c *check.C) {
 	os.Setenv("SNAP_CLIENT_DEBUG_HTTP", "7")
 
 	cli := client.New(&client.Config{BaseURL: srv.URL})
-	c.Assert(cli, check.NotNil)
+	c.Assert(cli, NotNil)
 	_, err := cli.Do("GET", "/", nil, strings.NewReader("foo"), nil, nil)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, IsNil)
 
 	// check request
 	c.Assert(buf.String(), testutil.Contains, `logger.go:67: DEBUG: > "GET`)

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -46,6 +46,14 @@ Configuration option may be unset with exclamation mark:
     $ snap set snap-name author!
 `)
 
+// TODO: check the experimental feature is enabled and append this to set's help
+var longAspectSetHelp = i18n.G(`
+With the aspects experimental feature enabled, if the first argument passed
+into set is an aspect identifier matching the format <account-id>/<bundle>/<aspect>,
+set will use the aspects configuration API. In this case, the command sets the
+values as provided for the dot-separated aspect paths.
+`)
+
 type cmdSet struct {
 	waitMixin
 	Positional struct {
@@ -58,7 +66,7 @@ type cmdSet struct {
 }
 
 func init() {
-	addCommand("set", shortSetHelp, longSetHelp, func() flags.Commander { return &cmdSet{} },
+	addCommand("set", shortSetHelp, longSetHelp+longAspectSetHelp, func() flags.Commander { return &cmdSet{} },
 		waitDescs.also(map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"t": i18n.G("Parse the value strictly as JSON document"),
@@ -78,7 +86,7 @@ func init() {
 		})
 }
 
-func (x *cmdSet) Execute(args []string) error {
+func (x *cmdSet) Execute([]string) error {
 	if x.String && x.Typed {
 		return fmt.Errorf(i18n.G("cannot use -t and -s together"))
 	}
@@ -112,16 +120,46 @@ func (x *cmdSet) Execute(args []string) error {
 	}
 
 	snapName := string(x.Positional.Snap)
-	id, err := x.client.SetConf(snapName, patchValues)
+
+	var chgID string
+	var err error
+	// TODO: check that the experimental aspect feature is enabled
+	if isAspectID(snapName) {
+		// first argument is an aspectID, use the aspects API
+		aspectID := snapName
+		if err := validateAspectID(aspectID); err != nil {
+			return err
+		}
+
+		chgID, err = x.client.AspectSet(aspectID, patchValues)
+	} else {
+		chgID, err = x.client.SetConf(snapName, patchValues)
+	}
+
 	if err != nil {
 		return err
 	}
 
-	if _, err := x.wait(id); err != nil {
+	if _, err := x.wait(chgID); err != nil {
 		if err == noWait {
 			return nil
 		}
 		return err
+	}
+
+	return nil
+}
+
+func isAspectID(s string) bool {
+	return len(strings.Split(s, "/")) == 3
+}
+
+func validateAspectID(id string) error {
+	parts := strings.Split(id, "/")
+	for _, part := range parts {
+		if part == "" {
+			return fmt.Errorf(i18n.G("aspect identifier must conform to format: <account-id>/<bundle>/<aspect>"))
+		}
 	}
 
 	return nil

--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/aspects"
 	"github.com/snapcore/snapd/overlord/aspectstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -41,6 +42,7 @@ var (
 )
 
 func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
+	// TODO: check that the experimental aspects feature is enabled
 	vars := muxVars(r)
 	account, bundleName, aspect := vars["account"], vars["bundle"], vars["aspect"]
 	fields := strutil.CommaSeparatedList(r.URL.Query().Get("fields"))
@@ -48,7 +50,6 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 	if len(fields) == 0 {
 		return BadRequest("missing aspect fields")
 	}
-	results := make(map[string]interface{})
 
 	st := c.d.state
 	st.Lock()
@@ -59,6 +60,7 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 		return toAPIError(err)
 	}
 
+	results := make(map[string]interface{})
 	for _, field := range fields {
 		result, err := aspectstateGetAspect(tx, account, bundleName, aspect, field)
 		if err != nil {
@@ -83,6 +85,7 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 }
 
 func setAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
+	// TODO: check that the experimental aspects feature is enabled
 	vars := muxVars(r)
 	account, bundleName, aspect := vars["account"], vars["bundle"], vars["aspect"]
 
@@ -115,6 +118,7 @@ func setAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 	// NOTE: could be sync but this is closer to the final version and the conf API
 	summary := fmt.Sprintf("Set aspect %s/%s/%s", account, bundleName, aspect)
 	chg := newChange(st, "set-aspect", summary, nil, nil)
+	chg.SetStatus(state.DoneStatus)
 	ensureStateSoon(st)
 
 	return AsyncResponse(nil, chg.ID())

--- a/daemon/api_aspects_test.go
+++ b/daemon/api_aspects_test.go
@@ -265,6 +265,7 @@ func (s *aspectsSuite) testAspectSetMany(c *C) {
 	chg := st.Change(rspe.Change)
 	c.Check(chg.Kind(), check.Equals, "set-aspect")
 	c.Check(chg.Summary(), check.Equals, `Set aspect system/network/wifi-setup`)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
 
 	var databags map[string]map[string]aspects.JSONDataBag
 	err = st.Get("aspect-databags", &databags)
@@ -381,6 +382,8 @@ func (s *aspectsSuite) TestSetAspect(c *C) {
 		c.Check(chg.Summary(), Equals, `Set aspect system/network/wifi-setup`, cmt)
 
 		st.Lock()
+		c.Check(chg.Status(), Equals, state.DoneStatus)
+
 		var databags map[string]map[string]aspects.JSONDataBag
 		err = st.Get("aspect-databags", &databags)
 		st.Unlock()
@@ -416,10 +419,11 @@ func (s *aspectsSuite) TestUnsetAspect(c *C) {
 	st := s.d.Overlord().State()
 	st.Lock()
 	chg := st.Change(rspe.Change)
-	st.Unlock()
 
 	c.Check(chg.Kind(), check.Equals, "set-aspect")
 	c.Check(chg.Summary(), check.Equals, `Set aspect system/network/wifi-setup`)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	st.Unlock()
 }
 
 func (s *aspectsSuite) TestSetAspectError(c *C) {

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -49,11 +49,7 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 		}
 	}
 
-	if err := asp.Set(databag, field, value); err != nil {
-		return err
-	}
-
-	return nil
+	return asp.Set(databag, field, value)
 }
 
 // GetAspect finds the aspect identified by the account, bundleName and aspect
@@ -80,12 +76,7 @@ func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 		}
 	}
 
-	result, err := asp.Get(databag, field)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return asp.Get(databag, field)
 }
 
 // NewTransaction returns a transaction configured to read and write databags

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -48,7 +48,7 @@ func (s *aspectTestSuite) TestGetAspect(c *C) {
 
 	res, err := aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid")
 	c.Assert(err, IsNil)
-	c.Assert(res, DeepEquals, map[string]interface{}{"ssid": "foo"})
+	c.Assert(res, DeepEquals, "foo")
 }
 
 func (s *aspectTestSuite) TestGetNotFound(c *C) {


### PR DESCRIPTION
Adds a CLI for getting and setting data through aspects. Doesn't include support for "unset". The first commit is a refactor that changes where the result of a get is namespaced just to make it easier to combine results at the API (it's mostly test changes).