### PR TITLE
asserts: update username regex allowed by system-user assertion

### DIFF
--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -28,9 +28,8 @@ import (
 	"time"
 )
 
-// validSystemUserUsernames matches very closely the regex we allow by osutil/user.go:IsValidUsername
-// however this regex is a tiny bit less strict by also allowing '-' in the username.
-var validSystemUserUsernames = regexp.MustCompile(`^[a-z0-9][-a-z0-9.-_]*$`)
+// validSystemUserUsernames matches the regex we allow by osutil/user.go:IsValidUsername
+var validSystemUserUsernames = regexp.MustCompile(`^[a-z0-9][-a-z0-9._]*$`)
 
 // SystemUser holds a system-user assertion which allows creating local
 // system users.

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -28,7 +28,9 @@ import (
 	"time"
 )
 
-var validSystemUserUsernames = regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`)
+// validSystemUserUsernames matches very closely the regex we allow by osutil/user.go:IsValidUsername
+// however this regex is a tiny bit less strict by also allowing '-' in the username.
+var validSystemUserUsernames = regexp.MustCompile(`^[a-z0-9][-a-z0-9.-_]*$`)
 
 // SystemUser holds a system-user assertion which allows creating local
 // system users.


### PR DESCRIPTION
Followup for one of the comments made by @pedronis in https://github.com/snapcore/snapd/pull/13236.

Since '+' is not allowed by adduser anyway (even with --force-badnames), there is no reason for us to allow it in our regexes. So we drop '+' from the regex here as well.
