### PR TITLE
many: handlers and backend for kernel-modules components

### DIFF
--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -91,7 +91,7 @@ func KernelVersionFromPlaceInfo(spi snap.PlaceInfo) (string, error) {
 		return "", fmt.Errorf("internal error: %w", err)
 	}
 	if len(matches) != 1 {
-		return "", fmt.Errorf("number of matches for %s is %d", matchPath, len(matches))
+		return "", fmt.Errorf("unexpected number of matches (%d) for glob %s", len(matches), matchPath)
 	}
 	version := strings.TrimPrefix(matches[0], systemMapPathPrefix)
 	if version == "" {

--- a/kernel/kernel_test.go
+++ b/kernel/kernel_test.go
@@ -156,7 +156,7 @@ func (s *kernelTestSuite) TestKernelVersionFromPlaceInfo(c *C) {
 
 	// No map file
 	ver, err := kernel.KernelVersionFromPlaceInfo(spi)
-	c.Check(err, ErrorMatches, `number of matches for .* is 0`)
+	c.Check(err, ErrorMatches, `unexpected number of matches \(0\) for glob .*`)
 	c.Check(ver, Equals, "")
 
 	// Create file so kernel version can be found
@@ -170,7 +170,7 @@ func (s *kernelTestSuite) TestKernelVersionFromPlaceInfo(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(
 		spi.MountDir(), "System.map-6.8.0-71-generic"), []byte{}, 0644), IsNil)
 	ver, err = kernel.KernelVersionFromPlaceInfo(spi)
-	c.Check(err, ErrorMatches, `number of matches for .* is 2`)
+	c.Check(err, ErrorMatches, `unexpected number of matches \(2\) for glob .*`)
 	c.Check(ver, Equals, "")
 }
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -80,6 +80,8 @@ type managerBackend interface {
 	StartServices(svcs []*snap.AppInfo, disabledSvcs []string, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error)
+	SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) (err error)
+	UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error
 
 	// the undoers for install
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -73,3 +73,11 @@ func MockMkdirAllChown(f func(string, os.FileMode, sys.UserID, sys.GroupID) erro
 		mkdirAllChown = old
 	}
 }
+
+func MockRunDepmod(f func(baseDir, kernelVersion string) error) func() {
+	old := runDepmod
+	runDepmod = f
+	return func() {
+		runDepmod = old
+	}
+}

