### PR TITLE
seed: implement Copier for seed20

### DIFF
--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -76,17 +76,17 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 
 	fin, err := openfile(src, os.O_RDONLY, 0)
 	if err != nil {
-		return fmt.Errorf("unable to open %s: %v", src, err)
+		return fmt.Errorf("unable to open %s: %w", src, err)
 	}
 	defer func() {
 		if cerr := fin.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("when closing %s: %v", src, cerr)
+			err = fmt.Errorf("when closing %s: %w", src, cerr)
 		}
 	}()
 
 	fi, err := fin.Stat()
 	if err != nil {
-		return fmt.Errorf("unable to stat %s: %v", src, err)
+		return fmt.Errorf("unable to stat %s: %w", src, err)
 	}
 
 	outflags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
@@ -96,21 +96,21 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 
 	fout, err := openfile(dst, outflags, fi.Mode())
 	if err != nil {
-		return fmt.Errorf("unable to create %s: %v", dst, err)
+		return fmt.Errorf("unable to create %s: %w", dst, err)
 	}
 	defer func() {
 		if cerr := fout.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("when closing %s: %v", dst, cerr)
+			err = fmt.Errorf("when closing %s: %w", dst, cerr)
 		}
 	}()
 
 	if err := copyfile(fin, fout, fi); err != nil {
-		return fmt.Errorf("unable to copy %s to %s: %v", src, dst, err)
+		return fmt.Errorf("unable to copy %s to %s: %w", src, dst, err)
 	}
 
 	if flags&CopyFlagSync != 0 {
 		if err = fout.Sync(); err != nil {
-			return fmt.Errorf("unable to sync %s: %v", dst, err)
+			return fmt.Errorf("unable to sync %s: %w", dst, err)
 		}
 	}
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -212,8 +212,10 @@ type Copier interface {
 	// Copy copies the seed to the given seedDir with the label provided. If
 	// label is empty, then the label of the seed that implements Copier is
 	// used. This interface only makes sense to implement for UC20+ seeds. Copy
-	// requires you to call the methods LoadAssertions and LoadMeta first. Only
-	// the snaps for the mode that was passed to LoadMeta will be copied.
+	// requires you to call the LoadAssertions method first. Note that LoadMeta
+	// for all modes will be called by Copy. If LoadMeta was called previously
+	// on this Seed with a different mode, then that metadata will be
+	// overwritten by the metadata for all modes.
 	Copy(seedDir string, label string) error
 }
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -205,6 +205,14 @@ type PreseedCapable interface {
 	LoadPreseedAssertion() (*asserts.Preseed, error)
 }
 
