### PR TITLE
snap: add hooks to snap component types

### DIFF
--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -231,7 +231,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathWrongType(c *C) {
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, "other-comp")
 	// The component in snap.yaml has type different to the one in component.yaml
 	// (we have to set it in this way as parsers check for allowed types).
-	info.Components[compName] = snap.Component{
+	info.Components[compName] = &snap.Component{
 		Type: "random-comp-type",
 	}
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -28,11 +28,11 @@ import (
 
 // ComponentInfo is the content of a component.yaml file.
 type ComponentInfo struct {
-	Component   naming.ComponentRef `yaml:"component"`
-	Type        ComponentType       `yaml:"type"`
-	Version     string              `yaml:"version"`
-	Summary     string              `yaml:"summary"`
-	Description string              `yaml:"description"`
+	Component   naming.ComponentRef
+	Type        ComponentType
+	Version     string
+	Summary     string
+	Description string
 
 	// TODO: we will need to add fields here to carry around details about
 	// explicit and implicit hooks.

--- a/snap/component.go
+++ b/snap/component.go
@@ -33,6 +33,9 @@ type ComponentInfo struct {
 	Version     string              `yaml:"version"`
 	Summary     string              `yaml:"summary"`
 	Description string              `yaml:"description"`
+
+	// TODO: we will need to add fields here to carry around details about
+	// explicit and implicit hooks.
 }
 
 // NewComponentInfo creates a new ComponentInfo.

--- a/snap/component.go
+++ b/snap/component.go
@@ -28,11 +28,11 @@ import (
 
 // ComponentInfo is the content of a component.yaml file.
 type ComponentInfo struct {
-	Component   naming.ComponentRef
-	Type        ComponentType
-	Version     string
-	Summary     string
-	Description string
+	Component   naming.ComponentRef `yaml:"component"`
+	Type        ComponentType       `yaml:"type"`
+	Version     string              `yaml:"version"`
+	Summary     string              `yaml:"summary"`
+	Description string              `yaml:"description"`
 
 	// TODO: we will need to add fields here to carry around details about
 	// explicit and implicit hooks.

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -41,6 +41,13 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
 }
 
+var supportedComponentHooks = []*HookType{
+	NewHookType(regexp.MustCompile("^install$")),
+	NewHookType(regexp.MustCompile("^pre-refresh$")),
+	NewHookType(regexp.MustCompile("^post-refresh$")),
+	NewHookType(regexp.MustCompile("^remove$")),
+}
+
 // HookType represents a pattern of supported hook names.
 type HookType struct {
 	pattern *regexp.Regexp
@@ -62,6 +69,18 @@ func (hookType HookType) Match(hookName string) bool {
 // supported hooks.
 func IsHookSupported(hookName string) bool {
 	for _, hookType := range supportedHooks {
+		if hookType.Match(hookName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsComponentHookSupported returns true if the given hook name matches one of
+// the supported hooks.
+func IsComponentHookSupported(hookName string) bool {
+	for _, hookType := range supportedComponentHooks {
 		if hookType.Match(hookName) {
 			return true
 		}

--- a/snap/info.go
+++ b/snap/info.go
@@ -355,7 +355,7 @@ type Info struct {
 	Plugs            map[string]*PlugInfo
 	Slots            map[string]*SlotInfo
 
-	Components map[string]Component
+	Components map[string]*Component
 
 	// Plugs or slots with issues (they are not included in Plugs or Slots)
 	BadInterfaces map[string]string // slot or plug => message
@@ -1197,6 +1197,9 @@ func (mis MediaInfos) IconURL() string {
 // HookInfo provides information about a hook.
 type HookInfo struct {
 	Snap *Info
+
+	// Component will be nil if the hook is not a component hook.
+	Component *Component
 
 	Name  string
 	Plugs map[string]*PlugInfo

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -344,6 +344,11 @@ func setComponentsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) erro
 				Explicit:     true,
 			}
 
+			// TODO: this might need to change one day
+			if len(hookData.SlotNames) > 0 {
+				return fmt.Errorf("component hooks cannot have slots")
+			}
+
 			if len(hookData.PlugNames) > 0 {
 				componentHook.Plugs = make(map[string]*PlugInfo, len(hookData.PlugNames))
 			}

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -327,7 +327,7 @@ func setComponentsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) erro
 		}
 
 		if len(data.Hooks) > 0 {
-			component.Hooks = make(map[string]*HookInfo, len(data.Hooks))
+			component.ExplicitHooks = make(map[string]*HookInfo, len(data.Hooks))
 		}
 
 		for hookName, hookData := range data.Hooks {
@@ -355,7 +355,7 @@ func setComponentsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) erro
 
 			bindPlugsToHook(componentHook, hookData.PlugNames, snap, strk)
 
-			component.Hooks[hookName] = componentHook
+			component.ExplicitHooks[hookName] = componentHook
 		}
 
 		snap.Components[name] = &component
@@ -649,7 +649,7 @@ func bindUnscopedPlugs(snap *Info, strk *scopedTracker) {
 		}
 
 		for _, component := range snap.Components {
-			for _, componentHook := range component.Hooks {
+			for _, componentHook := range component.ExplicitHooks {
 				if componentHook.Plugs == nil {
 					componentHook.Plugs = make(map[string]*PlugInfo)
 				}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -2228,7 +2228,7 @@ components:
 	component := info.Components["test1"]
 	c.Assert(component, NotNil)
 
-	hook := component.Hooks["install"]
+	hook := component.ExplicitHooks["install"]
 	c.Assert(hook, NotNil)
 	c.Check(hook.CommandChain, DeepEquals, []string{"chain1", "chain2"})
 	c.Check(hook.Environment, DeepEquals, *strutil.NewOrderedMap("k1", "v1", "k2", "v2"))
@@ -2296,7 +2296,9 @@ plugs:
 	foundComponents := make(map[string]component, len(info.Components))
 	for _, foundComponent := range info.Components {
 		foundHooks := make(map[string]hook)
-		for _, foundHook := range foundComponent.Hooks {
+		for _, foundHook := range foundComponent.ExplicitHooks {
+			c.Check(foundHook.Explicit, Equals, true)
+
 			foundPlugs := make([]string, 0, len(foundHook.Plugs))
 			for _, foundPlug := range foundHook.Plugs {
 				foundPlugs = append(foundPlugs, foundPlug.Name)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -2344,3 +2344,17 @@ components:
 	c.Assert(err.Error(), Equals, `cannot parse snap.yaml: unknown component type "badtype"`)
 	c.Assert(info, IsNil)
 }
+
+func (s *YamlSuite) TestUnmarshalComponentsHookSlotsError(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+components:
+  test1:
+    type: test
+    hooks:
+      install:
+        slots: [slot-for-install]
+`))
+	c.Assert(err.Error(), Equals, `component hooks cannot have slots`)
+	c.Assert(info, IsNil)
+}

--- a/snap/types.go
+++ b/snap/types.go
@@ -204,10 +204,6 @@ type Component struct {
 	ExplicitHooks map[string]*HookInfo
 }
 
-type ComponentHookPlugs struct {
-	PlugNames []string `yaml:"plugs"`
-}
-
 func (ct *ComponentType) UnmarshalYAML(unmarshall func(interface{}) error) error {
 	typeStr := ""
 	if err := unmarshall(&typeStr); err != nil {

--- a/snap/types.go
+++ b/snap/types.go
@@ -197,11 +197,11 @@ var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesCompone
 
 // Component represents a snap component.
 type Component struct {
-	Type        ComponentType
-	Summary     string
-	Description string
-	Name        string
-	Hooks       map[string]*HookInfo
+	Type          ComponentType
+	Summary       string
+	Description   string
+	Name          string
+	ExplicitHooks map[string]*HookInfo
 }
 
 type ComponentHookPlugs struct {

--- a/snap/types.go
+++ b/snap/types.go
@@ -197,9 +197,9 @@ var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesCompone
 
 // Component represents a snap component.
 type Component struct {
-	Type        ComponentType `yaml:"type"`
-	Summary     string        `yaml:"summary"`
-	Description string        `yaml:"description"`
+	Type        ComponentType
+	Summary     string
+	Description string
 }
 
 func (ct *ComponentType) UnmarshalYAML(unmarshall func(interface{}) error) error {

--- a/snap/types.go
+++ b/snap/types.go
@@ -200,6 +200,12 @@ type Component struct {
 	Type        ComponentType
 	Summary     string
 	Description string
+	Name        string
+	Hooks       map[string]*HookInfo
+}
+
+type ComponentHookPlugs struct {
+	PlugNames []string `yaml:"plugs"`
 }
 
 func (ct *ComponentType) UnmarshalYAML(unmarshall func(interface{}) error) error {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -363,6 +363,11 @@ func Validate(info *Info) error {
 		if err := ValidateDescription(comp.Description); err != nil {
 			return err
 		}
+		for _, hook := range comp.Hooks {
+			if err := ValidateHook(hook); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := validateTitle(info.Title()); err != nil {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -363,7 +363,7 @@ func Validate(info *Info) error {
 		if err := ValidateDescription(comp.Description); err != nil {
 			return err
 		}
-		for _, hook := range comp.Hooks {
+		for _, hook := range comp.ExplicitHooks {
 			if err := ValidateHook(hook); err != nil {
 				return err
 			}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2635,3 +2635,19 @@ components:
 		c.Check(err, ErrorMatches, fmt.Sprintf("%s can have up to %d codepoints, got %d", tc.field, tc.maxCodePoints, utf8.RuneCountInString(text)))
 	}
 }
+
+func (s *ValidateSuite) TestDetectInvalidComponentHooks(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+components:
+  test:
+    type: test
+    hooks:
+      install:
+        command-chain: [">_>"]
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `hook command-chain contains illegal.*`)
+}


### PR DESCRIPTION
Adds fields to types in `snap` package pertaining to component hooks.