### PR TITLE
intefaces/apparmor: do not combine unconfined and complain profile flags

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -860,7 +860,16 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 			// This is also done for classic so that no confinement applies. Just in
 			// case the profile we start with is not permissive enough.
 			if (opts.DevMode || opts.Classic) && !opts.JailMode {
-				flags = append(flags, "complain")
+				if !strutil.ListContains(flags, "unconfined") {
+					// Profile modes unconfined and complain
+					// conflict with each other and are
+					// rejected by the parser, in any case
+					// this is fine since we already
+					// requested unconfined based on the
+					// spec and complain would no enforce
+					// any rules anyway.
+					flags = append(flags, "complain")
+				}
 			}
 			if len(flags) > 0 {
 				return "flags=(" + strings.Join(flags, ",") + ")"

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1113,7 +1113,6 @@ func (s *backendSuite) TestUnconfinedFlag(c *C) {
 		flags := []string{"attach_disconnected", "mediate_deleted", "unconfined"}
 		prefix := commonPrefix
 		if opts.Classic {
-			flags = append(flags, "complain")
 			prefix = "\n#classic" + commonPrefix
 		}
 		contents := fmt.Sprintf(prefix+"\nprofile \"snap.samba.smbd\" flags=(%s) {\n\n}\n",

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -6,8 +6,7 @@ details: |
     Delegate=true snippet added to prevent CVE-2020-27352.
 
 # ubuntu-14.04: Docker is not supported anymore in ubuntu 14.04
-# arch: issue with generated AppArmor profiles, see https://paste.ubuntu.com/p/c5B3SFdqtx/
-systems: [-ubuntu-14.04-64, -arch-linux-*]
+systems: [-ubuntu-14.04-64]
 
 prepare: |
     # build and install the strict test snap


### PR DESCRIPTION
https://github.com/snapcore/snapd/commit/d0023970be05279255028cbacb556b050890735b
added support for unconfined profile mode, however it is possible that in
certain scenarios snapd would produce a profile which contains both unconfined
and complain. This is rejected by the parser, as profile mode are exclusive.

I've looked at both the kernel bits in https://elixir.bootlin.com/linux/v6.7/source/security/apparmor/policy_unpack.c#L903 and apparmor parser bits in https://gitlab.com/apparmor/apparmor/-/blob/master/parser/profile.h?ref_type=heads#L60-85 and the code suggests that the profile modes enforce, complain, kill, unconfined and user (prompt), default_allow are indeed exclusive.