### PR TITLE
many: add handlers and backend methods to {set,clean}-up kernel snaps

### DIFF
--- a/data/preseed.json
+++ b/data/preseed.json
@@ -17,6 +17,7 @@
         "var/lib/snapd/cookie",
         "var/lib/snapd/dbus-1",
         "var/lib/snapd/mount",
+        "var/lib/snapd/kernel",
         "var/snap",
         "var/cache/snapd/aux",
         "var/cache/apparmor"

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2837,8 +2837,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 		c.Logf("%s: %s", t.Kind(), t.Summary())
 	}
 
-	// 3 snaps (2 tasks for each) + assets update from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 3*2+1+3+2+1)
+	// 3 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 3*2+2+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -2852,23 +2852,26 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 
 	// check the tasks
 	tPrepareKernel := tl[0]
-	tUpdateAssetsKernel := tl[1]
-	tLinkKernel := tl[2]
-	tPrepareBase := tl[3]
-	tLinkBase := tl[4]
-	tPrepareGadget := tl[5]
-	tUpdateAssets := tl[6]
-	tUpdateCmdline := tl[7]
-	tValidateApp := tl[8]
-	tInstallApp := tl[9]
-	tCreateRecovery := tl[10]
-	tFinalizeRecovery := tl[11]
-	tSetModel := tl[12]
+	tSetupKernelSnap := tl[1]
+	tUpdateAssetsKernel := tl[2]
+	tLinkKernel := tl[3]
+	tPrepareBase := tl[4]
+	tLinkBase := tl[5]
+	tPrepareGadget := tl[6]
+	tUpdateAssets := tl[7]
+	tUpdateCmdline := tl[8]
+	tValidateApp := tl[9]
+	tInstallApp := tl[10]
+	tCreateRecovery := tl[11]
+	tFinalizeRecovery := tl[12]
+	tSetModel := tl[13]
 
 	// check the tasks
 	c.Assert(tPrepareKernel.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareKernel.Summary(), Equals, `Prepare snap "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareKernel.WaitTasks(), HasLen, 0)
+	c.Assert(tSetupKernelSnap.Kind(), Equals, "setup-kernel-snap")
+	c.Assert(tSetupKernelSnap.Summary(), Equals, `Setup kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -2903,11 +2906,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
 		tValidateApp,
 		tCreateRecovery,
 		tFinalizeRecovery,
+	})
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
@@ -2939,8 +2945,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tPrepareKernel, tUpdateAssetsKernel, tLinkKernel,
-		tPrepareBase, tLinkBase,
+		tPrepareKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tLinkKernel, tPrepareBase, tLinkBase,
 		tPrepareGadget, tUpdateAssets, tUpdateCmdline,
 		tValidateApp, tInstallApp,
 		tCreateRecovery, tFinalizeRecovery,
@@ -3088,8 +3094,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 		c.Logf("%s: %s", t.Kind(), t.Summary())
 	}
 
-	// 3 snaps (2 tasks for each) + assets update from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 3*2+1+3+2+1)
+	// 3 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 3*2+2+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3103,23 +3109,26 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 
 	// check the tasks
 	tSwitchKernel := tl[0]
-	tUpdateAssetsKernel := tl[1]
-	tLinkKernel := tl[2]
-	tPrepareBase := tl[3]
-	tLinkBase := tl[4]
-	tSwitchGadget := tl[5]
-	tUpdateAssets := tl[6]
-	tUpdateCmdline := tl[7]
-	tValidateApp := tl[8]
-	tInstallApp := tl[9]
-	tCreateRecovery := tl[10]
-	tFinalizeRecovery := tl[11]
-	tSetModel := tl[12]
+	tSetupKernelSnap := tl[1]
+	tUpdateAssetsKernel := tl[2]
+	tLinkKernel := tl[3]
+	tPrepareBase := tl[4]
+	tLinkBase := tl[5]
+	tSwitchGadget := tl[6]
+	tUpdateAssets := tl[7]
+	tUpdateCmdline := tl[8]
+	tValidateApp := tl[9]
+	tInstallApp := tl[10]
+	tCreateRecovery := tl[11]
+	tFinalizeRecovery := tl[12]
+	tSetModel := tl[13]
 
 	// check the tasks
 	c.Assert(tSwitchKernel.Kind(), Equals, "switch-snap")
 	c.Assert(tSwitchKernel.Summary(), Equals, `Switch snap "pc-kernel-new" from channel "20/stable" to "20/edge"`)
 	c.Assert(tSwitchKernel.WaitTasks(), HasLen, 0)
