### PR TITLE
sandbox/cgroup: refactor and cleanup, fix path tracking and watch removal

### DIFF
--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -19,6 +19,7 @@
 package cgroup
 
 import (
+	"context"
 	"time"
 
 	"github.com/godbus/dbus"
@@ -113,3 +114,24 @@ func MockCgroupsFilePath(path string) (restore func()) {
 func MonitorDelete(folders []string, name string, channel chan string) error {
 	return currentWatcher.monitorDelete(folders, name, channel)
 }
+
+type InotifyWatcher = inotifyWatcher
+
+func MockInotifyWatcher(ctx context.Context, obsMonitor func(w *InotifyWatcher, name string)) (restore func()) {
+	old := currentWatcher
+	currentWatcher = newInotifyWatcher(ctx)
+	currentWatcher.observeMonitorCb = obsMonitor
+	return func() { currentWatcher = old }
+}
+
+func MockInitWatcherClose() { currentWatcher.Close() }
+
+func (iw *inotifyWatcher) MonitoredDirs() map[string]uint {
+	return iw.pathList
+}
+
+func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel chan string) error {
+	return iw.monitorDelete(folders, name, channel)
+}
+
+var NewInotifyWatcher = newInotifyWatcher

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -118,10 +118,10 @@ func MonitorDelete(folders []string, name string, channel chan string) error {
 type InotifyWatcher = inotifyWatcher
 
 func MockInotifyWatcher(ctx context.Context, obsMonitor func(w *InotifyWatcher, name string)) (restore func()) {
-	old := currentWatcher
+	restore = testutil.Backup(&currentWatcher)
 	currentWatcher = newInotifyWatcher(ctx)
 	currentWatcher.observeMonitorCb = obsMonitor
-	return func() { currentWatcher = old }
+	return restore
 }
 
 func MockInitWatcherClose() { currentWatcher.Close() }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -282,5 +282,7 @@ func MonitorSnapEnded(snapName string, channel chan<- string) error {
 	if err != nil {
 		return err
 	}
+
+	logger.Debugf("snap %v has %v processes: %v", snapName, len(paths), paths)
 	return currentWatcher.monitorDelete(paths, snapName, channel)
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -22,7 +22,6 @@ package cgroup
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -115,10 +114,8 @@ func (iw *inotifyWatcher) addWatch(newWatch *groupToWatch) {
 		if _, exists := iw.pathList[basePath]; !exists {
 			iw.pathList[basePath] = 0
 			if err := iw.wd.AddWatch(basePath, inotify.InDelete); err != nil {
-				target := &os.PathError{}
-				if !errors.As(err, &target) {
-					logger.Noticef("cannot add watch for path %s: %s", target.Path, target.Err)
-				}
+				// TODO propagate the error back to the caller
+				logger.Noticef("cannot add watch %v", err)
 				delete(iw.pathList, basePath)
 				continue
 			}

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -20,6 +20,7 @@
 package cgroup_test
 
 import (
+	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -35,6 +37,7 @@ import (
 type monitorSuite struct {
 	testutil.BaseTest
 
+	tempDir  string
 	eventsCh chan string
 
 	inotifyWait time.Duration
@@ -43,72 +46,59 @@ type monitorSuite struct {
 var _ = Suite(&monitorSuite{})
 
 func (s *monitorSuite) SetUpTest(c *C) {
+	logger.SimpleSetup()
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 
+	s.tempDir = c.MkDir()
+
 	s.eventsCh = make(chan string)
 	s.AddCleanup(func() { close(s.eventsCh) })
-
-	s.calibrateInotifyDelay(c)
 }
 
-func (s *monitorSuite) calibrateInotifyDelay(c *C) {
-	folder1 := s.makeTestFolder(c, "folder1")
-	filelist := []string{folder1}
-	err := cgroup.MonitorDelete(filelist, "test1", s.eventsCh)
-	c.Assert(err, IsNil)
-	var start time.Time
-	go func() {
-		start = time.Now()
-		err = os.Remove(folder1)
-		c.Assert(err, IsNil)
-	}()
-	<-s.eventsCh
-	d := time.Now().Sub(start)
-	// On a modern machine the duration "d" for inotify delivery is
-	// around 30-100µs so even the very conservative multiplication means
-	// the delay is typically 3ms-10ms.
-	s.inotifyWait = 100 * d
-	switch {
-	case s.inotifyWait > 1*time.Second:
-		s.inotifyWait = 1 * time.Second
-	case s.inotifyWait < 10*time.Millisecond:
-		s.inotifyWait = 10 * time.Millisecond
-	}
-}
-
-func (s *monitorSuite) makeTestFolder(c *C, name string) (fullPath string) {
-	fullPath = path.Join(c.MkDir(), name)
+func makeTestFolder(c *C, root string, name string) (fullPath string) {
+	fullPath = path.Join(root, name)
 	err := os.Mkdir(fullPath, 0755)
 	c.Assert(err, IsNil)
 	return fullPath
 }
 
 func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
-	folder1 := s.makeTestFolder(c, "folder1")
-	folder2 := s.makeTestFolder(c, "folder2")
+	cb := 0
+	monitorAdded := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, func(w *cgroup.InotifyWatcher, name string) {
+		cb++
+		switch cb {
+		case 1:
+			if cb == 1 {
+				close(monitorAdded)
+			}
+			c.Check(name, Equals, "test1")
+		case 2, 3:
+		default:
+			c.Fatalf("unexpected callback: %v %q", cb, name)
+		}
+
+	}))
+	defer cgroup.MockInitWatcherClose()
+	defer cancel()
+
+	folder1 := makeTestFolder(c, s.tempDir, "folder1")
+	// canary
+	folder2 := makeTestFolder(c, s.tempDir, "folder2")
 
 	filelist := []string{folder1}
 	err := cgroup.MonitorDelete(filelist, "test1", s.eventsCh)
 	c.Assert(err, IsNil)
 
-	time.Sleep(s.inotifyWait)
+	<-monitorAdded
 
+	// removing an unwatched directory does not trigger an event
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
-
-	// Wait for bit to ensure that nothing spurious
-	// is received from the channel due to removing folder2
-	// Wait for a bit to ensure that nothing spurious
-	// is received from the channel due to creating or
-	// removing folder3
-	select {
-	case event := <-s.eventsCh:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
-	}
 
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
@@ -117,39 +107,57 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 }
 
 func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
-	folder1 := s.makeTestFolder(c, "folder1")
-	folder2 := s.makeTestFolder(c, "folder2")
-
+	folder1 := makeTestFolder(c, s.tempDir, "folder1")
+	folder2 := makeTestFolder(c, s.tempDir, "folder2")
 	filelist := []string{folder1, folder2}
+	cb := 0
+	monitorAdded := make(chan struct{})
+	allDone := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, func(w *cgroup.InotifyWatcher, name string) {
+		cb++
+		switch cb {
+		case 1:
+			// add for folder1 and folder2
+			if cb == 1 {
+				close(monitorAdded)
+				// paths we track + the parent dir is referenced twice
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{
+					s.tempDir: uint(2),
+					folder1:   uint(1),
+					folder2:   uint(1),
+				})
+			}
+			fallthrough
+		case 2, 3, 4:
+			// removal of folder1, folder2, folder3
+			c.Check(name, Equals, "test2")
+			if cb == 4 {
+				close(allDone)
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{})
+			}
+		default:
+			c.Fatalf("unexpected callback: %v %q", cb, name)
+		}
+
+	}))
+	defer cancel()
+
 	err := cgroup.MonitorDelete(filelist, "test2", s.eventsCh)
 	c.Assert(err, Equals, nil)
 
-	time.Sleep(s.inotifyWait)
+	<-monitorAdded
 
-	folder3 := s.makeTestFolder(c, "folder3")
+	folder3 := makeTestFolder(c, s.tempDir, "folder3")
 
 	time.Sleep(s.inotifyWait)
 
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
 
-	// Wait for a bit to ensure that nothing spurious
-	// is received from the channel due to creating or
-	// removing folder3
-	select {
-	case event := <-s.eventsCh:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
-	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
-	// Only one file has been removed, so wait a bit to ensure
-	// that nothing spurious is received from the channel
-	select {
-	case event := <-s.eventsCh:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
-	}
+
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
 
@@ -157,11 +165,92 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	// something from the channel
 	event := <-s.eventsCh
 	c.Assert(event, Equals, "test2")
+
+	// wait for all events to be processed
+	<-allDone
+}
+
+func (s *monitorSuite) TestMonitorOverlap(c *C) {
+	// add 2 groups with different notification channels monitoring the same
+	// set of paths
+
+	folder1 := makeTestFolder(c, s.tempDir, "folder1")
+	folder2 := makeTestFolder(c, s.tempDir, "folder2")
+	filelist := []string{folder1, folder2}
+	cb := 0
+	monitorAdded := make(chan struct{}, 2)
+	allDone := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, func(w *cgroup.InotifyWatcher, name string) {
+		cb++
+		switch cb {
+		case 1, 2:
+			// add for set1 and set2
+			monitorAdded <- struct{}{}
+			if cb == 1 {
+				// paths we track + the parent dir is referenced twice
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{
+					s.tempDir: uint(2),
+					folder1:   uint(1),
+					folder2:   uint(1),
+				})
+			} else {
+				// previous ref counts + a new full set
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{
+					s.tempDir: uint(4),
+					folder1:   uint(2),
+					folder2:   uint(2),
+				})
+			}
+			fallthrough
+		case 3, 4, 5, 6, 7, 8:
+			// removal of folder1, folder2 and then group, for both groups
+			if cb == 8 {
+				close(allDone)
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{})
+			}
+		default:
+			c.Fatalf("unexpected callback: %v %q", cb, name)
+		}
+
+	}))
+	defer cancel()
+
+	set1Ch := make(chan string, 1)
+	set2Ch := make(chan string, 1)
+	err := cgroup.MonitorDelete(filelist, "set1", set1Ch)
+	c.Assert(err, Equals, nil)
+
+	err = cgroup.MonitorDelete(filelist, "set2", set2Ch)
+	c.Assert(err, Equals, nil)
+
+	<-monitorAdded
+	<-monitorAdded
+
+	err = os.Remove(folder1)
+	c.Assert(err, IsNil)
+
+	err = os.Remove(folder2)
+	c.Assert(err, IsNil)
+
+	// both sets are notified
+	event := <-set1Ch
+	c.Assert(event, Equals, "set1")
+
+	event = <-set2Ch
+	c.Assert(event, Equals, "set2")
+
+	// wait for all events to be processed
+	<-allDone
 }
 
 func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, nil))
