### PR TITLE
cmd/snap: add CLI support for unsetting aspects

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -52,10 +52,10 @@ Nested values may be retrieved via a dotted path:
 `)
 
 var longAspectGetHelp = i18n.G(`
-With the aspects experimental feature enabled, if the first argument passed
-into get is an aspect identifier matching the format <account-id>/<bundle>/<aspect>,
-get will use the aspects configuration API. In this case, the command returns
-the data retrieved from the requested dot-separated aspect paths.
+If the first argument passed into get is an aspect identifier matching the
+format <account-id>/<bundle>/<aspect>, get will use the aspects configuration
+API. In this case, the command returns the data retrieved from the requested
+dot-separated aspect paths.
 `)
 
 type cmdGet struct {

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -46,12 +46,11 @@ Configuration option may be unset with exclamation mark:
     $ snap set snap-name author!
 `)
 
-// TODO: check the experimental feature is enabled and append this to set's help
 var longAspectSetHelp = i18n.G(`
-With the aspects experimental feature enabled, if the first argument passed
-into set is an aspect identifier matching the format <account-id>/<bundle>/<aspect>,
-set will use the aspects configuration API. In this case, the command sets the
-values as provided for the dot-separated aspect paths.
+If the first argument passed into set is an aspect identifier matching the
+format <account-id>/<bundle>/<aspect>, set will use the aspects configuration
+API. In this case, the command sets the values as provided for the dot-separated
+aspect paths.
 `)
 
 type cmdSet struct {
@@ -69,6 +68,7 @@ func init() {
 	if err := validateAspectFeatureFlag(); err == nil {
 		longSetHelp += longAspectSetHelp
 	}
+
 	addCommand("set", shortSetHelp, longSetHelp, func() flags.Commander { return &cmdSet{} },
 		waitDescs.also(map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.


### PR DESCRIPTION
Add support for unsetting aspects in the `snap set` command.