### PR TITLE
o/devicestate: check for previously installed revisions when falling back to installed snaps during offline remodel

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -539,19 +539,17 @@ func (ro *remodelVariant) UpdateWithDeviceContext(st *state.State, snapName stri
 			return nil, err
 		}
 
-		// if the current revision isn't the revision that is installed,
-		// then look at the previous revisions that we have to see if any of
-		// those match
-		for _, rev := range ss.Sequence.Revisions {
-			if rev.Snap.Revision == opts.Revision {
-				// this won't reach out to the store since we know that we
-				// already have the snap revision on disk
-				return snapstateUpdateWithDeviceContext(st, snapName, opts,
-					userID, snapStateFlags, tracker, deviceCtx, fromChange)
-			}
+		// if the current revision isn't the revision that is installed, then
+		// look at the previous revisions that we have to see if any of those
+		// match
+		if ss.Sequence.LastIndex(opts.Revision) == -1 {
+			return nil, fmt.Errorf("installed snap %q does not match revision required to be used for offline remodel: %s != %s", snapName, opts.Revision, info.Revision)
 		}
 
-		return nil, fmt.Errorf("installed snap %q does not match revision required to be used for offline remodel: %s != %s", snapName, opts.Revision, info.Revision)
+		// this won't reach out to the store since we know that we already have
+		// the snap revision on disk
+		return snapstateUpdateWithDeviceContext(st, snapName, opts,
+			userID, snapStateFlags, tracker, deviceCtx, fromChange)
 	}
 
 	// this would only occur from programmer error, since

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1697,18 +1697,17 @@ volumes:
 		Serial: "serial",
 	})
 
-	const required = true
-	kernelInfo := snapstatetest.InstallSnap(c, s.state, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	kernelInfo := snapstatetest.InstallSnap(c, s.state, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core18\nversion: 1\ntype: base\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: core18\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("core18"),
 		Revision: snap.R(1),
 		RealName: "core18",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	devicestate.SetBootRevisionsUpdated(s.mgr, true)
 
@@ -1893,18 +1892,17 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 		Serial: "serial",
 	})
 
-	const required = true
-	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core18\nversion: 1\ntype: base\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: core18\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("core18"),
 		Revision: snap.R(1),
 		RealName: "core18",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	devicestate.SetBootRevisionsUpdated(s.mgr, true)
 
@@ -2765,26 +2763,26 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", nil)
 
 	// install snaps that will be needed for new model
-	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-new"),
 		Revision: snap.R(222),
 		RealName: "pc-new",
 		Channel:  "20/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel-new\nversion: 1\ntype: kernel\n", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel-new\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-kernel-new"),
 		Revision: snap.R(222),
 		RealName: "pc-kernel-new",
 		Channel:  "20/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("core20-new"),
 		Revision: snap.R(222),
 		RealName: "core20-new",
 		Channel:  "latest/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	// not yet installed app-snap, that will be provided as a local snap
 	appSnap := &snap.SideInfo{
@@ -3016,26 +3014,26 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", nil)
 
 	// install snaps that will be needed for new model
-	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-new"),
 		Revision: snap.R(222),
 		RealName: "pc-new",
 		Channel:  "20/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel-new\nversion: 1\ntype: kernel\n", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-kernel-new\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-kernel-new"),
 		Revision: snap.R(222),
 		RealName: "pc-kernel-new",
 		Channel:  "20/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", true, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("core20-new"),
 		Revision: snap.R(222),
 		RealName: "core20-new",
 		Channel:  "latest/stable",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	// not yet installed app-snap, that will be provided as a local snap
 	appSnap := &snap.SideInfo{

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -5203,12 +5203,11 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBase(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
@@ -5371,12 +5370,11 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndo(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
@@ -5539,18 +5537,17 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndoOnRollback(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, st, "name: core18\nversion: 1\ntype: base\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: core18\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("core18"),
 		Revision: snap.R(1),
 		RealName: "core18",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	si2 := &snap.SideInfo{RealName: "pc", SnapID: fakeSnapID("pc"), Revision: snap.R(1)}
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
@@ -6362,18 +6359,17 @@ func (s *mgrsSuiteCore) TestRemodelSwitchGadgetTrack(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, st, "name: core\nversion: 1\ntype: base\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: core\nversion: 1\ntype: base\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("core"),
 		Revision: snap.R(1),
 		RealName: "core",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	err := bloader.SetBootVars(map[string]string{
 		"snap_mode":   boot.DefaultStatus,
@@ -6494,12 +6490,11 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToDifferentGadget(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
@@ -6659,12 +6654,11 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToIncompatibleGadget(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	const required = true
-	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", required, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
-	})
+	}, snapstatetest.InstallSnapOptions{Required: true})
 
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -79,6 +79,11 @@ execute: |
   # install/download app required for the new model
   if [ "${USE_INSTALLED_APP}" = 'true' ]; then
       remote.exec "snap install --revision=28 hello-world"
+
+      # refresh to the latest revision to make sure that remodeling will look
+      # for previsouly installed revisions when doing an offline remodel
+      remote.exec "snap refresh hello-world"
+      remote.exec "snap list hello-world" | awk 'NR != 1 { print $3 }' | NOMATCH 28
   else
       remote.exec "snap download --revision=28 --basename=hello-world hello-world"
       remodel_options="$remodel_options --snap hello-world.snap --assertion hello-world.assert"

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -81,7 +81,7 @@ execute: |
       remote.exec "snap install --revision=28 hello-world"
 
       # refresh to the latest revision to make sure that remodeling will look
-      # for previsouly installed revisions when doing an offline remodel
+      # for previously installed revisions when doing an offline remodel
       remote.exec "snap refresh hello-world"
       remote.exec "snap list hello-world" | awk 'NR != 1 { print $3 }' | NOMATCH 28
   else


### PR DESCRIPTION
This PR enables offline remodeling to look back at recently installed revisions of snaps, and will use one of those if any fulfill the revision requirements of the remodel.