--- a/overlord/snapstate/backend/kernel_modules_components.go
+++ b/overlord/snapstate/backend/kernel_modules_components.go
@@ -64,8 +64,6 @@ type kernelModulesCleanupParts struct {
 }
 
 func cleanupKernelModulesSetup(parts *kernelModulesCleanupParts, kernelVersion string, meter progress.Meter) error {
-	fmt.Printf("cleaning up comp: %s\n", parts.compMountDir)
-	fmt.Printf("cleaning up mods: %s\n", parts.modulesMountDir)
 	if parts.modulesMountDir != "" {
 		if err := cleanupMount(parts.modulesMountDir, meter); err != nil {
 			return err
@@ -145,7 +143,6 @@ func (b Backend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref n
 		return fmt.Errorf("cannot create mount in %q: %w", componentMount, err)
 	}
 	cleanOnFailure.compMountDir = componentMount
-	fmt.Printf("created comp: %s\n", componentMount)
 
 	if hasModules {
 		// systemd automatically works out dependencies on the "what"
@@ -165,7 +162,6 @@ func (b Backend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref n
 			return fmt.Errorf("cannot create mount in %q: %w", modulesDir, err)
 		}
 		cleanOnFailure.modulesMountDir = modulesDir
-		fmt.Printf("created mods: %s\n", modulesDir)
 
 		// Rebuild modinfo files
 		if err := runDepmod("/usr", kernelVersion); err != nil {

--- a/overlord/snapstate/backend/kernel_modules_components.go
+++ b/overlord/snapstate/backend/kernel_modules_components.go
@@ -201,7 +201,9 @@ func (b Backend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cr
 		// /usr/lib/firmware/updates (set var in kernelModulesCleanupParts)
 	}
 
-	// Remove created mount units
+	// Remove created mount units. If the component had modules we need to
+	// re-create the modules metainformation by running depmod so it is
+	// consistent with the currently available modules.
 	if hasModules {
 		partsToClean.modulesMountDir =
 			modulesMountPoint(cref.ComponentName, kernelVersion)

--- a/overlord/snapstate/backend/kernel_modules_components.go
+++ b/overlord/snapstate/backend/kernel_modules_components.go
@@ -1,0 +1,217 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/systemd"
+)
+
+type NoKernelDriversError struct {
+	cref          naming.ComponentRef
+	kernelVersion string
+}
+
+func (e NoKernelDriversError) Error() string {
+	return fmt.Sprintf("%s does not contain firmware or components for %s",
+		e.cref, e.kernelVersion)
+}
+
+func cleanupMount(mountDir string, meter progress.Meter) error {
+	mountDir = filepath.Join(dirs.GlobalRootDir, mountDir)
+	// this also ensures that the mount unit stops
+	if err := removeMountUnit(mountDir, meter); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(mountDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type kernelModulesCleanupParts struct {
+	compMountDir    string
+	modulesMountDir string
+	rerunDepmod     bool
+}
+
+func cleanupKernelModulesSetup(parts *kernelModulesCleanupParts, kernelVersion string, meter progress.Meter) error {
+	if parts.modulesMountDir != "" {
+		if err := cleanupMount(parts.modulesMountDir, meter); err != nil {
+			return err
+		}
+		if parts.rerunDepmod {
+			if err := runDepmod("/usr", kernelVersion); err != nil {
+				return err
+			}
+		}
+	}
+
+	if parts.compMountDir != "" {
+		if err := cleanupMount(parts.compMountDir, meter); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkKernelModulesCompContent(mountDir, kernelVersion string) (bool, bool) {
+	hasModules := osutil.IsDirectory(filepath.Join(mountDir, "modules", kernelVersion))
+	hasFirmware := osutil.IsDirectory(filepath.Join(mountDir, "firmware"))
+	return hasModules, hasFirmware
+}
+
+func componentMountPoint(componentName, kernelVersion string) string {
+	return filepath.Join("/run/mnt/kernel-modules/", kernelVersion, componentName)
+}
+
+func modulesMountPoint(componentName, kernelVersion string) string {
+	return filepath.Join("/usr/lib/modules", kernelVersion, "updates", componentName)
+}
+
+// SetupKernelModulesComponent creates and starts mount units for
+// kernel-modules components.
+func (b Backend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) (err error) {
+	var sysd systemd.Systemd
+	if b.preseed {
+		sysd = systemd.NewEmulationMode(dirs.GlobalRootDir)
+	} else {
+		sysd = systemd.New(systemd.SystemMode, meter)
+	}
+
+	// Restore state if something goes wrong
+	var cleanOnFailure kernelModulesCleanupParts
+	defer func() {
+		if err == nil {
+			return
+		}
+		if err := cleanupKernelModulesSetup(&cleanOnFailure, kernelVersion, meter); err != nil {
+			logger.Noticef("while cleaning up a failed kernel-modules set-up: %v", err)
+		}
+	}()
+
+	// Check that the kernel-modules component really has
+	// something we must mount on early boot.
+	hasModules, hasFirmware := checkKernelModulesCompContent(cpi.MountDir(), kernelVersion)
+	if !hasModules && !hasFirmware {
+		return &NoKernelDriversError{cref: cref, kernelVersion: kernelVersion}
+	}
+
+	// Mount the component itself (we need it early, so the mount in /snap cannot
+	// be used).
+	componentMount := componentMountPoint(cref.ComponentName, kernelVersion)
+	addMountUnitOptions := &systemd.MountUnitOptions{
+		MountUnitType: systemd.BeforeDriversLoadMountUnit,
+		Lifetime:      systemd.Persistent,
+		Description:   fmt.Sprintf("Mount unit for kernel-modules component %s", cref),
+		What:          cpi.MountFile(),
+		Where:         componentMount,
+		Fstype:        "squashfs",
+		Options:       []string{"nodev,ro,x-gdu.hide,x-gvfs-hide"},
+	}
+	_, err = sysd.EnsureMountUnitFileWithOptions(addMountUnitOptions)
+	if err != nil {
+		return fmt.Errorf("cannot create mount in %q: %w", componentMount, err)
+	}
+	cleanOnFailure.compMountDir = componentMount
+
+	if hasModules {
+		// systemd automatically works out dependencies on the "what"
+		// path too so this mount happens after the component one.
+		modulesDir := modulesMountPoint(cref.ComponentName, kernelVersion)
+		addMountUnitOptions = &systemd.MountUnitOptions{
+			MountUnitType: systemd.BeforeDriversLoadMountUnit,
+			Lifetime:      systemd.Persistent,
+			Description:   fmt.Sprintf("Mount unit for modules from %s", cref.String()),
+			What:          filepath.Join(componentMount, "modules", kernelVersion),
+			Where:         modulesDir,
+			Fstype:        "none",
+			Options:       []string{"bind"},
+		}
+		_, err = sysd.EnsureMountUnitFileWithOptions(addMountUnitOptions)
+		if err != nil {
+			return fmt.Errorf("cannot create mount in %q: %w", modulesDir, err)
+		}
+		cleanOnFailure.modulesMountDir = modulesDir
+
+		// Rebuild modinfo files
+		if err := runDepmod("/usr", kernelVersion); err != nil {
+			return err
+		}
+		cleanOnFailure.rerunDepmod = true
+	}
+
+	if hasFirmware {
+		// TODO create recursively symlinks in
+		// /usr/lib/firmware/updates while checking for conflicts with
+		// existing files.
+	}
+
+	return nil
+}
+
+var runDepmod = runDepmodImpl
+
+func runDepmodImpl(baseDir, kernelVersion string) error {
+	logger.Debugf("running depmod on %q for kernel %s", baseDir, kernelVersion)
+	stdout, stderr, err := osutil.RunSplitOutput("depmod", "-b", baseDir, kernelVersion)
+	logger.Debugf("depmod stderr:\n%s\n\ndepmod stdout:\n%s",
+		string(stderr), string(stdout))
+	if err != nil {
+		return osutil.OutputErrCombine(stdout, stderr, err)
+	}
+	return nil
+}
+
+// UndoSetupKernelModulesComponent undoes the work of SetupKernelModulesComponent
+func (b Backend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error {
+	hasModules, hasFirmware := checkKernelModulesCompContent(cpi.MountDir(), kernelVersion)
+	var partsToClean kernelModulesCleanupParts
+	if hasFirmware {
+		// TODO remove recursively symlinks in
+		// /usr/lib/firmware/updates (set var in kernelModulesCleanupParts)
+	}
+
+	// Remove created mount units
+	if hasModules {
+		partsToClean.modulesMountDir =
+			modulesMountPoint(cref.ComponentName, kernelVersion)
+		partsToClean.rerunDepmod = true
+	}
+
+	if hasModules || hasFirmware {
+		partsToClean.compMountDir =
+			componentMountPoint(cref.ComponentName, kernelVersion)
+	}
+
+	return cleanupKernelModulesSetup(&partsToClean, kernelVersion, meter)
+}

--- a/overlord/snapstate/backend/kernel_modules_components.go
+++ b/overlord/snapstate/backend/kernel_modules_components.go
@@ -64,6 +64,8 @@ type kernelModulesCleanupParts struct {
 }
 
 func cleanupKernelModulesSetup(parts *kernelModulesCleanupParts, kernelVersion string, meter progress.Meter) error {
+	fmt.Printf("cleaning up comp: %s\n", parts.compMountDir)
+	fmt.Printf("cleaning up mods: %s\n", parts.modulesMountDir)
 	if parts.modulesMountDir != "" {
 		if err := cleanupMount(parts.modulesMountDir, meter); err != nil {
 			return err
@@ -143,6 +145,7 @@ func (b Backend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref n
 		return fmt.Errorf("cannot create mount in %q: %w", componentMount, err)
 	}
 	cleanOnFailure.compMountDir = componentMount
+	fmt.Printf("created comp: %s\n", componentMount)
 
 	if hasModules {
 		// systemd automatically works out dependencies on the "what"
@@ -162,6 +165,7 @@ func (b Backend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref n
 			return fmt.Errorf("cannot create mount in %q: %w", modulesDir, err)
 		}
 		cleanOnFailure.modulesMountDir = modulesDir
+		fmt.Printf("created mods: %s\n", modulesDir)
 
 		// Rebuild modinfo files
 		if err := runDepmod("/usr", kernelVersion); err != nil {

--- a/overlord/snapstate/backend/kernel_modules_components_test.go
+++ b/overlord/snapstate/backend/kernel_modules_components_test.go
@@ -21,7 +21,6 @@ package backend_test
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -82,8 +81,6 @@ func (s *kernelModulesSuite) TestSetupKernelModulesComponentNoModules(c *C) {
 }
 
 func (s *kernelModulesSuite) TestSetupKernelModulesComponentWithModules(c *C) {
-	fmt.Println("TestSetupKernelModulesComponentWithModules")
-	defer fmt.Println("TestSetupKernelModulesComponentWithModules")
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	const kernelVersion = "5.15.0-78-generic"

--- a/overlord/snapstate/backend/kernel_modules_components_test.go
+++ b/overlord/snapstate/backend/kernel_modules_components_test.go
@@ -1,0 +1,200 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type kernelModulesSuite struct {
+	testutil.BaseTest
+
+	be         backend.Backend
+	sysctlArgs [][]string
+}
+
+var _ = Suite(&kernelModulesSuite{})
+
+func (s *kernelModulesSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	restore := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysctlArgs = append(s.sysctlArgs, cmd)
+		return []byte{}, nil
+	})
+	s.AddCleanup(restore)
+	s.AddCleanup(func() { s.sysctlArgs = nil })
+
+	s.AddCleanup(backend.MockRunDepmod(func(baseDir, kernelVersion string) error {
+		return nil
+	}))
+
+	s.AddCleanup(osutil.MockMountInfo(""))
+}
+
+func (s *kernelModulesSuite) TestSetupKernelModulesComponentNoModules(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const kernelVersion = "5.15.0-78-generic"
+
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(33), snapName, snap.R(1))
+	cref := naming.NewComponentRef(snapName, compName)
+
+	err := s.be.SetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err.Error(), Equals,
+		"mysnap+mycomp does not contain firmware or components for 5.15.0-78-generic")
+	_, ok := err.(*backend.NoKernelDriversError)
+	c.Assert(ok, Equals, true)
+}
+
+func (s *kernelModulesSuite) TestSetupKernelModulesComponentWithModules(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const kernelVersion = "5.15.0-78-generic"
+
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(33), snapName, snap.R(1))
+	cref := naming.NewComponentRef(snapName, compName)
+	// Make directories so the method thinks there are modules
+	compDir := filepath.Join(dirs.SnapMountDir, snapName, "components/1", compName)
+	modsDir := filepath.Join(compDir, "modules", kernelVersion)
+	fwDir := filepath.Join(compDir, "firmware")
+	c.Assert(os.MkdirAll(modsDir, os.ModePerm), IsNil)
+	c.Assert(os.MkdirAll(fwDir, os.ModePerm), IsNil)
+
+	err := s.be.SetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err, IsNil)
+	kmodMountUnit := "run-mnt-kernel\\x2dmodules-5.15.0\\x2d78\\x2dgeneric-mycomp.mount"
+	ktreeMountUnit := "usr-lib-modules-5.15.0\\x2d78\\x2dgeneric-updates-mycomp.mount"
+	c.Assert(s.sysctlArgs, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--no-reload", "enable", kmodMountUnit},
+		{"reload-or-restart", kmodMountUnit},
+		{"daemon-reload"},
+		{"--no-reload", "enable", ktreeMountUnit},
+		{"reload-or-restart", ktreeMountUnit},
+	})
+	// Check mount files exist
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, kmodMountUnit)), Equals, true)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, ktreeMountUnit)), Equals, true)
+
+	// Now do a clean-up
+	s.sysctlArgs = nil
+	err = s.be.UndoSetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err, IsNil)
+	c.Assert(s.sysctlArgs, DeepEquals, [][]string{
+		{"--no-reload", "disable", ktreeMountUnit},
+		{"daemon-reload"},
+		{"--no-reload", "disable", kmodMountUnit},
+		{"daemon-reload"},
+	})
+	// Check mount files do not exist
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, kmodMountUnit)), Equals, false)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, ktreeMountUnit)), Equals, false)
+}
+
+func (s *kernelModulesSuite) TestSetupKernelModulesComponentJustFirmware(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const kernelVersion = "5.15.0-78-generic"
+
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(33), snapName, snap.R(1))
+	cref := naming.NewComponentRef(snapName, compName)
+	// Make directories so the method thinks there are modules
+	compDir := filepath.Join(dirs.SnapMountDir, snapName, "components/1", compName)
+	fwDir := filepath.Join(compDir, "firmware")
+	c.Assert(os.MkdirAll(fwDir, os.ModePerm), IsNil)
+
+	err := s.be.SetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err, IsNil)
+	kmodMountUnit := "run-mnt-kernel\\x2dmodules-5.15.0\\x2d78\\x2dgeneric-mycomp.mount"
+	c.Assert(s.sysctlArgs, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--no-reload", "enable", kmodMountUnit},
+		{"reload-or-restart", kmodMountUnit},
+	})
+	// Check mount files exist
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, kmodMountUnit)), Equals, true)
+
+	// Now do a clean-up
+	s.sysctlArgs = nil
+	err = s.be.UndoSetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err, IsNil)
+	c.Assert(s.sysctlArgs, DeepEquals, [][]string{
+		{"--no-reload", "disable", kmodMountUnit},
+		{"daemon-reload"},
+	})
+	// Check mount files do not exist
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, kmodMountUnit)), Equals, false)
+}
+
+func (s *kernelModulesSuite) TestSetupKernelModulesComponentDepmodFailed(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const kernelVersion = "5.15.0-78-generic"
+
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(33), snapName, snap.R(1))
+	cref := naming.NewComponentRef(snapName, compName)
+	// Make directories so the method thinks there are modules
+	compDir := filepath.Join(dirs.SnapMountDir, snapName, "components/1", compName)
+	modsDir := filepath.Join(compDir, "modules", kernelVersion)
+	fwDir := filepath.Join(compDir, "firmware")
+	c.Assert(os.MkdirAll(modsDir, os.ModePerm), IsNil)
+	c.Assert(os.MkdirAll(fwDir, os.ModePerm), IsNil)
+	// make depmod fail
+	s.AddCleanup(backend.MockRunDepmod(func(baseDir, kernelVersion string) error {
+		return errors.New("depmod failure")
+	}))
+
+	err := s.be.SetupKernelModulesComponent(cpi, cref, kernelVersion, progress.Null)
+	c.Assert(err.Error(), Equals, "depmod failure")
+	kmodMountUnit := "run-mnt-kernel\\x2dmodules-5.15.0\\x2d78\\x2dgeneric-mycomp.mount"
+	ktreeMountUnit := "usr-lib-modules-5.15.0\\x2d78\\x2dgeneric-updates-mycomp.mount"
+	c.Assert(s.sysctlArgs, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--no-reload", "enable", kmodMountUnit},
+		{"reload-or-restart", kmodMountUnit},
+		{"daemon-reload"},
+		{"--no-reload", "enable", ktreeMountUnit},
+		{"reload-or-restart", ktreeMountUnit},
+		{"--no-reload", "disable", ktreeMountUnit},
+		{"daemon-reload"},
+		{"--no-reload", "disable", kmodMountUnit},
+		{"daemon-reload"},
+	})
+	// Check mount files do not exist
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, kmodMountUnit)), Equals, false)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, ktreeMountUnit)), Equals, false)
+}

