### PR TITLE
overlord: fix prerequisite base snap silently not being installed due to conflict

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -370,6 +370,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "some-snap-now-classic"
 	case "some-snap-was-classic-id":
 		name = "some-snap-was-classic"
+	case "some-snap-with-new-base-id":
+		name = "some-snap-with-new-base"
+		base = "core22"
 	case "core-snap-id":
 		name = "core"
 		typ = snap.TypeOS
@@ -396,7 +399,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "snap-content-plug"
 	case "snap-content-slot-id":
 		name = "snap-content-slot"
-	case "snapd-snap-id":
+	case "snapd-snap-id", "snapd-without-version-id":
 		name = "snapd"
 		typ = snap.TypeSnapd
 	case "kernel-id":
@@ -468,6 +471,10 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		Architectures: []string{"all"},
 		Epoch:         epoch,
 		Base:          base,
+	}
+
+	if strings.HasSuffix(cand.snapID, "-without-version-id") {
+		info.Version = ""
 	}
 
 	if name == "outdated-consumer" {

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -102,7 +102,7 @@ func affectedSnaps(t *state.Task) ([]string, error) {
 func snapSetupFromChange(chg *state.Change) (*SnapSetup, error) {
 	for _, t := range chg.Tasks() {
 		// Check a known task of each change that we know keep snap info.
-		if t.Kind() != "prerequisites" {
+		if t.Kind() != "prepare-snap" && t.Kind() != "download-snap" {
 			continue
 		}
 		return TaskSnapSetup(t)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -852,6 +852,10 @@ func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		if err != nil {
 			return fmt.Errorf("cannot get current snapd snap info: %v", err)
 		}
+
+		// Old versions of snapd did not fill in the version field, unintentionally
+		// triggering snapd downgrade detection logic. Fill in the version from the
+		// snapd we are currently using.
 		if snapsup.Version == "" {
 			snapsup.Version = snapdInfo.Version
 			if err = SetTaskSnapSetup(task, snapsup); err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -848,14 +848,21 @@ func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 			return fmt.Errorf("there was a snapd rollback across the restart")
 		}
 
+		snapdInfo, err := snap.ReadCurrentInfo(snapsup.SnapName())
+		if err != nil {
+			return fmt.Errorf("cannot get current snapd snap info: %v", err)
+		}
+		if snapsup.Version == "" {
+			snapsup.Version = snapdInfo.Version
+			if err = SetTaskSnapSetup(task, snapsup); err != nil {
+				return err
+			}
+		}
+
 		// if we have restarted and snapd was refreshed, then we need to generate
 		// snapd wrappers again with current snapd, as the logic of generating
 		// wrappers may have changed between previous and new snapd code.
 		if !release.OnClassic {
-			snapdInfo, err := snap.ReadCurrentInfo(snapsup.SnapName())
-			if err != nil {
-				return fmt.Errorf("cannot get current snapd snap info: %v", err)
-			}
 			// TODO: if future changes to wrappers need one more snapd restart,
 			// then it should be handled here as well.
 			if err := generateSnapdWrappers(snapdInfo, nil); err != nil {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4409,6 +4409,7 @@ type: snapd
 		si := &snap.SideInfo{Revision: snap.R("x2"), RealName: tc.snapName}
 		snapInfo := snaptest.MockSnapCurrent(c, string(tc.snapYaml), si)
 		snapsup := &snapstate.SnapSetup{SideInfo: si, Type: snapInfo.SnapType}
+		task.Set("snap-setup", snapsup)
 
 		// restarting
 		restart.MockPending(st, restart.RestartUnset)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -11895,4 +11895,85 @@ func (s *snapmgrTestSuite) TestUpdateManyFilteredNotAutoRefreshNoRetry(c *C) {
 	c.Check(storeSnapIDs, HasLen, 2)
 	c.Check(storeSnapIDs["some-snap-id"], Equals, true)
 	c.Check(storeSnapIDs["some-other-snap-id"], Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateSnapdAndSnapPullingNewBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.snapd-snap", true)
+	tr.Commit()
+
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	snapstate.Set(s.state, "core22", nil) // NOTE: core22 is not installed.
+	snapstate.Set(s.state, "some-snap-with-new-base", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{
+				RealName: "some-snap-with-new-base",
+				SnapID:   "some-snap-with-new-base-id",
+				Revision: snap.R(1),
+			},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{
+				RealName: "snapd",
+				SnapID:   "snapd-without-version-id",
+				Revision: snap.R(1),
+			},
+		}),
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	updated, taskSets, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"snapd", "some-snap-with-new-base"},
+		[]*snapstate.RevisionOptions{{
+			Revision: snap.R(1),
+			Channel:  "latest/stable",
+		}, {
+			Revision: snap.R(1),
+			Channel:  "some-channel",
+		}},
+		s.user.ID, &snapstate.Flags{
+			IgnoreRunning: true,
+			Transaction:   client.TransactionPerSnap, // XXX: it is unclear if this represents the real-world behavior.
+		})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh-snap", "refresh snapd and some other snap pulling in a base")
+
+	for _, taskSet := range taskSets {
+		chg.AddAll(taskSet)
+	}
+
+	// XXX: This mimics newChange from daemon/api.go
+	if updated != nil {
+		chg.Set("snap-names", updated)
+	}
+
+	s.state.EnsureBefore(0)
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	fmt.Printf("Settle returned\n")
+
+	didDownloadCore22 := false
+
+	for _, fakeOp := range s.fakeBackend.ops {
+		if fakeOp.op == "storesvc-download" && fakeOp.name == "core22" {
+			didDownloadCore22 = true
+		}
+	}
+
+	c.Assert(didDownloadCore22, Equals, true, Commentf("core22 was *not* downloaded"))
 }


### PR DESCRIPTION
This pull request contains a number of patches that should be dropped, followed by a currently-failing test that reproduces the scenario from https://warthogs.atlassian.net/browse/SNAPDENG-13768

As debugged by Ernest and Samuele earlier, the debug output of the test shows (in messages prefixed with `@@@`) that a conflict is detected and then subsequently ignored.

This branch serves as a playground for fixing the problem.