### PR TITLE
o/snapstate: assorted typos

### DIFF
--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -358,9 +358,9 @@ func (s *quotaControlSuite) TestCreateQuotaJournalNotEnabled(c *C) {
 	tr.Set("core", "experimental.quota-groups", false)
 	tr.Commit()
 
-	quotaConstraits := quota.NewResourcesBuilder().WithJournalNamespace().Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithJournalNamespace().Build()
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
 }
@@ -373,9 +373,9 @@ func (s *quotaControlSuite) TestCreateQuotaJournalEnabled(c *C) {
 	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()
 
-	quotaConstraits := quota.NewResourcesBuilder().WithJournalNamespace().Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithJournalNamespace().Build()
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 }
@@ -477,12 +477,12 @@ func (s *quotaControlSuite) TestCreateUnhappyCheckFeatureReqs(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota constraints to use for the test
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 
 	// create the quota group
 	_, err := servicestate.CreateQuota(st, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Check(err, ErrorMatches, `cannot create quota group "foo": check feature requirements error`)
 }
@@ -503,12 +503,12 @@ func (s *quotaControlSuite) TestUpdateUnhappyCheckFeatureReqs(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota constraints to use for the test
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 
 	// create the quota group
 	ts, err := servicestate.CreateQuota(st, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 	chg := st.NewChange("quota-control", "...")
@@ -526,7 +526,7 @@ func (s *quotaControlSuite) TestUpdateUnhappyCheckFeatureReqs(c *C) {
 	})
 	defer r()
 
-	_, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: quotaConstraits})
+	_, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: quotaConstraints})
 	c.Check(err, ErrorMatches, `cannot update group "foo": check feature requirements error`)
 }
 
@@ -561,12 +561,12 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota constraints to use for the test
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 
 	// create the quota group
 	ts, err := servicestate.CreateQuota(st, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 	c.Check(resCheckFeatureRequirementsCalled, Equals, 1)
@@ -578,7 +578,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -593,14 +593,14 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quotaConstraits,
+			ResourceLimits: quotaConstraints,
 			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// increase the memory limit
-	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
-	ts, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraits})
+	newConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	ts, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraints})
 	c.Assert(err, IsNil)
 	c.Check(resCheckFeatureRequirementsCalled, Equals, 2)
 
@@ -610,7 +610,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	exp2 := &servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: newConstraits,
+		ResourceLimits: newConstraints,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -624,7 +624,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: newConstraits,
+			ResourceLimits: newConstraints,
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -694,10 +694,10 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	ts1, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap", "test-snap2"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 
@@ -707,7 +707,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 
 	// run the change
@@ -746,7 +746,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quotaConstraits,
+			ResourceLimits: quotaConstraints,
 			Snaps:          []string{"test-snap", "test-snap2"},
 			SubGroups:      []string{"foo2"},
 		},
@@ -763,7 +763,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quotaConstraits,
+			ResourceLimits: quotaConstraints,
 			Snaps:          []string{"test-snap2"},
 			SubGroups:      []string{"foo2"},
 		},
@@ -784,7 +784,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quotaConstraits,
+			ResourceLimits: quotaConstraints,
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
@@ -821,18 +821,18 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraits)
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraints)
 	c.Assert(err, IsNil)
 
-	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	newConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	tests := []struct {
 		name string
 		opts servicestate.UpdateQuotaOptions
 		err  string
 	}{
 		{"what", servicestate.UpdateQuotaOptions{}, `group "what" does not exist`},
-		{"foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraints}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}, AddServices: []string{"baz.svc"}}, `cannot mix services and snaps in the same quota group`},
 		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz"}}, `invalid snap service: baz`},
@@ -850,12 +850,12 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	quotaConstraits2GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraits2GB)
+	quotaConstraints2GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraints2GB)
 	c.Assert(err, IsNil)
 
-	quotaConstraits1GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quotaConstraits1GB)
+	quotaConstraints1GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quotaConstraints1GB)
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -909,8 +909,8 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -935,10 +935,10 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	_, err = servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
@@ -960,8 +960,8 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -981,10 +981,10 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	ts, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
@@ -1021,8 +1021,8 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -1050,8 +1050,8 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -1079,8 +1079,8 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -1129,16 +1129,16 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
-	_, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraits})
+	newConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	_, err = servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraints})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
@@ -1169,8 +1169,8 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -1208,8 +1208,8 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	s.createQuota(c, "foo", quotaConstraits, "test-snap")
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraints, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -1239,10 +1239,10 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	quotaConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	ts, err := servicestate.CreateQuota(st, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap"},
-		ResourceLimits: quotaConstraits,
+		ResourceLimits: quotaConstraints,
 	})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -354,7 +354,7 @@ func checkAliasesConflicts(st *state.State, snapName string, candAutoDisabled bo
 }
 
 // checkSnapAliasConflict checks whether instanceName and its command
