### PR TITLE
interface/upower-observe: allow to Refresh statistics for devices

### DIFF
--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -195,7 +195,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/UPower/devices/**
     interface=org.freedesktop.UPower.Device
-    member=GetHistory
+    member={GetHistory,Refresh}
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Receive property changed events


### PR DESCRIPTION
Refresh is commonly used by applications like steam and others to get accurate
power usage information. Whilst calling this has a side-effect of causing the
daemon to refresh its data from the power source, this seems pretty innocuous
and so should just be added to the existing upower-observe interface rather than
creating a new interface such as upower-control or similar just to allow this
one method.

Signed-off-by: Alex Murray <alex.murray@canonical.com>