### PR TITLE
many: add `refresh-inhibit` notice

### DIFF
--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -131,9 +131,11 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	st.Unlock()
 
-	req, err := http.NewRequest("GET", "/v2/notices?types=change-update&types=warning", nil)
+	req, err := http.NewRequest("GET", "/v2/notices?types=change-update&types=warning&types=refresh-inhibit", nil)
 	c.Assert(err, IsNil)
 	req.RemoteAddr = "pid=100;uid=1000;socket=;"
 	rsp := s.syncReq(c, req, nil)
@@ -141,11 +143,13 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 
 	notices, ok := rsp.Result.([]*state.Notice)
 	c.Assert(ok, Equals, true)
-	c.Assert(notices, HasLen, 2)
+	c.Assert(notices, HasLen, 3)
 	n := noticeToMap(c, notices[0])
 	c.Assert(n["type"], Equals, "change-update")
 	n = noticeToMap(c, notices[1])
 	c.Assert(n["type"], Equals, "warning")
+	n = noticeToMap(c, notices[2])
+	c.Assert(n["type"], Equals, "refresh-inhibit")
 }
 
 func (s *noticesSuite) TestNoticesFilterMultipleKeys(c *C) {

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -594,7 +594,6 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -651,7 +650,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceAliasRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -769,7 +767,6 @@ func (s *snapmgrTestSuite) TestAliasOverAutoRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -970,7 +967,6 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1040,7 +1036,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableAllAliasesRunThrough(c *C)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1135,7 +1130,6 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1185,7 +1179,6 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasOverAutoRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1232,7 +1225,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveManualAliasRunThrough(c *C)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1398,7 +1390,6 @@ func (s *snapmgrTestSuite) TestPreferRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1460,7 +1451,6 @@ func (s *snapmgrTestSuite) TestParallelInstancePreferRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1985,7 +1985,6 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2(c *C, beforePhase1 func(), gate
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -2276,7 +2275,6 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2DiskSpaceCheck(c *C, fail bool) 
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(installSizeCalled, Equals, true)
@@ -2353,7 +2351,6 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Conflict(c *C) {
 	conflictChange.AddTask(conflictTask)
 	conflictTask.WaitFor(tss[0].Tasks()[0])
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2519,7 +2516,6 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2GatedSnaps(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -221,6 +221,10 @@ func MockNextRefresh(ar *autoRefresh, when time.Time) {
 	ar.nextRefresh = when
 }
 
+func (snapmgr *SnapManager) MockNextRefresh(when time.Time) {
+	snapmgr.autoRefresh.nextRefresh = when
+}
+
 func MockLastRefreshSchedule(ar *autoRefresh, schedule string) {
 	ar.lastRefreshSchedule = schedule
 }
@@ -377,9 +381,10 @@ var (
 
 // autorefresh
 var (
-	InhibitRefresh = inhibitRefresh
-	MaxInhibition  = maxInhibition
-	MaxDuration    = maxDuration
+	InhibitRefresh               = inhibitRefresh
+	MaxInhibition                = maxInhibition
+	MaxDuration                  = maxDuration
+	MaybeAddRefreshInhibitNotice = maybeAddRefreshInhibitNotice
 )
 
 type RefreshCandidate = refreshCandidate

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -868,7 +868,6 @@ func (s *snapmgrTestSuite) TestInstallStrictIgnoresClassic(c *C) {
 	chg := s.state.NewChange("install", "install snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -896,7 +895,6 @@ func (s *snapmgrTestSuite) TestInstallSnapWithDefaultTrack(c *C) {
 	chg := s.state.NewChange("install", "install snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -922,7 +920,6 @@ func (s *snapmgrTestSuite) TestInstallIgnoreValidation(c *C) {
 	chg := s.state.NewChange("install", "install snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -951,7 +948,6 @@ func (s *snapmgrTestSuite) TestInstallManySnapOneWithDefaultTrack(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -1074,7 +1070,6 @@ confinement: strict
 	chg := s.state.NewChange("install", "install snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -1113,7 +1108,6 @@ epoch: 1
 	chg := s.state.NewChange("install", "install snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -1183,7 +1177,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -1575,7 +1568,6 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 	terr.JoinLane(last.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	mountTask := tasks[len(tasks)-12]
@@ -1734,7 +1726,6 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -1904,7 +1895,6 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -2068,7 +2058,6 @@ func (s *snapmgrTestSuite) TestInstallStartOrder(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -2131,7 +2120,6 @@ version: 1.0`)
 	c.Check(info.SideInfo.RealName, Equals, "mock")
 	c.Check(info.Version, Equals, "1.0")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2247,7 +2235,6 @@ epoch: 1*
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2390,7 +2377,6 @@ epoch: 1*
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2497,7 +2483,6 @@ version: 1.0`)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure only local install was run, i.e. first actions are pseudo-action current
@@ -2583,7 +2568,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -2817,7 +2801,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg2.AddAll(ts2)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran and core was only installed once
@@ -2847,7 +2830,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 	restore := snapstate.MockPrerequisitesRetryTimeout(40 * time.Millisecond)
 	defer restore()
 
-	defer s.se.Stop()
 	// Two changes are created, the first will fails, the second will
 	// be fine. The order of what change runs first is random, the
 	// first change will also install core in its own lane. This test
@@ -3004,8 +2986,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	s.state.Unlock()
 	defer s.state.Lock()
 
-	defer s.se.Stop()
-
 	// start running the change, this will trigger the
 	// prerequisites task, which will trigger the install of core
 	// and also call our mock store which will generate a parallel
@@ -3073,7 +3053,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -3241,7 +3220,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderCompat(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -3628,7 +3606,6 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	terr.JoinLane(last.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	mountTask := tasks[len(tasks)-12]
@@ -3652,7 +3629,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderCircular(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -3794,7 +3770,6 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -3859,7 +3834,6 @@ func (s *snapmgrTestSuite) TestInstallManyTransactionallyFails(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n.*Download snap \"some-other-snap\" \\(11\\) from channel \"stable\" \\(boom\\).*")
@@ -3952,7 +3926,6 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 
 	s.fakeBackend.copySnapDataFailTrigger = filepath.Join(dirs.SnapMountDir, "some-snap/11")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -4037,7 +4010,6 @@ func (s *snapmgrTestSuite) TestSideInfoPaid(c *C) {
 	chg := s.state.NewChange("install", "install paid snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snap has paid sideinfo
@@ -4059,7 +4031,6 @@ func (s *snapmgrTestSuite) TestSideInfoPrivate(c *C) {
 	chg := s.state.NewChange("install", "install private snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snap has private sideinfo
@@ -4244,7 +4215,6 @@ func (s *snapmgrTestSuite) TestInstallContentProviderDownloadFailure(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n.*Download snap \"snap-content-slot\" \\(11\\) from channel \"stable\" \\(boom\\).*")
@@ -4586,7 +4556,7 @@ func (s *validationSetsSuite) testInstallSnapRequiredByValidationSetWithBase(c *
 
 	s.state.Unlock()
 	defer s.state.Lock()
-	defer s.se.Stop()
+
 	err = s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
 	c.Assert(err, IsNil)
 
@@ -5135,7 +5105,6 @@ epoch: 1
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -5187,7 +5156,6 @@ epoch: 1
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), NotNil)
@@ -5240,7 +5208,6 @@ epoch: 1
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -5284,7 +5251,6 @@ epoch: 1
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), NotNil)
@@ -5342,7 +5308,6 @@ epoch: 1
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -5683,7 +5648,6 @@ type: base
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -254,7 +254,6 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -669,7 +668,6 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -842,7 +840,6 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(len(s.fakeBackend.ops), Equals, 2)
@@ -923,7 +920,6 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionDropsRevertStatus(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -958,7 +954,6 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(len(s.fakeBackend.ops), Equals, 10)
@@ -1194,7 +1189,6 @@ func (s *snapmgrTestSuite) TestRemoveDeletesConfigOnLastRevision(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -1245,7 +1239,6 @@ func (s *snapmgrTestSuite) TestRemoveDoesntDeleteConfigIfNotLastRevision(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -1523,7 +1516,6 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 	// are still present.
 	injectError(c, chg, "clear-snap", snap.Revision{N: 1})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -1601,7 +1593,6 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 	// current rev 1), before discarding the snap completely.
 	injectError(c, chg, "discard-snap", snap.Revision{N: 1})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -1741,7 +1732,6 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -1800,7 +1790,6 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snap in the system state

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -209,6 +209,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	s.o.AddManager(s.o.TaskRunner())
 	s.se = s.o.StateEngine()
 	c.Assert(s.o.StartUp(), IsNil)
+	s.BaseTest.AddCleanup(func() { s.o.Stop() })
 
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo))
 	s.BaseTest.AddCleanup(snapstate.MockOpenSnapFile(s.fakeBackend.OpenSnapFile))
@@ -692,7 +693,6 @@ func (s *snapmgrTestSuite) testRevertTasksFullFlags(flags fullFlags, c *C) {
 	chg := s.state.NewChange("revert", "revert snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	var snapst snapstate.SnapState
@@ -1150,7 +1150,6 @@ func (s *snapmgrTestSuite) TestDisableSnapDisabledServicesSaved(c *C) {
 	c.Assert(err, IsNil)
 	disableChg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(disableChg.Err(), IsNil)
@@ -1191,7 +1190,6 @@ func (s *snapmgrTestSuite) TestEnableSnapDisabledServicesPassedAroundHappy(c *C)
 	c.Assert(err, IsNil)
 	disableChg.AddAll(disableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(disableChg.Err(), IsNil)
@@ -1212,7 +1210,6 @@ func (s *snapmgrTestSuite) TestEnableSnapDisabledServicesPassedAroundHappy(c *C)
 	c.Assert(err, IsNil)
 	enableChg.AddAll(enableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(enableChg.Err(), IsNil)
@@ -1253,7 +1250,6 @@ func (s *snapmgrTestSuite) TestEnableSnapDisabledServicesNotSaved(c *C) {
 	c.Assert(err, IsNil)
 	disableChg.AddAll(disableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(disableChg.Err(), IsNil)
@@ -1274,7 +1270,6 @@ func (s *snapmgrTestSuite) TestEnableSnapDisabledServicesNotSaved(c *C) {
 	c.Assert(err, IsNil)
 	enableChg.AddAll(enableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(enableChg.Err(), IsNil)
@@ -1317,7 +1312,6 @@ func (s *snapmgrTestSuite) TestEnableSnapMissingDisabledServicesMergedAndSaved(c
 	c.Assert(err, IsNil)
 	disableChg.AddAll(disableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(disableChg.Err(), IsNil)
@@ -1338,7 +1332,6 @@ func (s *snapmgrTestSuite) TestEnableSnapMissingDisabledServicesMergedAndSaved(c
 	c.Assert(err, IsNil)
 	enableChg.AddAll(enableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(enableChg.Err(), IsNil)
@@ -1373,7 +1366,6 @@ func (s *snapmgrTestSuite) TestEnableSnapMissingDisabledServicesSaved(c *C) {
 	c.Assert(err, IsNil)
 	disableChg.AddAll(disableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(disableChg.Err(), IsNil)
@@ -1394,7 +1386,6 @@ func (s *snapmgrTestSuite) TestEnableSnapMissingDisabledServicesSaved(c *C) {
 	c.Assert(err, IsNil)
 	enableChg.AddAll(enableTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(enableChg.Err(), IsNil)
@@ -1446,7 +1437,6 @@ func (s *snapmgrTestSuite) TestRevertRestoresConfigSnapshot(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// config snapshot of rev. 2 has been made by 'revert'
@@ -1582,7 +1572,6 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -1693,7 +1682,6 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlocked(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify that the R(2) version is active now and R(7) is still there
@@ -1757,7 +1745,6 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlockedUndo(c *C) {
 	chg.AddAll(ts)
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -1818,7 +1805,6 @@ func (s *snapmgrTestSuite) TestRevertWithBaseRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -1907,7 +1893,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2007,7 +1992,6 @@ func (s *snapmgrTestSuite) TestRevertWithLocalRevisionRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 8)
@@ -2049,7 +2033,6 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2138,7 +2121,6 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 	terr.WaitFor(last)
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2247,7 +2229,6 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 
 	s.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "some-snap/1")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2342,7 +2323,6 @@ func (s *snapmgrTestSuite) TestRevertUndoMigrationAfterUnsetFlag(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2381,7 +2361,6 @@ func (s *snapmgrTestSuite) TestRevertKeepMigrationWithSetFlag(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2419,7 +2398,6 @@ func (s *snapmgrTestSuite) TestRevertDoHiddenMigration(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2464,7 +2442,6 @@ func (s *snapmgrTestSuite) TestUndoRevertDoHiddenMigration(c *C) {
 
 	expectedErr := failAfterLinkSnap(s.o, chg)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -2536,7 +2513,6 @@ func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -2590,7 +2566,6 @@ func (s *snapmgrTestSuite) TestRevertToCore22WithoutFlagSet(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -2666,7 +2641,6 @@ func (s *snapmgrTestSuite) testRevertToCore22AfterRevertedMigration(c *C, migrat
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -2747,7 +2721,6 @@ func (s *snapmgrTestSuite) testUndoRevertToCore22AfterRevertedMigration(c *C, mi
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -2808,7 +2781,6 @@ func (s *snapmgrTestSuite) testRevertUndoHiddenMigrationFails(c *C, prepFail pre
 
 	expectedErr := prepFail(s.o, chg)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -2852,7 +2824,6 @@ func (s *snapmgrTestSuite) TestRevertUndoExposedMigrationFailsAfterWritingState(
 
 	expectedErr := failAfterLinkSnap(s.o, chg)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -2912,7 +2883,6 @@ func (s *snapmgrTestSuite) testRevertUndoFullMigrationFails(c *C, prepFail prepF
 
 	expectedErr := prepFail(s.o, chg)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
@@ -2974,7 +2944,6 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -3051,7 +3020,6 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -3449,7 +3417,6 @@ func (s *snapmgrTestSuite) TestParallelInstallSwitchRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// switch is not really really doing anything backend related
@@ -5465,7 +5432,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -5662,7 +5628,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -5748,7 +5713,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreStartsAutomatically(c *C) {
 		SnapType: "os",
 	})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -5769,7 +5733,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreTooEarly(c *C) {
 		SnapType: "os",
 	})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 0)
@@ -5793,7 +5756,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreTimeLimitWorks(c *C) {
 	// tried 3h ago, no retry
 	s.state.Set("ubuntu-core-transition-last-retry-time", time.Now().Add(-3*time.Hour))
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 0)
@@ -5801,7 +5763,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreTimeLimitWorks(c *C) {
 	// tried 7h ago, retry
 	s.state.Set("ubuntu-core-transition-last-retry-time", time.Now().Add(-7*time.Hour))
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -5824,7 +5785,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreNoOtherChanges(c *C) {
 	chg := s.state.NewChange("unrelated-change", "unfinished change blocks core transition")
 	chg.SetStatus(state.DoStatus)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -5863,7 +5823,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapDoesNotRunWithoutSnaps(c *C) {
 	// no snaps installed on this system (e.g. fresh classic)
 	snapstate.Set(s.state, "core", nil)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 0)
@@ -5885,7 +5844,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapDoesRunWithAnySnap(c *C) {
 		Current:  snap.R(1),
 	})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -5902,7 +5860,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapDoesNotRunWhenNotEnabled(c *C)
 		SnapType: "os",
 	})
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 0)
@@ -5922,7 +5879,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapStartsAutomaticallyWhenEnabled
 	tr.Set("core", "experimental.snapd-snap", true)
 	tr.Commit()
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -5956,7 +5912,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapWithCoreRunthrough(c *C) {
 	tr.Set("core", "experimental.snapd-snap", true)
 	tr.Commit()
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(s.state.Changes(), HasLen, 1)
@@ -5987,7 +5942,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapTimeLimitWorks(c *C) {
 	// tried 3h ago, no retry
 	s.state.Set("snapd-transition-last-retry-time", time.Now().Add(-3*time.Hour))
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 0)
@@ -5995,7 +5949,6 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapTimeLimitWorks(c *C) {
 	// tried 7h ago, retry
 	s.state.Set("snapd-transition-last-retry-time", time.Now().Add(-7*time.Hour))
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.state.Changes(), HasLen, 1)
@@ -6028,7 +5981,7 @@ func (s *snapmgrTestSuite) TestTransitionSnapdSnapError(c *C) {
 	tr.Commit()
 
 	s.state.Unlock()
-	defer s.se.Stop()
+
 	err := s.o.Settle(5 * time.Second)
 	c.Assert(err, ErrorMatches, `state ensure errors: \[a grumpy store\]`)
 
@@ -6110,7 +6063,6 @@ func (s *snapmgrTestSuite) checkForceDevModeCleanupRuns(c *C, name string, shoul
 	snapstate.Get(s.state, name, &snapst1)
 	c.Assert(snapst1.DevMode, Equals, true)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	var snapst2 snapstate.SnapState
@@ -6131,7 +6083,6 @@ func (s *snapmgrTestSuite) TestForceDevModeCleanupRunsNoSnaps(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	var n int
@@ -6163,7 +6114,6 @@ func (s *snapmgrTestSuite) TestForceDevModeCleanupSkipsNonForcedOS(c *C) {
 	snapstate.Get(s.state, "core", &snapst1)
 	c.Assert(snapst1.DevMode, Equals, true)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	var snapst2 snapstate.SnapState
@@ -6982,7 +6932,6 @@ func (s *snapmgrTestSuite) TestRequestSalt(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(len(s.fakeBackend.ops) >= 1, Equals, true)
@@ -7338,7 +7287,6 @@ func (s *snapmgrTestSuite) runStartSnapServicesWithDisabledServices(c *C, disabl
 	t.Set("snap-setup", sup)
 	chg.AddTask(t)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -7403,7 +7351,6 @@ func (s *snapmgrTestSuite) TestStartSnapServicesUndo(c *C) {
 	terr.JoinLane(t.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -7463,7 +7410,6 @@ func (s *snapmgrTestSuite) TestStopSnapServicesUndo(c *C) {
 	terr.JoinLane(t.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -7530,7 +7476,6 @@ func (s *snapmgrTestSuite) TestStopSnapServicesErrInUndo(c *C) {
 		return nil
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.IsReady(), Equals, true)
@@ -7632,7 +7577,6 @@ func (s *snapmgrTestSuite) TestInstallModeDisableFreshInstall(c *C) {
 	c.Assert(err, IsNil)
 	installChg.AddAll(installTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(installChg.Err(), IsNil)
@@ -7672,7 +7616,6 @@ func (s *snapmgrTestSuite) TestInstallModeDisableUpdateServiceNotDisabled(c *C) 
 	c.Assert(err, IsNil)
 	updateChg.AddAll(updateTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(updateChg.Err(), IsNil)
@@ -7717,7 +7660,6 @@ func (s *snapmgrTestSuite) TestInstallModeDisableFreshInstallEnabledByHook(c *C)
 	c.Assert(err, IsNil)
 	installChg.AddAll(installTs)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(installChg.Err(), IsNil)
@@ -7750,7 +7692,6 @@ func (s *snapmgrTestSuite) TestSnapdRefreshTasks(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// various backend operations, but no unlink-current-snap
@@ -8429,7 +8370,6 @@ func (s *snapmgrTestSuite) TestMigrateHome(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(tss, HasLen, 1)
@@ -8513,7 +8453,6 @@ func (s *snapmgrTestSuite) TestMigrateHomeUndo(c *C) {
 		failingTask.JoinLane(lane)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), ErrorMatches, `(.|\s)* expected failure \(boom\)`)
@@ -8741,7 +8680,6 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementError(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 	c.Assert(chg.Err(), IsNil)
 
@@ -8823,7 +8761,6 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorReverse(c *C
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 	c.Assert(chg.Err(), ErrorMatches, fmt.Sprintf(`(.|\s)*%s\)?`, expectedErr))
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)

--- a/overlord/snapstate/snapstate_try_test.go
+++ b/overlord/snapstate/snapstate_try_test.go
@@ -71,7 +71,6 @@ func (s *snapmgrTestSuite) testTrySetsTryMode(flags snapstate.Flags, c *C, extra
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -114,7 +114,6 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure garbage collection runs as the last tasks
@@ -184,8 +183,6 @@ func (s *snapmgrTestSuite) TestRepeatedUpdatesDoGC(c *C) {
 	tr.Commit()
 
 	s.fakeStore.refreshRevnos = make(map[string]snap.Revision)
-
-	defer s.se.Stop()
 
 	for refreshRev := 2; refreshRev < 10; refreshRev++ {
 		s.fakeStore.refreshRevnos["some-snap-id"] = snap.R(refreshRev)
@@ -367,7 +364,6 @@ func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX 
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -516,7 +512,6 @@ func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.Sna
 	}
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	var snapst snapstate.SnapState
@@ -778,7 +773,6 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -934,7 +928,6 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 	c.Assert(te, NotNil)
 	c.Assert(te.Kind(), Equals, "validate-snap")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -1188,7 +1181,6 @@ func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snaps in the system state
@@ -1542,7 +1534,6 @@ func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
@@ -1586,7 +1577,6 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
@@ -1621,7 +1611,6 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
@@ -1680,7 +1669,6 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
@@ -1707,7 +1695,6 @@ func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -1763,7 +1750,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
@@ -1887,7 +1873,6 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 	}
 	c.Check(updated, HasLen, 3)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -1993,7 +1978,6 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 	}
 	c.Check(updated, HasLen, 3)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2118,7 +2102,6 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 	}
 	c.Check(updated, HasLen, 3)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2210,7 +2193,6 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 
 	s.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/some-snap/11")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2460,7 +2442,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRestoresRevisionConfig(c *C) {
 	terr.JoinLane(last.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -2499,8 +2480,6 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
-
-	defer s.se.Stop()
 
 	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, true)
 	defer restore()
@@ -2551,7 +2530,6 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 	terr.JoinLane(last.Lanes()[0])
 	chg.AddTask(terr)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -2800,7 +2778,6 @@ func (s *snapmgrTestSuite) TestUpdateToRevisionRememberedUserRunThrough(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
@@ -2961,7 +2938,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 	te := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(te, IsNil)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	expected := fakeOps{
@@ -3103,7 +3079,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 	chg := s.state.NewChange("refresh", "refresh a snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snapSetup info
@@ -3268,7 +3243,6 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	chg := s.state.NewChange("refresh", "refresh snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snap has IgnoreValidation set
@@ -3315,7 +3289,6 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	chg = s.state.NewChange("refresh", "refresh snaps")
 	chg.AddAll(tts[0])
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	snapst = snapstate.SnapState{}
@@ -3367,7 +3340,6 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	chg = s.state.NewChange("refresh", "refresh snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	snapst = snapstate.SnapState{}
@@ -3458,7 +3430,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 	chg := s.state.NewChange("refresh", "refresh snaps")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// ensure all our tasks ran
@@ -3864,7 +3835,6 @@ func (s *snapmgrTestSuite) TestUpdateManyPartialFailureCheckRerefreshDone(c *C) 
 
 	checkIsAutoRefresh(c, chg.Tasks(), true)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// not updated
@@ -4620,7 +4590,6 @@ func (s *snapmgrTestSuite) TestUpdateClassicConfinementFiltering(c *C) {
 	chg := s.state.NewChange("refresh", "refresh snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -4692,7 +4661,6 @@ func (s *snapmgrTestSuite) TestUpdateClassicFromClassic(c *C) {
 	chg := s.state.NewChange("refresh", "refresh snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// verify snap is in classic
@@ -5040,7 +5008,6 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionallyFails(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// content consumer snap fails to download
@@ -5115,7 +5082,6 @@ func (s *snapmgrTestSuite) TestUpdateManyFailureDoesntUndoSnapdRefresh(c *C) {
 	// refresh of some-snap fails on link-snap
 	s.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/some-snap/11")
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Check(chg.Err(), ErrorMatches, ".*cannot perform the following tasks:\n- Make snap \"some-snap\" \\(11\\) available to the system.*")
@@ -5848,7 +5814,6 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapLastActiveDisabledServicesSet(c 
 		}
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -5905,7 +5870,6 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapMergedLastActiveDisabledServices
 		}
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -5962,7 +5926,6 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapPassthroughLastActiveDisabledSer
 		}
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -6017,7 +5980,6 @@ func (s *snapmgrTestSuite) TestStopSnapServicesSavesSnapSetupLastActiveDisabledS
 	chg.AddTask(t1)
 	chg.AddTask(t2)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -6069,7 +6031,6 @@ func (s *snapmgrTestSuite) TestStopSnapServicesFirstSavesSnapSetupLastActiveDisa
 	t.Set("snap-setup", snapsup)
 	chg.AddTask(t)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -6120,7 +6081,6 @@ func (s *snapmgrTestSuite) TestRefreshDoesntRestoreRevisionConfig(c *C) {
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// config of rev. 1 has been stored in per-revision map
@@ -6183,7 +6143,6 @@ func (s *snapmgrTestSuite) TestUpdateContentProviderDownloadFailure(c *C) {
 		chg.AddAll(ts)
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// content consumer snap fails to download
@@ -6276,7 +6235,6 @@ func (s *snapmgrTestSuite) TestEmptyUpdateWithChannelChangeAndAutoAlias(c *C) {
 	chg := s.state.NewChange("refresh", "refresh snap")
 	chg.AddAll(ts)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	c.Assert(chg.Err(), IsNil)
@@ -8477,7 +8435,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		"core18": true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// mock restart for the 'link-snap' step and run change to
@@ -8667,7 +8624,6 @@ func (s *snapmgrTestSuite) TestUpdateGadgetKernelSingleRebootHappy(c *C) {
 		"gadget": true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// mock restart for the 'link-snap' step and run change to
@@ -8856,7 +8812,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetSingleRebootHappy(c *C) {
 		"gadget": true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// mock restart for the 'link-snap' step and run change to
@@ -9007,7 +8962,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootWithCannotRebootSetHa
 		"core18": true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// mock restart for the 'link-snap' step and run change to
@@ -9117,7 +9071,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 		"core":   true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// first 'auto-connect' restart here
@@ -9397,7 +9350,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 		return nil
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// both snaps have requested a restart at 'auto-connect', handle this here
@@ -9555,7 +9507,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetKernelSingleRebootUndone(c *C) {
 		return nil
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// kernel requests a reboot
@@ -9837,7 +9788,6 @@ NextSnap3:
 	}
 	s.fakeBackend.linkSnapMaybeReboot = len(s.fakeBackend.linkSnapRebootFor) > 0
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	if !s.fakeBackend.linkSnapMaybeReboot {
@@ -9976,7 +9926,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 		"core18": true,
 	}
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	// mock restart for the 'link-snap' step and run change to
@@ -11051,6 +11000,7 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 	monitorSignal <- "foo"
 	waitFor(s.state, c, func() bool { return s.state.Change("4") != nil })
 	s.state.Lock()
+	defer s.state.Unlock()
 	c.Assert(s.state.Change("4").Kind(), Equals, "auto-refresh")
 	s.settle(c)
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -34,6 +34,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/advisor"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
@@ -10236,6 +10237,345 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 	c.Assert(tasks[0].Summary(), testutil.Contains, "Pre-download snap \"some-snap\" (2) from channel")
 }
 
+func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecorded(c *C) {
+	refreshAppsCheckCalled := 0
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+		refreshAppsCheckCalled++
+		if si.SnapID == "some-snap-id" {
+			return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
+		}
+		return nil
+	})
+	defer restore()
+
+	var monitored int
+	restore = snapstate.MockCgroupMonitorSnapEnded(func(string, chan<- string) error {
+		monitored++
+		return nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+	// Trigger autorefresh.Ensure().
+	err := s.snapmgr.Ensure()
+	if errors.Is(err, advisor.ErrNotSupported) {
+		c.Skip("bolt is not supported")
+	}
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chgs := s.state.Changes()
+	sort.Slice(chgs, func(i, j int) bool {
+		return chgs[i].Kind() < chgs[j].Kind()
+	})
+	c.Assert(chgs, HasLen, 2)
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoStatus)
+	c.Check(chgs[0].Kind(), Equals, "auto-refresh")
+	c.Check(chgs[0].Status(), Equals, state.DoStatus)
+	// No notices are recorded until auto-refresh change is marked as ready.
+	checkRefreshInhibitNotice(c, s.state, 0)
+
+	s.settle(c)
+
+	// - Twice in soft-check of original auto-refresh (once per snap).
+	// - Once in pre-download (for some-snap).
+	// - Once in hard-check of original auto-refresh (for some-other-snap).
+	c.Check(refreshAppsCheckCalled, Equals, 4)
+	// Pre-downloaded snap is monitored.
+	c.Check(monitored, Equals, 1)
+
+	chgs = s.state.Changes()
+	sort.Slice(chgs, func(i, j int) bool {
+		return chgs[i].Kind() < chgs[j].Kind()
+	})
+	c.Assert(chgs, HasLen, 2)
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoneStatus)
+	// A continued auto-refresh shouldn't be created because snap is still monitored.
+	c.Check(chgs[0].Kind(), Equals, "auto-refresh")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+
+	// Aggregate notice is recorded when auto-refresh change is marked as ready.
+	checkRefreshInhibitNotice(c, s.state, 1)
+}
+
+func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecordedOnPreDownloadOnly(c *C) {
+	refreshAppsCheckCalled := 0
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+		refreshAppsCheckCalled++
+		if refreshAppsCheckCalled == 1 {
+			return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
+		}
+		return nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+	// Trigger autorefresh.Ensure().
+	err := s.snapmgr.Ensure()
+	if errors.Is(err, advisor.ErrNotSupported) {
+		c.Skip("bolt is not supported")
+	}
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chgs := s.state.Changes()
+	c.Assert(chgs, HasLen, 1)
+	c.Check(chgs[0].Kind(), Equals, "pre-download")
+	c.Check(chgs[0].Status(), Equals, state.DoStatus)
+	// If all refresh candidates are blocked from auto-refresh and only a
+	// pre-download change is created for those snaps we should still record
+	// a notice.
+	checkRefreshInhibitNotice(c, s.state, 1)
+
+	s.settle(c)
+
+	// - Once in soft-check of original auto-refresh.
+	// - Once in pre-download.
+	// - Once in soft-check of continued auto-refresh.
+	// - Once in hard-check of continued auto-refresh.
+	c.Check(refreshAppsCheckCalled, Equals, 4)
+
+	chgs = s.state.Changes()
+	sort.Slice(chgs, func(i, j int) bool {
+		return chgs[i].Kind() < chgs[j].Kind()
+	})
+
+	c.Assert(chgs, HasLen, 2)
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoneStatus)
+	// Continued auto-refresh.
+	c.Check(chgs[0].Kind(), Equals, "auto-refresh")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+
+	// No more snaps are marked as inhibited after the continued auto-refresh
+	// The set of inhibtied snaps changed to an empty set, so another notice is recorded.
+	checkRefreshInhibitNotice(c, s.state, 2)
+}
+
+func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeNotRecorded(c *C) {
+	s.state.Lock()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+	// Trigger autorefresh.Ensure().
+	err := s.snapmgr.Ensure()
+	if errors.Is(err, advisor.ErrNotSupported) {
+		c.Skip("bolt is not supported")
+	}
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chgs := s.state.Changes()
+	c.Assert(chgs, HasLen, 1)
+	c.Check(chgs[0].Kind(), Equals, "auto-refresh")
+	c.Check(chgs[0].Status(), Equals, state.DoStatus)
+	// No notices are recorded.
+	checkRefreshInhibitNotice(c, s.state, 0)
+
+	s.settle(c)
+
+	chgs = s.state.Changes()
+	c.Assert(chgs, HasLen, 1)
+	c.Check(chgs[0].Kind(), Equals, "auto-refresh")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+	// No notices are recorded because no snaps are blocked.
+	checkRefreshInhibitNotice(c, s.state, 0)
+}
+
+func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecordedOnce(c *C) {
+	refreshAppsCheckCalled := 0
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+		refreshAppsCheckCalled++
+		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
+	})
+	defer restore()
+
+	// Never close monitoring channel to avoid triggering a continued auto-refresh
+	var monitored int
+	restore = snapstate.MockCgroupMonitorSnapEnded(func(string, chan<- string) error {
+		monitored++
+		return nil
+	})
+	defer restore()
+
+	// Setup test snaps
+	s.state.Lock()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+	// Verify list is empty
+	checkLastRecordedInhibitedSnaps(c, s.state, nil)
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+	// Trigger autorefresh.Ensure().
+	err := s.snapmgr.Ensure()
+	if errors.Is(err, advisor.ErrNotSupported) {
+		c.Skip("bolt is not supported")
+	}
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// First auto-refresh attempt
+	s.settle(c)
+	chgs := s.state.Changes()
+	c.Assert(chgs, HasLen, 1)
+	c.Check(chgs[0].Kind(), Equals, "pre-download")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+	// If all refresh candidates are blocked from auto-refresh and only a
+	// pre-download change is created for those snaps we should still record
+	// a notice.
+	checkRefreshInhibitNotice(c, s.state, 1)
+	checkLastRecordedInhibitedSnaps(c, s.state, []string{"some-snap"})
+
+	forceAutoRefresh := func() {
+		s.state.Unlock()
+		// Fake nextRefresh to now.
+		s.snapmgr.MockNextRefresh(time.Now())
+		// Fake that the retryRefreshDelay is over
+		restore = snapstate.MockRefreshRetryDelay(1 * time.Millisecond)
+		defer restore()
+		time.Sleep(10 * time.Millisecond)
+		// Trigger autorefresh.Ensure().
+		c.Assert(s.snapmgr.Ensure(), IsNil)
+		s.state.Lock()
+	}
+
+	// Force another auto-refresh to check that notice is not repeated
+	// for the same set of inhibited snaps.
+	forceAutoRefresh()
+	s.settle(c)
+
+	chgs = s.state.Changes()
+	c.Assert(chgs, HasLen, 2)
+	// Old pre-download
+	c.Check(chgs[0].Kind(), Equals, "pre-download")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+	// New pre-download
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoneStatus)
+	// No new notices recorded because the set of inhibited snaps was not changed.
+	checkRefreshInhibitNotice(c, s.state, 1)
+	checkLastRecordedInhibitedSnaps(c, s.state, []string{"some-snap"})
+
+	// Add another inhibited snap.
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: string(snap.TypeApp),
+	})
+
+	// Force another auto-refresh to check that notice is recorded because
+	// the set of inhibited snaps changed.
+	forceAutoRefresh()
+	s.settle(c)
+
+	chgs = s.state.Changes()
+	c.Assert(chgs, HasLen, 3)
+	// Old pre-download
+	c.Check(chgs[0].Kind(), Equals, "pre-download")
+	c.Check(chgs[0].Status(), Equals, state.DoneStatus)
+	// Old pre-download
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoneStatus)
+	// Latest pre-download
+	c.Check(chgs[1].Kind(), Equals, "pre-download")
+	c.Check(chgs[1].Status(), Equals, state.DoneStatus)
+	// New notice occurrence is recorded because the set of inhibited snaps changed.
+	checkLastRecordedInhibitedSnaps(c, s.state, []string{"some-snap", "some-other-snap"})
+	checkRefreshInhibitNotice(c, s.state, 2)
+}
+
+func checkLastRecordedInhibitedSnaps(c *C, st *state.State, snaps []string) {
+	var lastRecordedInhibitedSnaps map[string]bool
+	err := st.Get("last-recorded-inhibited-snaps", &lastRecordedInhibitedSnaps)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		c.Fail()
+	}
+	c.Assert(len(lastRecordedInhibitedSnaps), Equals, len(snaps))
+	for _, snap := range snaps {
+		c.Assert(lastRecordedInhibitedSnaps[snap], Equals, true)
+	}
+}
+
+func checkRefreshInhibitNotice(c *C, st *state.State, occurrences int) {
+	notices := st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
+	if occurrences == 0 {
+		c.Assert(notices, HasLen, 0)
+		return
+	}
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "refresh-inhibit")
+	c.Check(n["key"], Equals, "-")
+	c.Check(n["occurrences"], Equals, float64(occurrences))
+	c.Check(n["user-id"], Equals, nil)
+}
+
 func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
@@ -12053,7 +12393,6 @@ type: snapd
 
 	s.state.EnsureBefore(0)
 
-	defer s.se.Stop()
 	s.settle(c)
 
 	fmt.Printf("Settle returned\n")

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -190,11 +190,14 @@ const (
 	// Warnings are a subset of notices where the key is a human-readable
 	// warning message.
 	WarningNotice NoticeType = "warning"
+
+	// Recorded whenever an auto-refresh is inhibited for one or more snaps.
+	RefreshInhibitNotice NoticeType = "refresh-inhibit"
 )
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, WarningNotice:
+	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice:
 		return true
 	}
 	return false
@@ -276,6 +279,9 @@ func validateNotice(noticeType NoticeType, key string, options *AddNoticeOptions
 	}
 	if key == "" {
 		return fmt.Errorf("internal error: attempted to add %s notice with invalid key %q", noticeType, key)
+	}
+	if noticeType == RefreshInhibitNotice && key != "-" {
+		return fmt.Errorf(`internal error: attempted to add %s notice with invalid key %q, only "-" key is supported`, noticeType, key)
 	}
 	return nil
 }

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -257,7 +257,7 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	addNotice(c, st, nil, state.ChangeUpdateNotice, "443", nil)
+	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
@@ -287,38 +287,34 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 	// Another type
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
-	c.Assert(notices, HasLen, 2)
+	c.Assert(notices, HasLen, 1)
 	n = noticeToMap(c, notices[0])
-	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "change-update")
-	c.Check(n["key"], Equals, "443")
-	n = noticeToMap(c, notices[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
 
+	// Another type
+	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
+	c.Assert(notices, HasLen, 1)
+	n = noticeToMap(c, notices[0])
+	c.Check(n["user-id"], Equals, nil)
+	c.Check(n["type"], Equals, "refresh-inhibit")
+	c.Check(n["key"], Equals, "-")
+
 	// Multiple types
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
 		state.ChangeUpdateNotice,
-		state.WarningNotice,
+		state.RefreshInhibitNotice,
 	}})
-	c.Assert(notices, HasLen, 4)
+	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])
 	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "change-update")
-	c.Check(n["key"], Equals, "443")
+	c.Check(n["type"], Equals, "refresh-inhibit")
+	c.Check(n["key"], Equals, "-")
 	n = noticeToMap(c, notices[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
-	n = noticeToMap(c, notices[2])
-	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "warning")
-	c.Check(n["key"], Equals, "Warning 1!")
-	n = noticeToMap(c, notices[3])
-	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "warning")
-	c.Check(n["key"], Equals, "Warning 2!")
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
@@ -622,6 +618,27 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 		c.Fatalf("timed out waiting for WaitNotice goroutines to finish")
 	case <-done:
 	}
+}
+
+func (s *noticesSuite) TestValidateNotice(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	// Invalid type
+	id, err := st.AddNotice(nil, "bad-type", "123", nil)
+	c.Check(err, ErrorMatches, `internal error: attempted to add notice with invalid type "bad-type"`)
+	c.Check(id, Equals, "")
+
+	// Empty key
+	id, err = st.AddNotice(nil, state.ChangeUpdateNotice, "", nil)
+	c.Check(err, ErrorMatches, `internal error: attempted to add change-update notice with invalid key ""`)
+	c.Check(id, Equals, "")
+
+	// Unxpected key for refresh-inhibit notice
+	id, err = st.AddNotice(nil, state.RefreshInhibitNotice, "123", nil)
+	c.Check(err, ErrorMatches, `internal error: attempted to add refresh-inhibit notice with invalid key "123", only "-" key is supported`)
+	c.Check(id, Equals, "")
 }
 
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.


### PR DESCRIPTION
This PR adds `refresh-inhibit` notice which is needed for RAA UX flow as mentioned in [RAA-UX spec SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.c40tauj2e3fo).

Once https://github.com/snapcore/snapd/pull/13576 is merged, more complex state-based decisions can be made, like only sending when the list of inhibited snaps changes.

This commit https://github.com/snapcore/snapd/commit/1e6dec8ec6e77e84be453d85c9e05dbc308965d7 can be split into a different PR if needed.