+	defer cancel()
+
 	// Note that there is no dir created in this test so
-	// this checks that the monitoring is correct is there
+	// this checks that the monitoring is correct when there
 	// is no dir
 	nonExistingFolder := path.Join(c.MkDir(), "non-exiting-dir")
 
@@ -174,8 +263,33 @@ func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
 }
 
 func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
-	folder1 := s.makeTestFolder(c, "folder1")
-	folder2 := s.makeTestFolder(c, "folder2")
+	folder1 := makeTestFolder(c, s.tempDir, "folder1")
+	folder2 := makeTestFolder(c, s.tempDir, "folder2")
+	folder3 := makeTestFolder(c, s.tempDir, "folder3")
+
+	events := 0
+	monitorAdded := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, func(w *cgroup.InotifyWatcher, name string) {
+		events++
+		switch events {
+		case 1, 2:
+			// notify about snap monitoring being added
+			monitorAdded <- name
+			if events == 2 {
+				c.Assert(w.MonitoredDirs(), DeepEquals, map[string]uint{
+					s.tempDir: uint(2),
+					folder1:   uint(1),
+					folder2:   uint(1),
+				})
+			}
+		case 3, 4, 5, 6:
+			// remove folder3, folder1, folder2
+		default:
+			c.Fatalf("unexpected callback: %d %q", events, name)
+		}
+	}))
+	defer cancel()
 
 	filelist1 := []string{folder1}
 	filelist2 := []string{folder2}
