### PR TITLE
packaging/ubuntu-16.04: install systemd files in correct place on 24.04

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -296,6 +296,16 @@ override_dh_install:
 
 	dh_install
 
+	# use "usr/lib" here because apparently systemd looks only there
+	dh_install usr/lib/systemd/system-environment-generators
+	# but on non usr-merge installations, system generators end up in lib
+	if [ -e debian/tmp/usr/lib/systemd/system-generators ]; then	\
+		dh_install usr/lib/systemd/system-generators;		\
+	else								\
+		dh_install lib/systemd/system-generators;		\
+	fi
+
+
 override_dh_auto_install: snap.8
 	dh_auto_install -O--buildsystem=golang
 

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -45,8 +45,3 @@ usr/lib/snapd/snap-gdbserver-shim
 
 # install squashfuse as snapfuse to ensure it is available in e.g. lxd
 c-vendor/squashfuse/snapfuse usr/bin
-
-# use "usr/lib" here because apparently systemd looks only there
-usr/lib/systemd/system-environment-generators
-# but system generators end up in lib
-lib/systemd/system-generators


### PR DESCRIPTION
On a usr-merge system, systemd there is no `/lib/systemd`, it is all in `/usr/lib/systemd`.