-// namepsace conflicts against installed snap aliases.
+// namespace conflicts against installed snap aliases.
 func checkSnapAliasConflict(st *state.State, instanceName string) error {
 	prefix := fmt.Sprintf("%s.", instanceName)
 	snapStates, err := All(st)

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -834,7 +834,7 @@ func (s *snapdOnCoreUnlinkSuite) TestUndoGeneratedWrappers(c *C) {
 	c.Assert(err, IsNil)
 
 	info, snapdUnits := mockSnapdSnapForLink(c)
-	// all generated untis
+	// all generated units
 	generatedSnapdUnits := append(snapdUnits,
 		[]string{"usr-lib-snapd.mount", "mount unit"})
 
@@ -852,7 +852,7 @@ func (s *snapdOnCoreUnlinkSuite) TestUndoGeneratedWrappers(c *C) {
 	// validity checks
 	c.Check(filepath.Join(dirs.SnapServicesDir, "snapd.service"), testutil.FileContains,
 		fmt.Sprintf("[Service]\nExecStart=%s/usr/lib/snapd/snapd\n", info.MountDir()))
-	// expecting all generated untis to be present
+	// expecting all generated units to be present
 	for _, entry := range generatedSnapdUnits {
 		c.Check(toEtcUnitPath(entry[0]), testutil.FilePresent)
 	}

--- a/overlord/snapstate/backend/locking_test.go
+++ b/overlord/snapstate/backend/locking_test.go
@@ -43,7 +43,7 @@ func (s *lockingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
 
-func (s *lockingSuite) TestRunInhibitSnapForUnlinkPositiveDescision(c *C) {
+func (s *lockingSuite) TestRunInhibitSnapForUnlinkPositiveDecision(c *C) {
 	const yaml = `name: snap-name
 version: 1
 `

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -346,7 +346,7 @@ func CheckUpdateKernelCommandLineConflict(st *state.State, ignoreChangeID string
 			}
 		case "update-managed-boot-config":
 			return &ChangeConflictError{
-				Message:    "boot config is being updated, no change in kernel commnd line is allowed meanwhile",
+				Message:    "boot config is being updated, no change in kernel command line is allowed meanwhile",
 				ChangeKind: task.Kind(),
 				ChangeID:   chg.ID(),
 			}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1520,7 +1520,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	// undo migration-related state changes (set in doLinkSnap). The respective
 	// file migrations are undone either above or in undoCopySnapData. State
 	// should only be set in tasks that link the snap for safety and consistency.
-	setMigrationFlagsinState(snapst, snapsup)
+	setMigrationFlagsInState(snapst, snapsup)
 
 	if err := writeMigrationStatus(t, snapst, snapsup); err != nil {
 		return err
@@ -2089,7 +2089,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// don't keep the old state because, if we fail, we may or may not be able to
 	// revert the migration. We set the migration status after undoing any
 	// migration related ops
-	setMigrationFlagsinState(snapst, snapsup)
+	setMigrationFlagsInState(snapst, snapsup)
 
 	newInfo, err := readInfo(snapsup.InstanceName(), cand.Snap, 0)
 	if err != nil {
@@ -2336,7 +2336,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	}
 }
 
-func setMigrationFlagsinState(snapst *SnapState, snapsup *SnapSetup) {
+func setMigrationFlagsInState(snapst *SnapState, snapsup *SnapSetup) {
 	if snapsup.MigratedHidden {
 		snapst.MigratedHidden = true
 	} else if snapsup.UndidHiddenMigration {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2888,7 +2888,7 @@ func installModeDisabledServices(st *state.State, snapst *SnapState, currentInfo
 		enabledByHookSvcs[svcName] = true
 	}
 
-	// find what servies the previous snap had
+	// find what services the previous snap had
 	prevCurrentSvcs := map[string]bool{}
 	if psi := snapst.previousSideInfo(); psi != nil {
 		var prevCurrentInfo *snap.Info

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4666,7 +4666,7 @@ var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSn
 		// if we hit ValidationSetsValidationError but it's not about wrong revisions,
 		// then something is really broken (we shouldn't have invalid or missing required
 		// snaps at this point).
-		return nil, fmt.Errorf("internal error: unexpected validation error of installed snaps after unsuccesfull refresh: %v", verr)
+		return nil, fmt.Errorf("internal error: unexpected validation error of installed snaps after unsuccessful refresh: %v", verr)
 	}
 
 	wrongRevSnaps := func() []string {

--- a/overlord/snapstate/progress_test.go
+++ b/overlord/snapstate/progress_test.go
@@ -68,7 +68,7 @@ func (s *progressAdapterTestSuite) TestProgressAdapterSetTaskProgress(c *C) {
 	// we expect 1000 bytes
 	m.Start("msg", 1000)
 
-	// write a single byte (0.1% of the toal)
+	// write a single byte (0.1% of the total)
 	m.Write([]byte("1"))
 
 	// check that the progress is not updated yet

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1104,7 +1104,7 @@ func ensureInstallPreconditions(st *state.State, info *snap.Info, flags Flags, s
 type PrereqTracker interface {
 	// Add adds a snap for tracking.
 	Add(*snap.Info)
-	// MissingProviderContetTags returns a map keyed by the names of all
+	// MissingProviderContentTags returns a map keyed by the names of all
 	// missing default-providers for the content plugs that the given
 	// snap.Info needs. The map values are the corresponding content tags.
 	// Different prerequisites trackers might decide in different

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -769,7 +769,7 @@ func (s *snapmgrTestSuite) TestGadgetInstallConflict(c *C) {
 
 	_, err := snapstate.Install(context.Background(), s.state, "brand-gadget",
 		nil, 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, "boot config is being updated, no change in kernel commnd line is allowed meanwhile")
+	c.Assert(err, ErrorMatches, "boot config is being updated, no change in kernel command line is allowed meanwhile")
 }
 
 func (s *snapmgrTestSuite) TestInstallNoRestartBoundaries(c *C) {


### PR DESCRIPTION
Random collection of typos from today and yesterday, as I was browsing through snapstate. Bulk of changes are in comments but a few affect non-test methods or tested messages.