### PR TITLE
tests: fix iterfaces-custom-device-app-slot test by installing core snap maually

### DIFF
--- a/tests/main/interfaces-custom-device-app-slot/task.yaml
+++ b/tests/main/interfaces-custom-device-app-slot/task.yaml
@@ -20,6 +20,11 @@ prepare: |
         exit
     fi
 
+    # Install core snap to avoid installing it using the fake store
+    if not snap list core; then
+      snap install core
+    fi
+
     snap debug can-manage-refreshes | MATCH false
 
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"


### PR DESCRIPTION
Install core snap to avoid installing it using the fake store

Fake store produces a problem when snapd tries to install core snap in uc18+

error: 
taskrunner.go:299: [change 9 "Ensure prerequisites for \"device-app\" are available" task] failed: cannot install snap base "core": unexpectedly empty response from the server (try again later)