### PR TITLE
many: add `refresh-inhibit-proceed-time` field to snaps api

### DIFF
--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -120,6 +120,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 		"MountedFrom",
 		"Hold",
 		"GatingHold",
+		"RefreshInhibitProceedTime",
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {

--- a/client/packages.go
+++ b/client/packages.go
@@ -89,6 +89,10 @@ type Snap struct {
 	Hold *time.Time `json:"hold,omitempty"`
 	// GatingHold is the time until which the snap's refreshes are held by a snap.
 	GatingHold *time.Time `json:"gating-hold,omitempty"`
+	// RefreshInhibitProceedTime is the time after which a pending refresh is forced
+	// for a running snap in the next auto-refresh. If RefreshInhibitProceedTime is
+	// nil, then there are no pending refreshes.
+	RefreshInhibitProceedTime *time.Time `json:"refresh-inhibit-proceed-time,omitempty"`
 }
 
 type SnapHealth struct {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -68,7 +68,8 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	name := vars["name"]
 
-	about, err := localSnapInfo(c.d.overlord.State(), name)
+	st := c.d.overlord.State()
+	about, err := localSnapInfo(st, name)
 	if err != nil {
 		if err == errNoSnap {
 			return SnapNotFound(name, err)
@@ -915,7 +916,8 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	found, err := allLocalSnapInfos(c.d.overlord.State(), all, wanted)
+	st := c.d.overlord.State()
+	found, err := allLocalSnapInfos(st, all, wanted)
 	if err != nil {
 		return InternalError("cannot list local snaps! %v", err)
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1316,6 +1316,80 @@ func (s *snapsSuite) TestSnapManyInfosReturnsHolds(c *check.C) {
 	}
 }
 
+func (s *snapsSuite) TestSnapInfoReturnsRefreshInhibitProceedTime(c *check.C) {
+	d := s.daemon(c)
+	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
+
+	st := d.Overlord().State()
+	st.Lock()
+	var snapst snapstate.SnapState
+	// Update snap state with RefreshInhibitedTime.
+	c.Assert(snapstate.Get(st, "foo", &snapst), check.IsNil)
+	refreshInhibitTime := time.Date(2024, 2, 15, 2, 29, 1, 9, time.UTC)
+	snapst.RefreshInhibitedTime = &refreshInhibitTime
+	snapstate.Set(st, "foo", &snapst)
+	// Get expected proceed time while we have the lock.
+	expectedProceedTime := snapst.RefreshInhibitProceedTime(st)
+	st.Unlock()
+
+	req, err := http.NewRequest("GET", "/v2/snaps/foo", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+
+	c.Assert(rsp.Result, check.FitsTypeOf, &client.Snap{})
+	snapInfo := rsp.Result.(*client.Snap)
+	c.Assert(snapInfo.RefreshInhibitProceedTime, check.NotNil)
+
+	c.Check(snapInfo.RefreshInhibitProceedTime.Equal(expectedProceedTime), check.Equals, true)
+}
+
+func (s *snapsSuite) TestSnapManyInfosReturnsRefreshInhibitProceedTime(c *check.C) {
+	d := s.daemon(c)
+	s.mkInstalledInState(c, d, "snap-a", "bar", "v0", snap.R(5), true, "")
+	s.mkInstalledInState(c, d, "snap-b", "bar", "v0", snap.R(5), true, "")
+	s.mkInstalledInState(c, d, "snap-c", "bar", "v0", snap.R(5), true, "")
+
+	st := d.Overlord().State()
+	st.Lock()
+	var snapst snapstate.SnapState
+	// Update snap-a state with RefreshInhibitedTime.
+	c.Assert(snapstate.Get(st, "snap-a", &snapst), check.IsNil)
+	refreshInhibitTime := time.Date(2024, 2, 15, 2, 29, 1, 9, time.UTC)
+	snapst.RefreshInhibitedTime = &refreshInhibitTime
+	snapstate.Set(st, "snap-a", &snapst)
+	// Get expected proceed time for snap-a while we have the lock.
+	expectedProceedTimeA := snapst.RefreshInhibitProceedTime(st)
+	// Update snap-b state with RefreshInhibitedTime.
+	c.Assert(snapstate.Get(st, "snap-b", &snapst), check.IsNil)
+	refreshInhibitTime = time.Date(2024, 1, 15, 2, 29, 1, 9, time.UTC)
+	snapst.RefreshInhibitedTime = &refreshInhibitTime
+	snapstate.Set(st, "snap-b", &snapst)
+	// Get expected proceed time for snap-a while we have the lock.
+	expectedProceedTimeB := snapst.RefreshInhibitProceedTime(st)
+	st.Unlock()
+
+	req, err := http.NewRequest("GET", "/v2/snaps", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.jsonReq(c, req, nil)
+	snaps := snapList(rsp.Result)
+	c.Assert(snaps, check.HasLen, 3)
+
+	for _, snap := range snaps {
+		testCmt := check.Commentf("snap %s failed", snap["name"])
+		switch snap["name"] {
+		case "snap-a":
+			c.Assert(snap["refresh-inhibit-proceed-time"], check.Equals, expectedProceedTimeA.Format(time.RFC3339Nano), testCmt)
+		case "snap-b":
+			c.Assert(snap["refresh-inhibit-proceed-time"], check.Equals, expectedProceedTimeB.Format(time.RFC3339Nano), testCmt)
+		case "snap-c":
+			_, ok := snap["refresh-inhibit-proceed-time"]
+			c.Assert(ok, check.Equals, false)
+		}
+	}
+}
+
 func (s *snapsSuite) TestMapLocalFields(c *check.C) {
 	media := snap.MediaInfos{
 		{

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -531,6 +531,22 @@ func (snapst *SnapState) InstanceName() string {
 	return snap.InstanceName(cur.RealName, snapst.InstanceKey)
 }
 
+// RefreshInhibitProceedTime is the time after which a pending refresh is forced
+// for a running snap in the next auto-refresh. Zero time indicates that there
+// are no pending refreshes.
+//
+// The provided state must be locked by the caller.
+func (snapst *SnapState) RefreshInhibitProceedTime(st *state.State) time.Time {
+	if snapst.RefreshInhibitedTime == nil {
+		// Zero time, no pending refreshes.
+		return time.Time{}
+	}
+	// TODO: state is needed for when configurable max inhibition
+	// is introduced (i.e. "core.refresh.max-inhibition-days").
+	proceedTime := snapst.RefreshInhibitedTime.Add(maxInhibition)
+	return proceedTime
+}
+
 func revisionInSequence(snapst *SnapState, needle snap.Revision) bool {
 	for _, si := range snapst.Sequence.SideInfos() {
 		if si.Revision == needle {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9988,3 +9988,15 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
 	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
 }
+
+func (s *snapmgrTestSuite) TestRefreshInhibitProceedTime(c *C) {
+	snapst := snapstate.SnapState{}
+	// No pending refresh
+	c.Check(snapst.RefreshInhibitProceedTime(s.state).IsZero(), Equals, true)
+
+	// Refresh inhibited
+	refreshInhibitedTime := time.Date(2024, 2, 12, 18, 36, 56, 0, time.UTC)
+	snapst.RefreshInhibitedTime = &refreshInhibitedTime
+	expectedRefreshInhibitProceedTime := refreshInhibitedTime.Add(snapstate.MaxInhibition)
+	c.Check(snapst.RefreshInhibitProceedTime(s.state), Equals, expectedRefreshInhibitProceedTime)
+}


### PR DESCRIPTION
This field is needed to allow api clients to know the time remaining until a refresh is forced for a running snap in the next auto-refresh as mentioned in [RAA-UX spec SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.c40tauj2e3fo).