@@ -188,57 +302,46 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 
 	err := cgroup.MonitorDelete(filelist1, "test4a", channel1)
 	c.Assert(err, Equals, nil)
+
+	c.Assert(<-monitorAdded, Equals, "test4a")
+
 	err = cgroup.MonitorDelete(filelist2, "test4b", channel2)
 	c.Assert(err, Equals, nil)
 
-	time.Sleep(s.inotifyWait)
-
-	folder3 := s.makeTestFolder(c, "folder3")
+	c.Assert(<-monitorAdded, Equals, "test4b")
 
 	time.Sleep(s.inotifyWait)
 
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
 
-	// Wait for a bit to ensure that nothing spurious
-	// is received from the channel due to creating or
-	// removing folder3
-	select {
-	case event := <-channel1:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case event := <-channel2:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
-	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
-	// Only one file has been removed, so wait a bit to ensure
-	// that nothing spurious is received from the channel
+	// Expect to receive an event about the first snap
 	var receivedEvent string
 	select {
 	case receivedEvent = <-channel1:
-	case event := <-channel2:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
+	case <-time.After(time.Minute):
 	}
 
 	c.Assert(receivedEvent, Equals, "test4a")
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
 
-	// All files have been deleted, so NOW we must receive
-	// something from the channel
+	// Expect to receive an event about the second snap
 	receivedEvent = ""
 	select {
 	case receivedEvent = <-channel2:
-	case event := <-channel1:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(s.inotifyWait):
+	case <-time.After(time.Minute):
 	}
 	c.Assert(receivedEvent, Equals, "test4b")
 }
 
 func (s *monitorSuite) TestMonitorSnapEndedNonExisting(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, nil))
