### PR TITLE
.github: update golangci-lint version to v1.55.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,7 +154,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.51.2
+        version: v1.55.2
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work


### PR DESCRIPTION
Backport https://github.com/snapcore/snapd/pull/13422 to 2.61, bumping the golangci-lint version. The 2.61 release branch is showing some vetting failures that are similar to the ones we had on master a while ago and were fixed by bumping up the golangci version (https://github.com/snapcore/snapd/commits/master/?after=3c938060718edd4eab8f68042b5c924c80d4c7dd+139)