--- a/overlord/snapstate/backend/kernel_modules_components_test.go
+++ b/overlord/snapstate/backend/kernel_modules_components_test.go
@@ -21,6 +21,7 @@ package backend_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -81,6 +82,8 @@ func (s *kernelModulesSuite) TestSetupKernelModulesComponentNoModules(c *C) {
 }
 
 func (s *kernelModulesSuite) TestSetupKernelModulesComponentWithModules(c *C) {
+	fmt.Println("TestSetupKernelModulesComponentWithModules")
+	defer fmt.Println("TestSetupKernelModulesComponentWithModules")
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	const kernelVersion = "5.15.0-78-generic"

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -914,10 +914,18 @@ func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.Cont
 }
 
 func (f *fakeSnappyBackend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) (err error) {
+	meter.Notify("setup-kernel-modules-component")
+	f.appendOp(&fakeOp{
+		op: "setup-kernel-modules-component",
+	})
 	return nil
 }
 
-func (b *fakeSnappyBackend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error {
+func (f *fakeSnappyBackend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error {
+	meter.Notify("undo-setup-kernel-modules-component")
+	f.appendOp(&fakeOp{
+		op: "undo-setup-kernel-modules-component",
+	})
 	return nil
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
@@ -910,6 +911,14 @@ func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.Cont
 		return nil, fmt.Errorf("cannot set-up component %q", compPi.ContainerName())
 	}
 	return &backend.InstallRecord{}, nil
+}
+
+func (f *fakeSnappyBackend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) (err error) {
+	return nil
+}
+
+func (b *fakeSnappyBackend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error {
+	return nil
 }
 
 func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -85,6 +85,13 @@ type fakeOp struct {
 
 	dirOpts  *dirs.SnapDirOptions
 	undoInfo *backend.UndoInfo
+
+	// Used for component related interface calls
+	compFilePath  string
+	compMountDir  string
+	compMountFile string
+	cref          naming.ComponentRef
+	kernelVersion string
 }
 
 type fakeOps []fakeOp
@@ -905,7 +912,10 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *sna
 func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.ContainerPlaceInfo, dev snap.Device, meter progress.Meter) (installRecord *backend.InstallRecord, err error) {
 	meter.Notify("setup-component")
 	f.appendOp(&fakeOp{
-		op: "setup-component",
+		op:            "setup-component",
+		compFilePath:  compFilePath,
+		compMountDir:  compPi.MountDir(),
+		compMountFile: compPi.MountFile(),
 	})
 	if strings.HasSuffix(compPi.ContainerName(), "+broken") {
 		return nil, fmt.Errorf("cannot set-up component %q", compPi.ContainerName())
@@ -916,7 +926,11 @@ func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.Cont
 func (f *fakeSnappyBackend) SetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) (err error) {
 	meter.Notify("setup-kernel-modules-component")
 	f.appendOp(&fakeOp{
-		op: "setup-kernel-modules-component",
+		op:            "setup-kernel-modules-component",
+		compMountDir:  cpi.MountDir(),
+		compMountFile: cpi.MountFile(),
+		cref:          cref,
+		kernelVersion: kernelVersion,
 	})
 	return nil
 }
@@ -924,7 +938,11 @@ func (f *fakeSnappyBackend) SetupKernelModulesComponent(cpi snap.ContainerPlaceI
 func (f *fakeSnappyBackend) UndoSetupKernelModulesComponent(cpi snap.ContainerPlaceInfo, cref naming.ComponentRef, kernelVersion string, meter progress.Meter) error {
 	meter.Notify("undo-setup-kernel-modules-component")
 	f.appendOp(&fakeOp{
-		op: "undo-setup-kernel-modules-component",
+		op:            "undo-setup-kernel-modules-component",
+		compMountDir:  cpi.MountDir(),
+		compMountFile: cpi.MountFile(),
+		cref:          cref,
+		kernelVersion: kernelVersion,
 	})
 	return nil
 }
@@ -932,7 +950,9 @@ func (f *fakeSnappyBackend) UndoSetupKernelModulesComponent(cpi snap.ContainerPl
 func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error {
 	meter.Notify("undo-setup-component")
 	f.appendOp(&fakeOp{
-		op: "undo-setup-component",
+		op:            "undo-setup-component",
+		compMountDir:  cpi.MountDir(),
+		compMountFile: cpi.MountFile(),
 	})
 	if strings.HasSuffix(cpi.ContainerName(), "+brokenundo") {
 		return fmt.Errorf("cannot undo set-up of component %q", cpi.ContainerName())
@@ -942,7 +962,9 @@ func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, inst
 
 func (f *fakeSnappyBackend) RemoveComponentDir(cpi snap.ContainerPlaceInfo) error {
 	f.appendOp(&fakeOp{
-		op: "remove-component-dir",
+		op:            "remove-component-dir",
+		compMountDir:  cpi.MountDir(),
+		compMountFile: cpi.MountFile(),
 	})
 	return nil
 }

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -168,16 +168,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 		}
 	}
 
-	compInstalled := snapst.IsComponentInCurrentSeq(compSi.Component)
-
 	if compSetup.CompType == snap.KernelModulesComponent {
-		// Remove units from previous component
-		if compInstalled {
-			undoSetupKernMod := st.NewTask("cleanup-kernel-modules-component",
-				fmt.Sprintf(i18n.G("Clean-up previous kernel-modules component %q%s"),
-					compSi.Component, revisionStr))
-			addTask(undoSetupKernMod)
-		}
 		setupKernMod := st.NewTask("setup-kernel-modules-component",
 			fmt.Sprintf(i18n.G("Set-up kernel-modules component %q%s"),
 				compSi.Component, revisionStr))
@@ -188,6 +179,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 
 	// We might be replacing a component if a local install, otherwise
 	// this is not really possible.
+	compInstalled := snapst.IsComponentInCurrentSeq(compSi.Component)
 	if compInstalled {
 		unlink := st.NewTask("unlink-current-component", fmt.Sprintf(i18n.G(
 			"Make current revision for component %q unavailable"),

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -174,12 +174,12 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 		// Remove units from previous component
 		if compInstalled {
 			undoSetupKernMod := st.NewTask("cleanup-kernel-modules-component",
-				fmt.Sprintf(i18n.G("Clean-up previous kernel-modules component"),
+				fmt.Sprintf(i18n.G("Clean-up previous kernel-modules component %q%s"),
 					compSi.Component, revisionStr))
 			addTask(undoSetupKernMod)
 		}
 		setupKernMod := st.NewTask("setup-kernel-modules-component",
-			fmt.Sprintf(i18n.G("Set-up kernel-modules component"),
+			fmt.Sprintf(i18n.G("Set-up kernel-modules component %q%s"),
 				compSi.Component, revisionStr))
 		addTask(setupKernMod)
 	}

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -168,11 +168,26 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 		}
 	}
 
+	compInstalled := snapst.IsComponentInCurrentSeq(compSi.Component)
+
+	if compSetup.CompType == snap.KernelModulesComponent {
+		// Remove units from previous component
+		if compInstalled {
+			undoSetupKernMod := st.NewTask("cleanup-kernel-modules-component",
+				fmt.Sprintf(i18n.G("Clean-up previous kernel-modules component"),
+					compSi.Component, revisionStr))
+			addTask(undoSetupKernMod)
+		}
+		setupKernMod := st.NewTask("setup-kernel-modules-component",
+			fmt.Sprintf(i18n.G("Set-up kernel-modules component"),
+				compSi.Component, revisionStr))
+		addTask(setupKernMod)
+	}
+
 	// TODO hooks for components
 
 	// We might be replacing a component if a local install, otherwise
 	// this is not really possible.
-	compInstalled := snapst.IsComponentInCurrentSeq(compSi.Component)
 	if compInstalled {
 		unlink := st.NewTask("unlink-current-component", fmt.Sprintf(i18n.G(
 			"Make current revision for component %q unavailable"),

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -60,9 +60,6 @@ func expectedComponentInstallTasks(opts int) []string {
 	}
 	// This task is only for kernel-modules
 	if opts&compOptKernelModules != 0 {
-		if opts&compOptIsActive != 0 {
-			startTasks = append(startTasks, "cleanup-kernel-modules-component")
-		}
 		startTasks = append(startTasks, "setup-kernel-modules-component")
 	}
 	// Component is installed (implicit if compOptRevisionPresent is set)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -400,8 +400,8 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 }
 
 func kernelVersionFromPlaceInfo(spi snap.PlaceInfo) (string, error) {
-	const systemMapFilePrefix = "System.map-"
-	matchPath := filepath.Join(spi.MountDir(), systemMapFilePrefix+"*")
+	systemMapPathPrefix := filepath.Join(spi.MountDir(), "System.map-")
+	matchPath := systemMapPathPrefix + "*"
 	matches, err := filepath.Glob(matchPath)
 	if err != nil {
 		// could be only ErrBadPattern, should not really happen
@@ -410,7 +410,7 @@ func kernelVersionFromPlaceInfo(spi snap.PlaceInfo) (string, error) {
 	if len(matches) != 1 {
 		return "", fmt.Errorf("number of matches for %s is %d", matchPath, len(matches))
 	}
-	return strings.TrimPrefix(matches[0], systemMapFilePrefix), nil
+	return strings.TrimPrefix(matches[0], systemMapPathPrefix), nil
 }
 
 func (m *SnapManager) doSetupKernelModulesComponent(t *state.Task, _ *tomb.Tomb) error {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -22,10 +22,9 @@ package snapstate
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
 	"time"
 
+	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
@@ -399,20 +398,6 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 	return nil
 }
 
-func kernelVersionFromPlaceInfo(spi snap.PlaceInfo) (string, error) {
-	systemMapPathPrefix := filepath.Join(spi.MountDir(), "System.map-")
-	matchPath := systemMapPathPrefix + "*"
-	matches, err := filepath.Glob(matchPath)
-	if err != nil {
-		// could be only ErrBadPattern, should not really happen
-		return "", fmt.Errorf("internal error: %w", err)
-	}
-	if len(matches) != 1 {
-		return "", fmt.Errorf("number of matches for %s is %d", matchPath, len(matches))
-	}
-	return strings.TrimPrefix(matches[0], systemMapPathPrefix), nil
-}
-
 func (m *SnapManager) doSetupKernelModulesComponent(t *state.Task, _ *tomb.Tomb) error {
 	// kernel snap is expected to be mounted
 	st := t.State()
@@ -432,7 +417,7 @@ func (m *SnapManager) doSetupKernelModulesComponent(t *state.Task, _ *tomb.Tomb)
 
 	// Find kernel version from matching kernel
 	spi := snap.MinimalPlaceInfo(snapsup.InstanceName(), snapsup.Revision())
-	kernelVersion, err := kernelVersionFromPlaceInfo(spi)
+	kernelVersion, err := kernel.KernelVersionFromPlaceInfo(spi)
 	if err != nil {
 		return err
 	}
@@ -474,7 +459,7 @@ func (m *SnapManager) undoSetupKernelModulesComponent(t *state.Task, _ *tomb.Tom
 
 	// Find kernel version from matching kernel
 	spi := snap.MinimalPlaceInfo(snapsup.InstanceName(), snapsup.Revision())
-	kernelVersion, err := kernelVersionFromPlaceInfo(spi)
+	kernelVersion, err := kernel.KernelVersionFromPlaceInfo(spi)
 	if err != nil {
 		return err
 	}
@@ -536,7 +521,7 @@ func (m *SnapManager) doCleanupKernelModulesComponent(t *state.Task, _ *tomb.Tom
 
 	// Find kernel version from matching kernel
 	spi := snap.MinimalPlaceInfo(snapsup.InstanceName(), snapsup.Revision())
-	kernelVersion, err := kernelVersionFromPlaceInfo(spi)
+	kernelVersion, err := kernel.KernelVersionFromPlaceInfo(spi)
 	if err != nil {
 		return err
 	}
@@ -578,7 +563,7 @@ func (m *SnapManager) undoCleanupKernelModulesComponent(t *state.Task, _ *tomb.T
 
 	// Find kernel version from matching kernel
 	spi := snap.MinimalPlaceInfo(snapsup.InstanceName(), snapsup.Revision())
-	kernelVersion, err := kernelVersionFromPlaceInfo(spi)
+	kernelVersion, err := kernel.KernelVersionFromPlaceInfo(spi)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_components_mount_test.go
+++ b/overlord/snapstate/handlers_components_mount_test.go
@@ -21,7 +21,9 @@ package snapstate_test
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -76,7 +78,10 @@ func (s *mountCompSnapSuite) TestDoMountComponent(c *C) {
 	// Ensure backend calls have happened with the expected data
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:            "setup-component",
+			compFilePath:  compPath,
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 	})
 	// File not removed
@@ -127,13 +132,20 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponent(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:            "setup-component",
+			compFilePath:  compPath,
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 		{
-			op: "undo-setup-component",
+			op:            "undo-setup-component",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 		{
-			op: "remove-component-dir",
+			op:            "remove-component-dir",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 	})
 }
@@ -177,10 +189,15 @@ func (s *mountCompSnapSuite) TestDoMountComponentSetupFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:            "setup-component",
+			compFilePath:  compPath,
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/broken"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+broken_7.comp"),
 		},
 		{
-			op: "remove-component-dir",
+			op:            "remove-component-dir",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/broken"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+broken_7.comp"),
 		},
 	})
 }
@@ -231,10 +248,15 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponentFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:            "setup-component",
+			compFilePath:  compPath,
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/brokenundo"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+brokenundo_7.comp"),
 		},
 		{
-			op: "undo-setup-component",
+			op:            "undo-setup-component",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/brokenundo"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+brokenundo_7.comp"),
 		},
 	})
 }
@@ -278,13 +300,20 @@ func (s *mountCompSnapSuite) TestDoMountComponentMountFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:            "setup-component",
+			compFilePath:  compPath,
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 		{
-			op: "undo-setup-component",
+			op:            "undo-setup-component",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 		{
-			op: "remove-component-dir",
+			op:            "remove-component-dir",
+			compMountDir:  filepath.Join(dirs.SnapMountDir, "mysnap/components/1/mycomp"),
+			compMountFile: filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap+mycomp_7.comp"),
 		},
 	})
 }

--- a/overlord/snapstate/handlers_kernel_modules_components_test.go
+++ b/overlord/snapstate/handlers_kernel_modules_components_test.go
@@ -134,7 +134,7 @@ func (s *kernelModulesCompSnapSuite) TestDoSetupKernelModulesComponentNoKernVers
 
 	s.state.Lock()
 	c.Check(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n"+
-		`\- task desc \(number of matches for .*System.map-\* is 0\)`)
+		`\- task desc \(unexpected number of matches \(0\) for glob .*System.map-\*\)`)
 	c.Assert(t.Status(), Equals, state.ErrorStatus)
 	s.state.Unlock()
 

--- a/overlord/snapstate/handlers_kernel_modules_components_test.go
+++ b/overlord/snapstate/handlers_kernel_modules_components_test.go
@@ -1,0 +1,307 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+type kernelModulesCompSnapSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&kernelModulesCompSnapSuite{})
+
+func (s *kernelModulesCompSnapSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+
+	var err error
+	taskRunTime, err := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+	c.Assert(err, IsNil)
+	s.AddCleanup(snapstate.MockTimeNow(func() time.Time {
+		return taskRunTime
+	}))
+}
+
+func (s *kernelModulesCompSnapSuite) TestDoSetupKernelModulesComponent(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+	ci, compPath := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+	// Create file so kernel version can be found
+	c.Assert(os.MkdirAll(si.MountDir(), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(
+		si.MountDir(), "System.map-5.15.0-78-generic"), []byte{}, 0644), IsNil)
+
+	s.state.Lock()
+
+	t := s.state.NewTask("setup-kernel-modules-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup",
+		snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), IsNil)
+	// State of task is as expected
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+	s.state.Unlock()
+
+	// Ensure backend calls have happened with the expected data
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "setup-kernel-modules-component",
+		},
+	})
+}
+
+func (s *kernelModulesCompSnapSuite) TestDoSetupKernelModulesComponentNoKernVersion(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+	ci, compPath := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+
+	s.state.Lock()
+
+	t := s.state.NewTask("setup-kernel-modules-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup",
+		snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n"+
+		`\- task desc \(number of matches for .*System.map-\* is 0\)`)
+	c.Assert(t.Status(), Equals, state.ErrorStatus)
+	s.state.Unlock()
+
+	c.Check(len(s.fakeBackend.ops), Equals, 0)
+}
+
+func (s *kernelModulesCompSnapSuite) TestDoThenUndoSetupKernelModulesComponent(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+	ci, compPath := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+	// Create file so kernel version can be found
+	c.Assert(os.MkdirAll(si.MountDir(), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(
+		si.MountDir(), "System.map-5.15.0-78-generic"), []byte{}, 0644), IsNil)
+
+	s.state.Lock()
+
+	t := s.state.NewTask("setup-kernel-modules-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup",
+		snapstate.NewComponentSetup(csi, snap.TestComponent, compPath))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking undo setup")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(chg.Err().Error(), Equals, "cannot perform the following tasks:\n"+
+		"- provoking undo setup (error out)")
+	// State of task is as expected
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	s.state.Unlock()
+
+	// Ensure backend calls have happened with the expected data
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "setup-kernel-modules-component",
+		},
+		{
+			op: "undo-setup-kernel-modules-component",
+		},
+	})
+}
+
+func (s *kernelModulesCompSnapSuite) TestDoCleanupKernelModulesComponent(c *C) {
+	const snapName = "kernelsnap"
+	const compName = "kmodcomp"
+	snapRev := snap.R(1)
+	currentCompRev := snap.R(5)
+	compRev := snap.R(7)
+
+	ci, _ := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+	// Create file so kernel version can be found
+	c.Assert(os.MkdirAll(si.MountDir(), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(
+		si.MountDir(), "System.map-5.15.0-78-generic"), []byte{}, 0644), IsNil)
+
+	s.state.Lock()
+
+	// state must contain the component
+	setStateWithOneComponent(s.state, snapName, snapRev, compName, currentCompRev)
+
+	t := s.state.NewTask("cleanup-kernel-modules-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), IsNil)
+	// State of task is as expected
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+	s.state.Unlock()
+
+	// Ensure backend calls have happened with the expected data
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "undo-setup-kernel-modules-component",
+		},
+	})
+}
+
+func (s *kernelModulesCompSnapSuite) TestDoThenUndoCleanupKernelModulesComponent(c *C) {
+	const snapName = "kernelsnap"
+	const compName = "kmodcomp"
+	snapRev := snap.R(1)
+	currentCompRev := snap.R(5)
+	compRev := snap.R(7)
+
+	ci, _ := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+	// Create file so kernel version can be found
+	c.Assert(os.MkdirAll(si.MountDir(), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(
+		si.MountDir(), "System.map-5.15.0-78-generic"), []byte{}, 0644), IsNil)
+
+	s.state.Lock()
+
+	// state must contain the component
+	setStateWithOneComponent(s.state, snapName, snapRev, compName, currentCompRev)
+
+	t := s.state.NewTask("cleanup-kernel-modules-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking undo setup")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	c.Check(chg.Err().Error(), Equals, "cannot perform the following tasks:\n"+
+		"- provoking undo setup (error out)")
+	// State of task is as expected
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	s.state.Unlock()
+
+	// Ensure backend calls have happened with the expected data
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "undo-setup-kernel-modules-component",
+		},
+		{
+			op: "setup-kernel-modules-component",
+		},
+	})
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -657,6 +657,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)
 	runner.AddHandler("link-component", m.doLinkComponent, m.undoLinkComponent)
+	runner.AddHandler("setup-kernel-modules-component", m.doSetupKernelModulesComponent, m.undoSetupKernelModulesComponent)
+	runner.AddHandler("cleanup-kernel-modules-component", m.doCleanupKernelModulesComponent, m.undoCleanupKernelModulesComponent)
 
 	// control serialisation
 	runner.AddBlocked(m.blockedTask)

--- a/snap/types.go
+++ b/snap/types.go
@@ -188,12 +188,12 @@ type ComponentType string
 
 const (
 	// TestComponent is just for testing purposes.
-	// TODO add here new component when there is more progress on the
-	// components implementation.
 	TestComponent ComponentType = "test"
+	// KernelModulesComponent is for components containing modules/firmware
+	KernelModulesComponent ComponentType = "kernel-modules"
 )
 
-var validComponentTypes = [...]ComponentType{TestComponent}
+var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesComponent}
 
 // Component represents a snap component.
 type Component struct {


### PR DESCRIPTION
Implementation of specific tasks and handlers for kernel-modules components, that need additional mount units and rebuilding modinfo files.

A spread test for this will depend on core24 changes.