### PR TITLE
interfaces/builtin/gpg_public_keys: add permissions for required lock…

### DIFF
--- a/interfaces/builtin/gpg_public_keys.go
+++ b/interfaces/builtin/gpg_public_keys.go
@@ -48,7 +48,7 @@ owner @{HOME}/.gnupg/trustdb.gpg r,
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
 
-# Certain gpg operations (like --export) require to create a look file
+# Certain gpg operations (like --export) require to create a lock file
 # to return successfully. 
 owner @{HOME}/.gnupg/.#lk0x* w,
 owner @{HOME}/.gnupg/pubring.kbx.lock rwk,

--- a/interfaces/builtin/gpg_public_keys.go
+++ b/interfaces/builtin/gpg_public_keys.go
@@ -47,6 +47,11 @@ owner @{HOME}/.gnupg/trustdb.gpg r,
 # gpg sometimes updates the trustdb to decide whether or not to update the
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
+
+# Certain gpg operations (like --export) require to create a look file
+# to return successfully. 
+owner @{HOME}/.gnupg/.#lk0x* w,
+owner @{HOME}/.gnupg/pubring.kbx.lock rwk,
 `
 
 func init() {


### PR DESCRIPTION
Certain gpg operations (like --export) require to create a look file in .gnupg to return successfully, otherwise error code 2 is returned. This PR adds the required apparmor rules to the gpg-public-keys interface to solve this issue 