### PR TITLE
o/s/policy: allow "core" snap to be removed on classic systems

### DIFF
--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -14,8 +14,12 @@ import (
 // involved in an operation. Rather than have a forest of `if`s
 // looking at type, model, etc, we move it to Policy and look it up.
 type Policy interface {
-	// CanRemove verifies that a snap can be removed.
-	// If rev is not unset, check for removing only that revision.
+	// CanRemove verifies that a snap can be removed. If rev is set, check
+	// for removing only that revision. A revision which is unset means that
+	// the snap will be completely gone after the operation, i.e. all
+	// installed revisions will be removed, which is equally true when
+	// removing the last remaining revision of the snap, even if said
+	// revision was explicitly passed by the user.
 	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev snap.Device) error
 }
 

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -154,7 +154,7 @@ func (s *canRemoveSuite) TestOSNoSnapdNotOK(c *check.C) {
 		Current:  snap.R(1),
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
-	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.Equals, policy.ErrIsModel)
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.Equals, policy.ErrSnapdNotInstalled)
 }
 
 func (s *canRemoveSuite) TestOSRequiredNotOK(c *check.C) {

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -32,6 +32,15 @@ func (s *canRemoveSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
 
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapstate.Set(s.st, "snapd", &snapstate.SnapState{
+		SnapType: "snapd",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "snapd"}}),
+		Current:  snap.R(1),
+	})
+
 	s.bootloader = boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
 	bootloader.Force(s.bootloader)
 	s.bootloader.SetBootBase("base_99.snap")
