### PR TITLE
aspects: make aspect a map with a list of rules

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -183,14 +183,17 @@ func NewBundle(account string, bundleName string, aspects map[string]interface{}
 	}
 
 	for name, v := range aspects {
-		accessPatterns, ok := v.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("cannot define aspect %q: access patterns should be a list of maps", name)
-		} else if len(accessPatterns) == 0 {
-			return nil, fmt.Errorf("cannot define aspect %q: no access patterns found", name)
+		aspectMap, ok := v.(map[string]interface{})
+		if !ok || len(aspectMap) == 0 {
+			return nil, fmt.Errorf("cannot define aspect %q: aspect must be non-empty map", name)
 		}
 
-		aspect, err := newAspect(aspectBundle, name, accessPatterns)
+		rules, ok := aspectMap["rules"].([]interface{})
+		if !ok || len(rules) == 0 {
+			return nil, fmt.Errorf("cannot define aspect %q: aspect rules must be non-empty list", name)
+		}
+
+		aspect, err := newAspect(aspectBundle, name, rules)
 		if err != nil {
 			return nil, fmt.Errorf("cannot define aspect %q: %w", name, err)
 		}

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -64,11 +64,11 @@ func (*aspectSuite) TestNewAspectBundle(c *C) {
 		},
 		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{"a"}}},
-			err:    `cannot define aspect "bar": each access pattern should be a map`,
+			err:    `cannot define aspect "bar": each aspect rule should be a map`,
 		},
 		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{}}}},
-			err:    `cannot define aspect "bar": access patterns must have a "request" field`,
+			err:    `cannot define aspect "bar": aspect rules must have a "request" field`,
 		},
 		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": 1}}}},
@@ -76,7 +76,7 @@ func (*aspectSuite) TestNewAspectBundle(c *C) {
 		},
 		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo"}}}},
-			err:    `cannot define aspect "bar": access patterns must have a "storage" field`,
+			err:    `cannot define aspect "bar": aspect rules must have a "storage" field`,
 		},
 		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": 1}}}},

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -71,8 +71,16 @@ func (*aspectSuite) TestNewAspectBundle(c *C) {
 			err:    `cannot define aspect "bar": access patterns must have a "request" field`,
 		},
 		{
+			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": 1}}}},
+			err:    `cannot define aspect "bar": "request" must be a string`,
+		},
+		{
 			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo"}}}},
 			err:    `cannot define aspect "bar": access patterns must have a "storage" field`,
+		},
+		{
+			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": 1}}}},
+			err:    `cannot define aspect "bar": "storage" must be a string`,
 		},
 		{
 			bundle: map[string]interface{}{
@@ -84,6 +92,10 @@ func (*aspectSuite) TestNewAspectBundle(c *C) {
 				},
 			},
 			err: `cannot define aspect "bar": cannot have several reading rules with the same "request" field`,
+		},
+		{
+			bundle: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": "bar", "access": 1}}}},
+			err:    `cannot define aspect "bar": "access" must be a string`,
 		},
 		{
 			bundle: map[string]interface{}{

--- a/asserts/aspect_bundle_test.go
+++ b/asserts/aspect_bundle_test.go
@@ -117,7 +117,7 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 		{s.tsLine, "", `"timestamp" header is mandatory`},
 		{aspectsStanza, "aspects: foo\n", `"aspects" header must be a map`},
 		{aspectsStanza, "", `"aspects" stanza is mandatory`},
-		{"read-write", "update", `cannot define aspect "wifi-setup": cannot create aspect pattern:.*`},
+		{"read-write", "update", `cannot define aspect "wifi-setup": cannot create aspect rule:.*`},
 		{storageStanza, "", `"storage" stanza is mandatory`},
 		{storageStanza, "storage:\n  - foo\n", `invalid "storage" schema stanza, expected schema text`},
 		{storageStanza, "storage:\n    {}\n", `invalid "storage" schema stanza: cannot parse top level schema: must have a "schema" constraint`},

--- a/asserts/aspect_bundle_test.go
+++ b/asserts/aspect_bundle_test.go
@@ -47,24 +47,25 @@ account-id: brand-id1
 name: my-network
 aspects:
   wifi-setup:
-    -
-      request: ssids
-      storage: wifi.ssids
-    -
-      request: ssid
-      storage: wifi.ssid
-      access: read-write
-    -
-      request: password
-      storage: wifi.psk
-      access: write
-    -
-      request: status
-      storage: wifi.status
-      access: read
-    -
-      request: private.{key}
-      storage: wifi.{key}
+    rules:
+      -
+        request: ssids
+        storage: wifi.ssids
+      -
+        request: ssid
+        storage: wifi.ssid
+        access: read-write
+      -
+        request: password
+        storage: wifi.psk
+        access: write
+      -
+        request: status
+        storage: wifi.status
+        access: read
+      -
+        request: private.{key}
+        storage: wifi.{key}
 storage:
     {
       "schema": {

--- a/overlord/aspectstate/aspecttest/mock_aspect.go
+++ b/overlord/aspectstate/aspecttest/mock_aspect.go
@@ -18,17 +18,19 @@
 
 package aspecttest
 
-// MockWifiSetupAspect returns some mocked aspect access patterns for the
+// MockWifiSetupAspect returns some mocked aspect rules for the
 // system/network/wifi-setup. This will eventually be replaced by proper
 // aspect assertions.
 func MockWifiSetupAspect() map[string]interface{} {
 	return map[string]interface{}{
-		"wifi-setup": []interface{}{
-			map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
-			map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
-			map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
-			map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
-			map[string]interface{}{"request": "private.{placeholder}", "storage": "wifi.{placeholder}"},
+		"wifi-setup": map[string]interface{}{
+			"rules": []interface{}{
+				map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
+				map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
+				map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
+				map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
+				map[string]interface{}{"request": "private.{placeholder}", "storage": "wifi.{placeholder}"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR makes each aspect a map with a mandatory list of rules under the "rules" key instead of just a list of rules. This allows us to add new fields later (like the "summary", which will come after). The 2nd commit adds some new test cases to improve coverage that was missing after the changes to prepare for the schema. The 3rd commit makes the terminology more consistent so we only use "rules" when referring to them and not "access patterns" as we sometimes did.