### PR TITLE
snap:  parse correctly base snap version for core desktop

### DIFF
--- a/snap/naming/core_version.go
+++ b/snap/naming/core_version.go
@@ -26,8 +26,7 @@ import (
 )
 
 var (
-	coreNameFormat        = regexp.MustCompile("^core(?P<version>[0-9]*)$")
-	coreDesktopNameFormat = regexp.MustCompile("^core(?P<version>[0-9]*)-desktop$")
+	coreNameFormat = regexp.MustCompile("^core(?P<version>[0-9]*)(?:-.*)?$")
 )
 
 // CoreVersion extract the version component of the core snap name
@@ -38,10 +37,7 @@ func CoreVersion(base string) (int, error) {
 	foundCore := coreNameFormat.FindStringSubmatch(base)
 
 	if foundCore == nil {
-		foundCore = coreDesktopNameFormat.FindStringSubmatch(base)
-		if foundCore == nil {
-			return 0, fmt.Errorf("not a core base")
-		}
+		return 0, fmt.Errorf("not a core base")
 	}
 
 	coreVersionStr := foundCore[coreNameFormat.SubexpIndex("version")]

--- a/snap/naming/core_version.go
+++ b/snap/naming/core_version.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	coreNameFormat = regexp.MustCompile("^core(?P<version>[0-9]*)$")
+	coreNameFormat        = regexp.MustCompile("^core(?P<version>[0-9]*)$")
+	coreDesktopNameFormat = regexp.MustCompile("^core(?P<version>[0-9]*)-desktop$")
 )
 
 // CoreVersion extract the version component of the core snap name
@@ -37,7 +38,10 @@ func CoreVersion(base string) (int, error) {
 	foundCore := coreNameFormat.FindStringSubmatch(base)
 
 	if foundCore == nil {
-		return 0, fmt.Errorf("not a core base")
+		foundCore = coreDesktopNameFormat.FindStringSubmatch(base)
+		if foundCore == nil {
+			return 0, fmt.Errorf("not a core base")
+		}
 	}
 
 	coreVersionStr := foundCore[coreNameFormat.SubexpIndex("version")]

--- a/snap/naming/core_version_test.go
+++ b/snap/naming/core_version_test.go
@@ -38,6 +38,7 @@ func (s *CoreVersionTestSuite) TestCoreVersion(c *C) {
 		{"core20", 20},
 		{"core22", 22},
 		{"core24", 24},
+		{"core24-desktop", 24},
 	} {
 		v, err := naming.CoreVersion(tst.name)
 		c.Check(err, IsNil)

--- a/snap/naming/core_version_test.go
+++ b/snap/naming/core_version_test.go
@@ -39,6 +39,7 @@ func (s *CoreVersionTestSuite) TestCoreVersion(c *C) {
 		{"core22", 22},
 		{"core24", 24},
 		{"core24-desktop", 24},
+		{"core24-server", 24},
 	} {
 		v, err := naming.CoreVersion(tst.name)
 		c.Check(err, IsNil)
@@ -47,7 +48,7 @@ func (s *CoreVersionTestSuite) TestCoreVersion(c *C) {
 }
 
 func (s *CoreVersionTestSuite) TestCoreOther(c *C) {
-	for _, tst := range []string{"bare", "coreXX"} {
+	for _, tst := range []string{"bare", "coreXX", "coreXX-desktop", "core24_desktop"} {
 		_, err := naming.CoreVersion(tst)
 		c.Check(err, ErrorMatches, "not a core base")
 	}


### PR DESCRIPTION
This is essential to enable preseeding for core desktop, as preseeding is gated based on the base snap version.