+	c.Assert(tSetupKernelSnap.Kind(), Equals, "setup-kernel-snap")
+	c.Assert(tSetupKernelSnap.Summary(), Equals, `Setup kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -3154,11 +3163,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchKernel,
 		tValidateApp,
 		tCreateRecovery,
 		tFinalizeRecovery,
+	})
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchKernel,
@@ -3190,8 +3202,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tSwitchKernel, tUpdateAssetsKernel, tLinkKernel,
-		tPrepareBase, tLinkBase,
+		tSwitchKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tLinkKernel, tPrepareBase, tLinkBase,
 		tSwitchGadget, tUpdateAssets, tUpdateCmdline,
 		tValidateApp, tInstallApp,
 		tCreateRecovery, tFinalizeRecovery,
@@ -3344,8 +3356,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	c.Assert(chg.Summary(), Equals, "Refresh model assertion from revision 0 to 1")
 
 	tl := chg.Tasks()
-	// 2 snaps (2 tasks for each) + assets update from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 2*2+1+3+2+1)
+	// 2 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 2*2+2+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3359,21 +3371,24 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	// check the tasks
 	tPrepareKernel := tl[0]
-	tUpdateAssetsKernel := tl[1]
-	tLinkKernel := tl[2]
-	tPrepareBase := tl[3]
-	tLinkBase := tl[4]
-	tPrepareGadget := tl[5]
-	tUpdateAssets := tl[6]
-	tUpdateCmdline := tl[7]
-	tCreateRecovery := tl[8]
-	tFinalizeRecovery := tl[9]
-	tSetModel := tl[10]
+	tSetupKernelSnap := tl[1]
+	tUpdateAssetsKernel := tl[2]
+	tLinkKernel := tl[3]
+	tPrepareBase := tl[4]
+	tLinkBase := tl[5]
+	tPrepareGadget := tl[6]
+	tUpdateAssets := tl[7]
+	tUpdateCmdline := tl[8]
+	tCreateRecovery := tl[9]
+	tFinalizeRecovery := tl[10]
+	tSetModel := tl[11]
 
 	// check the tasks
 	c.Assert(tPrepareKernel.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareKernel.Summary(), Equals, `Prepare snap "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareKernel.WaitTasks(), HasLen, 0)
+	c.Assert(tSetupKernelSnap.Kind(), Equals, "setup-kernel-snap")
+	c.Assert(tSetupKernelSnap.Summary(), Equals, `Setup kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -3404,11 +3419,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
 		tPrepareGadget,
 		tCreateRecovery,
 		tFinalizeRecovery,
+	})
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
+		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
@@ -3440,8 +3458,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tPrepareKernel, tUpdateAssetsKernel, tLinkKernel,
-		tPrepareBase, tLinkBase,
+		tPrepareKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tLinkKernel, tPrepareBase, tLinkBase,
 		tPrepareGadget, tUpdateAssets, tUpdateCmdline,
 		tCreateRecovery, tFinalizeRecovery,
 	})
@@ -3691,10 +3709,10 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 
 	tl := chg.Tasks()
-	// 2 snaps with (snap switch channel + link snap) + gadget assets update
+	// 2 snaps with (snap switch channel + link snap) + assets update and setup
 	// for the kernel snap + gadget snap (switch channel, assets update, cmdline update) +
 	// recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 2*2+1+3+2+1)
+	c.Assert(tl, HasLen, 2*2+2+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3708,21 +3726,24 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	// check the tasks
 	tSwitchChannelKernel := tl[0]
-	tUpdateAssetsFromKernel := tl[1]
-	tLinkKernel := tl[2]
-	tSwitchChannelBase := tl[3]
-	tLinkBase := tl[4]
-	tSwitchChannelGadget := tl[5]
-	tUpdateAssetsFromGadget := tl[6]
-	tUpdateCmdlineFromGadget := tl[7]
-	tCreateRecovery := tl[8]
-	tFinalizeRecovery := tl[9]
-	tSetModel := tl[10]
+	tSetupKernelSnap := tl[1]
+	tUpdateAssetsFromKernel := tl[2]
+	tLinkKernel := tl[3]
+	tSwitchChannelBase := tl[4]
+	tLinkBase := tl[5]
+	tSwitchChannelGadget := tl[6]
+	tUpdateAssetsFromGadget := tl[7]
+	tUpdateCmdlineFromGadget := tl[8]
+	tCreateRecovery := tl[9]
+	tFinalizeRecovery := tl[10]
+	tSetModel := tl[11]
 
 	// check the tasks
 	c.Assert(tSwitchChannelKernel.Kind(), Equals, "switch-snap-channel")
 	c.Assert(tSwitchChannelKernel.Summary(), Equals, `Switch pc-kernel-new channel to 20/stable`)
 	c.Assert(tSwitchChannelKernel.WaitTasks(), HasLen, 0)
+	c.Assert(tSetupKernelSnap.Kind(), Equals, "setup-kernel-snap")
+	c.Assert(tSetupKernelSnap.Summary(), Equals, `Setup kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tUpdateAssetsFromKernel.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateAssetsFromKernel.Summary(), Equals, `Update assets from kernel "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
@@ -3760,9 +3781,12 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		tCreateRecovery,
 		tSwitchChannelGadget,
 	})
-	c.Check(tUpdateAssetsFromKernel.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchChannelKernel, tSwitchChannelGadget,
 		tCreateRecovery, tFinalizeRecovery,
+	})
+	c.Assert(tUpdateAssetsFromKernel.WaitTasks(), DeepEquals, []*state.Task{
+		tSetupKernelSnap,
 	})
 	c.Check(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsFromKernel,
@@ -3772,8 +3796,8 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tSwitchChannelKernel, tUpdateAssetsFromKernel, tLinkKernel,
-		tSwitchChannelBase, tLinkBase,
+		tSwitchChannelKernel, tSetupKernelSnap, tUpdateAssetsFromKernel,
+		tLinkKernel, tSwitchChannelBase, tLinkBase,
 		tSwitchChannelGadget, tUpdateAssetsFromGadget, tUpdateCmdlineFromGadget,
 		tCreateRecovery, tFinalizeRecovery,
 	})

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -31,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 )
 
 func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
@@ -71,6 +73,17 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 				logger.Debugf("unmounting snap %s at %s", info.InstanceName(), info.MountDir())
 				if _, err := exec.Command("umount", "-d", "-l", info.MountDir()).CombinedOutput(); err != nil {
 					return err
+				}
+				// Remove early mount for the kernel snap
+				// TODO we need something like EarlyKernelPlaceInfo
+				// to avoid repeating the kernel-snaps path.
+				if tp, _ := snapSt.Type(); tp == snap.TypeKernel {
+					earlyMntPt := filepath.Join("/run/mnt/kernel-snaps",
+						info.RealName, info.Revision.String())
+					if _, err := exec.Command("umount", "-d", "-l",
+						earlyMntPt).CombinedOutput(); err != nil {
+						return err
+					}
 				}
 			}
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4826,6 +4826,7 @@ const (
 	noConfigure = 1 << iota
 	isGadget
 	isKernel
+	hasModeenv
 )
 
 func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags int) int {
@@ -4836,6 +4837,10 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 		what := "gadget"
 		if flags&isKernel != 0 {
 			what = "kernel"
+		}
+		if flags&isKernel != 0 && flags&hasModeenv != 0 {
+			c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup kernel driver tree for "%s" (%s)`, name, revno))
+			i++
 		}
 		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Update assets from %s "%s" (%s)`, what, name, revno))
 		i++
@@ -4850,6 +4855,10 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Make snap "%s" (%s) available to the system`, name, revno))
 	i++
