### PR TITLE
o/snapstate: fix RAA refresh triggering when app gets closed

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -14031,11 +14031,11 @@ func (s *mgrsSuite) TestUpdateManyStoreUpdateWhileWaitingWithMonitoring(c *C) {
 	c.Assert(os.WriteFile(dirs.SnapNamesFile, nil, 0644), IsNil)
 
 	st.Unlock()
-	// ensure to trigger refresh-hints update
-	s.o.SnapManager().Ensure()
+	s.o.Settle(settleTimeout)
 	st.Lock()
 
-	c.Logf("single Ensure() done")
+	dumpTasks(c, "after settle", chg.Tasks())
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*snap "held-with-app-running" has running apps.*`)
 
 	// remove the entry as if the app has closed
 	err = os.RemoveAll(filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/snap.held-with-app-running.app.scope"))

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -14088,7 +14088,7 @@ waitLoop:
 				break waitLoop
 			}
 		case <-timeout:
-			c.Errorf("timeout waiting for prune to complete")
+			c.Errorf("timeout waiting for change to complete")
 			c.FailNow()
 		}
 	}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -13740,7 +13740,7 @@ apps:
         command: $SNAP/foo
 `
 
-func (s *mgrsSuite) TestUpdateOneWithMonitoring(c *C) {
+func (s *mgrsSuite) TestAutoRefreshOneWithMonitoring(c *C) {
 	restore := cgroup.MockVersion(cgroup.V2, nil)
 	defer restore()
 
@@ -13826,7 +13826,7 @@ func (s *mgrsSuite) TestUpdateOneWithMonitoring(c *C) {
 	c.Check(si.Revision, Equals, snap.R(2))
 }
 
-func (s *mgrsSuite) TestUpdateManyWithMonitoring(c *C) {
+func (s *mgrsSuite) TestAutoRefreshWithMonitoring(c *C) {
 	// similar to a test with a single snap, but 2 snaps are being
 	// refreshed, one refresh gets fully completed while the other is held
 	// back due to a running application
@@ -13928,7 +13928,7 @@ func (s *mgrsSuite) TestUpdateManyWithMonitoring(c *C) {
 	c.Check(si.Revision, Equals, snap.R(2))
 }
 
-func (s *mgrsSuite) TestUpdateManyStoreUpdateWhileWaitingWithMonitoring(c *C) {
+func (s *mgrsSuite) TestAutoRefreshStoreUpdateWhileWaitingWithMonitoring(c *C) {
 	// similar to a test with many snaps, but a new revision of a snap gets
 	// published to the store, while we are waiting for the app to close, as
 	// a result it should be picked up if refresh hints run in the meantime

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -13769,13 +13769,12 @@ func (s *mgrsSuite) TestUpdateOneWithMonitoring(c *C) {
 	s.serveSnap(snapPath, revno)
 
 	// auto-refresh
-	affected, tasksets, err := snapstate.UpdateMany(context.TODO(), st, nil, nil, 0,
-		&snapstate.Flags{IsAutoRefresh: true})
+	affected, tasksets, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Assert(err, IsNil)
 	sort.Strings(affected)
 	c.Check(affected, DeepEquals, []string{"held-with-app-running"})
 	chg := st.NewChange("refresh-snaps", "...")
-	for _, taskset := range tasksets {
+	for _, taskset := range append(tasksets.PreDownload, tasksets.Refresh...) {
 		chg.AddAll(taskset)
 	}
 
@@ -13828,9 +13827,9 @@ func (s *mgrsSuite) TestUpdateOneWithMonitoring(c *C) {
 }
 
 func (s *mgrsSuite) TestUpdateManyWithMonitoring(c *C) {
-	// similar to a test with a single snap, bu 2 snaps are being refresh,
-	// one refresh gets fully completed while the other is held back due to
-	// a running application
+	// similar to a test with a single snap, but 2 snaps are being
+	// refreshed, one refresh gets fully completed while the other is held
+	// back due to a running application
 	restore := cgroup.MockVersion(cgroup.V2, nil)
 	defer restore()
 
@@ -13864,13 +13863,13 @@ func (s *mgrsSuite) TestUpdateManyWithMonitoring(c *C) {
 	}
 
 	// auto-refresh
-	affected, tasksets, err := snapstate.UpdateMany(context.TODO(), st, nil, nil, 0,
-		&snapstate.Flags{IsAutoRefresh: true})
+	// auto-refresh
+	affected, tasksets, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Assert(err, IsNil)
 	sort.Strings(affected)
 	c.Check(affected, DeepEquals, snapNames)
 	chg := st.NewChange("refresh-snaps", "...")
-	for _, taskset := range tasksets {
+	for _, taskset := range append(tasksets.PreDownload, tasksets.Refresh...) {
 		chg.AddAll(taskset)
 	}
 
@@ -13967,13 +13966,12 @@ func (s *mgrsSuite) TestUpdateManyStoreUpdateWhileWaitingWithMonitoring(c *C) {
 	}
 
 	// auto-refresh
-	affected, tasksets, err := snapstate.UpdateMany(context.TODO(), st, nil, nil, 0,
-		&snapstate.Flags{IsAutoRefresh: true})
+	affected, tasksets, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Assert(err, IsNil)
 	sort.Strings(affected)
 	c.Check(affected, DeepEquals, snapNames)
 	chg := st.NewChange("refresh-snaps", "...")
-	for _, taskset := range tasksets {
+	for _, taskset := range append(tasksets.PreDownload, tasksets.Refresh...) {
 		chg.AddAll(taskset)
 	}
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -418,6 +418,7 @@ var (
 	HoldDurationLeft           = holdDurationLeft
 	LastRefreshed              = lastRefreshed
 	PruneRefreshCandidates     = pruneRefreshCandidates
+	UpdateRefreshCandidates    = updateRefreshCandidates
 	ResetGatingForRefreshed    = resetGatingForRefreshed
 	PruneGating                = pruneGating
 	PruneSnapsHold             = pruneSnapsHold

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -268,7 +268,7 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 
 // updateRefreshCandidates updates the current set of refresh candidates stored
 // in the state. When the list of canDropOldNames is empty, existing entries
-// which aren't part of the update are dropped. When the list if non empty, only
+// which aren't part of the update are dropped. When the list is non empty, only
 // those entries mentioned in the list are dropped, other existing entries are
 // preserved. Whenever an existing entry is to be replaced, the caller must have
 // provided a hint which preserves the hint's state outside of snap-setup.
@@ -285,19 +285,17 @@ func updateRefreshCandidates(st *state.State, hints map[string]*refreshCandidate
 		return nil
 	}
 
-	dropSelectOld := len(canDropOldNames) != 0
+	dropAllOld := len(canDropOldNames) == 0
 
 	var deleted []string
 
 	// selectively process existing entries
 	for oldHintName := range oldHints {
-		newHint, hasUpdate := hints[oldHintName]
-
-		if hasUpdate {
+		if newHint, hasUpdate := hints[oldHintName]; hasUpdate {
 			// XXX we rely on the new hint preserving the state
 			oldHints[oldHintName] = newHint
 		} else {
-			if !dropSelectOld || (dropSelectOld && strutil.ListContains(canDropOldNames, oldHintName)) {
+			if dropAllOld || strutil.ListContains(canDropOldNames, oldHintName) {
 				// we have no new hint for this snap
 				deleted = append(deleted, oldHintName)
 				delete(oldHints, oldHintName)

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -100,7 +100,7 @@ func (r *refreshHints) refresh() error {
 		return fmt.Errorf("internal error: cannot get refresh-candidates: %v", err)
 	}
 
-	setNewRefreshCandidates(r.state, hints)
+	updateRefreshCandidates(r.state, hints, nil)
 	return nil
 }
 

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -579,3 +579,94 @@ func (s *refreshHintsTestSuite) TestSnapStoreOffline(c *C) {
 
 	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
 }
+
+func (s *refreshHintsTestSuite) TestUpdateCandidatesNonDiscriminating(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var hints map[string]*snapstate.RefreshCandidate
+
+	err := snapstate.UpdateRefreshCandidates(s.state, nil, nil)
+	c.Assert(err, IsNil)
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 0)
+
+	err = snapstate.UpdateRefreshCandidates(s.state, map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "foo", Revision: snap.R(1)}}},
+		"bar": {
+			SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "bar", Revision: snap.R(1)}},
+			Monitored: true,
+		},
+	}, nil)
+	c.Assert(err, IsNil)
+
+	hints = nil
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 2)
+	c.Check(hints["foo"], NotNil)
+	c.Assert(hints["bar"], NotNil)
+	c.Check(hints["bar"].SideInfo.Revision, Equals, snap.R(1))
+	c.Check(hints["bar"].Monitored, Equals, true)
+
+	err = snapstate.UpdateRefreshCandidates(s.state, map[string]*snapstate.RefreshCandidate{
+		// bar without Monitored flag
+		"bar": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "bar", Revision: snap.R(2)}}},
+		"baz": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "baz", Revision: snap.R(4)}}},
+	}, nil)
+	c.Assert(err, IsNil)
+
+	hints = nil
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 2)
+	// "foo" was dropped
+	c.Check(hints["foo"], IsNil)
+	// "bar" was 'updated'
+	c.Assert(hints["bar"], NotNil)
+	c.Check(hints["bar"].SideInfo.Revision, Equals, snap.R(2))
+	c.Check(hints["bar"].Monitored, Equals, true)
+	// "baz" was added
+	c.Check(hints["baz"], NotNil)
+}
+
+func (s *refreshHintsTestSuite) TestUpdateCandidatesDiscriminating(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var hints map[string]*snapstate.RefreshCandidate
+
+	err := snapstate.UpdateRefreshCandidates(s.state, nil, nil)
+	c.Assert(err, IsNil)
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 0)
+
+	err = snapstate.UpdateRefreshCandidates(s.state, map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "foo", Revision: snap.R(1)}}},
+		"bar": {
+			SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "bar", Revision: snap.R(1)}},
+			Monitored: true,
+		},
+	}, nil)
+	c.Assert(err, IsNil)
+
+	hints = nil
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 2)
+	c.Check(hints["foo"], NotNil)
+	c.Assert(hints["bar"], NotNil)
+	c.Check(hints["bar"].SideInfo.Revision, Equals, snap.R(1))
+	c.Check(hints["bar"].Monitored, Equals, true)
+
+	// like re-refresh code path would eventually call it
+	err = snapstate.UpdateRefreshCandidates(s.state, nil, []string{"foo"})
+	c.Assert(err, IsNil)
+
+	hints = nil
+	s.state.Get("refresh-candidates", &hints)
+	c.Check(hints, HasLen, 1)
+	// "foo" was dropped
+	c.Check(hints["foo"], IsNil)
+	// "bar" was preserved
+	c.Assert(hints["bar"], NotNil)
+	c.Check(hints["bar"].SideInfo.Revision, Equals, snap.R(1))
+	c.Check(hints["bar"].Monitored, Equals, true)
+}

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -609,8 +609,12 @@ func (s *refreshHintsTestSuite) TestUpdateCandidatesNonDiscriminating(c *C) {
 	c.Check(hints["bar"].Monitored, Equals, true)
 
 	err = snapstate.UpdateRefreshCandidates(s.state, map[string]*snapstate.RefreshCandidate{
-		// bar without Monitored flag
-		"bar": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "bar", Revision: snap.R(2)}}},
+		// bar with Monitored flag preserved by the caller, as in
+		// refreshHintsFromCandidates()
+		"bar": {
+			SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "bar", Revision: snap.R(2)}},
+			Monitored: true,
+		},
 		"baz": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "baz", Revision: snap.R(4)}}},
 	}, nil)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1838,7 +1838,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 			return nil, nil, err
 		}
 
-		setNewRefreshCandidates(st, hints)
+		updateRefreshCandidates(st, hints, names)
 	}
 
 	if filter != nil {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -11825,8 +11825,11 @@ func (s *snapmgrTestSuite) TestUpdateManyFilteredForSnapsNotInOldHints(c *C) {
 	err = s.state.Get("refresh-candidates", &newCands)
 	c.Assert(err, IsNil)
 
-	c.Assert(newCands, HasLen, 1)
+	c.Assert(newCands, HasLen, 2)
 	c.Check(newCands["some-snap"], NotNil)
+	// a monitored snap was preserved
+	c.Assert(newCands["some-other-snap"], NotNil)
+	c.Check(newCands["some-other-snap"].Monitored, Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyFilteredNotAutoRefreshNoRetry(c *C) {


### PR DESCRIPTION
Fix handling of refresh-candidates, such that a re-refresh handler does not blindly overwrite its contents and thus discarding all the information about snaps being monitored for the purpose of RAA.