### PR TITLE
data/selinux: add missing polkitd permission for snappy_t/snappy_cli_t

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -408,6 +408,7 @@ gen_require(`
     type policykit_exec_t;
 ')
 allow snappy_t policykit_auth_exec_t:file { getattr };
+allow snappy_t policykit_exec_t:file { getattr };
 allow snappy_cli_t policykit_exec_t:file { getattr };
 allow snappy_cli_t policykit_auth_exec_t:file { getattr };
 

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -405,7 +405,7 @@ allow snappy_t unconfined_t:file { open read };
 # Allow snapd to get file attributes in policykit{,_auth}_exec_t domain
 gen_require(`
     type policykit_auth_exec_t;
-	type policykit_exec_t;
+    type policykit_exec_t;
 ')
 allow snappy_t policykit_auth_exec_t:file { getattr };
 allow snappy_cli_t policykit_exec_t:file { getattr };

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -402,11 +402,13 @@ allow snappy_t var_t:sock_file unlink;
 allow snappy_t unconfined_t:dir search;
 allow snappy_t unconfined_t:file { open read };
 
-# Allow snapd to get file attributes in policykit_auth_exec_t domain
+# Allow snapd to get file attributes in policykit{,_auth}_exec_t domain
 gen_require(`
     type policykit_auth_exec_t;
+	type policykit_exec_t;
 ')
 allow snappy_t policykit_auth_exec_t:file { getattr };
+allow snappy_cli_t policykit_exec_t:file { getattr };
 allow snappy_cli_t policykit_auth_exec_t:file { getattr };
 
 # the release package calls stat() on /proc/sys/fs/binfmt_misc/WSLInterop to

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -407,8 +407,8 @@ gen_require(`
     type policykit_auth_exec_t;
     type policykit_exec_t;
 ')
-allow snappy_t policykit_auth_exec_t:file { getattr };
 allow snappy_t policykit_exec_t:file { getattr };
+allow snappy_t policykit_auth_exec_t:file { getattr };
 allow snappy_cli_t policykit_exec_t:file { getattr };
 allow snappy_cli_t policykit_auth_exec_t:file { getattr };
 


### PR DESCRIPTION
I had not updated the selinux profile to include the new polkitd path. So this is needed to fix the AVC denial

```
Error: 2024-02-07 06:48:20 Error executing google:fedora-38-64:tests/main/selinux-classic-confinement (feb070555-725780) : 
-----
+ snap install --dangerous --classic test-snapd-classic-service-hooks_1.0_all.snap
test-snapd-classic-service-hooks 1.0 installed
+ ausearch -i --checkpoint stamp --start checkpoint -m AVC
+ MATCH 'no matches'
grep error: pattern not found, got:
----
type=AVC msg=audit(02/07/24 06:48:18.930:22938) : avc:  denied  { getattr } for  pid=113984 comm=snap path=/usr/lib/polkit-1/polkitd dev="sda5" ino=113733 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:policykit_exec_t:s0 tclass=file permissive=1
-----
```