### PR TITLE
packaging: fix autopkgtest on Debian

### DIFF
--- a/packaging/debian-sid/tests/control
+++ b/packaging/debian-sid/tests/control
@@ -1,5 +1,5 @@
 Tests: integrationtests
-Restrictions: allow-stderr, rw-build-tree, needs-root, breaks-testbed, isolation-machine
+Restrictions: allow-stderr, rw-build-tree, needs-root, needs-sudo, breaks-testbed, isolation-machine
 Depends: @builddeps@,
          bzr,
          ca-certificates,

--- a/packaging/debian-sid/tests/control
+++ b/packaging/debian-sid/tests/control
@@ -1,5 +1,5 @@
 Tests: integrationtests
-Restrictions: allow-stderr, rw-build-tree, needs-root, needs-sudo, breaks-testbed, isolation-machine
+Restrictions: allow-stderr, rw-build-tree, needs-root, needs-sudo, needs-internet, breaks-testbed, isolation-machine
 Depends: @builddeps@,
          bzr,
          ca-certificates,

--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -24,7 +24,7 @@ printf '%s\n' "-950" > /proc/$$/oom_score_adj
 cat /proc/meminfo
 
 # ensure we can do a connect to localhost
-echo ubuntu:ubuntu|chpasswd
+echo "${AUTOPKGTEST_NORMAL_USER:-ubuntu}":"${AUTOPKGTEST_NORMAL_USER:-ubuntu}" | chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
 systemctl reload ssh.service
 

--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -23,6 +23,10 @@ printf '%s\n' "-950" > /proc/$$/oom_score_adj
 # see what mem we have (for debugging)
 cat /proc/meminfo
 
+# who are we?
+echo "We are running as $(id)"
+echo "Normal user is ${AUTOPKGTEST_NORMAL_USER:-unset}"
+
 # ensure we can do a connect to localhost
 echo "${AUTOPKGTEST_NORMAL_USER:-ubuntu}":"${AUTOPKGTEST_NORMAL_USER:-ubuntu}" | chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config

--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -46,6 +46,6 @@ export GOPATH=/tmp/go
 /snap/bin/go get -u github.com/snapcore/spread/cmd/spread
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)":tests/smoke/
 
-# store journal info for inspectsion
+# store journal info for inspection
 journalctl --sync
 journalctl -ab > "$ADT_ARTIFACTS"/journal.txt

--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -43,7 +43,7 @@ snap install --classic go
 # shellcheck disable=SC1091
 . /etc/os-release
 export GOPATH=/tmp/go
-/snap/bin/go get -u github.com/snapcore/spread/cmd/spread
+/snap/bin/go install github.com/snapcore/spread/cmd/spread@latest
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)":tests/smoke/
 
 # store journal info for inspection

--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -44,7 +44,7 @@ snap install --classic go
 . /etc/os-release
 export GOPATH=/tmp/go
 /snap/bin/go install github.com/snapcore/spread/cmd/spread@latest
-/tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)":tests/smoke/
+/tmp/go/bin/spread -v "autopkgtest:${ID:-linux}-${VERSION_ID:-sid}-$(dpkg --print-architecture)":tests/smoke/
 
 # store journal info for inspection
 journalctl --sync

--- a/spread.yaml
+++ b/spread.yaml
@@ -394,7 +394,7 @@ backends:
                 FATAL "adhoc only works inside autopkgtest"
                 exit 1
             fi
-            echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-spread-users
+            echo "${AUTOPKGTEST_NORMAL_USER:-ubuntu} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-spread-users
             ADDRESS localhost:22
         discard: |
             echo "Discarding ad-hoc $SPREAD_SYSTEM"

--- a/spread.yaml
+++ b/spread.yaml
@@ -394,6 +394,7 @@ backends:
                 FATAL "adhoc only works inside autopkgtest"
                 exit 1
             fi
+            # XXX: redundant with the needs-sudo flag?
             echo "${AUTOPKGTEST_NORMAL_USER:-ubuntu} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-spread-users
             ADDRESS localhost:22
         discard: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -479,6 +479,25 @@ backends:
             - ubuntu-22.04-arm64:
                   username: ubuntu
                   password: ubuntu
+            # Debian
+            - debian-sid-amd64:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+            - debian-sid-i386:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+            - debian-sid-armhf:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+            - debian-sid-ppc64el:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+            - debian-sid-s390x:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+            - debian-sid-arm64:
+                  username: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
+                  password: '$(HOST: echo "$AUTOPKGTEST_NORMAL_USER")'
 
     external:
         type: adhoc

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -83,8 +83,8 @@ distro_name_package() {
 
 distro_install_local_package() {
     allow_downgrades=false
-    while [ -n "$1" ]; do
-        case "$1" in
+    while [ -n "${1:-}" ]; do
+        case "${1:-}" in
             --allow-downgrades)
                 allow_downgrades=true
                 shift
@@ -97,8 +97,10 @@ distro_install_local_package() {
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*|debian-*)
             # relying on dpkg as apt(-get) does not support installation from local files in trusty.
-            eatmydata dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
-            eatmydata apt-get -f install -y
+            if [ -$# -gt 0 ]; then
+                eatmydata dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
+                eatmydata apt-get -f install -y
+            fi
             ;;
         ubuntu-*)
             flags="-y --no-install-recommends"
@@ -106,7 +108,9 @@ distro_install_local_package() {
                 flags="$flags --allow-downgrades"
             fi
             # shellcheck disable=SC2086
-            apt install $flags "$@"
+            if [ -$# -gt 0 ]; then
+                apt install $flags "$@"
+            fi
             ;;
         amazon-*|centos-7-*)
             quiet yum -y localinstall "$@"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -265,6 +265,7 @@ prepare_project() {
     # no need to modify anything further for autopkgtest
     # we want to run as pristine as possible
     if [ "$SPREAD_BACKEND" = autopkgtest ]; then
+        create_test_user
         exit 0
     fi
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -580,6 +580,11 @@ prepare_project() {
         install_dependencies_gce_bucket
     fi
 
+    # Snapd in autopkgtest may not auto-enable the socket.
+    if [ "$SPREAD_BACKEND" = autopkgtest ]; then
+        sudo systemctl enable --now snapd.socket
+    fi
+
     # Build fakestore.
     fakestore_tags=
     if [ "$REMOTE_STORE" = staging ]; then


### PR DESCRIPTION
Last week I've been iterating on getting autopkgtests to pass on Debian.

There are a number of changes here, some that should probably be split into their dedicated PRs. The general overview is as follows:

 - update autopkgtest meta-data to correctly reflect snapd requirements
 - do not assume autopkgtests run on ubuntu (hard-coded usernames)
 - add missing spread entries (autopkgtest is instructed to use spread internally)
 - fix installation of spread
 - do not build snapd again, test the package provided by autopkgtest
 - fix scripts breaking down when no packages need to be installed

Be aware that CI snapcore/snapd does not run autopkgtests AFAIK - definitely not for Debian.