### PR TITLE
i/builtin: add alternative mounts/mountinfo for mount-observe

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -45,6 +45,12 @@ const mountObserveConnectedPlugAppArmor = `
 owner @{PROC}/@{pid}/mounts r,
 owner @{PROC}/@{pid}/mountinfo r,
 owner @{PROC}/@{pid}/mountstats r,
+
+# some processes might read mount* from /proc/thread-self/ instead
+# and those resolve to the following: (no mountstats here)
+owner @{PROC}/@{pid}/task/@{tid}/mounts r,
+owner @{PROC}/@{pid}/task/@{tid}/mountinfo r,
+
 /sys/devices/*/block/{,**} r,
 
 # Needed by 'htop' to calculate RAM usage more accurately (and informational purposes, if enabled)


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/snapd/+bug/2053271.

Processes are observed to read the info from /proc/thread-self/mountinfo instead, which resolves to /proc/$pid/task/$task/mountinfo, 

(example, taken from LP bug: https://github.com/moby/sys/blob/mountinfo/v0.7.1/mountinfo/mountinfo_linux.go#L139-L174)

I've taken the liberty to add both /mounts and /mountinfo as that seems in line with the interface.

