### PR TITLE
i/b: dont have polkit interface being implicit on core read-only filesystems

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -40,6 +40,7 @@ var (
 	AareExclusivePatterns       = aareExclusivePatterns
 	GetDesktopFileRules         = getDesktopFileRules
 	StringListAttribute         = stringListAttribute
+	IsPathMountedWritable       = isPathMountedWritable
 )
 
 func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -271,9 +271,15 @@ apps:
 	c.Assert(err, ErrorMatches, `snap "other" has interface "polkit" with invalid value type bool for "action-prefix" attribute: \*string`)
 }
 
+func (s *polkitInterfaceSuite) isProfilePathAccessible(c *C) bool {
+	mntProfile, err := osutil.LoadMountProfile("/proc/self/mounts")
+	c.Assert(err, IsNil)
+	return builtin.IsPathMountedWritable(mntProfile, "/usr/share/polkit-1/actions")
+}
+
 func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/polkitd") || osutil.IsExecutable("/usr/lib/polkit-1/polkitd"))
+	c.Check(si.ImplicitOnCore, Equals, s.isProfilePathAccessible(c) && (osutil.IsExecutable("/usr/libexec/polkitd") || osutil.IsExecutable("/usr/lib/polkit-1/polkitd")))
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.Summary, Equals, "allows access to polkitd to check authorisation")
 	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")

--- a/osutil/mountprofile_darwin.go
+++ b/osutil/mountprofile_darwin.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+type MountProfile struct {
+	Entries []MountEntry
+}
+
+func LoadMountProfile(fname string) (*MountProfile, error) {
+	return nil, ErrDarwin
+}

--- a/osutil/mountprofile_darwin.go
+++ b/osutil/mountprofile_darwin.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
This should fix the interface tests that were failing due to polkit interface.

We check the mountpoints to ensure that the policy-path (/usr/share/polkit-1/actions) is indeed mounted in a read-write filesystems. On core-desktop this path is read-write, but on core systems this path is read-only.
