### PR TITLE
i/builtin/polkit: support different polkitd path on core24

### DIFF
--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -148,12 +148,24 @@ func (iface *polkitInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	return err
 }
 
+// hasPolkitDaemonExecutable checks known paths on core for the presence of
+// the polkit daemon executable. This function can be shortened but keep it like
+// this for readability.
+func hasPolkitDaemonExecutable() bool {
+	// On core22(+core-desktop?) polkitd is at /usr/libexec/polkitd
+	if osutil.IsExecutable("/usr/libexec/polkitd") {
+		return true
+	}
+	// On core24 polkitd is at /usr/lib/polkit-1/polkitd
+	return osutil.IsExecutable("/usr/lib/polkit-1/polkitd")
+}
+
 func init() {
 	registerIface(&polkitInterface{
 		commonInterface{
 			name:                  "polkit",
 			summary:               polkitSummary,
-			implicitOnCore:        osutil.IsExecutable("/usr/libexec/polkitd"),
+			implicitOnCore:        hasPolkitDaemonExecutable(),
 			implicitOnClassic:     true,
 			baseDeclarationPlugs:  polkitBaseDeclarationPlugs,
 			baseDeclarationSlots:  polkitBaseDeclarationSlots,

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -273,7 +273,7 @@ apps:
 
 func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/polkitd"))
+	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/polkitd") || osutil.IsExecutable("/usr/lib/polkit-1/polkitd"))
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.Summary, Equals, "allows access to polkitd to check authorisation")
 	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")


### PR DESCRIPTION
Discovered during fix of the polkit interface issue which we are trying to fix for core22 and core24 bases. The polkit daemon resides in different places in core22 base and core24 base.

The many-core interface tests will fail for core22 and core24 (core22 already failing) as snapd tries to write policy files into a read-only path in /usr/share/polkit-1/actions.