### PR TITLE
tests/main/interfaces-process-control: retry check for process being terminated

### DIFF
--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -28,7 +28,7 @@ execute: |
     pid=$!
     kill -s 0 "$pid"
     process-control-consumer.signal SIGTERM "$pid"
-    not kill -s 0 "$pid"
+    retry -n 10 not kill -s 0 "$pid"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit


### PR DESCRIPTION
We are sending a SIGTERM to the test process, and so its handling and test process termination is asynchronous and there is no guarantee the test process exits immediately. Retry the check a couple of times to account for this.

The problem was often seen to happen on openSUSE:

```
Error: 2024-01-17 21:36:40 Error executing google:opensuse-tumbleweed-64:tests/main/interfaces-process-control (jan172104-345478) : -----
+ echo 'The interface is disconnected by default' The interface is disconnected by default
+ snap interfaces -i process-control
+ MATCH -- '- +process-control-consumer:process-control'

'snap interfaces' is deprecated; use 'snap connections'.
+ echo 'When the plug is connected' When the plug is connected
+ snap connect process-control-consumer:process-control
+ echo 'Then the snap is able to kill an existing process' Then the snap is able to kill an existing process
+ pid=31252
+ sleep 5m
+ kill -s 0 31252
+ process-control-consumer.signal SIGTERM 31252
+ not kill -s 0 31252
-----
```
