### PR TITLE
interfaces: add usb-id for GoTrust Idem Key 1C

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -150,7 +150,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "GoTrust Idem Key",
 		VendorIDPattern:  "32a3",
-		ProductIDPattern: "3201",
+		ProductIDPattern: "3201|3203",
 	},
 	{
 		Name:             "Trezor",


### PR DESCRIPTION
I just meet some really nice people at FOSDEM asking me about support for their fido2 key. It looks like the key (GoTrust Idem Key 1C) is not currently in the allow-list. This commit adds it.

Given how popular these keys are and how fast they change I wonder if we should provide some way to provide the key ids via apparmor overrides (maybe it's already possible and I forgot?).

P.S. Hope you all doing well!