### PR TITLE
tests/regression/lp-1910456: temporarily disable the test on Arch

### DIFF
--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -5,8 +5,9 @@ details: |
     their systemd units, specifically container management interfaces have the
     Delegate=true snippet added to prevent CVE-2020-27352.
 
-# Docker is not supported anymore in ubuntu 14.04
-systems: [-ubuntu-14.04-64]
+# ubuntu-14.04: Docker is not supported anymore in ubuntu 14.04
+# arch: issue with generated AppArmor profiles, see https://paste.ubuntu.com/p/c5B3SFdqtx/
+systems: [-ubuntu-14.04-64, -arch-linux-*]
 
 prepare: |
     # build and install the strict test snap


### PR DESCRIPTION
https://github.com/snapcore/snapd/commit/d0023970be05279255028cbacb556b050890735b seems to have introduced a regression on Arch where we have the AppArmor userspace and kernel support, but apparently the profiles generated are not accepted by 3.1.6 parser currently present in Arch.