+// Copier can be implemented by a seed that supports copying itself to a given
+// destination.
+type Copier interface {
+	// Copy copies the seed to the given seed partition. The root parameter
+	// is treated as the root of the seed partition.
+	Copy(root string) error
+}
+
 // Open returns a Seed implementation for the seed at seedDir.
 // label if not empty is used to identify a Core 20 recovery system seed.
 func Open(seedDir, label string) (Seed, error) {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -216,7 +216,7 @@ type Copier interface {
 	// for all modes will be called by Copy. If LoadMeta was called previously
 	// on this Seed with a different mode, then that metadata will be
 	// overwritten by the metadata for all modes.
-	Copy(seedDir string, label string) error
+	Copy(seedDir string, label string, tm timings.Measurer) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -210,7 +210,9 @@ type PreseedCapable interface {
 type Copier interface {
 	// Copy copies the seed to the given seedDir with the label provided. If
 	// label is empty, then the label of the seed that implements Copier is
-	// used. This interface only makes sense to implement for UC20+ seeds.
+	// used. This interface only makes sense to implement for UC20+ seeds. Copy
+	// requires you to call the methods LoadAssertions and LoadMeta first. Only
+	// the snaps for the mode that was passed to LoadMeta will be copied.
 	Copy(seedDir string, label string) error
 }
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -208,9 +208,10 @@ type PreseedCapable interface {
 // Copier can be implemented by a seed that supports copying itself to a given
 // destination.
 type Copier interface {
-	// Copy copies the seed to the given seed partition. The root parameter
-	// is treated as the root of the seed partition.
-	Copy(root string) error
+	// Copy copies the seed to the given seedDir with the label provided. If
+	// label is empty, then the label of the seed that implements Copier is
+	// used. This interface only makes sense to implement for UC20+ seeds.
+	Copy(seedDir string, label string) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -208,6 +208,7 @@ type PreseedCapable interface {
 // Copier can be implemented by a seed that supports copying itself to a given
 // destination.
 type Copier interface {
+	Seed
 	// Copy copies the seed to the given seedDir with the label provided. If
 	// label is empty, then the label of the seed that implements Copier is
 	// used. This interface only makes sense to implement for UC20+ seeds. Copy

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -135,6 +135,16 @@ func (s *seed20) Copy(seedDir string, label string) (err error) {
 		return err
 	}
 
+	if err := s.LoadMeta(AllModes, nil, timings.New(nil)); err != nil {
+		return err
+	}
+
+	destAssertedSnapDir := filepath.Join(destSeedDir, "snaps")
+
+	if err := os.MkdirAll(destAssertedSnapDir, 0755); err != nil {
+		return err
+	}
+
 	// copy the asserted snaps that the seed needs
 	for _, sn := range s.snaps {
 		// unasserted snaps are already copied above, skip them
@@ -142,13 +152,9 @@ func (s *seed20) Copy(seedDir string, label string) (err error) {
 			continue
 		}
 
-		destPath := filepath.Join(destSeedDir, "snaps", filepath.Base(sn.Path))
+		destSnapPath := filepath.Join(destAssertedSnapDir, filepath.Base(sn.Path))
 
-		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-			return err
-		}
-
-		if err := osutil.CopyFile(sn.Path, destPath, osutil.CopyFlagOverwrite); err != nil {
+		if err := osutil.CopyFile(sn.Path, destSnapPath, osutil.CopyFlagOverwrite); err != nil {
 			return fmt.Errorf("cannot copy asserted snap: %w", err)
 		}
 	}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -86,11 +86,6 @@ type seed20 struct {
 
 // Copy implement Copier interface.
 func (s *seed20) Copy(seedDir string, label string) (err error) {
-	// TODO: right now this method requires you to call LoadAssertions and
-	// LoadMeta first. is that okay? should Copier embed the Seed interface to
-	// make that easier? i could call them in here, but then i'd need to take in
-	// a db as a parameter.
-
 	srcSystemDir, err := filepath.Abs(s.systemDir)
 	if err != nil {
 		return err

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3704,7 +3704,7 @@ func compareDirs(c *C, expected, got string) {
 	c.Assert(err, IsNil)
 
 	gotCount := 0
-	err = filepath.WalkDir(expected, func(_ string, _ fs.DirEntry, err error) error {
+	err = filepath.WalkDir(got, func(_ string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -3086,7 +3085,7 @@ func (s *seed20Suite) testLoadAutoImportAssertion(c *C, grade asserts.ModelGrade
 	sysLabel := "20191018"
 	seed20 := s.createMinimalSeed(c, string(grade), sysLabel)
 	c.Assert(seed20, NotNil)
-	c.Check(seed20.Model().Grade(), check.Equals, grade)
+	c.Check(seed20.Model().Grade(), Equals, grade)
 
 	// write test auto import assertion
 	switch sua {
@@ -3106,7 +3105,7 @@ func (s *seed20Suite) testLoadAutoImportAssertion(c *C, grade asserts.ModelGrade
 		c.Check(err, ErrorMatches, loadError.Error())
 	}
 	assertions, err := s.findAutoImportAssertion(seed20)
-	c.Check(err, check.ErrorMatches, "system-user assertion not found")
+	c.Check(err, ErrorMatches, "system-user assertion not found")
 	c.Assert(assertions, IsNil)
 }
 
@@ -3114,7 +3113,7 @@ func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAsserti
 	sysLabel := "20191018"
 	seed20 := s.createMinimalSeed(c, "dangerous", sysLabel)
 	c.Assert(seed20, NotNil)
-	c.Check(seed20.Model().Grade(), check.Equals, asserts.ModelDangerous)
+	c.Check(seed20.Model().Grade(), Equals, asserts.ModelDangerous)
 
 	seedtest.WriteValidAutoImportAssertion(c, s.Brands, s.SeedDir, sysLabel, 0644)
 
@@ -3126,12 +3125,12 @@ func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAsserti
 	assertions, err := s.findAutoImportAssertion(seed20)
 	c.Assert(err, IsNil)
 	// validate it's our assertion
-	c.Check(len(assertions), check.Equals, 1)
+	c.Check(len(assertions), Equals, 1)
 	systemUser := assertions[0].(*asserts.SystemUser)
-	c.Check(systemUser.Username(), check.Equals, "guy")
-	c.Check(systemUser.Email(), check.Equals, "foo@bar.com")
-	c.Check(systemUser.Name(), check.Equals, "Boring Guy")
-	c.Check(systemUser.AuthorityID(), check.Equals, "my-brand")
+	c.Check(systemUser.Username(), Equals, "guy")
+	c.Check(systemUser.Email(), Equals, "foo@bar.com")
+	c.Check(systemUser.Name(), Equals, "Boring Guy")
+	c.Check(systemUser.AuthorityID(), Equals, "my-brand")
 }
 
 func (s *seed20Suite) createMinimalSeed(c *C, grade string, sysLabel string) seed.Seed {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3647,13 +3647,15 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 	copier, ok := seed20.(seed.Copier)
 	c.Assert(ok, Equals, true)
 
+	removedSnap := filepath.Join(s.SeedDir, "snaps", "snapd_1.snap")
+
 	// remove a snap from the original seed to make the copy fail
-	err = os.Remove(filepath.Join(s.SeedDir, "snaps", "snapd_1.snap"))
+	err = os.Remove(removedSnap)
 	c.Assert(err, IsNil)
 
 	destSeedDir := c.MkDir()
 	err = copier.Copy(destSeedDir, label, s.perfTimings)
-	c.Check(err, NotNil)
+	c.Check(err, ErrorMatches, fmt.Sprintf("cannot stat snap: stat %s: no such file or directory", removedSnap))
 
 	// seed destination should have been cleaned up
 	c.Check(filepath.Join(destSeedDir, "systems", label), testutil.FileAbsent)

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3564,7 +3564,7 @@ func (s *seed20Suite) testCopy(c *C, destLabel string) {
 
 	destSeedDir := c.MkDir()
 
-	err = copier.Copy(destSeedDir, destLabel)
+	err = copier.Copy(destSeedDir, destLabel, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	checkDirContents(c, filepath.Join(destSeedDir, "snaps"), []string{
@@ -3600,7 +3600,7 @@ func (s *seed20Suite) testCopy(c *C, destLabel string) {
 	compareDirs(c, filepath.Join(s.SeedDir, "snaps"), filepath.Join(destSeedDir, "snaps"))
 	compareDirs(c, filepath.Join(s.SeedDir, "systems", srcLabel), destSystemDir)
 
-	err = copier.Copy(destSeedDir, copiedLabel)
+	err = copier.Copy(destSeedDir, copiedLabel, s.perfTimings)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot create system: system %q already exists at %q`, copiedLabel, destSystemDir))
 }
 
@@ -3652,7 +3652,7 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 	c.Assert(err, IsNil)
 
 	destSeedDir := c.MkDir()
-	err = copier.Copy(destSeedDir, label)
+	err = copier.Copy(destSeedDir, label, s.perfTimings)
 	c.Check(err, NotNil)
 
 	// seed destination should have been cleaned up

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3559,9 +3559,6 @@ func (s *seed20Suite) testCopy(c *C, destLabel string) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(seed.AllModes, nil, s.perfTimings)
-	c.Assert(err, IsNil)
-
 	copier, ok := seed20.(seed.Copier)
 	c.Assert(ok, Equals, true)
 
@@ -3647,9 +3644,6 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(seed.AllModes, nil, s.perfTimings)
-	c.Assert(err, IsNil)
-
 	copier, ok := seed20.(seed.Copier)
 	c.Assert(ok, Equals, true)
 
@@ -3659,7 +3653,7 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 
 	destSeedDir := c.MkDir()
 	err = copier.Copy(destSeedDir, label)
-	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+	c.Check(err, NotNil)
 
 	// seed destination should have been cleaned up
 	c.Check(filepath.Join(destSeedDir, "systems", label), testutil.FileAbsent)


### PR DESCRIPTION
This PR adds a `Copier` interface that seeds can implement to copy themselves to a given seed partition. Additionally, an implementation for seed20 is done here. This will be used as a part of installing seeds during UC installation via the snapd API.