### PR TITLE
i/builtin: system-packages-doc bare snap workaround

### DIFF
--- a/tests/regression/lp-2044335/task.yaml
+++ b/tests/regression/lp-2044335/task.yaml
@@ -1,0 +1,30 @@
+summary: 'snap with base: bare and system-packages-doc plug can check kernel version'
+
+details: |
+    As seen on https://bugs.launchpad.net/snapd/+bug/2044335
+    there used to be a problem with system-packages-doc and the snap-update-ns
+    apparmor profile that would prevent construction of the mount namespace,
+    leading to silent failures that would manifest as inability to correctly run
+    stat /usr/share/doc/linux-image-$(uname -r)/changelog.Debian.gz
+    The test is implemented with test-snapd-busybox-static, to avoid using
+    real canonical-livepatch snap.
+
+systems: [ubuntu-*]
+
+prepare: |
+    snap download test-snapd-busybox-static
+    unsquashfs test-snapd-busybox-static*.snap
+    rm -f ./*.snap ./*.assert
+    echo 'plugs:' >> squashfs-root/meta/snap.yaml
+    echo '    system-packages-doc:' >> squashfs-root/meta/snap.yaml
+    snap pack squashfs-root
+    rm -rf squashfs-root
+    snap install --dangerous ./test-snapd-busybox-static*.snap
+    rm -f test-snapd-busybox-static*.snap
+    snap connect test-snapd-busybox-static:system-packages-doc
+
+restore: |
+    snap remove --purge test-snapd-busybox-static
+
+execute: |
+    snap run test-snapd-busybox-static.busybox-static stat "/usr/share/doc/linux-image-$(uname -r)/changelog.Debian.gz"

--- a/tests/regression/lp-2044335/task.yaml
+++ b/tests/regression/lp-2044335/task.yaml
@@ -9,7 +9,7 @@ details: |
     The test is implemented with test-snapd-busybox-static, to avoid using
     real canonical-livepatch snap.
 
-systems: [ubuntu-*]
+systems: [ubuntu-1*, ubuntu-2*]
 
 prepare: |
     snap download test-snapd-busybox-static


### PR DESCRIPTION
The bare snap has few mount points, making the use of mimics, a workaround for creating mount points on an otherwise read-only squashfs, using a tmpfs and a farm of directories and files for bind-mounting, is required. In the particular case of system-packages-doc plug on a snap using the bare base snap, we need to create and re-create /usr.

The snap-update-ns program which is responsible for the bulk of mount manipulation, is invoked in one of two very different scenarios.  Most often, it is invoked from the "snap run" -> "snap-confine" -> "snap-update-ns", just before the "snap-exec" hop. In this scenario it is confined with a special, per-snap apparmor profile. This profile has so far had insufficient permissions to perform this manipulation. A user may work around the problem by disconnecting and re-connecting the system-packages-doc interface manually. When this happens, the mount namespace is adjusted and kept in kernel memory until the system re-boots. In this case snapd invokes snap-update-ns itself, and crucially, without the apparmor sandbox.

The rationale for this behavior is that snap-update-ns is invoked by an unprivileged user, using a setuid-root helper (snap-confine), so extra care is warranted and snap-update-ns should have all the power it needs, but no more.

One could argue that this is highly inconsistent and they would be right. For the moment the most conservative change is to detect this specific case and adjust the sandbox. A more general case for a different method of setting up the mount namespace, without the need to use mimics, or dropping the sandbox entirely would allow us to retain precise permissions.

Fixes: https://bugs.launchpad.net/snapd/+bug/2044335
