### PR TITLE
o/s/policy: allow "core" snap to be removed on classic systems

### DIFF
--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -14,8 +14,12 @@ import (
 // involved in an operation. Rather than have a forest of `if`s
 // looking at type, model, etc, we move it to Policy and look it up.
 type Policy interface {
-	// CanRemove verifies that a snap can be removed.
-	// If rev is not unset, check for removing only that revision.
+	// CanRemove verifies that a snap can be removed. If rev is set, check
+	// for removing only that revision. A revision which is unset means that
+	// the snap will be completely gone after the operation, i.e. all
+	// installed revisions will be removed, which is equally true when
+	// removing the last remaining revision of the snap, even if said
+	// revision was explicitly passed by the user.
 	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev snap.Device) error
 }
 

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -36,7 +36,7 @@ func (s *canRemoveSuite) SetUpTest(c *check.C) {
 
 	snapstate.Set(s.st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
-		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "snapd"}}),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "snapd"}},
 		Current:  snap.R(1),
 	})
 
@@ -152,7 +152,7 @@ func (s *canRemoveSuite) TestOSNoSnapdNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
 	}
 	// revision is unset as if we're fully removing core from the system
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.Revision{}, classicDev), check.Equals, policy.ErrSnapdNotInstalled)

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	errNoName       = errors.New("snap has no name (not installed?)")
-	errInUseForBoot = errors.New("snap is being used for boot")
-	errRequired     = errors.New("snap is required")
-	errIsModel      = errors.New("snap is used by the model")
+	errNoName            = errors.New("snap has no name (not installed?)")
+	errInUseForBoot      = errors.New("snap is being used for boot")
+	errRequired          = errors.New("snap is required")
+	errIsModel           = errors.New("snap is used by the model")
+	errSnapdNotInstalled = errors.New("core snap cannot be removed if snapd snap is not installed")
 
 	errSnapdNotRemovableOnCore       = errors.New("snapd required on core devices")
 	errSnapdNotYetRemovableOnClassic = errors.New("remove all other snaps first")

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -8,10 +8,11 @@ func NewOSPolicy(m string) *osPolicy             { return &osPolicy{modelBase: m
 func NewSnapdPolicy(onClassic bool) *snapdPolicy { return &snapdPolicy{onClassic: onClassic} }
 
 var (
-	ErrNoName       = errNoName
-	ErrInUseForBoot = errInUseForBoot
-	ErrRequired     = errRequired
-	ErrIsModel      = errIsModel
+	ErrNoName            = errNoName
+	ErrInUseForBoot      = errInUseForBoot
+	ErrRequired          = errRequired
+	ErrIsModel           = errIsModel
+	ErrSnapdNotInstalled = errSnapdNotInstalled
 
 	ErrSnapdNotRemovableOnCore       = errSnapdNotRemovableOnCore
 	ErrSnapdNotYetRemovableOnClassic = errSnapdNotYetRemovableOnClassic

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -20,6 +20,8 @@
 package policy
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -44,7 +46,10 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return nil
 	}
 
-	if p.modelBase == "" {
+	// consider the case of a UC16 system, where the model does not specify a base,
+	// since 'core' is already implied and is actively used by the system,
+	// which boots in the UC way
+	if p.modelBase == "" && dev.IsCoreBoot() {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
@@ -54,6 +59,25 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 			return nil
 		}
 		return errIsModel
+	}
+
+	if rev.Unset() {
+		// revision will be unset if we're attempting to remove all snaps or
+		// just the one last remaining revision. in either case, we need to
+		// ensure that the snapd snap is there
+
+		var snapdState snapstate.SnapState
+		err := snapstate.Get(st, "snapd", &snapdState)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+
+		// if snapd snap is not installed, then this might be a system that has
+		// received snapd updates via the core snap. in that case, we can't remove
+		// the core snap.
+		if !snapdState.IsInstalled() {
+			return errSnapdNotInstalled
+		}
 	}
 
 	if !rev.Unset() {

--- a/tests/main/remove-core/task.yaml
+++ b/tests/main/remove-core/task.yaml
@@ -1,0 +1,32 @@
+summary: Check that we can remove core snap on classic systems.
+
+details: |
+    This test checks that we can remove core snap on classic systems, as long as
+    snapd is installed as a snap. Classic systems do not have 'base' set in
+    their model. On UC systems, that would be interpreted as 'core' being the
+    base. On classic (non-hybrid) systems, that should be interpreted as there
+    not being a base required.
+
+    If snapd is not installed as a snap, then we can't remove the core snap
+    since it might be providing snapd.
+
+systems: [ubuntu-22.04-64]
+
+execute: |
+    # we should not be able to remove the core snap, since the snapd snap is not
+    # installed.
+    not snap remove core
+
+    # make sure that the model does not have 'base' set
+    snap model --assertion | NOMATCH 'base:'
+
+    # enable transitioning to the snapd snap
+    snap set core experimental.snapd-snap=true
+    snap debug ensure-state-soon
+    retry -n 30 snap watch --last=transition-to-snapd-snap
+    snap list snapd
+
+    # now remove the core snap, since we know that it isn't providing snapd
+    # anymore. this, in addition to this being a classic system, should allow us
+    # to remove the core snap.
+    snap remove core


### PR DESCRIPTION
This addresses this bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2039113?comments=all

Since classic systems do not have a base set in the model, this code was assuming that we were on a UC16 system that required the "core" snap. Adding the dev.IsCoreBoot() check allows classic (non-hybrid) systems to remove "core", if it isn't required by other snaps.

This is a cherry-pick of #13509.