### PR TITLE
github/workflows/cla-check: enable comments by running in the context of the base repository

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,7 +1,8 @@
 name: cla-check
 on:
-  # Only run on pull requests: not pushes
-  pull_request:
+  # Only run when a pull request get opened; run in the context of the base
+  # repository, not the fork so that comments can be posted
+  pull_request_target:
     branches: [ "master", "release/**" ]
 
 jobs:


### PR DESCRIPTION
Enable running the action in the context of the base repository, see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target so that write permissions are set and comments can be posted to the PR.

Also see https://github.com/canonical/has-signed-canonical-cla?tab=readme-ov-file#has-signed-canonical-cla

