### PR TITLE
many: add pluggable stateful repeat checks to notices

### DIFF
--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -128,10 +128,6 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		notices = st.Notices(filter)
 	}
 
-	if notices == nil {
-		notices = []*state.Notice{} // avoid null result
-	}
-
 	noticeInfos := make([]*noticeInfo, 0, len(notices))
 	for _, notice := range notices {
 		noticeInfos = append(noticeInfos, notice2noticeInfo(notice))
@@ -236,20 +232,20 @@ type noticeInfo struct {
 
 func notice2noticeInfo(n *state.Notice) *noticeInfo {
 	info := noticeInfo{
-		ID:            n.ID(),
-		Type:          string(n.Type()),
-		Key:           n.Key(),
-		FirstOccurred: n.FirstOccurred(),
-		LastOccurred:  n.LastOccurred(),
-		LastRepeated:  n.LastRepeated(),
-		Occurrences:   n.Occurrences(),
-		LastData:      n.LastData(),
+		ID:            n.ID,
+		Type:          string(n.Type),
+		Key:           n.Key,
+		FirstOccurred: n.FirstOccurred,
+		LastOccurred:  n.LastOccurred,
+		LastRepeated:  n.LastRepeated,
+		Occurrences:   n.Occurrences,
+		LastData:      n.LastData,
 	}
-	if n.RepeatAfter() != 0 {
-		info.RepeatAfter = n.RepeatAfter().String()
+	if n.RepeatAfter != 0 {
+		info.RepeatAfter = n.RepeatAfter.String()
 	}
-	if n.ExpireAfter() != 0 {
-		info.ExpireAfter = n.ExpireAfter().String()
+	if n.ExpireAfter != 0 {
+		info.ExpireAfter = n.ExpireAfter.String()
 	}
 	if userID, isSet := n.UserID(); isSet {
 		info.UserID = &userID

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -16,7 +16,6 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -24,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
@@ -237,14 +235,24 @@ type noticeInfo struct {
 }
 
 func notice2noticeInfo(n *state.Notice) *noticeInfo {
-	raw, err := json.Marshal(n)
-	if err != nil {
-		logger.Panicf("internal error: cannot marshal notice: %v", err)
+	info := noticeInfo{
+		ID:            n.ID(),
+		Type:          string(n.Type()),
+		Key:           n.Key(),
+		FirstOccurred: n.FirstOccurred(),
+		LastOccurred:  n.LastOccurred(),
+		LastRepeated:  n.LastRepeated(),
+		Occurrences:   n.Occurrences(),
+		LastData:      n.LastData(),
 	}
-	var info noticeInfo
-	err = json.Unmarshal(raw, &info)
-	if err != nil {
-		logger.Panicf("internal error: cannot unmarshal notice: %v", err)
+	if n.RepeatAfter() != 0 {
+		info.RepeatAfter = n.RepeatAfter().String()
+	}
+	if n.ExpireAfter() != 0 {
+		info.ExpireAfter = n.ExpireAfter().String()
+	}
+	if userID, isSet := n.UserID(); isSet {
+		info.UserID = &userID
 	}
 	return &info
 }

--- a/daemon/export_api_notices_test.go
+++ b/daemon/export_api_notices_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+type (
+	NoticeInfo = noticeInfo
+)

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -79,11 +79,3 @@ var (
 func (s *State) NumNotices() int {
 	return len(s.notices)
 }
-
-func (n *Notice) Get(k string, v interface{}) error {
-	return n.internalData.get(k, v)
-}
-
-func (n *Notice) Set(k string, v interface{}) {
-	n.internalData.set(k, v)
-}

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -79,3 +79,11 @@ var (
 func (s *State) NumNotices() int {
 	return len(s.notices)
 }
+
+func (n *Notice) Get(k string, v interface{}) error {
+	return n.internalData.get(k, v)
+}
+
+func (n *Notice) Set(k string, v interface{}) {
+	n.internalData.set(k, v)
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -99,6 +99,11 @@ func (n *Notice) String() string {
 	return fmt.Sprintf("Notice %s (%s:%s:%s)", n.id, userIDStr, n.noticeType, n.key)
 }
 
+// ID is the unique ID for this notice.
+func (n *Notice) ID() string {
+	return n.id
+}
+
 // UserID returns the value of the notice's user ID and whether it is set.
 // If it is nil, then the returned userID is 0, and isSet is false.
 func (n *Notice) UserID() (userID uint32, isSet bool) {
@@ -114,16 +119,65 @@ func flattenUserID(userID *uint32) (uid uint32, isSet bool) {
 	return *userID, true
 }
 
+// Type represents a group of notices originating from a common source.
+func (n *Notice) Type() NoticeType {
+	return n.noticeType
+}
+
+// Key is a string that differentiates notices of the same type.
+func (n *Notice) Key() string {
+	return n.key
+}
+
+// FirstOccurred is the first time this notice occurs.
+func (n *Notice) FirstOccurred() time.Time {
+	return n.firstOccurred
+}
+
+// LastOccurred is the last time this notice occurred.
+func (n *Notice) LastOccurred() time.Time {
+	return n.lastOccurred
+}
+
+// LastRepeated is the time this notice was last "repeated".
+func (n *Notice) LastRepeated() time.Time {
+	return n.lastRepeated
+}
+
+// Occurrences is the number of times this notice has occurred.
+func (n *Notice) Occurrences() int {
+	return n.occurrences
+}
+
+// LastData is additional data captured from the last occurrence of this notice.
+func (n *Notice) LastData() map[string]string {
+	return n.lastData
+}
+
+// RepeatAfter is how long after this notice was last repeated should we allow
+// it to repeat.
+func (n *Notice) RepeatAfter() time.Duration {
+	return n.repeatAfter
+}
+
+// ExpireAfter is how long since this notice last occurred until we should drop it.
+func (n *Notice) ExpireAfter() time.Duration {
+	return n.expireAfter
+}
+
 // expired reports whether this notice has expired (relative to the given "now").
 func (n *Notice) expired(now time.Time) bool {
 	return n.lastOccurred.Add(n.expireAfter).Before(now)
 }
 
-func (n *Notice) GetRepeatCheckValue(v interface{}) error {
+// GetRepeatCheckValue gets current RepeatCheckData.
+//
+// NOTE: "value" must be JSON unmarshallable.
+func (n *Notice) GetRepeatCheckValue(value interface{}) error {
 	if n.repeatCheckData == nil {
 		return ErrNoState
 	}
-	if err := json.Unmarshal(*n.repeatCheckData, v); err != nil {
+	if err := json.Unmarshal(*n.repeatCheckData, value); err != nil {
 		return fmt.Errorf("internal error: could not unmarshal RepeatCheckData: %v", err)
 	}
 	return nil

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -306,7 +306,9 @@ type AddNoticeOptions struct {
 	// RepeatCheck, if set, returns whether this notice is forced to not be repeated
 	// and also returns the new repeat check data.
 	//
-	// NOTE: Current state can be accessed through oldNotice.GetRepeatCheckValue().
+	// NOTE:
+	//	- Current state can be accessed through oldNotice.GetRepeatCheckValue().
+	//	- If RepeatAfter is set, it takes precedence but RepeatCheck is still run to set new repeat check data.
 	RepeatCheck func(oldNotice *Notice, newNoticeOpts *AddNoticeOptions) (repeatOk bool, newRepeatCheckData interface{}, err error)
 }
 
@@ -316,6 +318,15 @@ func (options *AddNoticeOptions) runRepeatCheck(notice *Notice) (repeatOk bool, 
 		return true, options.RepeatCheckData, nil
 	}
 	return options.RepeatCheck(notice, options)
+}
+
+func (options *AddNoticeOptions) shouldRepeat(now time.Time, notice *Notice, repeatCheckOk bool) (repeatOk bool) {
+	// if options.RepeatAfter is set, it takes precedence
+	if options.RepeatAfter != 0 {
+		return now.After(notice.lastRepeated.Add(options.RepeatAfter))
+	}
+	// Otherwise, fallback to options.RepeatCheck result
+	return repeatCheckOk
 }
 
 // AddNotice records an occurrence of a notice with the specified type and key
@@ -356,7 +367,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 		s.notices[uniqueKey] = notice
 		newOrRepeated = true
 	} else {
-		repeatOk, newRepeatCheckData, err := options.runRepeatCheck(notice)
+		repeatCheckOk, newRepeatCheckData, err := options.runRepeatCheck(notice)
 		if err != nil {
 			return "", err
 		}
@@ -364,7 +375,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 		notice.setRepeatCheckValue(newRepeatCheckData)
 		// Additional occurrence, update existing notice
 		notice.occurrences++
-		if repeatOk && (options.RepeatAfter == 0 || now.After(notice.lastRepeated.Add(options.RepeatAfter))) {
+		if options.shouldRepeat(now, notice, repeatCheckOk) {
 			// Update last repeated time if repeat-after time has elapsed (or is zero)
 			notice.lastRepeated = now
 			newOrRepeated = true

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -170,9 +170,8 @@ func (n *Notice) expired(now time.Time) bool {
 	return n.lastOccurred.Add(n.expireAfter).Before(now)
 }
 
-// GetRepeatCheckValue gets current RepeatCheckData.
-//
-// NOTE: "value" must be JSON unmarshallable.
+// GetRepeatCheckData unmarshals the previously stored repeat check data (from
+// AddNoticeOptions or RepeatCheck) into the value parameter
 func (n *Notice) GetRepeatCheckValue(value interface{}) error {
 	if n.repeatCheckData == nil {
 		return ErrNoState

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -340,7 +340,7 @@ func (s *noticesSuite) TestRepeatCheckNoRepeat(c *C) {
 			c.Assert(err, IsNil)
 			c.Check(value, Equals, state.DefaultStatus)
 
-			// don't repeat
+			// don't repeat, repeatCheckData will not be updated
 			return false, state.DoStatus, nil
 		},
 	})
@@ -354,9 +354,9 @@ func (s *noticesSuite) TestRepeatCheckNoRepeat(c *C) {
 	c.Check(notices[0].LastOccurred(), Equals, baseTime.Add(24*time.Hour))
 	// Second notice was not repeated
 	c.Check(notices[0].LastRepeated(), Equals, baseTime)
-	// RepeatCheckData is updated
+	// RepeatCheckData is not updated because notice wasn't repeated
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
-	c.Check(repeatCheckData, Equals, state.DoStatus)
+	c.Check(repeatCheckData, Equals, state.DefaultStatus)
 }
 
 func (s *noticesSuite) TestRepeatCheckError(c *C) {

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -102,19 +102,19 @@ func (s *noticesSuite) TestUnmarshal(c *C) {
 	err := json.Unmarshal(noticeJSON, &notice)
 	c.Assert(err, IsNil)
 
-	c.Check(notice.ID(), Equals, "1")
+	c.Check(notice.ID, Equals, "1")
 	userID, isSet := notice.UserID()
 	c.Assert(isSet, Equals, true)
 	c.Check(userID, Equals, uint32(1000))
-	c.Check(notice.Type(), Equals, state.ChangeUpdateNotice)
-	c.Check(notice.Key(), Equals, "123")
-	c.Check(notice.FirstOccurred(), Equals, time.Date(2023, 9, 1, 5, 23, 1, 0, time.UTC))
-	c.Check(notice.LastOccurred(), Equals, time.Date(2023, 9, 1, 7, 23, 2, 0, time.UTC))
-	c.Check(notice.LastRepeated(), Equals, time.Date(2023, 9, 1, 6, 23, 3, 123456789, time.UTC))
-	c.Check(notice.Occurrences(), Equals, 2)
-	c.Check(notice.LastData(), DeepEquals, map[string]string{"k": "v"})
-	c.Check(notice.RepeatAfter(), Equals, time.Hour)
-	c.Check(notice.ExpireAfter(), Equals, 168*time.Hour)
+	c.Check(notice.Type, Equals, state.ChangeUpdateNotice)
+	c.Check(notice.Key, Equals, "123")
+	c.Check(notice.FirstOccurred, Equals, time.Date(2023, 9, 1, 5, 23, 1, 0, time.UTC))
+	c.Check(notice.LastOccurred, Equals, time.Date(2023, 9, 1, 7, 23, 2, 0, time.UTC))
+	c.Check(notice.LastRepeated, Equals, time.Date(2023, 9, 1, 6, 23, 3, 123456789, time.UTC))
+	c.Check(notice.Occurrences, Equals, 2)
+	c.Check(notice.LastData, DeepEquals, map[string]string{"k": "v"})
+	c.Check(notice.RepeatAfter, Equals, time.Hour)
+	c.Check(notice.ExpireAfter, Equals, 168*time.Hour)
 	var repeatCheckData map[string]any
 	c.Assert(notice.GetRepeatCheckValue(&repeatCheckData), IsNil)
 	c.Check(repeatCheckData, DeepEquals, map[string]any{
@@ -254,7 +254,7 @@ func (s *noticesSuite) TestRepeatCheckData(c *C) {
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Occurrences(), Equals, 1)
+	c.Check(notices[0].Occurrences, Equals, 1)
 	var repeatCheckData state.Status
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
 	c.Check(repeatCheckData, Equals, state.DoStatus)
@@ -266,7 +266,7 @@ func (s *noticesSuite) TestRepeatCheckData(c *C) {
 
 	notices = st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Occurrences(), Equals, 2)
+	c.Check(notices[0].Occurrences, Equals, 2)
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
 	c.Check(repeatCheckData, Equals, state.DoingStatus)
 }
@@ -299,7 +299,7 @@ func (s *noticesSuite) TestRepeatCheckRepeat(c *C) {
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Occurrences(), Equals, 2)
+	c.Check(notices[0].Occurrences, Equals, 2)
 	var repeatCheckData state.Status
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
 	c.Check(repeatCheckData, Equals, state.DoStatus)
@@ -320,10 +320,10 @@ func (s *noticesSuite) TestRepeatCheckNoRepeat(c *C) {
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Occurrences(), Equals, 1)
-	c.Check(notices[0].FirstOccurred(), Equals, baseTime)
-	c.Check(notices[0].LastOccurred(), Equals, baseTime)
-	c.Check(notices[0].LastRepeated(), Equals, baseTime)
+	c.Check(notices[0].Occurrences, Equals, 1)
+	c.Check(notices[0].FirstOccurred, Equals, baseTime)
+	c.Check(notices[0].LastOccurred, Equals, baseTime)
+	c.Check(notices[0].LastRepeated, Equals, baseTime)
 	// RepeatCheckData is initialized
 	var repeatCheckData state.Status
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
@@ -349,11 +349,11 @@ func (s *noticesSuite) TestRepeatCheckNoRepeat(c *C) {
 
 	notices = st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Occurrences(), Equals, 2)
-	c.Check(notices[0].FirstOccurred(), Equals, baseTime)
-	c.Check(notices[0].LastOccurred(), Equals, baseTime.Add(24*time.Hour))
+	c.Check(notices[0].Occurrences, Equals, 2)
+	c.Check(notices[0].FirstOccurred, Equals, baseTime)
+	c.Check(notices[0].LastOccurred, Equals, baseTime.Add(24*time.Hour))
 	// Second notice was not repeated
-	c.Check(notices[0].LastRepeated(), Equals, baseTime)
+	c.Check(notices[0].LastRepeated, Equals, baseTime)
 	// RepeatCheckData is not updated because notice wasn't repeated
 	c.Assert(notices[0].GetRepeatCheckValue(&repeatCheckData), IsNil)
 	c.Check(repeatCheckData, Equals, state.DefaultStatus)
@@ -417,8 +417,8 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 	c.Assert(err, IsNil)
 	// Check notice
 	notice := st.Notice(id)
-	c.Check(notice.Occurrences(), Equals, 1)
-	c.Check(notice.LastRepeated(), Equals, baseTime)
+	c.Check(notice.Occurrences, Equals, 1)
+	c.Check(notice.LastRepeated, Equals, baseTime)
 	var status state.Status
 	c.Assert(notice.GetRepeatCheckValue(&status), IsNil)
 	c.Check(status, Equals, state.DefaultStatus)
@@ -456,12 +456,12 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 	for i := 0; i < 10; i++ {
 		now = now.Add(1 * time.Second)
 		onChangeStatus(state.DoStatus)
-		if st.Notice(id).LastRepeated().Equal(now) {
+		if st.Notice(id).LastRepeated.Equal(now) {
 			DoCnt++
 		}
 		now = now.Add(1 * time.Second)
 		onChangeStatus(state.DoingStatus)
-		if st.Notice(id).LastRepeated().Equal(now) {
+		if st.Notice(id).LastRepeated.Equal(now) {
 			DoingCnt++
 		}
 	}
@@ -471,9 +471,9 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 
 	// Check notice
 	notice = st.Notice(id)
-	c.Check(notice.Occurrences(), Equals, 21)
+	c.Check(notice.Occurrences, Equals, 21)
 	// Default -> Do -> Doing then stop alternating
-	c.Check(notice.LastRepeated(), Equals, baseTime.Add(2*time.Second))
+	c.Check(notice.LastRepeated, Equals, baseTime.Add(2*time.Second))
 	c.Assert(notice.GetRepeatCheckValue(&status), IsNil)
 	c.Check(status, Equals, state.DoingStatus)
 
@@ -481,9 +481,9 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 	onChangeStatus(state.DoneStatus)
 	// Check notice
 	notice = st.Notice(id)
-	c.Check(notice.Occurrences(), Equals, 22)
+	c.Check(notice.Occurrences, Equals, 22)
 	// Doing -> Done should repeat
-	c.Check(notice.LastRepeated(), Equals, baseTime.Add(21*time.Second))
+	c.Check(notice.LastRepeated, Equals, baseTime.Add(21*time.Second))
 	c.Assert(notice.GetRepeatCheckValue(&status), IsNil)
 	c.Check(status, Equals, state.DoneStatus)
 }

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -415,7 +415,6 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 		RepeatCheckData: state.DefaultStatus,
 	})
 	c.Assert(err, IsNil)
-	time.Sleep(time.Microsecond)
 	// Check notice
 	notice := st.Notice(id)
 	c.Check(notice.Occurrences(), Equals, 1)
@@ -466,7 +465,6 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 			DoingCnt++
 		}
 	}
-	time.Sleep(time.Microsecond)
 	// Do, Doing only repeated once
 	c.Check(DoCnt, Equals, 1)
 	c.Check(DoingCnt, Equals, 1)
@@ -481,7 +479,6 @@ func (s *noticesSuite) TestRepeatCheckChangeUpdateScenario(c *C) {
 
 	now = now.Add(1 * time.Second)
 	onChangeStatus(state.DoneStatus)
-	time.Sleep(time.Microsecond)
 	// Check notice
 	notice = st.Notice(id)
 	c.Check(notice.Occurrences(), Equals, 22)


### PR DESCRIPTION
This PR adds pluggable stateful repeat checks to allow more control on how notices are repeated.

This stems from the discussion here https://github.com/snapcore/snapd/pull/13528#discussion_r1473577775, where a mechanism was needed to allow suppressing alternating rapid `change-update` notices which needs some state to make its decision as mentioned in the discussion.