### PR TITLE
interfaces/builtin/libvirt: add /run/libvirt/libvirt-sock-ro

### DIFF
--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -30,6 +30,7 @@ const libvirtBaseDeclarationSlots = `
 `
 
 const libvirtConnectedPlugAppArmor = `
+/run/libvirt/libvirt-sock-ro rw,
 /run/libvirt/libvirt-sock rw,
 /etc/libvirt/* r,
 `


### PR DESCRIPTION
virt-viewer requires read/write access to /run/libvirt/libvirt-sock-ro  to work properly. This PR adds the required rule to libvirt interface.