### PR TITLE
tests: fix snapd-maintenance-msg spread test

### DIFF
--- a/tests/core/snapd-maintenance-msg/task.yaml
+++ b/tests/core/snapd-maintenance-msg/task.yaml
@@ -40,7 +40,7 @@ execute: |
         snap revert snapd
 
         echo "Testing maintenance message for system reboots"
-        snap refresh core20 --channel=stable &
+        snap refresh core20 --channel=stable --amend &
         retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "system is restarting"'
         wait
 


### PR DESCRIPTION
The core20 refresh was failing with a message that `core20` is local and unknown to the store because it's installed from a locally built revision. While trying to figure out what triggered this, I noticed the same fix was committed and then reverted at some point but I'll have to ask Sergio why once he's back. I think it's still worth merging this now to unblock PRs.