### PR TITLE
daemon: add `snap-names` data field to single-snap changes

### DIFF
--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -336,7 +336,10 @@ func sideloadSnap(st *state.State, snapFile *uploadedSnap, flags sideloadFlags) 
 
 	msg := fmt.Sprintf(i18n.G("Install %q %s from file %q"), instanceName, container, snapFile.filename)
 	chg := newChange(st, "install-"+container, msg, []*state.TaskSet{tset}, []string{instanceName})
-	apiData := map[string]string{"snap-name": instanceName}
+	apiData := map[string]interface{}{
+		"snap-name":  instanceName,
+		"snap-names": []string{instanceName},
+	}
 	if compInfo != nil {
 		apiData["component-name"] = compInfo.Component.ComponentName
 	}
@@ -578,7 +581,10 @@ func trySnap(st *state.State, trydir string, flags snapstate.Flags) Response {
 
 	msg := fmt.Sprintf(i18n.G("Try %q snap from %s"), info.InstanceName(), trydir)
 	chg := newChange(st, "try-snap", msg, []*state.TaskSet{tset}, []string{info.InstanceName()})
-	chg.Set("api-data", map[string]string{"snap-name": info.InstanceName()})
+	chg.Set("api-data", map[string]interface{}{
+		"snap-name":  info.InstanceName(),
+		"snap-names": []string{info.InstanceName()},
+	})
 
 	ensureStateSoon(st)
 

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -261,7 +261,8 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
 	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"snap-name": expectedInstanceName,
+		"snap-name":  expectedInstanceName,
+		"snap-names": []interface{}{expectedInstanceName},
 	})
 
 	summary = chg.Summary()
@@ -486,6 +487,7 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 	c.Assert(err, check.IsNil)
 	c.Check(apiData, check.DeepEquals, map[string]interface{}{
 		"snap-name":      expectedInstanceName,
+		"snap-names":     []interface{}{expectedInstanceName},
 		"component-name": expectedCompSideInfo.Component.ComponentName,
 	})
 
@@ -621,7 +623,8 @@ version: 1`, nil)
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
 	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"snap-name": "foo",
+		"snap-name":  "foo",
+		"snap-names": []interface{}{"foo"},
 	})
 }
 
@@ -1337,7 +1340,8 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 		err = chg.Get("api-data", &apiData)
 		c.Assert(err, check.IsNil, check.Commentf(t.desc))
 		c.Check(apiData, check.DeepEquals, map[string]interface{}{
-			"snap-name": "foo",
+			"snap-name":  "foo",
+			"snap-names": []interface{}{"foo"},
 		}, check.Commentf(t.desc))
 
 		c.Check(soon, check.Equals, 1, check.Commentf(t.desc))

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -158,6 +158,8 @@ func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 		chg.Set("system-restart-immediate", true)
 	}
 
+	chg.Set("api-data", map[string]interface{}{"snap-names": inst.Snaps})
+
 	ensureStateSoon(st)
 
 	return AsyncResponse(nil, chg.ID())
@@ -675,9 +677,9 @@ func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {
 		chg.Set("system-restart-immediate", true)
 	}
 
-	ensureStateSoon(st)
-
 	chg.Set("api-data", map[string]interface{}{"snap-names": res.Affected})
+
+	ensureStateSoon(st)
 
 	return AsyncResponse(res.Result, chg.ID())
 }

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1556,6 +1556,10 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 	c.Check(soon, check.Equals, 1)
 	c.Check(chg.Tasks()[0].Summary(), check.Equals, "Doing a fake install")
 
+	var apiData map[string]interface{}
+	c.Check(chg.Get("api-data", &apiData), check.IsNil)
+	c.Check(apiData["snap-names"], check.DeepEquals, []interface{}{"foo"})
+
 	summary = chg.Summary()
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
 	if err != nil && !errors.Is(err, state.ErrNoState) {


### PR DESCRIPTION
This information is needed to allow api clients to associate single-snap changes with the relevant snap as mentioned in [RAA-UX spec](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.c40tauj2e3fo).

This field is already present in multi-snap changes.

NOTE: I am bit hesitant between `snap-names` and `snap-name`. It seems that the `snap-name` convention is used for side-loading a single snap or trying a single snap, everywhere else `snap-names` is used. I am open to suggestions and discussions.