### PR TITLE
packaging/ubuntu-16.04: install systemd files in correct place on 24.04

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -259,7 +259,13 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	$(MAKE) -C cmd check
 endif
 
-override_dh_install:
+
+debian/snapd.install: SYSTEMD_LIBDIR=$(shell pkg-config --variable=systemdutildir systemd)
+debian/snapd.install: debian/snapd.install.in
+	sed 's,@systemd-lib@,$(SYSTEMD_LIBDIR),g' $< >$@.tmp
+	mv $@.tmp $@
+
+override_dh_install: debian/snapd.install
 	# we do not need this in the package, its just needed during build
 	rm -rf ${CURDIR}/debian/tmp/usr/bin/xgettext-go
 	# toolbelt is not shippable

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -49,4 +49,4 @@ c-vendor/squashfuse/snapfuse usr/bin
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
 # but system generators end up in lib
-lib/systemd/system-generators
+@systemd-lib@/system-generators


### PR DESCRIPTION
On a usr-merge system, systemd there is no `/lib/systemd`, it is all in `/usr/lib/systemd`.
