### PR TITLE
aspects: support alternative types in schemas

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -312,6 +312,7 @@ func (v *alternativesSchema) Validate(raw []byte) error {
 	}
 
 	var sb strings.Builder
+	sb.WriteString("no matching schema:")
 	for _, err := range errs {
 		sb.WriteString("\n\t")
 

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -239,7 +239,26 @@ func (s *StorageSchema) parseAlternatives(alternatives []json.RawMessage) (*alte
 		return nil, fmt.Errorf(`alternative type list cannot be empty`)
 	}
 
+	flatAlts := flattenAlternatives(alt)
+	alt.schemas = flatAlts
+
 	return alt, nil
+}
+
+// flattenAlternatives takes the schemas that comprise the alternative schema
+// and flattens them into a single list.
+func flattenAlternatives(alt *alternativesSchema) []Schema {
+	var flat []Schema
+	for _, schema := range alt.schemas {
+		if altSchema, ok := schema.(*alternativesSchema); ok {
+			nestedAlts := flattenAlternatives(altSchema)
+			flat = append(flat, nestedAlts...)
+		} else {
+			flat = append(flat, schema)
+		}
+	}
+
+	return flat
 }
 
 func (s *StorageSchema) newTypeSchema(typ string) (parser, error) {

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -313,8 +313,11 @@ func (v *alternativesSchema) Validate(raw []byte) error {
 
 	var sb strings.Builder
 	sb.WriteString("no matching schema:")
-	for _, err := range errs {
+	for i, err := range errs {
 		sb.WriteString("\n\t")
+		if i > 0 {
+			sb.WriteString("or ")
+		}
 
 		if verr, ok := err.(*ValidationError); ok {
 			err = verr.Err
@@ -1022,6 +1025,10 @@ func (v *arraySchema) parseConstraints(constraints map[string]json.RawMessage) e
 
 func (v *arraySchema) expectsConstraints() bool { return true }
 
+// TODO: keep a list of expected types (to support alternatives), an actual type/value
+// and then optional unmet constraints for the expected types. Then this could be used
+// to have more concise errors when there are many possible types
+// https://github.com/snapcore/snapd/pull/13502#discussion_r1463658230
 type ValidationError struct {
 	Path []interface{}
 	Err  error

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -352,7 +352,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 	if err := json.Unmarshal(raw, &mapValue); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return validationErrorf("expected map type but got %s", typeErr.Value)
+			return validationErrorf("expected map type but value was %s", typeErr.Value)
 		}
 		return validationErrorFrom(err)
 	}
@@ -572,7 +572,7 @@ func (v *mapSchema) parseMapKeyType(raw json.RawMessage) (Schema, error) {
 			}
 
 			if typ != "string" {
-				return nil, fmt.Errorf(`must be based on string but got %q`, typ)
+				return nil, fmt.Errorf(`must be based on string but type was %s`, typ)
 			}
 		}
 
@@ -601,7 +601,7 @@ func (v *mapSchema) parseMapKeyType(raw json.RawMessage) (Schema, error) {
 		return userType, nil
 	}
 
-	return nil, fmt.Errorf(`keys must be based on string but got %q`, typ)
+	return nil, fmt.Errorf(`keys must be based on string but type was %s`, typ)
 }
 
 func (v *mapSchema) expectsConstraints() bool { return true }
@@ -626,7 +626,7 @@ func (v *stringSchema) Validate(raw []byte) (err error) {
 	if err := json.Unmarshal(raw, &value); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return fmt.Errorf("expected string type but got %s", typeErr.Value)
+			return fmt.Errorf("expected string type but value was %s", typeErr.Value)
 		}
 		return err
 	}
@@ -640,7 +640,7 @@ func (v *stringSchema) Validate(raw []byte) (err error) {
 	}
 
 	if v.pattern != nil && !v.pattern.Match([]byte(*value)) {
-		return fmt.Errorf(`string %q doesn't match schema pattern %s`, *value, v.pattern.String())
+		return fmt.Errorf(`expected string matching %s but value was %q`, v.pattern.String(), *value)
 	}
 
 	return nil
@@ -699,7 +699,7 @@ func (v *intSchema) Validate(raw []byte) (err error) {
 	if err := json.Unmarshal(raw, &num); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return fmt.Errorf("expected int type but got %s", typeErr.Value)
+			return fmt.Errorf("expected int type but value was %s", typeErr.Value)
 		}
 		return err
 	}
@@ -804,7 +804,7 @@ func (v *numberSchema) Validate(raw []byte) (err error) {
 	if err := json.Unmarshal(raw, &num); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return fmt.Errorf("expected number type but got %s", typeErr.Value)
+			return fmt.Errorf("expected number type but value was %s", typeErr.Value)
 		}
 		return err
 	}
@@ -905,7 +905,7 @@ func (v *booleanSchema) Validate(raw []byte) (err error) {
 	if err := json.Unmarshal(raw, &val); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return fmt.Errorf("expected bool type but got %s", typeErr.Value)
+			return fmt.Errorf("expected bool type but value was %s", typeErr.Value)
 		}
 		return err
 	}
