### PR TITLE
gadget: add unit test for default policy and no previous edition

### DIFF
--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -3434,6 +3434,66 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesArePolicyControlled(c *C) {
 	})
 }
 
+func (u *updateTestSuite) TestUpdateApplyUpdatesDefaultPolicy(c *C) {
+	oldData, newData, rollbackDir := u.policyDataSet(c)
+	c.Assert(oldData.Info.Volumes["foo"].Structure, HasLen, 5)
+	c.Assert(newData.Info.Volumes["foo"].Structure, HasLen, 5)
+
+	c.Check(oldData.Info.Volumes["foo"].Structure[1].Name, Equals, "first")
+	// no previous edition specified in the structure, as if it was not
+	// specified in gadget.yaml
+	c.Assert(oldData.Info.Volumes["foo"].Structure[1].Update, DeepEquals, gadget.VolumeUpdate{})
+	// new one has edition set explcitly
+	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 5
+
+	r := gadget.MockVolumeStructureToLocationMap(func(_ gadget.GadgetData, _ gadget.Model, _ map[string]*gadget.Volume) (map[string]map[int]gadget.StructureLocation, map[string]map[int]*gadget.OnDiskStructure, error) {
+		return map[string]map[int]gadget.StructureLocation{
+				"foo": {
+					0: {
+						Device: "/dev/foo",
+						Offset: quantity.OffsetMiB,
+					},
+					1: {
+						RootMountPoint: "/foo",
+					},
+					2: {
+						RootMountPoint: "/foo",
+					},
+					3: {
+						RootMountPoint: "/foo",
+					},
+					4: {
+						RootMountPoint: "/foo",
+					},
+				},
+			}, map[string]map[int]*gadget.OnDiskStructure{
+				"foo": {
+					0: {},
+					1: {},
+					2: {},
+					3: {},
+					4: {},
+				},
+			},
+			nil
+	})
+	defer r()
+
+	toUpdate := map[string]int{}
+	restore := gadget.MockUpdaterForStructure(func(loc gadget.StructureLocation, ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
+		toUpdate[ps.Name()] = toUpdate[ps.Name()] + 1
+		return &mockUpdater{}, nil
+	})
+	defer restore()
+
+	err := gadget.Update(uc16Model, oldData, newData, rollbackDir, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(toUpdate, DeepEquals, map[string]int{
+		// the structure was picked for update
+		"first": 1,
+	})
+}
+
 func (u *updateTestSuite) TestUpdateApplyUpdatesRemodelPolicy(c *C) {
 	oldData, newData, rollbackDir := u.policyDataSet(c)
 

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -3443,7 +3443,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesDefaultPolicy(c *C) {
 	// no previous edition specified in the structure, as if it was not
 	// specified in gadget.yaml
 	c.Assert(oldData.Info.Volumes["foo"].Structure[1].Update, DeepEquals, gadget.VolumeUpdate{})
-	// new one has edition set explcitly
+	// new one has edition set explicitly
 	newData.Info.Volumes["foo"].Structure[1].Update.Edition = 5
 
 	r := gadget.MockVolumeStructureToLocationMap(func(_ gadget.GadgetData, _ gadget.Model, _ map[string]*gadget.Volume) (map[string]map[int]gadget.StructureLocation, map[string]map[int]*gadget.OnDiskStructure, error) {
@@ -3481,7 +3481,7 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesDefaultPolicy(c *C) {
 
 	toUpdate := map[string]int{}
 	restore := gadget.MockUpdaterForStructure(func(loc gadget.StructureLocation, ps *gadget.LaidOutStructure, psRootDir, psRollbackDir string, observer gadget.ContentUpdateObserver) (gadget.Updater, error) {
-		toUpdate[ps.Name()] = toUpdate[ps.Name()] + 1
+		toUpdate[ps.Name()]++
 		return &mockUpdater{}, nil
 	})
 	defer restore()


### PR DESCRIPTION
Add a unit test which checks the update with default policy and with a volume structure without any prior edition.


A question came up in the forum https://forum.snapcraft.io/t/updating-config-txt-for-device-tree-overlays-in-gadget-snap/33793/11?u=mborzecki1 and while double checking I noticed that we did not have an explicit unit test for this.