### PR TITLE
o/state: record change-update notices on change status updates

### DIFF
--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -343,6 +343,11 @@ func (s *State) NewChange(kind, summary string) *Change {
 	id := strconv.Itoa(s.lastChangeId)
 	chg := newChange(s, id, kind, summary)
 	s.changes[id] = chg
+	// Add change-update notice for newly spawned change
+	// NOTE: Implies State.writing()
+	if err := chg.addNotice(); err != nil {
+		logger.Panicf(`internal error: failed to add "change-update" notice for new change: %v`, err)
+	}
 	return chg
 }
 


### PR DESCRIPTION
This PR adds trigger points to the `change-update` notice based on the [JU048](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA/edit) spec.

- `NewChange` trigger point is to address the `change spawned` case.
- `notifyStatusChange` is for all other status changes.

~~**Note:** Change status alternates rapidly between `Do` and `Doing` statuses because it gets computed based on an aggregation of its tasks' statuses which might cause the listener to hit the `/v2/changes` a lot hence putting pressure on snapd, no?~~

~~There are no test currently, I will add unit and spread tests as soon we align on the notice trigger points.~~