@@ -941,7 +941,7 @@ func (v *arraySchema) Validate(raw []byte) error {
 	if err := json.Unmarshal(raw, &array); err != nil {
 		typeErr := &json.UnmarshalTypeError{}
 		if errors.As(err, &typeErr) {
-			return validationErrorf("expected array type but got %s", typeErr.Value)
+			return validationErrorf("expected array type but value was %s", typeErr.Value)
 		}
 		return validationErrorFrom(err)
 	}

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -2019,7 +2019,7 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsFail(c *C) {
 	expected string matching \[bB\]ar but value was "bAR"`)
 }
 
-func (*schemaSuite) TestAlternativeTypesNested(c *C) {
+func (*schemaSuite) TestAlternativeTypesNestedHappy(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
 		"foo": ["int", ["number", ["string"]]]
@@ -2033,6 +2033,22 @@ func (*schemaSuite) TestAlternativeTypesNested(c *C) {
 		err = schema.Validate(input)
 		c.Assert(err, IsNil)
 	}
+}
+
+func (*schemaSuite) TestAlternativeTypesNestedFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": ["int", ["number", ["string"]]]
+	}
+}`)
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate([]byte(`{"foo":false}`))
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
+	expected int type but value was bool
+	expected number type but value was bool
+	expected string type but value was bool`)
 }
 
 func (*schemaSuite) TestAlternativeTypesUnknownType(c *C) {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -230,7 +230,7 @@ func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "map"`)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but type was map`)
 
 	schemaStr = []byte(`{
 	"schema": {
@@ -241,7 +241,7 @@ func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 }`)
 
 	_, err = aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: keys must be based on string but got "int"`)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: keys must be based on string but type was int`)
 }
 
 func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
@@ -298,7 +298,7 @@ func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept element in "snaps.foo": expected string type but got object`)
+	c.Assert(err, ErrorMatches, `cannot accept element in "snaps.foo": expected string type but value was object`)
 }
 
 func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
@@ -339,7 +339,7 @@ func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept element in "bar": expected string type but got object`)
+	c.Assert(err, ErrorMatches, `cannot accept element in "bar": expected string type but value was object`)
 }
 
 func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
@@ -674,7 +674,7 @@ func (*schemaSuite) TestStringPatternNoMatch(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept element in "foo": string "F00" doesn't match schema pattern \[fb\]00`)
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo": expected string matching \[fb\]00 but value was "F00"`)
 }
 
 func (*schemaSuite) TestStringPatternWrongFormat(c *C) {
@@ -936,7 +936,7 @@ func (*schemaSuite) TestMapBasedUserDefinedTypeFail(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept element in "snaps.core20.version": expected string type but got number`)
+	c.Assert(err, ErrorMatches, `cannot accept element in "snaps.core20.version": expected string type but value was number`)
 }
 
 func (*schemaSuite) TestBadUserDefinedTypeName(c *C) {
@@ -1601,7 +1601,7 @@ func (*schemaSuite) TestArrayEnforcesOnlyOneType(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept element in "foo\[1\]": expected string type but got number`)
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo\[1\]": expected string type but value was number`)
 }
 
 func (*schemaSuite) TestArrayWithUniqueRejectsDuplicates(c *C) {
@@ -1925,7 +1925,7 @@ func (*schemaSuite) TestUnexpectedTypes(c *C) {
 
 		input := []byte(fmt.Sprintf(`{"foo": %v}`, tc.testValue))
 		err = schema.Validate(input)
-		c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot accept element in "foo": expected %s type but got %T`, tc.expectedType, tc.testValue))
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot accept element in "foo": expected %s type but value was %T`, tc.expectedType, tc.testValue))
 	}
 }
 
@@ -2011,12 +2011,12 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsFail(c *C) {
 	err = schema.Validate([]byte(`{"foo":-1}`))
 	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
 	-1 is less than the allowed minimum 0
-	expected string type but got number`)
+	expected string type but value was number`)
 
 	err = schema.Validate([]byte(`{"foo":"bAR"}`))
 	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
