### PR TITLE
cmd/snap-confine: add libcudnn.so to list of NVIDIA libraries

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -140,6 +140,7 @@ static const char *nvidia_globs[] = {
 	// libraries for CUDA DNN
 	// https://docs.nvidia.com/deeplearning/cudnn/api/index.html
 	// https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html
+	"libcudnn.so*",
 	"libcudnn_adv_infer*",
 	"libcudnn_adv_train*",
 	"libcudnn_cnn_infer*",


### PR DESCRIPTION
This lib is needed for onnxruntime with CUDA support to work (nvidia-cudnn 8.9.2.26~cuda12+1).