+	if flags&isKernel != 0 && flags&hasModeenv != 0 {
+		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Cleanup kernel driver tree for "%s" (%s)`, name, revno))
+		i++
+	}
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set automatic aliases for snap "%s"`, name))
@@ -4890,6 +4899,10 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 		if flags&isKernel != 0 {
 			what = "kernel"
 		}
+		if flags&isKernel != 0 && flags&hasModeenv != 0 {
+			c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup kernel driver tree for "%s" (%s)`, name, revno))
+			i++
+		}
 		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Update assets from %s %q (%s)`, what, name, revno))
 		i++
 	}
@@ -4905,6 +4918,10 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
 	i++
+	if flags&isKernel != 0 && flags&hasModeenv != 0 {
+		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Cleanup kernel driver tree for "%s" (%s)`, name, revno))
+		i++
+	}
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set automatic aliases for snap "%s"`, name))
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup snap "%s" aliases`, name))
@@ -7918,7 +7935,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all installs in sequential order
-	validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
+	validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
 }
 
 func (s *mgrsSuiteCore) TestRemodelUC20DifferentGadgetChannel(c *C) {
@@ -9574,7 +9591,7 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all refreshes and install in sequential order (no configure hooks for bases though)
-	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
+	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
 	i += validateInstallTasks(c, tasks[i:], "core22", "1", noConfigure)
 	i += validateRefreshTasks(c, tasks[i:], "pc", "34", isGadget)
 	// finally new model assertion
@@ -9886,7 +9903,7 @@ func (s *mgrsSuiteCore) testRemodelUC20ToUC22(c *C, mockSnapdRefresh bool) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all refreshes and install in sequential order (no configure hooks for bases though)
-	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
+	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
 	i += validateInstallTasks(c, tasks[i:], "core22", "1", noConfigure)
 	i += validateRefreshTasks(c, tasks[i:], "pc", "34", isGadget)
 	// finally new model assertion

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -73,6 +73,7 @@ type StoreService interface {
 type managerBackend interface {
 	// install related
 	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev snap.Device, opts *backend.SetupSnapOptions, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
+	SetupKernelSnap(instanceName string, rev snap.Revision, meter progress.Meter) (err error)
 	SetupComponent(compFilePath string, compPi snap.ContainerPlaceInfo, dev snap.Device, meter progress.Meter) (installRecord *backend.InstallRecord, err error)
 	CopySnapData(newSnap, oldSnap *snap.Info, opts *dirs.SnapDirOptions, meter progress.Meter) error
 	SetupSnapSaveData(info *snap.Info, dev snap.Device, meter progress.Meter) error
@@ -102,6 +103,7 @@ type managerBackend interface {
 	DiscardSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string) error
 	RemoveAllSnapAppArmorProfiles() error
+	RemoveKernelSnapSetup(instanceName string, rev snap.Revision, meter progress.Meter) error
 
 	// alias related
 	UpdateAliases(add []*backend.Alias, remove []*backend.Alias) error

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -26,9 +26,12 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 )
 
 // InstallRecord keeps a record of what installation effectively did as hints
@@ -109,6 +112,67 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 
 	installRecord = &InstallRecord{TargetSnapExisted: didNothing}
 	return t, installRecord, nil
+}
+
+func earlyKernelMountDir(ksnapName string, rev snap.Revision) string {
+	return filepath.Join("/run/mnt/kernel-snaps", ksnapName, rev.String())
+}
+
+// SetupKernelSnap does extra configuration for kernel snaps.
+func (b Backend) SetupKernelSnap(instanceName string, rev snap.Revision, meter progress.Meter) (err error) {
+	var sysd systemd.Systemd
+	if b.preseed {
+		sysd = systemd.NewEmulationMode(dirs.GlobalRootDir)
+	} else {
+		sysd = systemd.New(systemd.SystemMode, meter)
+	}
+
+	// Create early mount for the snap
+	cpi := snap.MinimalSnapContainerPlaceInfo(instanceName, rev)
+
+	earlyMountDir := earlyKernelMountDir(instanceName, rev)
+	addMountUnitOptions := &systemd.MountUnitOptions{
+		MountUnitType: systemd.BeforeDriversLoadMountUnit,
+		Lifetime:      systemd.Persistent,
+		Description:   "Early mount unit for kernel snap",
+		What:          cpi.MountFile(),
+		Where:         earlyMountDir,
+		Fstype:        "squashfs",
+		Options:       []string{"nodev,ro,x-gdu.hide,x-gvfs-hide"},
+	}
+	_, err = sysd.EnsureMountUnitFileWithOptions(addMountUnitOptions)
+	if err != nil {
+		return fmt.Errorf("cannot create mount in %q: %w", earlyMountDir, err)
+	}
+
+	// Clean-up mount if the kernel tree cannot be built
+	defer func() {
+		if err == nil {
+			return
+		}
+		if e := sysd.RemoveMountUnitFile(filepath.Join(dirs.GlobalRootDir, earlyMountDir)); e != nil {
+			meter.Notify(fmt.Sprintf("while trying to clean up due to previous failure: %v", e))
+		}
+	}()
+
+	// Build kernel tree that will be mounted from initramfs
+	return kernel.EnsureKernelDriversTree(instanceName, rev, filepath.Join(dirs.GlobalRootDir, earlyMountDir))
+}
+
+func (b Backend) RemoveKernelSnapSetup(instanceName string, rev snap.Revision, meter progress.Meter) error {
+	if err := kernel.RemoveKernelDriversTree(instanceName, rev); err != nil {
+		return err
+	}
+
+	var sysd systemd.Systemd
+	if b.preseed {
+		sysd = systemd.NewEmulationMode(dirs.GlobalRootDir)
+	} else {
+		sysd = systemd.New(systemd.SystemMode, meter)
+	}
+
+	earlyMountDir := earlyKernelMountDir(instanceName, rev)
+	return sysd.RemoveMountUnitFile(filepath.Join(dirs.GlobalRootDir, earlyMountDir))
 }
 
 // SetupComponent prepares and mounts a component for further processing.

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -902,6 +902,22 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *sna
 	return snapType, &backend.InstallRecord{}, nil
 }
 
+func (f *fakeSnappyBackend) SetupKernelSnap(instanceName string, rev snap.Revision, meter progress.Meter) (err error) {
+	meter.Notify("setup-kernel-snap")
+	f.appendOp(&fakeOp{
+		op: "setup-kernel-snap",
+	})
+	return nil
+}
+
+func (f *fakeSnappyBackend) RemoveKernelSnapSetup(instanceName string, rev snap.Revision, meter progress.Meter) error {
+	meter.Notify("remove-kernel-snap-setup")
+	f.appendOp(&fakeOp{
+		op: "remove-kernel-snap-setup",
+	})
+	return nil
+}
+
 func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.ContainerPlaceInfo, dev snap.Device, meter progress.Meter) (installRecord *backend.InstallRecord, err error) {
 	meter.Notify("setup-component")
 	f.appendOp(&fakeOp{

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4814,3 +4814,162 @@ var getDirMigrationOpts = func(st *state.State, snapst *SnapState, snapsup *Snap
 
 	return opts, nil
 }
+
+func (m *SnapManager) doSetupKernelSnap(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(t)
+	snapsup, snapSt, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	st.Unlock()
+	pm := NewTaskProgressAdapterUnlocked(t)
+	timings.Run(perfTimings, "setup-kernel-snap",
+		fmt.Sprintf("setup of kernel snap %q", snapsup.InstanceName()),
+		func(timings.Measurer) {
+			err = m.backend.SetupKernelSnap(
+				snapsup.InstanceName(), snapsup.Revision(), pm)
+		})
+	st.Lock()
+	if err != nil {
+		return err
+	}
+
+	perfTimings.Save(st)
+
+	// Needed so the old drivers tree can be removed later
+	prevRev := snapSt.Current
+	t.Change().Set("previous-kernel-rev", prevRev)
+
+	// Make sure we won't be rerun
+	t.SetStatus(state.DoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) undoSetupKernelSnap(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(t)
+	snapsup, _, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	st.Unlock()
+	pm := NewTaskProgressAdapterUnlocked(t)
+	timings.Run(perfTimings, "remove-kernel-snap-setup",
+		fmt.Sprintf("remove kernel snap setup %q", snapsup.InstanceName()),
+		func(timings.Measurer) {
+			err = m.backend.RemoveKernelSnapSetup(
+				snapsup.InstanceName(), snapsup.Revision(), pm)
+		})
+	st.Lock()
+	if err != nil {
+		return err
+	}
+
+	perfTimings.Save(st)
+	// Make sure we won't be rerun
+	t.SetStatus(state.UndoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) doCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(t)
+	_, snapst, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	currInfo, err := snapst.CurrentInfo()
+	if err != nil {
+		return err
+	}
+
+	// This is stored by doSetupKernelSnap - now after the reboot triggered
+	// after linking the new snap, we can remove the old drivers tree.
+	var prevRev snap.Revision
+	err = t.Change().Get("previous-kernel-rev", &prevRev)
+	if err != nil {
+		return err
+	}
+
+	// Might be unset on first installation
+	if !prevRev.Unset() {
+		st.Unlock()
+		pm := NewTaskProgressAdapterUnlocked(t)
+		timings.Run(perfTimings, "remove-old-kernel-snap-setup",
+			fmt.Sprintf("cleanup of previous kernel snap %q", currInfo.InstanceName()),
+			func(timings.Measurer) {
+				err = m.backend.RemoveKernelSnapSetup(
+					currInfo.InstanceName(), prevRev, pm)
+			})
+		st.Lock()
+		if err != nil {
+			return err
+		}
+	}
+
+	perfTimings.Save(st)
+	// Make sure we won't be rerun
+	t.SetStatus(state.DoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) undoCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(t)
+	_, snapst, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	currInfo, err := snapst.CurrentInfo()
+	if err != nil {
+		return err
+	}
+
+	// Now we must re-do the previous revision kernel drivers tree
+	var prevRev snap.Revision
+	err = t.Change().Get("previous-kernel-rev", &prevRev)
+	if err != nil {
+		return err
+	}
+
+	if !prevRev.Unset() {
+		st.Unlock()
+		pm := NewTaskProgressAdapterUnlocked(t)
+		timings.Run(perfTimings, "undo-remove-old-kernel-snap-setup",
+			fmt.Sprintf("undo cleanup of previous kernel snap %q", currInfo.InstanceName()),
+			func(timings.Measurer) {
+				err = m.backend.SetupKernelSnap(
+					currInfo.InstanceName(), prevRev, pm)
+			})
+		st.Lock()
+		if err != nil {
+			return err
+		}
+	}
+
+	perfTimings.Save(st)
+	// Make sure we won't be rerun
+	t.SetStatus(state.UndoneStatus)
+
+	return nil
+}

--- a/overlord/snapstate/handlers_setup_kernel_test.go
+++ b/overlord/snapstate/handlers_setup_kernel_test.go
@@ -1,0 +1,215 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+type setupKernelSnapSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&setupKernelSnapSuite{})
+
+func (s *setupKernelSnapSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+}
+
+func (s *setupKernelSnapSuite) TestSetupKernelSnap(c *C) {
+	v1 := "name: mykernel\nversion: 1.0\ntype: kernel\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+
+	t := s.state.NewTask("setup-kernel-snap", "test kernel setup")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "mykernel",
+			Revision: snap.R(33),
+		},
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), IsNil)
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	var prevRev snap.Revision
+	c.Check(chg.Get("previous-kernel-rev", &prevRev), IsNil)
+	c.Check(prevRev, Equals, snap.R(0))
+	s.state.Unlock()
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "setup-kernel-snap",
+		},
+	})
+}
+
+func (s *setupKernelSnapSuite) TestUndoSetupKernelSnap(c *C) {
+	v1 := "name: mykernel\nversion: 1.0\ntype: kernel\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+
+	t := s.state.NewTask("setup-kernel-snap", "test kernel setup")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "mykernel",
+			Revision: snap.R(33),
+		},
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+	terr := s.state.NewTask("error-trigger", "provoking undo kernel setup")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	c.Check(chg.Err(), ErrorMatches, `(?s).*provoking undo kernel setup.*`)
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	var prevRev snap.Revision
+	c.Check(chg.Get("previous-kernel-rev", &prevRev), IsNil)
+	c.Check(prevRev, Equals, snap.R(0))
+	s.state.Unlock()
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "setup-kernel-snap",
+		},
+		{
+			op: "remove-kernel-snap-setup",
+		},
+	})
+}
+
+func (s *setupKernelSnapSuite) TestRemoveKernelSnapSetup(c *C) {
+	v1 := "name: mykernel\nversion: 1.0\ntype: kernel\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+
+	snapstate.Set(s.state, "mykernel", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "mykernel", Revision: snap.R(33)},
+		}),
+		Current: snap.R(33),
+		UserID:  1,
+	})
+	t := s.state.NewTask("remove-old-kernel-snap-setup", "test remove kernel set-up")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "mykernel",
+			Revision: snap.R(33),
+		},
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+	chg.Set("previous-kernel-rev", snap.R(33))
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), IsNil)
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	s.state.Unlock()
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "remove-kernel-snap-setup",
+		},
+	})
+}
+
+func (s *setupKernelSnapSuite) TestUndoRemoveKernelSnapSetup(c *C) {
+	v1 := "name: mykernel\nversion: 1.0\ntype: kernel\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+
+	snapstate.Set(s.state, "mykernel", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "mykernel", Revision: snap.R(33)},
+		}),
+		Current: snap.R(33),
+		UserID:  1,
+	})
+	t := s.state.NewTask("remove-old-kernel-snap-setup", "test kernel setup")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "mykernel",
+			Revision: snap.R(33),
+		},
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+	terr := s.state.NewTask("error-trigger", "provoking undo kernel cleanup")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+	chg.Set("previous-kernel-rev", snap.R(33))
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	c.Check(chg.Err(), ErrorMatches, `(?s).*provoking undo kernel cleanup.*`)
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	s.state.Unlock()
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "remove-kernel-snap-setup",
+		},
+		{
+			op: "setup-kernel-snap",
+		},
+	})
+}

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -1,8 +1,6 @@
 package snapstate
 
 import (
-	"errors"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
@@ -36,22 +34,4 @@ func inUseFor(deviceCtx DeviceContext) func(snap.Type) (boot.InUseFunc, error) {
 	return func(typ snap.Type) (boot.InUseFunc, error) {
 		return boot.InUse(typ, deviceCtx)
 	}
-}
-
-func isCoreBootDevice(st *state.State) (bool, error) {
-	// TODO: turn this into a function that takes a DeviceContext
-	// that can be nil (TransitionCore case)
-
-	// Use device context just to find out if this is a core boot device.
-	// state.ErrNoState is returned if we cannot find the model,
-	// which can happen on classic when upgrading from ubuntu-core
-	// to core snap (model is set later).
-	deviceCtx, err := DeviceCtx(st, nil, nil)
-	if err != nil {
-		if !errors.Is(err, state.ErrNoState) {
-			return false, err
-		}
-		return false, nil
-	}
-	return deviceCtx.IsCoreBoot(), nil
 }

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -96,8 +96,11 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 			"run-hook[pre-refresh]",
 			"stop-snap-services",
 			"remove-aliases",
-			"unlink-current-snap",
 		)
+		expected = append(expected, "unlink-current-snap")
+	}
+	if opts&updatesGadgetAssets != 0 && opts&hasModeenv != 0 {
+		expected = append(expected, "setup-kernel-snap")
 	}
 	if opts&(updatesGadget|updatesGadgetAssets) != 0 {
 		expected = append(expected, "update-gadget-assets")
@@ -109,7 +112,11 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
-		"auto-connect",
+		"auto-connect")
+	if opts&updatesGadgetAssets != 0 && opts&hasModeenv != 0 {
+		expected = append(expected, "remove-old-kernel-snap-setup")
+	}
+	expected = append(expected,
 		"set-auto-aliases",
 		"setup-aliases")
 	if opts&preferInstalled != 0 {

--- a/snap/types.go
+++ b/snap/types.go
@@ -188,12 +188,12 @@ type ComponentType string
 
 const (
 	// TestComponent is just for testing purposes.
-	// TODO add here new component when there is more progress on the
-	// components implementation.
 	TestComponent ComponentType = "test"
+	// KernelModulesComponent is for components containing modules/firmware
+	KernelModulesComponent ComponentType = "kernel-modules"
 )
 
-var validComponentTypes = [...]ComponentType{TestComponent}
+var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesComponent}
 
 // Component represents a snap component.
 type Component struct {

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -141,6 +141,10 @@ execute: |
   MATCH "^etc/systemd/system/getty.target.wants/getty@tty1.service" < files.log
   MATCH "^etc/systemd/system/snapd.failure.service" < files.log
 
+  # tar tf already escapes '\', so we need to double escape it here
+  MATCH '^etc/systemd/system/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
+  MATCH '^etc/systemd/system/sysinit.target.wants/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
+
   MATCH "^snap/pc-kernel/current" < files.log
   MATCH "^snap/core20/current" < files.log
   MATCH "^snap/snapd/current" < files.log
@@ -166,6 +170,9 @@ execute: |
   MATCH "^var/lib/snapd/assertions/asserts-v0/model/16/developer1/testkeys-snapd-dangerous-core-20-amd64/" < files.log
   MATCH "^var/lib/snapd/assertions/asserts-v0/snap-revision/.*" < files.log
   MATCH "^var/lib/snapd/assertions/asserts-v0/account-key/.*" < files.log
+
+  MATCH "^var/lib/snapd/kernel/.*/lib/modules/.*" < files.log
+  MATCH "^var/lib/snapd/kernel/.*/lib/firmware/.*" < files.log
 
   MATCH "^var/lib/extrausers/group" < files.log
   MATCH "^var/lib/extrausers/passwd" < files.log


### PR DESCRIPTION
On kernel snap installation, a drivers tree is now created so it can
be mounted on early boot stages. This is needed to support
kernel-modules components.