### PR TITLE
interfaces/builtin: Add Kensington VeriMark Guard Fingerprint Key

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -182,6 +182,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "15e1",
 		ProductIDPattern: "2019",
 	},
+	{
+		Name:             "Kensington VeriMark Guard Fingerprint Key",
+		VendorIDPattern:  "047d",
+		ProductIDPattern: "8055",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 29)
+	c.Assert(spec.Snippets(), HasLen, 30)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Adding  Kensington VeriMark Guard Fingerprint Key to be used by Firefox, tested on Ubuntu 22.04
