### PR TITLE
spread, github: disable xdelta for Amazon Linux 2023

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -493,6 +493,15 @@ jobs:
               SPREAD=spread-arm
           fi
 
+          if [[ "${{ matrix.systems }}" =~ amazon-linux-2023 ]]; then
+              # Amazon Linux 2023 has no xdelta, however we cannot disable
+              # xdelta on a per-target basis as it's used in the repack section
+              # of spread.yaml, which is shared by all targets, so all systems
+              # in this batch will not use delta for transferring project data
+              echo "Disabling xdelta support"
+              export NO_DELTA=1
+          fi
+
           RUN_TESTS=""
           # Save previous failed test results in FAILED_TESTS env var
           if [ -n "$FAILED_TESTS" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -488,6 +488,8 @@ jobs:
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
 
+          set -x
+
           SPREAD=spread
           if [[ "${{ matrix.systems }}" =~ -arm- ]]; then
               SPREAD=spread-arm

--- a/spread.yaml
+++ b/spread.yaml
@@ -674,6 +674,9 @@ repack: |
         cat <&3 >&4
     elif ! git show-ref "$DELTA_REF" > /dev/null; then
         cat <&3 >&4
+    elif [ -n "${NO_DELTA-}" ]; then
+        # delta has been disabled by the caller
+        cat <&3 >&4
     else
         tmpdir="$(mktemp -d)"
         #shellcheck disable=SC2064

--- a/spread.yaml
+++ b/spread.yaml
@@ -815,9 +815,8 @@ prepare: |
                 apt-get install -y xdelta3 curl eatmydata >& "$tf" || ( cat "$tf"; exit 1 )
                 ;;
             amazon-linux-2023-*)
-                # Amazon linux 2023 has already pre-installed the xdelta package
-                # which is not in the repo yet
-                yum install -y --allowerasing curl &> "$tf" || (cat "$tf"; exit 1)
+                echo "deltas are not supported on $SPREAD_SYSTEM, use NO_DELTA=1 when running spread"
+                exit 1
                 ;;
             amazon-*|centos-7-*)
                 yum install -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -736,7 +736,7 @@ pkg_dependencies_amazon(){
     if os.query is-amazon-linux 2023; then
         echo "
             bpftool
-            gnupg2-full
+            gpg
             python-docutils
             python3-gobject
             "

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -194,12 +194,12 @@ distro_install_package() {
             quiet eatmydata apt-get install $APT_FLAGS -y "${pkg_names[@]}"
             retval=$?
             ;;
-        amazon-*|centos-7-*)
+        amazon-linux-2-*|centos-7-*)
             # shellcheck disable=SC2086
             quiet yum -y install $YUM_FLAGS "${pkg_names[@]}"
             retval=$?
             ;;
-        fedora-*|centos-*)
+        fedora-*|centos-*|amazon-linux-2023-*)
             # shellcheck disable=SC2086
             quiet dnf -y --refresh install $DNF_FLAGS "${pkg_names[@]}"
             retval=$?

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -742,7 +742,6 @@ pkg_dependencies_amazon(){
             "
     fi
     echo "
-        curl
         dbus-x11
         expect
         fontconfig

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -340,13 +340,6 @@ prepare_project() {
         fi
     fi
 
-    if os.query is-amazon-linux 2023; then
-        # Amazon Linux 2023 does not have xdelta in repositories, but it is
-        # installed in our images, drop it to ensure 'vanilla' experience, see
-        # SNAPDENG-15306
-        dnf remove xdelta -y
-    fi
-
     # debian-sid packaging is special
     if os.query is-debian sid; then
         if [ ! -d packaging/debian-sid ]; then

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,5 +1,8 @@
 summary: Check different completions
 
+details: |
+    Check bash completion functionality.
+
 # takes >6min to run in total
 backends: [-autopkgtest]
 

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -4,7 +4,8 @@ summary: Check different completions
 backends: [-autopkgtest]
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
+# amazon-linux-2023: ships with gnupg2-minimal which is missing options
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -amazon-linux-2023-*]
 
 environment:
     NAMES: /var/cache/snapd/names

--- a/tests/main/interfaces-polkit/task.yaml
+++ b/tests/main/interfaces-polkit/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that the polkit interface works.
 
+details: |
+  Verify polkit interface.
+
 # amazon-linux-2023: polkit not installed by default
 systems: [-ubuntu-core-*, -amazon-linux-2023-*]
 

--- a/tests/main/interfaces-polkit/task.yaml
+++ b/tests/main/interfaces-polkit/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure that the polkit interface works.
 
-systems: [-ubuntu-core-*]
+# amazon-linux-2023: polkit not installed by default
+systems: [-ubuntu-core-*, -amazon-linux-2023-*]
 
 prepare: |
     if ! tests.session has-session-systemd-and-dbus; then


### PR DESCRIPTION
To be as close to the vanilla images as possible we no longer have a preinstalled xdelta in the Amazon Linux 2023 images. As such using xdelta to pack the project content will fail.