-	expected int type but got string
-	string "bAR" doesn't match schema pattern \[bB\]ar`)
+	expected int type but value was string
+	expected string matching \[bB\]ar but value was "bAR"`)
 }
 
 func (*schemaSuite) TestAlternativeTypesNested(c *C) {
@@ -2071,8 +2071,8 @@ func (*schemaSuite) TestAlternativeTypesPathError(c *C) {
 	err = schema.Validate([]byte(`{"foo":{"bar": {"baz": {"zab": [1]}}}}`))
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, `cannot accept element in "foo.bar": 
-	..."baz": expected int type but got object
-	..."baz.zab[0]": expected string type but got number`)
+	..."baz": expected int type but value was object
+	..."baz.zab[0]": expected string type but value was number`)
 }
 
 func (*schemaSuite) TestInvalidTypeDefinition(c *C) {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1959,7 +1959,7 @@ func (*schemaSuite) TestAlternativeTypesFail(c *C) {
 	for _, val := range []interface{}{"1.1", "true", `{"bar": 1}`, `[1, 2]`} {
 		input := []byte(fmt.Sprintf(`{"foo":%s}`, val))
 		err = schema.Validate(input)
-		c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
+		c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected string .*
 	expected int .*`)
 	}
@@ -2009,12 +2009,12 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsFail(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate([]byte(`{"foo":-1}`))
-	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	-1 is less than the allowed minimum 0
 	expected string type but value was number`)
 
 	err = schema.Validate([]byte(`{"foo":"bAR"}`))
-	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected int type but value was string
 	expected string matching \[bB\]ar but value was "bAR"`)
 }
@@ -2045,7 +2045,7 @@ func (*schemaSuite) TestAlternativeTypesNestedFail(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate([]byte(`{"foo":false}`))
-	c.Assert(err, ErrorMatches, `cannot accept element in "foo": 
+	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected int type but value was bool
 	expected number type but value was bool
 	expected string type but value was bool`)
@@ -2086,7 +2086,7 @@ func (*schemaSuite) TestAlternativeTypesPathError(c *C) {
 
 	err = schema.Validate([]byte(`{"foo":{"bar": {"baz": {"zab": [1]}}}}`))
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, `cannot accept element in "foo.bar": 
+	c.Assert(err.Error(), Equals, `cannot accept element in "foo.bar": no matching schema:
 	..."baz": expected int type but value was object
 	..."baz.zab[0]": expected string type but value was number`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1975,7 +1975,7 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsHappy(c *C) {
 			},
 			{
 				"type": "string",
-				"format": "[bB]ar"
+				"pattern": "[bB]ar"
 			}
 		]
 	}

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -119,6 +119,22 @@ func (*schemaSuite) TestMapSchemasRequireConstraints(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse "map": must be schema definition with constraints`)
 }
 
+func (*schemaSuite) TestTypeConstraintMustBeString(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"type": 1,
+			"schema": {
+				"foo": "string"
+			}
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "type" constraint in type definition: json: cannot unmarshal number into.*`)
+}
+
 func (*schemaSuite) TestMapSchemasRequireSchemaOrKeyValues(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -2026,7 +2042,7 @@ func (*schemaSuite) TestAlternativeTypesUnknownType(c *C) {
 	}
 }`)
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse aspect schema: cannot parse unknown type "foo"`)
+	c.Assert(err, ErrorMatches, `cannot parse alternative types: cannot parse unknown type "foo"`)
 }
 
 func (*schemaSuite) TestAlternativeTypesEmpty(c *C) {
@@ -2036,7 +2052,7 @@ func (*schemaSuite) TestAlternativeTypesEmpty(c *C) {
 	}
 }`)
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse aspect schema: alternative type list cannot be empty`)
+	c.Assert(err, ErrorMatches, `cannot parse alternative types: alternative type list cannot be empty`)
 }
 
 func (*schemaSuite) TestAlternativeTypesPathError(c *C) {
@@ -2057,4 +2073,14 @@ func (*schemaSuite) TestAlternativeTypesPathError(c *C) {
 	c.Assert(err.Error(), Equals, `cannot accept element in "foo.bar": 
 	..."baz": expected int type but got object
 	..."baz.zab[0]": expected string type but got number`)
+}
+
+func (*schemaSuite) TestInvalidTypeDefinition(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": 1
+	}
+}`)
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse type definition: type must be expressed as map, string or list: json: cannot unmarshal number.*`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1961,7 +1961,7 @@ func (*schemaSuite) TestAlternativeTypesFail(c *C) {
 		err = schema.Validate(input)
 		c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected string .*
-	expected int .*`)
+	or expected int .*`)
 	}
 }
 
@@ -2011,12 +2011,12 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsFail(c *C) {
 	err = schema.Validate([]byte(`{"foo":-1}`))
 	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	-1 is less than the allowed minimum 0
-	expected string type but value was number`)
+	or expected string type but value was number`)
 
 	err = schema.Validate([]byte(`{"foo":"bAR"}`))
 	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected int type but value was string
-	expected string matching \[bB\]ar but value was "bAR"`)
+	or expected string matching \[bB\]ar but value was "bAR"`)
 }
 
 func (*schemaSuite) TestAlternativeTypesNestedHappy(c *C) {
@@ -2047,8 +2047,8 @@ func (*schemaSuite) TestAlternativeTypesNestedFail(c *C) {
 	err = schema.Validate([]byte(`{"foo":false}`))
 	c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
 	expected int type but value was bool
-	expected number type but value was bool
-	expected string type but value was bool`)
+	or expected number type but value was bool
+	or expected string type but value was bool`)
 }
 
 func (*schemaSuite) TestAlternativeTypesUnknownType(c *C) {
@@ -2088,7 +2088,7 @@ func (*schemaSuite) TestAlternativeTypesPathError(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, `cannot accept element in "foo.bar": no matching schema:
 	..."baz": expected int type but value was object
-	..."baz.zab[0]": expected string type but value was number`)
+	or ..."baz.zab[0]": expected string type but value was number`)
 }
 
 func (*schemaSuite) TestInvalidTypeDefinition(c *C) {


### PR DESCRIPTION
Add support for defining a JSON list of alternative types (can be simple types or map-like types with constraints) that a schema should allow at that location.