### PR TITLE
tests: detect if nested tests need to be executed based on change files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -642,7 +642,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
-      fetch-depth: 0
+      with:
+        # needed for git commit history
+        fetch-depth: 0
 
     - name: Get previous attempt
       id: get-previous-attempt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,14 +7,6 @@ on:
     # branch, the master branch runs are just for unit tests + codecov.io
     branches: [ "master","release/**" ]
 
-  # XXX we suspect that the whenever the labeler workflow executes successfully
-  # it will trigger another workflow of tests on master, temporarily disable to
-  # see if that improves the situation
-  # workflow_run:
-  #   workflows: ["Pull Request Labeler"]
-  #   types:
-  #     - completed
-
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -701,10 +693,28 @@ jobs:
           echo "Collected labels: $LABELS"
       shell: bash
 
+    - name: Get changed files
+      id: get-changed-files
+      uses: tj-actions/changed-files@v34.5.1
+      with:
+        path: ./src/github.com/snapcore/snapd
+
+    - name: Detect changes files
+      id: detect-changes
+      run: |
+          CHANGED_FILES="${{ steps.get-changed-files.outputs.all_changed_files }}"
+          for file in CHANGED_FILES; do
+              if [[ "$file" == tests/nested/**/* ]] || [[ "$file" == tests/lib/nested.sh ]]
+                  echo "changes_found=true" >> $GITHUB_OUTPUT
+                  exit 0
+              fi
+          done
+          echo "changes_found=false" >> $GITHUB_OUTPUT
+
     - name: Run spread tests
       # run if the commit is pushed to the release/* branch or there is a 'Run
-      # nested' label set on the PR
-      if: "contains(steps.collect-pr-labels.outputs.labels, 'Run nested') || contains(github.ref, 'refs/heads/release/')"
+      # nested' label set on the PR or there is a change in a nested test/lib
+      if: "contains(steps.collect-pr-labels.outputs.labels, 'Run nested') || contains(steps.detect-changes.outputs.changes_found, 'true') || contains(github.ref, 'refs/heads/release/')"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -696,8 +696,6 @@ jobs:
     - name: Get changed files
       id: get-changed-files
       uses: tj-actions/changed-files@v34.5.1
-      with:
-        path: ./src/github.com/snapcore/snapd
 
     - name: Detect changes files
       id: detect-changes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -702,7 +702,7 @@ jobs:
       run: |
           CHANGED_FILES="${{ steps.get-changed-files.outputs.all_changed_files }}"
           for file in CHANGED_FILES; do
-              if [[ "$file" == tests/nested/**/* ]] || [[ "$file" == tests/lib/nested.sh ]]
+              if [[ "$file" == tests/nested/**/* ]] || [[ "$file" == tests/lib/nested.sh ]]; then
                   echo "changes_found=true" >> $GITHUB_OUTPUT
                   exit 0
               fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -642,6 +642,7 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
+      fetch-depth: 0
 
     - name: Get previous attempt
       id: get-previous-attempt

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -292,7 +292,6 @@ nested_qemu_name() {
     else
         command -v qemu-system-x86_64
     fi
-
 }
 
 nested_get_snap_rev_for_channel() {


### PR DESCRIPTION
This change allows to detect changes in nested files even if there is not a dependency with labeler workflow.

The dependency with the labeler workflow was creating duplicated runs, so it has been removed and we need to detect manually the changes to make sure the first time a nested test/lib is changed the nested tests are triggered.