@@ -133,6 +142,19 @@ func (s *canRemoveSuite) TestOSInUseNotOK(c *check.C) {
 	// but not if it's the one we booted
 	s.bootloader.SetBootBase("core_1.snap")
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), coreDev), check.Equals, policy.ErrInUseForBoot)
+}
+
+func (s *canRemoveSuite) TestOSNoSnapdNotOK(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapstate.Set(s.st, "snapd", nil)
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
+	}
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.Equals, policy.ErrIsModel)
 }
 
 func (s *canRemoveSuite) TestOSRequiredNotOK(c *check.C) {

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -154,12 +154,7 @@ func (s *canRemoveSuite) TestOSNoSnapdNotOK(c *check.C) {
 		Current:  snap.R(1),
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
-	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.Equals, policy.ErrSnapdNotInstalled)
-
-	snapst = &snapstate.SnapState{
-		Current:  snap.R(1),
-		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
-	}
+	// revision is unset as if we're fully removing core from the system
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.Revision{}, classicDev), check.Equals, policy.ErrSnapdNotInstalled)
 }
 

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -121,6 +121,7 @@ func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *check.C) {
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), coreDev), check.Equals, policy.ErrIsModel)
 	// (well, single revisions are ok)
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.IsNil)
 	// removing os is also ok on classic systems
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), classicDev), check.IsNil)
 	// model kernel == snap kernel -> can't be removed

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -112,6 +112,8 @@ func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *check.C) {
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), coreDev), check.Equals, policy.ErrIsModel)
 	// (well, single revisions are ok)
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
+	// removing os is also ok on classic systems
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), classicDev), check.IsNil)
 	// model kernel == snap kernel -> can't be removed
 	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, snap.R(0), coreDev), check.Equals, policy.ErrIsModel)
 	// (well, single revisions are ok)

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -155,6 +155,12 @@ func (s *canRemoveSuite) TestOSNoSnapdNotOK(c *check.C) {
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), classicDev), check.Equals, policy.ErrSnapdNotInstalled)
+
+	snapst = &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
+	}
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.Revision{}, classicDev), check.Equals, policy.ErrSnapdNotInstalled)
 }
 
 func (s *canRemoveSuite) TestOSRequiredNotOK(c *check.C) {

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	errNoName       = errors.New("snap has no name (not installed?)")
-	errInUseForBoot = errors.New("snap is being used for boot")
-	errRequired     = errors.New("snap is required")
-	errIsModel      = errors.New("snap is used by the model")
+	errNoName            = errors.New("snap has no name (not installed?)")
+	errInUseForBoot      = errors.New("snap is being used for boot")
+	errRequired          = errors.New("snap is required")
+	errIsModel           = errors.New("snap is used by the model")
+	errSnapdNotInstalled = errors.New("core snap cannot be removed if snapd snap is not installed")
 
 	errSnapdNotRemovableOnCore       = errors.New("snapd required on core devices")
 	errSnapdNotYetRemovableOnClassic = errors.New("remove all other snaps first")

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -8,10 +8,11 @@ func NewOSPolicy(m string) *osPolicy             { return &osPolicy{modelBase: m
 func NewSnapdPolicy(onClassic bool) *snapdPolicy { return &snapdPolicy{onClassic: onClassic} }
 
 var (
-	ErrNoName       = errNoName
-	ErrInUseForBoot = errInUseForBoot
-	ErrRequired     = errRequired
-	ErrIsModel      = errIsModel
+	ErrNoName            = errNoName
+	ErrInUseForBoot      = errInUseForBoot
+	ErrRequired          = errRequired
+	ErrIsModel           = errIsModel
+	ErrSnapdNotInstalled = errSnapdNotInstalled
 
 	ErrSnapdNotRemovableOnCore       = errSnapdNotRemovableOnCore
 	ErrSnapdNotYetRemovableOnClassic = errSnapdNotYetRemovableOnClassic

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -71,7 +71,7 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 	// received snapd updates via the core snap. in that case, we can't remove
 	// the core snap.
 	if !snapdState.IsInstalled() {
-		return errIsModel
+		return errSnapdNotInstalled
 	}
 
 	if !rev.Unset() {

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -62,10 +62,9 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 	}
 
 	if rev.Unset() {
-		// revision will be unset if we're attempting to remove all
-		// snaps or just the one last remaining revision (although
-		// double check that), in either case, we need to ensure that
-		// the snapd snap is there
+		// revision will be unset if we're attempting to remove all snaps or
+		// just the one last remaining revision. in either case, we need to
+		// ensure that the snapd snap is there
 
 		var snapdState snapstate.SnapState
 		err := snapstate.Get(st, "snapd", &snapdState)

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -61,7 +61,7 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return errIsModel
 	}
 
-	if rev.Unset() || len(snapst.Sequence.Revisions) == 1 {
+	if rev.Unset() {
 		// revision will be unset if we're attempting to remove all
 		// snaps or just the one last remaining revision (although
 		// double check that), in either case, we need to ensure that

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -44,7 +44,10 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return nil
 	}
 
-	if p.modelBase == "" {
+	// if the base is unset and dev.IsCoreBoot is true, then we know this is a
+	// UC16 system. note that base might be unset on classic models, so we must
+	// check dev.IsCoreBoot as well.
+	if p.modelBase == "" && dev.IsCoreBoot() {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -46,9 +46,9 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return nil
 	}
 
-	// if the base is unset and dev.IsCoreBoot is true, then we know this is a
-	// UC16 system. note that base might be unset on classic models, so we must
-	// check dev.IsCoreBoot as well.
+	// consider the case of a UC16 system, where the model does not specify a base, 
+	// since 'core' is already implied and is actively used by the system, 
+	// which boots in the UC way
 	if p.modelBase == "" && dev.IsCoreBoot() {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -46,8 +46,8 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return nil
 	}
 
-	// consider the case of a UC16 system, where the model does not specify a base, 
-	// since 'core' is already implied and is actively used by the system, 
+	// consider the case of a UC16 system, where the model does not specify a base,
+	// since 'core' is already implied and is actively used by the system,
 	// which boots in the UC way
 	if p.modelBase == "" && dev.IsCoreBoot() {
 		if !rev.Unset() {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3477,15 +3477,6 @@ func (s *snapmgrTestSuite) TestDisableDoesNotEnableAgain(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestEnsureRemovesVulnerableCoreSnap(c *C) {
-	// install the snapd snap so that the core snap can be removed
-	s.state.Lock()
-	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		SnapType: "snapd",
-		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "snapd"}}),
-		Current:  snap.R(1),
-	})
-	s.state.Unlock()
-
 	s.testEnsureRemovesVulnerableSnap(c, "core")
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3523,6 +3523,9 @@ SNAPD_APPARMOR_REEXEC=1
 
 	st := s.state
 	st.Lock()
+	// ensure that only this specific snap is installed
+	snapstate.Set(s.state, "core", nil)
+	snapstate.Set(s.state, "snapd", nil)
 
 	snapSt := &snapstate.SnapState{
 		Active: true,

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3477,6 +3477,15 @@ func (s *snapmgrTestSuite) TestDisableDoesNotEnableAgain(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestEnsureRemovesVulnerableCoreSnap(c *C) {
+	// install the snapd snap so that the core snap can be removed
+	s.state.Lock()
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		SnapType: "snapd",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "snapd"}}),
+		Current:  snap.R(1),
+	})
+	s.state.Unlock()
+
 	s.testEnsureRemovesVulnerableSnap(c, "core")
 }
 
@@ -3523,9 +3532,6 @@ SNAPD_APPARMOR_REEXEC=1
 
 	st := s.state
 	st.Lock()
-	// ensure that only this specific snap is installed
-	snapstate.Set(s.state, "core", nil)
-	snapstate.Set(s.state, "snapd", nil)
 
 	snapSt := &snapstate.SnapState{
 		Active: true,

--- a/tests/main/remove-core/task.yaml
+++ b/tests/main/remove-core/task.yaml
@@ -1,0 +1,17 @@
+summary: Check that we can remove core snap on classic systems.
+
+details: |
+    This test checks that we can remove core snap on classic systems. Classic
+    systems do not have 'base' set in their model. On UC systems, that would be
+    interpreted as 'core' being the base. On classic (non-hybrid) systems, that
+    should be interpreted as there not being a base required.
+
+# we just need a single system to verify this
+systems: [ubuntu-22.04-64]
+
+execute: |
+    snap install core
+
+    snap model --assertion | NOMATCH "base:"
+
+    snap remove core

--- a/tests/main/remove-core/task.yaml
+++ b/tests/main/remove-core/task.yaml
@@ -1,17 +1,32 @@
 summary: Check that we can remove core snap on classic systems.
 
 details: |
-    This test checks that we can remove core snap on classic systems. Classic
-    systems do not have 'base' set in their model. On UC systems, that would be
-    interpreted as 'core' being the base. On classic (non-hybrid) systems, that
-    should be interpreted as there not being a base required.
+    This test checks that we can remove core snap on classic systems, as long as
+    snapd is installed as a snap. Classic systems do not have 'base' set in
+    their model. On UC systems, that would be interpreted as 'core' being the
+    base. On classic (non-hybrid) systems, that should be interpreted as there
+    not being a base required.
 
-# we just need a single system to verify this
+    If snapd is not installed as a snap, then we can't remove the core snap
+    since it might be providing snapd.
+
 systems: [ubuntu-22.04-64]
 
 execute: |
-    snap install core
+    # we should not be able to remove the core snap, since the snapd snap is not
+    # installed.
+    not snap remove core
 
-    snap model --assertion | NOMATCH "base:"
+    # make sure that the model does not have 'base' set
+    snap model --assertion | NOMATCH 'base:'
 
+    # enable transitioning to the snapd snap
+    snap set core experimental.snapd-snap=true
+    snap debug ensure-state-soon
+    retry -n 30 snap watch --last=transition-to-snapd-snap
+    snap list snapd
+
+    # now remove the core snap, since we know that it isn't providing snapd
+    # anymore. this, in addition to this being a classic system, should allow us
+    # to remove the core snap.
     snap remove core


### PR DESCRIPTION
This addresses this bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2039113?comments=all

Since classic systems do not have a base set in the model, this code was assuming that we were on a UC16 system that required the "core" snap. Adding the `dev.IsCoreBoot()` check allows classic (non-hybrid) systems to remove "core", if it isn't required by other snaps.