### PR TITLE
o/devicestate, overlord, daemon: add flag to devicestate.Remodel to force an offline remodel

### DIFF
--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -116,7 +116,7 @@ func storeRemodel(c *Command, r *http.Request) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	chg, err := devicestateRemodel(st, newModel, nil, nil)
+	chg, err := devicestateRemodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	if err != nil {
 		return BadRequest("cannot remodel device: %v", err)
 	}
@@ -190,7 +190,9 @@ func startOfflineRemodelChange(st *state.State, newModel *asserts.Model,
 	}
 
 	// Now create and start the remodel change
-	chg, err := devicestateRemodel(st, newModel, slInfo.sideInfos, slInfo.tmpPaths)
+	chg, err := devicestateRemodel(st, newModel, slInfo.sideInfos, slInfo.tmpPaths, devicestate.RemodelOptions{
+		Offline: true,
+	})
 	if err != nil {
 		return nil, BadRequest("cannot remodel device: %v", err)
 	}

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -123,7 +123,8 @@ func (s *modelSuite) TestPostRemodel(c *check.C) {
 	defer restore()
 
 	var devicestateRemodelGotModel *asserts.Model
-	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, sis []*snap.SideInfo, paths []string) (*state.Change, error) {
+	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, localSnaps []*snap.SideInfo, paths []string, opts devicestate.RemodelOptions) (*state.Change, error) {
+		c.Check(opts.Offline, check.Equals, false)
 		devicestateRemodelGotModel = nm
 		chg := st.NewChange("remodel", "...")
 		return chg, nil
@@ -586,10 +587,11 @@ func (s *modelSuite) testPostOfflineRemodel(c *check.C, params *testPostOfflineR
 	snapRev := 1001
 	var devicestateRemodelGotModel *asserts.Model
 	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model,
-		sis []*snap.SideInfo, paths []string) (*state.Change, error) {
-		c.Check(len(sis), check.Equals, 1)
-		c.Check(sis[0].RealName, check.Equals, snapName)
-		c.Check(sis[0].Revision, check.Equals, snap.Revision{N: snapRev})
+		localSnaps []*snap.SideInfo, paths []string, opts devicestate.RemodelOptions) (*state.Change, error) {
+		c.Check(opts.Offline, check.Equals, true)
+		c.Check(len(localSnaps), check.Equals, 1)
+		c.Check(localSnaps[0].RealName, check.Equals, snapName)
+		c.Check(localSnaps[0].Revision, check.Equals, snap.Revision{N: snapRev})
 		c.Check(strings.HasSuffix(paths[0],
 			"/var/lib/snapd/snaps/"+snapName+"_"+strconv.Itoa(snapRev)+".snap"),
 			check.Equals, true)

--- a/daemon/export_api_model_test.go
+++ b/daemon/export_api_model_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-func MockDevicestateRemodel(mock func(*state.State, *asserts.Model, []*snap.SideInfo, []string) (*state.Change, error)) (restore func()) {
+func MockDevicestateRemodel(mock func(*state.State, *asserts.Model, []*snap.SideInfo, []string, devicestate.RemodelOptions) (*state.Change, error)) (restore func()) {
 	oldDevicestateRemodel := devicestateRemodel
 	devicestateRemodel = mock
 	return func() {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -514,7 +514,8 @@ func (ro *remodelVariant) UpdateWithDeviceContext(st *state.State, snapName stri
 
 		// this would only occur from programmer error, since
 		// UpdateWithDeviceContext should only be called if either the snap
-		// revision or channel needs to change
+		// revision or channel needs to change. once we get here, we know that
+		// the revision is the same, so the channel should be different.
 		if opts == nil || opts.Channel == info.Channel {
 			return nil, fmt.Errorf("internal error: installed snap %q already on channel %q", snapName, info.Channel)
 		}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1216,7 +1216,7 @@ func checkForInvalidSnapsInModel(model *asserts.Model, vSets *snapasserts.Valida
 // RemodelOptions are options for Remodel.
 type RemodelOptions struct {
 	// Offline is true if the remodel should be done without reaching out to the
-	// store. Any snaps needed for the remodel, and are not already installed,
+	// store. Any snaps needed for the remodel, that are not already installed,
 	// should be provided via the parameters to Remodel. Snaps that are already
 	// installed will be used if they match the revisions that are required by
 	// the model.

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -596,7 +596,7 @@ func remodelEssentialSnapTasks(ctx context.Context, st *state.State, pathSI *pat
 
 	revOpts := revisionOptionsForRemodel(newModelSnapChannel, ms.newRequiredRevision, ms.newModelValidationSets)
 
-	newSnapID := ""
+	var newSnapID string
 	// a nil model snap will happen for bases on UC16 models.
 	if ms.newModelSnap != nil {
 		newSnapID = ms.newModelSnap.SnapID

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -600,7 +600,7 @@ func revisionOptionsForRemodel(channel string, revision snap.Revision, valsets [
 	return opts
 }
 
-func remodelEssentialSnapTasks(ctx context.Context, st *state.State, pathSI *pathSideInfo, ms modelSnapsForRemodel, remodelVar remodelVariant, deviceCtx snapstate.DeviceContext, fromChange string, tracker snapstate.PrereqTracker) (*state.TaskSet, error) {
+func remodelEssentialSnapTasks(ctx context.Context, st *state.State, ms modelSnapsForRemodel, remodelVar remodelVariant, deviceCtx snapstate.DeviceContext, fromChange string, tracker snapstate.PrereqTracker) (*state.TaskSet, error) {
 	userID := 0
 	newModelSnapChannel, err := modelSnapChannelFromDefaultOrPinnedTrack(ms.new, ms.newModelSnap)
 	if err != nil {
@@ -769,7 +769,7 @@ func tasksForEssentialSnap(ctx context.Context, st *state.State,
 		newRequiredRevision:    revision,
 		newModelValidationSets: vSetKeys,
 	}
-	ts, err := remodelEssentialSnapTasks(ctx, st, nil, ms, remodelVar, deviceCtx, fromChange, tracker)
+	ts, err := remodelEssentialSnapTasks(ctx, st, ms, remodelVar, deviceCtx, fromChange, tracker)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -507,7 +507,7 @@ func (ro *remodelVariant) UpdateWithDeviceContext(st *state.State, snapName stri
 			// this case is unexpected, since UpdateWithDeviceContext should
 			// only be called if the snap is already installed
 			if errors.Is(err, &snap.NotInstalledError{}) {
-				return nil, fmt.Errorf("no snap file provided for %q", snapName)
+				return nil, fmt.Errorf("internal error: no snap file provided for %q", snapName)
 			}
 			return nil, err
 		}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -504,6 +504,8 @@ func (ro *remodelVariant) UpdateWithDeviceContext(st *state.State, snapName stri
 		// might have on the system (the revisions in SnapState.Sequence)
 		info, err := snapstate.CurrentInfo(st, snapName)
 		if err != nil {
+			// this case is unexpected, since UpdateWithDeviceContext should
+			// only be called if the snap is already installed
 			if errors.Is(err, &snap.NotInstalledError{}) {
 				return nil, fmt.Errorf("no snap file provided for %q", snapName)
 			}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -500,6 +500,8 @@ func (ro *remodelVariant) UpdateWithDeviceContext(st *state.State, snapName stri
 				userID, snapStateFlags, tracker, deviceCtx, fromChange)
 		}
 
+		// TODO: this should also take into account other revisions that we
+		// might have on the system (the revisions in SnapState.Sequence)
 		info, err := snapstate.CurrentInfo(st, snapName)
 		if err != nil {
 			if errors.Is(err, &snap.NotInstalledError{}) {

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2946,9 +2946,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch(c *C) {
-	// remodel switches to a new set of kernel, base and gadget snaps, but some
-	// of those (kernel, base) happen to be already installed and tracking the
-	// right channels.
+	// remodel switches to a new set of kernel, base and gadget snaps. some of
+	// those (kernel, base) happen to be already installed, and the channel must
+	// be switched.
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -313,7 +313,7 @@ func (m *DeviceManager) doPrepareRemodeling(t *state.Task, tmb *tomb.Tomb) error
 
 	chgID := t.Change().ID()
 
-	tss, err := remodelTasks(tmb.Context(nil), st, current, remodCtx.Model(), nil, nil, remodCtx, chgID)
+	tss, err := remodelTasks(tmb.Context(nil), st, current, remodCtx.Model(), remodCtx, chgID, nil, nil, RemodelOptions{})
 	if err != nil {
 		return err
 	}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -5002,7 +5002,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
 		"revision":       "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	c.Check(devicestate.RemodelingChange(st), NotNil)
@@ -5111,7 +5111,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5178,7 +5178,7 @@ type: base`
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, ErrorMatches, "cannot remodel from core to bases yet")
 	c.Assert(chg, IsNil)
 }
@@ -5286,7 +5286,7 @@ version: 20.04`
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5459,7 +5459,7 @@ version: 20.04`
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5621,7 +5621,7 @@ version: 20.04`
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5993,7 +5993,7 @@ func (s *kernelSuite) TestRemodelSwitchKernelTrack(c *C) {
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6047,7 +6047,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernel(c *C) {
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6139,7 +6139,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndo(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6197,7 +6197,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndoOnRollback(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6319,7 +6319,7 @@ func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
 	s.expectedStore = "switched-store"
 	s.sessionMacaroon = "switched-store-session"
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6434,7 +6434,7 @@ volumes:
 	})
 	defer r()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6603,7 +6603,7 @@ volumes:
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6739,7 +6739,7 @@ volumes:
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6980,7 +6980,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 	s.expectedStore = "my-brand-substore"
 	s.sessionMacaroon = "other-store-session"
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -7432,7 +7432,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	c.Check(devicestate.RemodelingChange(st), NotNil)
@@ -7821,7 +7821,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {
 	})
 	defer r()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -7981,7 +7981,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentGadgetChannel(c *C) {
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8105,7 +8105,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentBaseChannel(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8272,7 +8272,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8460,7 +8460,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8636,7 +8636,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 		},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 
 	msg := `cannot remodel to model that is not self contained:
   - cannot use snap "prereq": base "prereq-base" is missing
@@ -8940,7 +8940,7 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 
@@ -9400,7 +9400,7 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 
@@ -9698,7 +9698,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ToUC22(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, nil)
+	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2331,6 +2331,7 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 		// set the from state (i.e. no change), they are overridden from opts as needed below
 		CohortKey: snapst.CohortKey,
 		Channel:   snapst.TrackingChannel,
+		Type:      snap.Type(snapst.SnapType),
 	}
 
 	if opts.Channel != "" {

--- a/overlord/snapstate/snapstatetest/snapstate.go
+++ b/overlord/snapstate/snapstatetest/snapstate.go
@@ -49,11 +49,12 @@ func InstallSnap(c *check.C, st *state.State, yaml string, required bool, si *sn
 	}
 
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
-		SnapType: string(t),
-		Active:   true,
-		Sequence: NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
-		Current:  info.Revision,
-		Flags:    snapstate.Flags{Required: required},
+		SnapType:        string(t),
+		Active:          true,
+		Sequence:        NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
+		Current:         info.Revision,
+		Flags:           snapstate.Flags{Required: required},
+		TrackingChannel: si.Channel,
 	})
 	return info
 }

--- a/snap/errors.go
+++ b/snap/errors.go
@@ -43,6 +43,11 @@ func (e NotInstalledError) Error() string {
 	return fmt.Sprintf("revision %s of snap %q is not installed", e.Rev, e.Snap)
 }
 
+func (e *NotInstalledError) Is(err error) bool {
+	_, ok := err.(*NotInstalledError)
+	return ok
+}
+
 // NotSnapError is returned if an operation expects a snap file or snap dir
 // but no valid input is provided. When creating it ensure "Err" is set
 // so that a useful error can be displayed to the user.

--- a/snap/errors_test.go
+++ b/snap/errors_test.go
@@ -20,6 +20,7 @@
 package snap_test
 
 import (
+	"errors"
 	"fmt"
 
 	. "gopkg.in/check.v1"
@@ -39,4 +40,10 @@ func (s *errorsSuite) TestNotSnapErrorNoDetails(c *C) {
 func (s *errorsSuite) TestNotSnapErrorWithDetails(c *C) {
 	err := snap.NotSnapError{Path: "some-path", Err: fmt.Errorf(`cannot open "some path"`)}
 	c.Check(err, ErrorMatches, `cannot process snap or snapdir: cannot open "some path"`)
+}
+
+func (s *errorsSuite) TestNotInstalledErrorIs(c *C) {
+	err := snap.NotInstalledError{}
+	c.Check(err.Is(&snap.NotInstalledError{}), Equals, true)
+	c.Check(err.Is(errors.New("some error")), Equals, false)
 }


### PR DESCRIPTION
This flag will enable offline remodeling, even when all snaps required for the remodel are not provided locally. The remodel will fall back to using already installed snaps in situations that it can. This includes simple channel switches, and when the required revision of a snap is already installed. If a snap is required for the remodel, and the snap is neither provided locally or already installed, then the remodel will fail.