### PR TITLE
c/snap-bootstrap: lift requirement of fde-setup hook for single-boot install

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -246,10 +246,7 @@ func canInstallAndRunAtOnce(mst *initramfsMountsState) (bool, error) {
 		return false, nil
 	}
 
-	// TODO: when install in initrd is finished and it is tested
-	// without fde hook, turn the return into...
-	// return true, nil
-	return kernelHasFdeSetup, nil
+	return true, nil
 }
 
 func readSnapInfo(sysSnaps map[snap.Type]*seed.Snap, snapType snap.Type) (*snap.Info, error) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -8239,6 +8239,127 @@ echo '{"features":[]}'
 	c.Assert(nextBooEnsured, Equals, true)
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupNotPresent(c *C) {
+	var efiArch string
+	switch runtime.GOARCH {
+	case "amd64":
+		efiArch = "x64"
+	case "arm64":
+		efiArch = "aa64"
+	default:
+		c.Skip("Unknown EFI arch")
+	}
+
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
+
+	systemDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel)
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
+
+	kernelSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "snap.yaml")
+	c.Assert(os.MkdirAll(filepath.Dir(kernelSnapYaml), 0755), IsNil)
+	kernelSnapYamlContent := `{}`
+	c.Assert(os.WriteFile(kernelSnapYaml, []byte(kernelSnapYamlContent), 0555), IsNil)
+
+	baseSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "base", "meta", "snap.yaml")
+	c.Assert(os.MkdirAll(filepath.Dir(baseSnapYaml), 0755), IsNil)
+	baseSnapYamlContent := `{}`
+	c.Assert(os.WriteFile(baseSnapYaml, []byte(baseSnapYamlContent), 0555), IsNil)
+
+	gadgetSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "gadget", "meta", "snap.yaml")
+	c.Assert(os.MkdirAll(filepath.Dir(gadgetSnapYaml), 0755), IsNil)
+	gadgetSnapYamlContent := `{}`
+	c.Assert(os.WriteFile(gadgetSnapYaml, []byte(gadgetSnapYamlContent), 0555), IsNil)
+
+	grubConf := filepath.Join(boot.InitramfsRunMntDir, "gadget", "grub.conf")
+	c.Assert(os.MkdirAll(filepath.Dir(grubConf), 0755), IsNil)
+	c.Assert(os.WriteFile(grubConf, nil, 0555), IsNil)
+
+	bootloader := filepath.Join(boot.InitramfsRunMntDir, "ubuntu-seed", "EFI", "boot", fmt.Sprintf("boot%s.efi", efiArch))
+	c.Assert(os.MkdirAll(filepath.Dir(bootloader), 0755), IsNil)
+	c.Assert(os.WriteFile(bootloader, nil, 0555), IsNil)
+	grub := filepath.Join(boot.InitramfsRunMntDir, "ubuntu-seed", "EFI", "boot", fmt.Sprintf("grub%s.efi", efiArch))
+	c.Assert(os.MkdirAll(filepath.Dir(grub), 0755), IsNil)
+	c.Assert(os.WriteFile(grub, nil, 0555), IsNil)
+
+	writeGadget(c, "ubuntu-seed", "system-seed", "")
+
+	gadgetInstallCalled := false
+	restoreGadgetInstall := main.MockGadgetInstallRun(func(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options gadgetInstall.Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*gadgetInstall.InstalledSystemSideData, error) {
+		gadgetInstallCalled = true
+		c.Assert(options.Mount, Equals, true)
+		c.Assert(string(options.EncryptionType), Equals, "")
+		c.Assert(bootDevice, Equals, "")
+		c.Assert(model.Classic(), Equals, false)
+		c.Assert(string(model.Grade()), Equals, "signed")
+		c.Assert(gadgetRoot, Equals, filepath.Join(boot.InitramfsRunMntDir, "gadget"))
+		c.Assert(kernelRoot, Equals, filepath.Join(boot.InitramfsRunMntDir, "kernel"))
+		return &gadgetInstall.InstalledSystemSideData{}, nil
+	})
+	defer restoreGadgetInstall()
+
+	makeRunnableCalled := false
+	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, sealer *boot.TrustedAssetsInstallObserver) error {
+		makeRunnableCalled = true
+		c.Assert(model.Model(), Equals, "my-model")
+		c.Assert(bootWith.RecoverySystemLabel, Equals, s.sysLabel)
+		c.Assert(bootWith.BasePath, Equals, filepath.Join(s.seedDir, "snaps", "core20_1.snap"))
+		c.Assert(bootWith.KernelPath, Equals, filepath.Join(s.seedDir, "snaps", "pc-kernel_1.snap"))
+		c.Assert(bootWith.GadgetPath, Equals, filepath.Join(s.seedDir, "snaps", "pc_1.snap"))
+		return nil
+	})
+	defer restoreMakeRunnableStandaloneSystem()
+
+	applyPreseedCalled := false
+	restoreApplyPreseededData := main.MockApplyPreseededData(func(preseedSeed seed.PreseedCapable, writableDir string) error {
+		applyPreseedCalled = true
+		c.Assert(preseedSeed.ArtifactPath("preseed.tgz"), Equals, filepath.Join(systemDir, "preseed.tgz"))
+		c.Assert(writableDir, Equals, filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"))
+		return nil
+	})
+	defer restoreApplyPreseededData()
+
+	// ensure that we check that access to sealed keys were locked
+	sealedKeysLocked := false
+	defer main.MockSecbootLockSealedKeys(func() error {
+		sealedKeysLocked = true
+		return nil
+	})()
+
+	nextBootEnsured := false
+	defer main.MockEnsureNextBootToRunMode(func(systemLabel string) error {
+		nextBootEnsured = true
+		c.Assert(systemLabel, Equals, s.sysLabel)
+		return nil
+	})()
+
+	restore := s.mockSystemdMountSequence(c, []systemdMount{
+		s.ubuntuLabelMount("ubuntu-seed", "install"),
+		s.makeSeedSnapSystemdMount(snap.TypeSnapd),
+		s.makeSeedSnapSystemdMount(snap.TypeKernel),
+		s.makeSeedSnapSystemdMount(snap.TypeBase),
+		s.makeSeedSnapSystemdMount(snap.TypeGadget),
+		{
+			filepath.Join(s.tmpDir, "/run/mnt/ubuntu-data"),
+			boot.InitramfsDataDir,
+			bindOpts,
+			nil,
+		},
+	}, nil)
+	defer restore()
+
+	c.Assert(os.Remove(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model")), IsNil)
+
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Check(sealedKeysLocked, Equals, true)
+
+	c.Assert(applyPreseedCalled, Equals, true)
+	c.Assert(makeRunnableCalled, Equals, true)
+	c.Assert(gadgetInstallCalled, Equals, true)
+	c.Assert(nextBootEnsured, Equals, true)
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunInstallDeviceHook(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
 

--- a/tests/nested/manual/uc20-install-in-initrd/task.yaml
+++ b/tests/nested/manual/uc20-install-in-initrd/task.yaml
@@ -97,5 +97,5 @@ execute: |
   if [ "${INSTALL_MODE}" = secureboot ]; then
     remote.exec test -f /var/lib/snapd/device/fde/boot-chains
   else
-    remote.exec ! test -f /var/lib/snapd/device/fde/boot-chains
+    remote.exec not test -f /var/lib/snapd/device/fde/boot-chains
   fi

--- a/tests/nested/manual/uc20-install-in-initrd/task.yaml
+++ b/tests/nested/manual/uc20-install-in-initrd/task.yaml
@@ -1,5 +1,9 @@
 summary: Check installation in initrd
 
+details: |
+  This test checks that we are able to perform a single-boot installation in
+  various scenarios.
+
 systems: [ubuntu-20.04-64]
 
 environment:
@@ -9,27 +13,24 @@ environment:
   #  * both: fde-setup hook, secure boot and TPM2 are available
   #  * none: none of them are available
   INSTALL_MODE/hook: "hook"
-  # TODO: enable when non hook mode works
-  # INSTALL_MODE/secureboot: "secureboot"
-  # INSTALL_MODE/none: "none"
+  INSTALL_MODE/secureboot: "secureboot"
+  INSTALL_MODE/none: "none"
   INSTALL_MODE/both: "both"
 
-  NESTED_UBUNTU_IMAGE_PRESEED_KEY/hook: "\" (test)\""
   NESTED_ENABLE_TPM/hook: false
   NESTED_ENABLE_SECURE_BOOT/hook: false
 
-  # TODO: enable when non hook mode works
-  # NESTED_ENABLE_TPM/none: false
-  # NESTED_ENABLE_SECURE_BOOT/none: false
+  NESTED_ENABLE_TPM/none: false
+  NESTED_ENABLE_SECURE_BOOT/none: false
 
-  NESTED_UBUNTU_IMAGE_PRESEED_KEY/both: "\" (test)\""
   NESTED_ENABLE_TPM/both: true
   NESTED_ENABLE_SECURE_BOOT/both: true
 
-  # TODO: enable when non hook mode works
-  # NESTED_ENABLE_TPM/secureboot: true
-  # NESTED_ENABLE_SECURE_BOOT/secureboot: true
+  NESTED_ENABLE_TPM/secureboot: true
+  NESTED_ENABLE_SECURE_BOOT/secureboot: true
 
+  # TODO: single boot install currently requires the system to be preseeded
+  NESTED_UBUNTU_IMAGE_PRESEED_KEY: "\" (test)\""
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-dangerous.model
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
@@ -69,26 +70,32 @@ restore: |
   rm -rf ~/.snap/gnupg
 
 execute: |
-  # TODO: in a normal run, ubuntu-data-<someid> is used instead of
-  # just "ubuntu-data". We need to figure out if this is OK.
-  remote.exec "ls /dev/mapper/ubuntu-data*"
-  remote.exec "ls /dev/mapper/ubuntu-save*"
   remote.exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=install"
-
   remote.exec "cat /var/lib/snapd/modeenv" > modeenv
 
   MATCH "mode=run" <modeenv
 
-  boot_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-  seed_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-  seed_shim_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+  if [ "${INSTALL_MODE}" != none ]; then
+    # TODO: in a normal run, ubuntu-data-<someid> is used instead of
+    # just "ubuntu-data". We need to figure out if this is OK.
+    remote.exec "ls /dev/mapper/ubuntu-data*"
+    remote.exec "ls /dev/mapper/ubuntu-save*"
 
-  boot_grub_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | "$TESTSLIB"/tools/sha3-384)"
-  seed_grub_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | "$TESTSLIB"/tools/sha3-384)"
-  seed_shim_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | "$TESTSLIB"/tools/sha3-384)"
+    boot_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_shim_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
 
-  [ "${boot_grub_sha3}" = "${boot_grub_asset_sha3}" ]
-  [ "${seed_grub_sha3}" = "${seed_grub_asset_sha3}" ]
-  [ "${seed_shim_sha3}" = "${seed_shim_asset_sha3}" ]
+    boot_grub_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | "$TESTSLIB"/tools/sha3-384)"
+    seed_grub_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | "$TESTSLIB"/tools/sha3-384)"
+    seed_shim_asset_sha3="$(remote.exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | "$TESTSLIB"/tools/sha3-384)"
 
-  # TODO: When testing with NESTED_ENABLE_TPM=true, check /var/lib/snapd/device/fde/boot-chains
+    [ "${boot_grub_sha3}" = "${boot_grub_asset_sha3}" ]
+    [ "${seed_grub_sha3}" = "${seed_grub_asset_sha3}" ]
+    [ "${seed_shim_sha3}" = "${seed_shim_asset_sha3}" ]
+  fi
+
+  if [ "${INSTALL_MODE}" = secureboot ]; then
+    remote.exec test -f /var/lib/snapd/device/fde/boot-chains
+  else
+    remote.exec ! test -f /var/lib/snapd/device/fde/boot-chains
+  fi


### PR DESCRIPTION
Single boot install appears to work, without modifications, for systems that do and don't have a FDE setup hook, and for systems that do and don't support secure boot.