### PR TITLE
interfaces/apparmor: update apparmor template of s-u-n for changes in Go

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -973,18 +973,19 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /sys/devices/system/cpu/online r,
 
   # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
-  @{PROC}/@{pid}/cmdline r,
+  owner @{PROC}/@{pid}/cmdline r,
 
   # Allow reading of own maps (Go runtime)
-  @{PROC}/@{pid}/maps r,
+  owner @{PROC}/@{pid}/maps r,
 
   # Allow reading file descriptor paths
-  @{PROC}/@{pid}/fd/* r,
+  owner @{PROC}/@{pid}/fd/* r,
+
   # Allow reading /proc/version. For release.go WSL detection.
   @{PROC}/version r,
 
   # Allow reading own cgroups
-  @{PROC}/@{pid}/cgroup r,
+  owner @{PROC}/@{pid}/cgroup r,
 
   # Allow reading somaxconn, required in newer distro releases
   @{PROC}/sys/net/core/somaxconn r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -975,6 +975,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
   @{PROC}/@{pid}/cmdline r,
 
+  # Allow reading of own maps (Go runtime)
+  @{PROC}/@{pid}/maps r,
+
   # Allow reading file descriptor paths
   @{PROC}/@{pid}/fd/* r,
   # Allow reading /proc/version. For release.go WSL detection.


### PR DESCRIPTION
Rebuilding snap-update-ns with Go 1.22.0 triggers a new denial with the process trying to read /proc/self/maps.

The denial shows up as:

```
audit: type=1400 audit(1707404561.548:1563): apparmor="DENIED"
       operation="open" class="file"
       profile="snap-update-ns.test-snapd-sh-core22"
       name="/proc/2993630/maps" pid=2993630 comm="5"
       requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

Inspecting with strace, the attempt to open /proc/self/maps happens just a handful of syscalls after execing into snap-update-ns.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
