### PR TITLE
client, cmd/snap, daemon: api level changes for introducing offline flag to remodel

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -38,12 +38,21 @@ import (
 
 type remodelData struct {
 	NewModel string `json:"new-model"`
+	Offline  bool   `json:"offline,omitempty"`
+}
+
+// RemodelOpts defines options to be used when remodeling the system.
+type RemodelOpts struct {
+	// Offline indicates whether the remodel should be done offline. If true,
+	// the remodel will be attempted to be done without contacting the store.
+	Offline bool
 }
 
 // Remodel tries to remodel the system with the given assertion data
-func (client *Client) Remodel(b []byte) (changeID string, err error) {
+func (client *Client) Remodel(b []byte, opts RemodelOpts) (changeID string, err error) {
 	data, err := json.Marshal(&remodelData{
 		NewModel: string(b),
+		Offline:  opts.Offline,
 	})
 	if err != nil {
 		return "", fmt.Errorf("cannot marshal remodel data: %v", err)
@@ -55,9 +64,9 @@ func (client *Client) Remodel(b []byte) (changeID string, err error) {
 	return client.doAsync("POST", "/v2/model", nil, headers, bytes.NewReader(data))
 }
 
-// RemodelOffline tries to remodel the system with the given model assertion
+// RemodelWithLocalSnaps tries to remodel the system with the given model assertion
 // and local snaps and assertion files.
-func (client *Client) RemodelOffline(
+func (client *Client) RemodelWithLocalSnaps(
 	model []byte, snapPaths, assertPaths []string) (changeID string, err error) {
 
 	// Check if all files exist before starting the go routine

--- a/client/model.go
+++ b/client/model.go
@@ -64,8 +64,9 @@ func (client *Client) Remodel(b []byte, opts RemodelOpts) (changeID string, err 
 	return client.doAsync("POST", "/v2/model", nil, headers, bytes.NewReader(data))
 }
 
-// RemodelWithLocalSnaps tries to remodel the system with the given model assertion
-// and local snaps and assertion files.
+// RemodelWithLocalSnaps tries to remodel the system with the given model
+// assertion and local snaps and assertion files. Remodeling using this method
+// will ensure that snapd does not contact the store.
 func (client *Client) RemodelWithLocalSnaps(
 	model []byte, snapPaths, assertPaths []string) (changeID string, err error) {
 

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -22,6 +22,7 @@ package client_test
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -33,6 +34,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 )
 
@@ -106,7 +108,7 @@ const noSerialAssertionYetResponse = `
 }`
 
 func (cs *clientSuite) TestClientRemodelEndpoint(c *C) {
-	cs.cli.Remodel([]byte(`{"new-model": "some-model"}`))
+	cs.cli.Remodel([]byte(`{"new-model": "some-model"}`), client.RemodelOpts{})
 	c.Check(cs.req.Method, Equals, "POST")
 	c.Check(cs.req.URL.Path, Equals, "/v2/model")
 }
@@ -120,18 +122,42 @@ func (cs *clientSuite) TestClientRemodel(c *C) {
 		"change": "d728"
 	}`
 	remodelJsonData := []byte(`{"new-model": "some-model"}`)
-	id, err := cs.cli.Remodel(remodelJsonData)
+	id, err := cs.cli.Remodel(remodelJsonData, client.RemodelOpts{})
 	c.Assert(err, IsNil)
 	c.Check(id, Equals, "d728")
 	c.Assert(cs.req.Header.Get("Content-Type"), Equals, "application/json")
 
 	body, err := ioutil.ReadAll(cs.req.Body)
 	c.Assert(err, IsNil)
-	jsonBody := make(map[string]string)
+	jsonBody := make(map[string]interface{})
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, IsNil)
 	c.Check(jsonBody, HasLen, 1)
 	c.Check(jsonBody["new-model"], Equals, string(remodelJsonData))
+}
+
+func (cs *clientSuite) TestClientRemodelOffline(c *C) {
+	cs.status = 202
+	cs.rsp = `{
+        "type": "async",
+        "status-code": 202,
+                "result": {},
+        "change": "d728"
+    }`
+	remodelJsonData := []byte(`{"new-model": "some-model"}`)
+	id, err := cs.cli.Remodel(remodelJsonData, client.RemodelOpts{Offline: true})
+	c.Assert(err, IsNil)
+	c.Check(id, Equals, "d728")
+	c.Assert(cs.req.Header.Get("Content-Type"), Equals, "application/json")
+
+	body, err := io.ReadAll(cs.req.Body)
+	c.Assert(err, IsNil)
+	jsonBody := make(map[string]interface{})
+	err = json.Unmarshal(body, &jsonBody)
+	c.Assert(err, IsNil)
+	c.Check(jsonBody, HasLen, 2)
+	c.Check(jsonBody["new-model"], Equals, string(remodelJsonData))
+	c.Check(jsonBody["offline"], Equals, true)
 }
 
 func (cs *clientSuite) TestClientGetModelHappy(c *C) {
@@ -197,7 +223,7 @@ func (cs *clientSuite) TestClientOfflineRemodel(c *C) {
 	err = os.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
 	c.Assert(err, IsNil)
 
-	id, err := cs.cli.RemodelOffline(rawModel, snapPaths, assertsPaths)
+	id, err := cs.cli.RemodelWithLocalSnaps(rawModel, snapPaths, assertsPaths)
 	c.Assert(err, IsNil)
 	c.Check(id, Equals, "d728")
 	contentTypeReStr := "^multipart/form-data; boundary=([A-Za-z0-9]*)$"
@@ -244,7 +270,7 @@ func (cs *clientSuite) TestClientOfflineRemodelServerError(c *C) {
 	err = os.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
 	c.Assert(err, IsNil)
 
-	id, err := cs.cli.RemodelOffline(rawModel, snapPaths, assertsPaths)
+	id, err := cs.cli.RemodelWithLocalSnaps(rawModel, snapPaths, assertsPaths)
 	c.Assert(err.Error(), Equals, "no serial assertion yet")
 	c.Check(id, Equals, "")
 }
@@ -255,12 +281,12 @@ func (cs *clientSuite) TestClientOfflineRemodelNoFile(c *C) {
 	paths := []string{filepath.Join(dirs.GlobalRootDir, "snap1.snap")}
 
 	// No snap file
-	id, err := cs.cli.RemodelOffline(rawModel, paths, nil)
+	id, err := cs.cli.RemodelWithLocalSnaps(rawModel, paths, nil)
 	c.Assert(err, ErrorMatches, `cannot open .*: no such file or directory`)
 	c.Assert(id, Equals, "")
 
 	// No assertions file
-	id, err = cs.cli.RemodelOffline(rawModel, nil, paths)
+	id, err = cs.cli.RemodelWithLocalSnaps(rawModel, nil, paths)
 	c.Assert(err, ErrorMatches, `cannot open .*: no such file or directory`)
 	c.Assert(id, Equals, "")
 }

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -134,6 +134,7 @@ func (cs *clientSuite) TestClientRemodel(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(jsonBody, HasLen, 1)
 	c.Check(jsonBody["new-model"], Equals, string(remodelJsonData))
+	c.Check(jsonBody["offline"], IsNil)
 }
 
 func (cs *clientSuite) TestClientRemodelOffline(c *C) {

--- a/cmd/snap/cmd_remodel_test.go
+++ b/cmd/snap/cmd_remodel_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -47,7 +48,42 @@ const remodelError = `{
   "status-code": 400
 }`
 
-func (s *SnapSuite) TestRemodelOfflineOk(c *C) {
+func (s *SnapSuite) TestRemodelOffline(c *C) {
+	n := 0
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "POST")
+		c.Check(r.URL.Path, Equals, "/v2/model")
+		w.WriteHeader(202)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		c.Assert(err, IsNil)
+
+		c.Check(req["offline"], Equals, true)
+
+		fmt.Fprint(w, remodelOk)
+		n++
+	})
+
+	var err error
+	modelPath := filepath.Join(dirs.GlobalRootDir, "new-model")
+	err = os.WriteFile(modelPath, []byte("snap1"), 0644)
+	c.Assert(err, IsNil)
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remodel", "--no-wait", "--offline", modelPath})
+
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(n, Equals, 1)
+
+	c.Check(s.Stdout(), Matches, "101\n")
+	c.Check(s.Stderr(), Equals, "")
+
+	s.ResetStdStreams()
+}
+
+func (s *SnapSuite) TestRemodelLocalSnapsOk(c *C) {
 	n := 0
 
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +114,7 @@ func (s *SnapSuite) TestRemodelOfflineOk(c *C) {
 	s.ResetStdStreams()
 }
 
-func (s *SnapSuite) TestRemodelOfflineError(c *C) {
+func (s *SnapSuite) TestRemodelLocalSnapsError(c *C) {
 	n := 0
 
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/snap/cmd_remodel_test.go
+++ b/cmd/snap/cmd_remodel_test.go
@@ -66,9 +66,8 @@ func (s *SnapSuite) TestRemodelOffline(c *C) {
 		n++
 	})
 
-	var err error
 	modelPath := filepath.Join(dirs.GlobalRootDir, "new-model")
-	err = os.WriteFile(modelPath, []byte("snap1"), 0644)
+	err := os.WriteFile(modelPath, []byte("snap1"), 0644)
 	c.Assert(err, IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remodel", "--no-wait", "--offline", modelPath})

--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -141,9 +141,13 @@ func readOfflineRemodelForm(form *Form) (*asserts.Model, []*uploadedSnap, *asser
 	}
 
 	// Snap files
-	snapFiles, errRsp := form.GetSnapFiles()
-	if errRsp != nil {
-		return nil, nil, nil, errRsp
+	var snapFiles []*uploadedSnap
+	if len(form.FileRefs["snap"]) > 0 {
+		snaps, errRsp := form.GetSnapFiles()
+		if errRsp != nil {
+			return nil, nil, nil, errRsp
+		}
+		snapFiles = snaps
 	}
 
 	// Assertions

--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -64,6 +64,7 @@ var (
 
 type postModelData struct {
 	NewModel string `json:"new-model"`
+	Offline  bool   `json:"offline"`
 }
 
 func postModel(c *Command, r *http.Request, _ *auth.UserState) Response {
@@ -77,12 +78,12 @@ func postModel(c *Command, r *http.Request, _ *auth.UserState) Response {
 	switch mediaType {
 	case "application/json":
 		// If json content type we get only the new model assertion and
-		// the rest is downloaded from the store.
-		return storeRemodel(c, r)
+		// the rest is either downloaded from the store or already installed.
+		return remodelJSON(c, r)
 	case "multipart/form-data":
 		// multipart/form-data content type can be used to sideload
 		// part of the things necessary for a remodel.
-		return offlineRemodel(c, r, params)
+		return remodelForm(c, r, params)
 	default:
 		return BadRequest("unexpected media type %q", mediaType)
 	}
@@ -101,7 +102,7 @@ func modelFromData(data []byte) (*asserts.Model, error) {
 	return newModel, nil
 }
 
-func storeRemodel(c *Command, r *http.Request) Response {
+func remodelJSON(c *Command, r *http.Request) Response {
 	var data postModelData
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&data); err != nil {
@@ -116,7 +117,9 @@ func storeRemodel(c *Command, r *http.Request) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	chg, err := devicestateRemodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
+	chg, err := devicestateRemodel(st, newModel, nil, nil, devicestate.RemodelOptions{
+		Offline: data.Offline,
+	})
 	if err != nil {
 		return BadRequest("cannot remodel device: %v", err)
 	}
@@ -191,6 +194,8 @@ func startOfflineRemodelChange(st *state.State, newModel *asserts.Model,
 
 	// Now create and start the remodel change
 	chg, err := devicestateRemodel(st, newModel, slInfo.sideInfos, slInfo.tmpPaths, devicestate.RemodelOptions{
+		// since this is the codepath that parses the form, offline is implcit
+		// because local snaps are being provided.
 		Offline: true,
 	})
 	if err != nil {
@@ -201,7 +206,7 @@ func startOfflineRemodelChange(st *state.State, newModel *asserts.Model,
 	return chg, nil
 }
 
-func offlineRemodel(c *Command, r *http.Request, contentTypeParams map[string]string) Response {
+func remodelForm(c *Command, r *http.Request, contentTypeParams map[string]string) Response {
 	boundary := contentTypeParams["boundary"]
 	mpReader := multipart.NewReader(r.Body, boundary)
 	form, errRsp := readForm(mpReader)

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -62,7 +62,7 @@ execute: |
   # if we are only using preinstalled/acked snaps/assertions, then we have to
   # use the --offline flag to indicate that we want to use already installed
   # snaps
-  if [ "${USE_INSTALLED_ESSENTIAL_SNAPS}" = 'true' -a "${USE_INSTALLED_VSET}" = 'true' -a "${USE_INSTALLED_APP}" = 'true' ]; then
+  if [ "${USE_INSTALLED_ESSENTIAL_SNAPS}" = 'true' ] && [ "${USE_INSTALLED_VSET}" = 'true' ] && [ "${USE_INSTALLED_APP}" = 'true' ]; then
       remodel_options="$remodel_options --offline"
   fi
 

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -16,6 +16,30 @@ environment:
   GADGET_NAME: test-snapd-remodel-pc
   NEW_GADGET_NAME: test-snapd-remodel-pc-min-size
 
+  # provide everything needed for the remodel via the CLI
+  USE_INSTALLED_APP/local_snaps: false
+  USE_INSTALLED_VSET/local_snaps: false
+  USE_INSTALLED_ESSENTIAL_SNAPS/local_snaps: false
+
+  # preinstall/ack everything needed for the remodel, this ensures that the
+  # --offline flag is working as expected
+  USE_INSTALLED_APP/installed_snaps: true
+  USE_INSTALLED_ESSENTIAL_SNAPS/installed_snaps: true
+  USE_INSTALLED_VSET/installed_snaps: true
+
+  # preinstall essential snaps needed for the remodel, app snap and validation
+  # set is provided via the CLI
+  USE_INSTALLED_APP/local_and_installed_snaps: false
+  USE_INSTALLED_ESSENTIAL_SNAPS/local_and_installed_snaps: true
+  USE_INSTALLED_VSET/local_and_installed_snaps: false
+
+  # preinstall essential and app snaps needed for the remodel, validation set is
+  # provided via the CLI. this catches the case where only assertions were sent
+  # with the form data, which was not previously supported
+  USE_INSTALLED_APP/local_assertions: true
+  USE_INSTALLED_ESSENTIAL_SNAPS/local_assertions: true
+  USE_INSTALLED_VSET/local_assertions: false
+
 prepare: |
   export NESTED_CUSTOM_MODEL="$TESTSLIB/assertions/test-snapd-remodel-offline-rev0.model"
   tests.nested build-image core
@@ -33,29 +57,61 @@ execute: |
 
   new_model_rev=test-snapd-remodel-offline-rev1.model
   remote.push "$TESTSLIB/assertions/$new_model_rev"
-  remodel_options="--no-wait"
-  # Get specific revision to grab pc 22 with compatible gadget with the one
-  # in 20/stable.
-  # TODO update this code to use pc from 22/stable when it has min-size
-  # for the ubuntu-save partition -> for sn_name in pc pc-kernel; do ...
-  remote.exec "snap download --revision=148 --basename=pc pc"
-  remodel_options="$remodel_options --snap pc.snap --assertion pc.assert"
-  #shellcheck disable=SC2043
-  for sn_name in pc-kernel; do
-      remote.exec "snap download --channel=22/stable --basename=$sn_name $sn_name"
-      remodel_options="$remodel_options --snap $sn_name.snap --assertion $sn_name.assert"
-  done
-
-  for sn_name in core22 core; do
-      remote.exec "snap download --basename=${sn_name} ${sn_name}"
-      remodel_options="$remodel_options --snap ${sn_name}.snap --assertion ${sn_name}.assert"
-  done
-
-  remote.exec "snap download --revision=28 --basename=hello-world hello-world"
-  remodel_options="$remodel_options --snap hello-world.snap --assertion hello-world.assert"
-
   remote.push "$TESTSLIB/assertions/test-snapd-core22-required-vset.assert"
-  remodel_options="$remodel_options --assertion test-snapd-core22-required-vset.assert"
+  remodel_options="--no-wait"
+
+  # if we are only using preinstalled/acked snaps/assertions, then we have to
+  # use the --offline flag to indicate that we want to use already installed
+  # snaps
+  if [ "${USE_INSTALLED_ESSENTIAL_SNAPS}" = 'true' -a "${USE_INSTALLED_VSET}" = 'true' -a "${USE_INSTALLED_APP}" = 'true' ]; then
+      remodel_options="$remodel_options --offline"
+  fi
+
+  # install/download new bases required for the new model
+  for sn_name in core22 core; do
+      if [ "${USE_INSTALLED_ESSENTIAL_SNAPS}" = 'true' ]; then
+          remote.exec "snap install ${sn_name}"
+      else
+          remote.exec "snap download --basename=${sn_name} ${sn_name}"
+          remodel_options="$remodel_options --snap ${sn_name}.snap --assertion ${sn_name}.assert"
+      fi
+  done
+
+  # install/download app required for the new model
+  if [ "${USE_INSTALLED_APP}" = 'true' ]; then
+      remote.exec "snap install --revision=28 hello-world"
+  else
+      remote.exec "snap download --revision=28 --basename=hello-world hello-world"
+      remodel_options="$remodel_options --snap hello-world.snap --assertion hello-world.assert"
+  fi
+
+  # install/download new kernel and gadget required for the new model
+  if [ "${USE_INSTALLED_ESSENTIAL_SNAPS}" = 'true' ]; then
+      # Get specific revision to grab pc 22 with compatible gadget with the one
+      # in 20/stable.
+      # TODO update this code to use pc from 22/stable when it has min-size
+      # for the ubuntu-save partition
+      remote.exec "snap refresh --revision=148 pc"
+
+      # --no-wait here, since this should trigger a reboot
+      remote.exec "snap refresh --no-wait --channel=22/stable pc-kernel"
+
+      remote.wait-for reboot "$boot_id"
+      boot_id="$(tests.nested boot-id)"
+  else
+      remote.exec "snap download --revision=148 --basename=pc pc"
+      remodel_options="$remodel_options --snap pc.snap --assertion pc.assert"
+
+      remote.exec "snap download --channel=22/stable --basename=pc-kernel pc-kernel"
+      remodel_options="$remodel_options --snap pc-kernel.snap --assertion pc-kernel.assert"
+  fi
+
+  # ack/add new assertions to CLI params
+  if [ "${USE_INSTALLED_VSET}" = 'true' ]; then
+      remote.exec "snap ack test-snapd-core22-required-vset.assert"
+  else
+      remodel_options="$remodel_options --assertion test-snapd-core22-required-vset.assert"
+  fi
 
   # Make sure we cannot access the store
   netplan_cfg=50-bad-gw.yaml

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -57,7 +57,6 @@ execute: |
 
   new_model_rev=test-snapd-remodel-offline-rev1.model
   remote.push "$TESTSLIB/assertions/$new_model_rev"
-  remote.push "$TESTSLIB/assertions/test-snapd-core22-required-vset.assert"
   remodel_options="--no-wait"
 
   # if we are only using preinstalled/acked snaps/assertions, then we have to
@@ -106,7 +105,8 @@ execute: |
       remodel_options="$remodel_options --snap pc-kernel.snap --assertion pc-kernel.assert"
   fi
 
-  # ack/add new assertions to CLI params
+  # ack/add new validation set assertion to CLI params
+  remote.push "$TESTSLIB/assertions/test-snapd-core22-required-vset.assert"
   if [ "${USE_INSTALLED_VSET}" = 'true' ]; then
       remote.exec "snap ack test-snapd-core22-required-vset.assert"
   else


### PR DESCRIPTION
These changes expose the changes made in #13494 in the snapd API and CLI. An `--offline` flag is introduced to the CLI, and an `offline` boolean field is added to the snapd JSON API.