### PR TITLE
steam_support: allow reading of nvidia version and debian_chroot

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -205,6 +205,8 @@ deny /usr/bin/{chfn,chsh,gpasswd,mount,newgrp,passwd,su,sudo,umount} x,
 /run/host/usr/sbin/ldconfig* ixr,
 /run/host/usr/bin/localedef ixr,
 /var/cache/ldconfig/** rw,
+/sys/module/nvidia/version r,
+/etc/debian_chroot r,
 
 capability sys_admin,
 capability sys_ptrace,


### PR DESCRIPTION
This allows for reading of `/sys/module/nvidia/version` and `/etc/debian_chroot` for the Steam Snap.

In order to properly determine the NVIDIA driver version, Steam needs to be able to read `/sys/module/nvidia/version`. This is a requirement for https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/merge_requests/652. This also would allow us to simplify the [Steam Snap NVIDIA dialog](https://github.com/canonical/steam-snap/blob/main/src/nvidia32) by making the driver version easier to obtain.

`/etc/debian_chroot` is needed to be able to determine container versions from inside Steam [Pressure Vessel](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/main/pressure-vessel) containers, which makes debugging easier.

Additional context: https://github.com/snapcore/snapd/pull/13489#issuecomment-1910935655

Fixes https://github.com/canonical/steam-snap/issues/360
Fixes https://github.com/canonical/steam-snap/issues/361