+	defer cancel()
+
 	err := cgroup.MonitorSnapEnded("non-existing-snap", s.eventsCh)
 	c.Assert(err, IsNil)
 
@@ -247,6 +350,10 @@ func (s *monitorSuite) TestMonitorSnapEndedNonExisting(c *C) {
 }
 
 func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, nil))
+	defer cancel()
+
 	restore := cgroup.MockVersion(cgroup.V2, nil)
 	s.AddCleanup(restore)
 
@@ -261,11 +368,7 @@ func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
 	err = cgroup.MonitorSnapEnded("firefox", s.eventsCh)
 	c.Assert(err, IsNil)
 
-	select {
-	case snapName := <-s.eventsCh:
-		c.Fatalf("unexpected stop reported for snap %v", snapName)
-	case <-time.After(s.inotifyWait):
-	}
+	// TODO observe
 
 	// simulate cgroup getting removed because firefox stopped
 	err = os.RemoveAll(filepath.Dir(mockProcsFile))
@@ -276,31 +379,57 @@ func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
 	c.Check(snapName, Equals, "firefox")
 }
 
-func (s *monitorSuite) TestMonitorCloseChannel(c *C) {
-	folder1 := s.makeTestFolder(c, "folder1")
-	folder2 := s.makeTestFolder(c, "folder2")
+func (s *monitorSuite) TestMonitorUnbuffered(c *C) {
+	cb := 0
+	monitorEvent := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.AddCleanup(cgroup.MockInotifyWatcher(ctx, func(w *cgroup.InotifyWatcher, name string) {
+		cb++
+		switch cb {
+		case 1:
+			// notify about snap monitoring being added
+			monitorEvent <- name
+		case 2, 3:
+			monitorEvent <- name
+		default:
+			c.Fatalf("unexpected callback: %d %q", cb, name)
+		}
+
+	}))
+	defer cancel()
+
+	folder1 := makeTestFolder(c, s.tempDir, "folder1")
 
 	filelist := []string{folder1}
 	ch := make(chan string)
 	err := cgroup.MonitorDelete(filelist, "test1", ch)
 	c.Assert(err, IsNil)
 
-	time.Sleep(s.inotifyWait)
+	<-monitorEvent
 
-	err = os.Remove(folder2)
-	c.Assert(err, IsNil)
-
-	// Wait for a bit to ensure that
-	// nothing spurious is received from the channel
-	select {
-	case event := <-ch:
-		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
-	}
-
+	// channel is closed
 	close(ch)
+
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
-	event := <-ch
-	c.Assert(event, Equals, "")
+
+	// remove was observed
+	c.Check(<-monitorEvent, Equals, "test1")
+}
+
+func (s *monitorSuite) TestMonitorClose(c *C) {
+	w := cgroup.NewInotifyWatcher(context.Background())
+	f := makeTestFolder(c, s.tempDir, "foo")
+	ch := make(chan string)
+
+	err := w.MonitorDelete([]string{f}, "test", ch)
+	c.Assert(err, IsNil)
+
+	w.Close()
+
+	select {
+	case <-ch:
+		c.Fatalf("unexpected event")
+	default:
+	}
 }

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -433,3 +433,14 @@ func (s *monitorSuite) TestMonitorClose(c *C) {
 	default:
 	}
 }
+
+func (s *monitorSuite) TestMonitorError(c *C) {
+	w := cgroup.NewInotifyWatcher(context.Background())
+	ch := make(chan string)
+
+	// XXX note the error isn't propagated back to the caller
+	err := w.MonitorDelete([]string{filepath.Join(s.tempDir, "foo/bar/baz")}, "test", ch)
+	c.Assert(err, IsNil)
+
+	w.Close()
+}


### PR DESCRIPTION
This is an bunch of fixes and refactors for the cgroup monitoring code. The main issue addressed is with tracked path removal. We have previously added references to the leaf paths internally, but the actual watch was established using the parent path, for which the reference was never updated. As a result if all leaf paths were gone, we did not clean up the watch on the parent path.

While at it, change the structure internally to use a hash map in the group to watch to simplify bookkeeping.

Next, added support for the context and a way to cleanup and close the watcher in a reasonable manner. 

A bunch of improvements to the tests, so that we are no longer guessing and sleeping hoping to observe the right events. Instead provide an observer which the tests can hook to and inspect the state as needed.
