### PR TITLE
kernel: add ancillary methods

### DIFF
--- a/kernel/export_test.go
+++ b/kernel/export_test.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package kernel
+
+// MockEnsureInterval sets the overlord ensure interval for tests.
+func MockOsSymlink(newSymlink func(string, string) error) (restore func()) {
+	old := osSymlink
+	osSymlink = newSymlink
+	return func() { osSymlink = old }
+}

--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -1,0 +1,212 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package kernel
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+// For testing purposes
+var osSymlink = os.Symlink
+
+// We expect as a minimum something that starts with three numbers
+// separated by dots for the kernel version.
+var utsRelease = regexp.MustCompile(`^([0-9]+\.){2}[0-9]+`)
+
+// KernelVersionFromModulesDir returns the kernel version for a mounted kernel
+// snap (this would be the output if "uname -r" for a running kernel). It
+// assumes that there is a folder named modules/$(uname -r) inside the snap.
+func KernelVersionFromModulesDir(mountPoint string) (string, error) {
+	modsDir := filepath.Join(mountPoint, "modules")
+	entries, err := os.ReadDir(modsDir)
+	if err != nil {
+		return "", err
+	}
+
+	kversion := ""
+	for _, node := range entries {
+		if !node.Type().IsDir() {
+			continue
+		}
+		if !utsRelease.MatchString(node.Name()) {
+			continue
+		}
+		if kversion != "" {
+			return "", fmt.Errorf("more than one modules directory in %q", modsDir)
+		}
+		kversion = node.Name()
+	}
+	if kversion == "" {
+		return "", fmt.Errorf("no modules directory found in %q", modsDir)
+	}
+
+	return kversion, nil
+}
+
+func createFirmwareSymlinks(orig, dest string) error {
+	fwOrig := filepath.Join(orig, "firmware")
+	fwDest := filepath.Join(dest, "lib", "firmware")
+	if err := os.MkdirAll(fwDest, 0755); err != nil {
+		return err
+	}
+
+	// Symbolic links inside firmware folder - it cannot be directly a
+	// symlink to "firmware" as we will use firmware/updates/ subfolder for
+	// components.
+	entries, err := os.ReadDir(fwOrig)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Bit of a corner case, but maybe possible. Log anyway.
+			logger.Noticef("no firmware found in %q", fwOrig)
+			return nil
+		}
+		return err
+	}
+
+	for _, node := range entries {
+		lpath := filepath.Join(fwDest, node.Name())
+		origPath := filepath.Join(fwOrig, node.Name())
+		switch node.Type() {
+		case 0, fs.ModeDir:
+			// Create link for regular files or directories
+			if err := os.Symlink(origPath, lpath); err != nil {
+				return err
+			}
+		case fs.ModeSymlink:
+			// Replicate link (it should be relative)
+			// TODO check this in snap pack
+			lpath := filepath.Join(fwDest, node.Name())
+			dest, err := os.Readlink(origPath)
+			if err != nil {
+				return err
+			}
+			if filepath.IsAbs(dest) {
+				return fmt.Errorf("symlink %q points to absolute path %q", lpath, dest)
+			}
+			if err := os.Symlink(dest, lpath); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%q has unexpected file type: %s",
+				node.Name(), node.Type())
+		}
+	}
+
+	return nil
+}
+
+func createModulesSubtree(origin, dest string) error {
+	kversion, err := KernelVersionFromModulesDir(origin)
+	if err != nil {
+		// Bit of a corner case, but maybe possible. Log anyway.
+		// TODO detect this issue in snap pack, should be enforced
+		// if the snap declares kernel-modules components.
+		logger.Noticef("no modules found in %q", origin)
+		return nil
+	}
+
+	// Although empty we need "lib" because "depmod" always appends
+	// "/lib/modules/<kernel_version>" to the directory passed with option
+	// "-b".
+	modsRoot := filepath.Join(dest, "lib", "modules", kversion)
+	if err := os.MkdirAll(modsRoot, 0755); err != nil {
+		return err
+	}
+
+	// Copy modinfo files from the snap (these might be overwritten if
+	// kernel-modules components are installed).
+	modsGlob := filepath.Join(origin, "modules", kversion, "modules.*")
+	modFiles, err := filepath.Glob(modsGlob)
+	if err != nil {
+		// Should not really happen (only possible error is ErrBadPattern)
+		return err
+	}
+	for _, orig := range modFiles {
+		target := filepath.Join(modsRoot, filepath.Base(orig))
+		if err := osutil.CopyFile(orig, target, osutil.CopyFlagDefault); err != nil {
+			return err
+		}
+	}
+
+	// Symbolic links to early mount kernel snap
+	earlyMntDir := filepath.Join(origin, "modules", kversion)
+	for _, d := range []string{"kernel", "vdso"} {
+		lname := filepath.Join(modsRoot, d)
+		to := filepath.Join(earlyMntDir, d)
+		if err := osSymlink(to, lname); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func driversTreeDir(ksnapName string, rev snap.Revision) string {
+	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", ksnapName, rev.String())
+}
+
+// RemoveKernelDriversTree cleans-up the writable kernel tree for a given snap
+// and revision.
+func RemoveKernelDriversTree(ksnapName string, rev snap.Revision) (err error) {
+	treeRoot := driversTreeDir(ksnapName, rev)
+	return os.RemoveAll(treeRoot)
+}
+
+// EnsureKernelDriversTree creates a tree in
+// /var/lib/snapd/kernel/<ksnapName>/<rev> with subfolders can be bind-mounted
+// on boot to /usr/lib/{modules,firmware}. This tree contains files from the
+// kernel snap mounted on kernelMount, as well as symlinks to it.
+// TODO this will be extended to consider kernel-modules components.
+func EnsureKernelDriversTree(ksnapName string, rev snap.Revision, kernelMount string) (err error) {
+	// Initial clean-up to make the function idempotent
+	if rmErr := RemoveKernelDriversTree(ksnapName, rev); rmErr != nil &&
+		!errors.Is(err, fs.ErrNotExist) {
+		logger.Noticef("while removing old kernel tree: %v", rmErr)
+	}
+
+	// Remove tree in case something goes wrong
+	defer func() {
+		if err != nil {
+			if rmErr := RemoveKernelDriversTree(ksnapName, rev); rmErr != nil &&
+				!errors.Is(err, fs.ErrNotExist) {
+				logger.Noticef("while cleaning up kernel tree: %v", rmErr)
+			}
+		}
+	}()
+
+	// Root of our kernel tree
+	treeRoot := driversTreeDir(ksnapName, rev)
+
+	if err := createModulesSubtree(kernelMount, treeRoot); err != nil {
+		return err
+	}
+
+	return createFirmwareSymlinks(kernelMount, treeRoot)
+}

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -1,0 +1,332 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package kernel_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/kernel"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type kernelDriversTestSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&kernelDriversTestSuite{})
+
+func (s *kernelDriversTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *kernelDriversTestSuite) TestKernelVersionFromModulesDir(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	c.Assert(os.MkdirAll(mountDir, 0755), IsNil)
+
+	// No map file
+	ver, err := kernel.KernelVersionFromModulesDir(mountDir)
+	c.Check(err, ErrorMatches, `open .*/run/mnt/pc-kernel/modules: no such file or directory`)
+	c.Check(ver, Equals, "")
+
+	// Create directory so kernel version can be found
+	c.Assert(os.MkdirAll(filepath.Join(
+		mountDir, "modules", "5.15.0-78-generic"), 0755), IsNil)
+	ver, err = kernel.KernelVersionFromModulesDir(mountDir)
+	c.Check(err, IsNil)
+	c.Check(ver, Equals, "5.15.0-78-generic")
+
+	// Too many matches
+	c.Assert(os.MkdirAll(filepath.Join(
+		mountDir, "modules", "5.15.0-90-generic"), 0755), IsNil)
+	ver, err = kernel.KernelVersionFromModulesDir(mountDir)
+	c.Check(err, ErrorMatches, `more than one modules directory in ".*/run/mnt/pc-kernel/modules"`)
+	c.Check(ver, Equals, "")
+}
+
+func (s *kernelDriversTestSuite) TestKernelVersionFromModulesDirNoModDir(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	c.Assert(os.MkdirAll(mountDir, 0755), IsNil)
+
+	c.Assert(os.MkdirAll(filepath.Join(mountDir, "modules"), 0755), IsNil)
+	// Create file instead of directory
+	c.Assert(os.WriteFile(filepath.Join(
+		mountDir, "modules", "5.15.0-78-generic"), []byte{}, 0644), IsNil)
+	ver, err := kernel.KernelVersionFromModulesDir(mountDir)
+	c.Check(err, ErrorMatches, `no modules directory found in ".*/run/mnt/pc-kernel/modules"`)
+	c.Check(ver, Equals, "")
+}
+
+func (s *kernelDriversTestSuite) TestKernelVersionFromModulesDirBadVersion(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	c.Assert(os.MkdirAll(filepath.Join(
+		mountDir, "modules", "5.15.myway"), 0755), IsNil)
+
+	ver, err := kernel.KernelVersionFromModulesDir(mountDir)
+	c.Check(err, ErrorMatches, `no modules directory found in ".*/run/mnt/pc-kernel/modules"`)
+	c.Check(ver, Equals, "")
+}
+
+func createKernelSnapFiles(c *C, kversion, kdir string) {
+	c.Assert(os.MkdirAll(kdir, 0755), IsNil)
+
+	// Create modinfo files
+	modDir := filepath.Join(kdir, "modules", kversion)
+	c.Assert(os.MkdirAll(modDir, 0755), IsNil)
+	modFile := []string{"modules.builtin.alias.bin", "modules.dep.bin", "modules.symbols"}
+	allFiles := append(modFile, "other.mod", "foo.bin")
+	for _, f := range allFiles {
+		c.Assert(os.WriteFile(filepath.Join(modDir, f), []byte{}, 0644), IsNil)
+	}
+
+	// Create firmware
+	fwDir := filepath.Join(kdir, "firmware")
+	c.Assert(os.MkdirAll(fwDir, 0755), IsNil)
+	// Regular files
+	for _, f := range []string{"blob1", "blob2"} {
+		c.Assert(os.WriteFile(filepath.Join(fwDir, f), []byte{}, 0644), IsNil)
+	}
+	// Directory, write file inside
+	fwSubDir := filepath.Join(fwDir, "subdir")
+	c.Assert(os.MkdirAll(fwSubDir, 0755), IsNil)
+	blob3 := filepath.Join(fwSubDir, "blob3")
+	c.Assert(os.WriteFile(blob3, []byte{}, 0644), IsNil)
+	// Symlink
+	os.Symlink("subdir/blob3", filepath.Join(fwDir, "ln_to_blob3"))
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversTree(c *C) {
+	// Build twice to make sure the function is idempotent
+	testBuildKernelDriversTree(c)
+	testBuildKernelDriversTree(c)
+
+	// Now remove and check
+	kernel.RemoveKernelDriversTree("pc-kernel", snap.R(1))
+	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
+	c.Assert(osutil.FileExists(treeRoot), Equals, false)
+}
+
+func testBuildKernelDriversTree(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFiles(c, kversion, mountDir)
+
+	// Now build the tree
+	c.Assert(kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir), IsNil)
+
+	// Check content is as expected
+	modsRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion)
+
+	entries, err := os.ReadDir(modsRoot)
+	c.Assert(err, IsNil)
+	type expectInode struct {
+		file       string
+		fType      fs.FileMode
+		linkTarget string
+	}
+	modsMntDir := filepath.Join(mountDir, "modules", kversion)
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(modsMntDir, "kernel")},
+		{"modules.builtin.alias.bin", 0, ""},
+		{"modules.dep.bin", 0, ""},
+		{"modules.symbols", 0, ""},
+		{"vdso", fs.ModeSymlink, filepath.Join(modsMntDir, "vdso")},
+	}
+	c.Assert(len(entries), Equals, len(expected))
+	for i, ent := range entries {
+		c.Check(ent.Name(), Equals, expected[i].file)
+		c.Check(ent.Type(), Equals, expected[i].fType)
+		if ent.Type() == fs.ModeSymlink {
+			dest, err := os.Readlink(filepath.Join(modsRoot, ent.Name()))
+			c.Assert(err, IsNil)
+			c.Check(dest, Equals, expected[i].linkTarget)
+		}
+	}
+
+	// Check firmware entries
+	fwRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "firmware")
+	fwMntDir := filepath.Join(mountDir, "firmware")
+	entries, err = os.ReadDir(fwRoot)
+	c.Assert(err, IsNil)
+	expected = []expectInode{
+		{"blob1", fs.ModeSymlink, filepath.Join(fwMntDir, "blob1")},
+		{"blob2", fs.ModeSymlink, filepath.Join(fwMntDir, "blob2")},
+		{"ln_to_blob3", fs.ModeSymlink, "subdir/blob3"},
+		{"subdir", fs.ModeSymlink, filepath.Join(fwMntDir, "subdir")},
+	}
+	for i, ent := range entries {
+		c.Check(ent.Name(), Equals, expected[i].file)
+		c.Check(ent.Type(), Equals, expected[i].fType)
+		// Must all be symlinks
+		dest, err := os.Readlink(filepath.Join(fwRoot, ent.Name()))
+		c.Assert(err, IsNil)
+		c.Check(dest, Equals, expected[i].linkTarget)
+		if ent.Name() == "subdir" {
+			// File can be accessed from symlink to directory
+			exists, isReg, err := osutil.RegularFileExists(filepath.Join(fwRoot, ent.Name(), "blob3"))
+			c.Assert(err, IsNil)
+			c.Check(exists, Equals, true)
+			c.Check(isReg, Equals, true)
+		}
+	}
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversNoModsOrFw(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	c.Assert(os.MkdirAll(mountDir, 0755), IsNil)
+
+	// Build the tree should not fail
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, IsNil)
+
+	// but log should warn about this
+	c.Assert(buf.String(), testutil.Contains, `no modules found in "`+mountDir+`"`)
+	c.Assert(buf.String(), testutil.Contains, `no firmware found in "`+mountDir+`/firmware"`)
+}
+
+func createKernelSnapFilesOnlyModules(c *C, kversion, kdir string) {
+	c.Assert(os.MkdirAll(kdir, 0755), IsNil)
+
+	// Create modinfo files
+	modDir := filepath.Join(kdir, "modules", kversion)
+	c.Assert(os.MkdirAll(modDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modDir, "modules.dep.bin"), []byte{}, 0644), IsNil)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyMods(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// Build the tree should not fail
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, IsNil)
+
+	// check created file
+	modPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion, "modules.dep.bin")
+	exists, isReg, err := osutil.RegularFileExists(modPath)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+	c.Check(isReg, Equals, true)
+
+	// but log should warn about this
+	c.Assert(buf.String(), testutil.Contains, `no firmware found in "`+mountDir+`/firmware"`)
+}
+
+func createKernelSnapFilesOnlyFw(c *C, kdir string) {
+	c.Assert(os.MkdirAll(kdir, 0755), IsNil)
+
+	// Create firmware files
+	fwDir := filepath.Join(kdir, "firmware")
+	c.Assert(os.MkdirAll(fwDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(fwDir, "wifi_fw.bin"), []byte{}, 0644), IsNil)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyFw(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	createKernelSnapFilesOnlyFw(c, mountDir)
+
+	// Build the tree should not fail
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, IsNil)
+
+	// check link
+	fwPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "firmware", "wifi_fw.bin")
+	c.Assert(osutil.IsSymlink(fwPath), Equals, true)
+
+	// but log should warn about this
+	c.Assert(buf.String(), testutil.Contains, `no modules found in "`+mountDir+`"`)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversAbsFwSymlink(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+
+	// Create firmware files
+	fwDir := filepath.Join(mountDir, "firmware")
+	c.Assert(os.MkdirAll(fwDir, 0755), IsNil)
+	// Symlink
+	os.Symlink("/absdir/blob3", filepath.Join(fwDir, "ln_to_abs"))
+
+	// Fails on the absolute path in the link
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, ErrorMatches, `symlink \".*lib/firmware/ln_to_abs\" points to absolute path \"/absdir/blob3\"`)
+
+	// Make sure the tree has been deleted
+	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
+	c.Assert(osutil.FileExists(treeRoot), Equals, false)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCleanup(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFiles(c, kversion, mountDir)
+
+	restore := kernel.MockOsSymlink(func(string, string) error {
+		return errors.New("mocked symlink error")
+	})
+	defer restore()
+
+	// Now build the tree
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, ErrorMatches, "mocked symlink error")
+
+	// Make sure the tree has been deleted
+	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
+	c.Assert(osutil.FileExists(treeRoot), Equals, false)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversBadFileType(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFiles(c, kversion, mountDir)
+
+	// Additional file of not expected type in "firmware"
+	fwDir := filepath.Join(mountDir, "firmware")
+	c.Assert(syscall.Mkfifo(filepath.Join(fwDir, "fifo"), 0666), IsNil)
+
+	// Now build the tree
+	err := kernel.EnsureKernelDriversTree("pc-kernel", snap.R(1), mountDir)
+	c.Assert(err, ErrorMatches, `"fifo" has unexpected file type: p---------`)
+
+	// Make sure the tree has been deleted
+	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
+	c.Assert(osutil.FileExists(treeRoot), Equals, false)
+}


### PR DESCRIPTION
Add ancillary methods:

- KernelVersionFromPlaceInfo, to find the kernel version ("uname -r") for a mounted snap.
- BuildKernelDriversTree, to build a tree from a mounted snap that can be bind-mounted to /usr/lib/{modules,firmware}.

These methods are needed to support kernel-modules components.