### PR TITLE
snapd.apparmor.service: add explicit dependency to snapd.mounts.target

### DIFF
--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -10,6 +10,12 @@ DefaultDependencies=no
 Before=sysinit.target
 # This dependency is meant to ensure that apparmor initialization (whatever that might entail) is complete.
 After=apparmor.service
+# In case of re-execution, snapd snap has to be mounted. apparmor.service has
+# a dependency to local-fs.target which is enough in theory. But in case
+# this dependency dispappears, it is better to have an explicit dependency to
+# snapd.mount.target here.
+After=snapd.mounts.target
+Wants=snapd.mounts.target
 ConditionSecurity=apparmor
 RequiresMountsFor=/var/cache/apparmor /var/lib/snapd/apparmor/profiles
 


### PR DESCRIPTION
In case of re-execution, snapd snap has to be mounted. apparmor.service has a dependency to local-fs.target which is enough in theory. But in case this dependency dispappears, it is better to have an explicit dependency to snapd.mount.target in the unit.