### PR TITLE
wrappers: fix unreliable tests to not use mocked systemctl command

### DIFF
--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type ServiceState struct {
@@ -39,7 +40,12 @@ type ServiceState struct {
 func HandleMockAllUnitsActiveOutput(cmd []string, states map[string]ServiceState) []byte {
 	osutil.MustBeTestBinary("mocking systemctl output can only be done from tests")
 	if cmd[0] != "show" ||
-		cmd[1] != "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload" {
+		!strutil.ListContains([]string{
+			// extended properties for services and mounts
+			"--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload",
+			// base properties for everything else
+			"--property=Id,ActiveState,UnitFileState,Names",
+		}, cmd[1]) {
 		return nil
 	}
 	var output []byte

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -2877,48 +2877,42 @@ func (s *servicesTestSuite) TestQueryDisabledServices(c *C) {
 	// This will mock the following:
 	// svc 1 will be reported as disabled
 	// svc 2 will be reported as enabled
-	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-		# shifting by 2 also drops the temp dir arg to --root
-	    shift 2
-	fi
-
-	case "$1" in
-		show)
-			case "$3" in 
-			"snap.hello-snap.svc1.service"|"snap.hello-snap.svc2.service")
-				for SVC in $3 $4
-				do
-					echo "Type=notify"
-					echo "Id=$SVC"
-					echo "Names=$SVC"
-					echo "NeedDaemonReload=no"
-					if [ "$SVC" = "snap.hello-snap.svc1.service" ]; then
-						echo "ActiveState=inactive"
-						echo "UnitFileState=disabled"
-					elif [ "$SVC" = "snap.hello-snap.svc2.service" ]; then
-						echo "ActiveState=inactive"
-						echo "UnitFileState=enabled"
-					fi
-					if [ "$SVC" != "$4" ]; then 
-						echo ""
-					fi
-				done
-				exit 0
-				;;
-			*)
-				shift 2
-				echo "unexpected show of service $*"
-				exit 2
-				;;
-			esac
-	        ;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-	`)
-	defer r.Restore()
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if len(cmd) >= 3 && cmd[0] == "show" {
+			svcNames := cmd[2:]
+			var output []byte
+			c.Logf("svc names: %v", svcNames)
+			for idx, svc := range svcNames {
+				if idx > 0 {
+					output = append(output, '\n')
+				}
+				switch svc {
+				case "snap.hello-snap.svc1.service":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc1.service
+Names=snap.hello-snap.svc1.service
+NeedDaemonReload=no
+ActiveState=inactive
+UnitFileState=disabled
+`)[1:]...)
+				case "snap.hello-snap.svc2.service":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc2.service
+Names=snap.hello-snap.svc2.service
+NeedDaemonReload=no
+ActiveState=inactive
+UnitFileState=enabled
+`)[1:]...)
+				}
+			}
+			c.Logf("output:\n%s\n<<<<end>>>", string(output))
+			return output, nil
+		}
+		return []byte("ActiveState=inactive\n"), nil
+	})
 
 	disabledSvcs, err := wrappers.QueryDisabledServices(info, progress.Null)
 	c.Assert(err, IsNil)
@@ -2928,10 +2922,10 @@ func (s *servicesTestSuite) TestQueryDisabledServices(c *C) {
 
 	// the calls could be out of order in the list, since iterating over a map
 	// is non-deterministic, so manually check each call
-	c.Assert(r.Calls(), HasLen, 1)
-	for _, call := range r.Calls() {
-		c.Assert(call, HasLen, 5)
-		c.Assert(call[:2], DeepEquals, []string{"systemctl", "show"})
+	c.Assert(s.sysdLog, HasLen, 1)
+	for _, call := range s.sysdLog {
+		c.Assert(call, HasLen, 4)
+		c.Assert(call[0], Equals, "show")
 		switch call[3] {
 		case "snap.hello-snap.svc1.service", "snap.hello-snap.svc2.service":
 		default:
@@ -2960,64 +2954,60 @@ func (s *servicesTestSuite) TestQueryDisabledServicesActivatedServices(c *C) {
 	// svc 1 will be reported as static
 	// svc 2 will be reported as enabled
 	// svc 1 has two socket activations that both will be reported as disabled
-	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-		# shifting by 2 also drops the temp dir arg to --root
-	    shift 2
-	fi
-
-	case "$1" in
-		show)
-			case "$3" in 
-			"snap.hello-snap.svc1.service"|"snap.hello-snap.svc2.service")
-				for SVC in $3 $4
-				do
-					echo "Type=notify"
-					echo "Id=$SVC"
-					echo "Names=$SVC"
-					echo "NeedDaemonReload=no"
-					if [ "$SVC" = "snap.hello-snap.svc1.service" ]; then
-						echo "ActiveState=inactive"
-						echo "UnitFileState=static"
-					elif [ "$SVC" = "snap.hello-snap.svc2.service" ]; then
-						echo "ActiveState=inactive"
-						echo "UnitFileState=enabled"
-					fi
-					if [ "$SVC" != "$4" ]; then 
-						echo ""
-					fi
-				done
-				exit 0
-				;;
-			"snap.hello-snap.svc1.sock1.socket"|"snap.hello-snap.svc1.sock2.socket")
-				echo "Type=notify"
-				echo "Id=snap.hello-snap.svc1.sock1.socket"
-				echo "Names=snap.hello-snap.svc1.sock1.socket"
-				echo "ActiveState=inactive"
-				echo "UnitFileState=disabled"
-				echo "NeedDaemonReload=no"
-				echo ""
-				echo "Type=notify"
-				echo "Id=snap.hello-snap.svc1.sock2.socket"
-				echo "Names=snap.hello-snap.svc1.sock2.socket"
-				echo "ActiveState=inactive"
-				echo "UnitFileState=disabled"
-				echo "NeedDaemonReload=no"
-				exit 0
-				;;
-			*)
-				shift 2
-				echo "unexpected show of service $*"
-				exit 2
-				;;
-			esac
-	        ;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-	`)
-	defer r.Restore()
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if len(cmd) >= 3 && cmd[0] == "show" {
+			svcNames := cmd[2:]
+			var output []byte
+			c.Logf("svc names: %v", svcNames)
+			for idx, svc := range svcNames {
+				if idx > 0 {
+					output = append(output, '\n')
+				}
+				switch svc {
+				case "snap.hello-snap.svc1.service":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc1.service
+Names=snap.hello-snap.svc1.service
+NeedDaemonReload=no
+ActiveState=inactive
+UnitFileState=static
+`)[1:]...)
+				case "snap.hello-snap.svc2.service":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc2.service
+Names=snap.hello-snap.svc2.service
+NeedDaemonReload=no
+ActiveState=inactive
+UnitFileState=enabled
+`)[1:]...)
+				case "snap.hello-snap.svc1.sock1.socket":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc1.sock1.socket
+Names=snap.hello-snap.svc1.sock1.socket
+ActiveState=inactive
+UnitFileState=disabled
+NeedDaemonReload=no
+`)[1:]...)
+				case "snap.hello-snap.svc1.sock2.socket":
+					output = append(output, []byte(`
+Type=notify
+Id=snap.hello-snap.svc1.sock2.socket
+Names=snap.hello-snap.svc1.sock2.socket
+ActiveState=inactive
+UnitFileState=disabled
+NeedDaemonReload=no
+`)[1:]...)
+				}
+			}
+			c.Logf("output:\n%s\n<<<<end>>>", string(output))
+			return output, nil
+		}
+		return []byte("ActiveState=inactive\n"), nil
+	})
 
 	disabledSvcs, err := wrappers.QueryDisabledServices(info, progress.Null)
 	c.Assert(err, IsNil)
@@ -3027,10 +3017,10 @@ func (s *servicesTestSuite) TestQueryDisabledServicesActivatedServices(c *C) {
 
 	// the calls could be out of order in the list, since iterating over a map
 	// is non-deterministic, so manually check each call
-	c.Assert(r.Calls(), HasLen, 2)
-	for _, call := range r.Calls() {
-		c.Assert(call, HasLen, 5)
-		c.Assert(call[:2], DeepEquals, []string{"systemctl", "show"})
+	c.Assert(s.sysdLog, HasLen, 2)
+	for _, call := range s.sysdLog {
+		c.Assert(call, HasLen, 4)
+		c.Assert(call[0], Equals, "show")
 		switch call[3] {
 		case "snap.hello-snap.svc1.service", "snap.hello-snap.svc2.service", "snap.hello-snap.svc3.service":
 		case "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket":
@@ -3047,73 +3037,27 @@ func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
   daemon: forking
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	s.systemctlRestorer()
-	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-	    shift 2
-	fi
-	if [ "$1" = "--no-reload" ]; then
-	    shift
-	fi
-
-	case "$1" in
-		enable)
-			case "$2" in 
-				"snap.hello-snap.svc1.service")
-					echo "unexpected enable of disabled service $2"
-					exit 1
-					;;
-				"snap.hello-snap.svc2.service")
-					exit 0
-					;;
-				*)
-					echo "unexpected enable of service $2"
-					exit 1
-					;;
-			esac
-			;;
-		start)
-			case "$2" in
-				"snap.hello-snap.svc2.service")
-					exit 0
-					;;
-			*)
-					echo "unexpected start of service $2"
-					exit 1
-					;;
-			esac
-			;;
-		daemon-reload)
-			exit 0
-			;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-	`)
-	defer r.Restore()
-
 	// svc1 will be disabled
 	disabledSvcs := []string{"svc1"}
 
 	err := s.addSnapServices(info, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(r.Calls(), DeepEquals, [][]string{
-		{"systemctl", "daemon-reload"},
+	c.Assert(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
 	})
 
-	r.ForgetCalls()
+	s.sysdLog = nil
 
 	flags := &wrappers.StartServicesFlags{Enable: true}
 	err = wrappers.StartServices(info.Services(), disabledSvcs, flags, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	// only svc2 should be enabled
-	c.Assert(r.Calls(), DeepEquals, [][]string{
-		{"systemctl", "--no-reload", "enable", "snap.hello-snap.svc2.service"},
-		{"systemctl", "daemon-reload"},
-		{"systemctl", "start", "snap.hello-snap.svc2.service"},
+	c.Assert(s.sysdLog, DeepEquals, [][]string{
+		{"--no-reload", "enable", "snap.hello-snap.svc2.service"},
+		{"daemon-reload"},
+		{"start", "snap.hello-snap.svc2.service"},
 	})
 }
 
@@ -3507,46 +3451,13 @@ func (s *servicesTestSuite) TestNoStartDisabledServices(c *C) {
   daemon: simple
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	s.systemctlRestorer()
-	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-	    shift 2
-	fi
-	if [ "$1" = "--no-reload" ]; then
-	    shift
-	fi
-
-	case "$1" in
-		start)
-			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				exit 0
-			fi
-			echo "unexpected start of service $2"
-			exit 1
-			;;
-		enable)
-			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				exit 0
-			fi
-			echo "unexpected enable of service $2"
-			exit 1
-			;;
-		daemon-reload)
-			;;
-	    *)
-	        echo "unexpected call $*"
-	        exit 2
-	esac
-	`)
-	defer r.Restore()
-
 	flags := &wrappers.StartServicesFlags{Enable: true}
 	err := wrappers.StartServices(info.Services(), []string{"svc1"}, flags, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
-	c.Assert(r.Calls(), DeepEquals, [][]string{
-		{"systemctl", "--no-reload", "enable", svc2Name},
-		{"systemctl", "daemon-reload"},
-		{"systemctl", "start", svc2Name},
+	c.Assert(s.sysdLog, DeepEquals, [][]string{
+		{"--no-reload", "enable", svc2Name},
+		{"daemon-reload"},
+		{"start", svc2Name},
 	})
 }
 


### PR DESCRIPTION
Fix the test to not use a mocked systemctl command so that we can get more reliable execution even when running in a slow environment. The issue is that parts of the 'stop' chain run in a goroutine, so the order of `systemctl show` and `systemctl stop` calls isn't guaranteed. No top of this, since this can run in parallel now, the code would need to use `testutilg.MockLockedCommand` to prevent corruption of the call log.

Fixes the following issue seen in unit tests or OBS builds:

```
----------------------------------------------------------------------
FAIL: services_test.go:3371: servicesTestSuite.TestStartServicesStopsServicesIncludingActivation

using shellcheck: "/usr/bin/shellcheck"
services_test.go:3433:
    c.Check(r.Calls(), DeepEquals, [][]string{
        // Enable phase for the service activation units, we have one set of system daemon and one set of user daemon
        {"systemctl", "daemon-reload"},
        {"systemctl", "--user", "daemon-reload"},
        {"systemctl", "--no-reload", "enable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"},
        {"systemctl", "daemon-reload"},
        {"systemctl", "--user", "--global", "--no-reload", "enable", "snap.hello-snap.svc2.sock1.socket", "snap.hello-snap.svc2.sock2.socket"},

        // Start phase for service activation units, we have rigged the game by making sure this stage fails,
        // so only one of the services will attempt to start
        {"systemctl", "start", "snap.hello-snap.svc1.sock1.socket"},

        // Stop phase, where we attempt to stop the activation units and the primary services
        // We first attempt to stop the user services, then the system services
        {"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock1.socket"},
        {"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock1.socket"},
        {"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock2.socket"},
        {"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock2.socket"},
        {"systemctl", "--user", "stop", "snap.hello-snap.svc2.service"},
        {"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.service"},

        {"systemctl", "stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.hello-snap.svc1.service"},
        {"systemctl", "show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"},

        // Disable phase, where the activation units are being disabled
        {"systemctl", "--no-reload", "disable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"},
        {"systemctl", "daemon-reload"},
        {"systemctl", "--user", "--global", "--no-reload", "disable", "snap.hello-snap.svc2.sock1.socket", "snap.hello-snap.svc2.sock2.socket"},
    })
... obtained [][]string = [][]string{[]string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "daemon-reload"}, []string{"systemctl", "--no-reload", "enable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"}, []string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "--global", "--no-reload", "enable", "snap.hello-snap.svc2.soc
k1.socket", "snap.hello-snap.svc2.sock2.socket"}, []string{"systemctl", "start", "snap.hello-snap.svc1.sock1.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock1.socket"}, []string{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock1.socket"}, []string{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap
.svc2.sock2.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock2.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.service"}, []string{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.service"}, []string{"systemctl", "stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.h
ello-snap.svc1.service"}, []string{"systemctl", "show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"}, []string{"systemctl", "--no-reload", "disable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"}, []string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "--global", "--no-reload", "disable", "snap.hello-snap.svc2.sock1.so
cket", "snap.hello-snap.svc2.sock2.socket"}}
... expected [][]string = [][]string{[]string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "daemon-reload"}, []string{"systemctl", "--no-reload", "enable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"}, []string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "--global", "--no-reload", "enable", "snap.hello-snap.svc2.soc
k1.socket", "snap.hello-snap.svc2.sock2.socket"}, []string{"systemctl", "start", "snap.hello-snap.svc1.sock1.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock1.socket"}, []string{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock1.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.sock2.socket"}, []st
ring{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock2.socket"}, []string{"systemctl", "--user", "stop", "snap.hello-snap.svc2.service"}, []string{"systemctl", "--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.service"}, []string{"systemctl", "stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.h
ello-snap.svc1.service"}, []string{"systemctl", "show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"}, []string{"systemctl", "--no-reload", "disable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"}, []string{"systemctl", "daemon-reload"}, []string{"systemctl", "--user", "--global", "--no-reload", "disable", "snap.hello-snap.svc2.sock1.so
cket", "snap.hello-snap.svc2.sock2.socket"}}
... Difference:
...     [8]: []string[5] != []string[4]
...     [9]: []string[4] != []string[5]
```

The following tests were also found to be unreliable on very slow systems:

```
----------------------------------------------------------------------
FAIL: services_test.go:3043: servicesTestSuite.TestAddSnapServicesWithDisabledServices

services_test.go:3102:
    c.Assert(r.Calls(), DeepEquals, [][]string{
        {"systemctl", "daemon-reload"},
    })
... obtained [][]string = [][]string(nil)
... expected [][]string = [][]string{[]string{"systemctl", "daemon-reload"}}
... Difference:
...     [][]string[0] != [][]string[1]

----------------------------------------------------------------------
FAIL: services_test.go:3500: servicesTestSuite.TestNoStartDisabledServices

services_test.go:3545:
    c.Assert(r.Calls(), DeepEquals, [][]string{
        {"systemctl", "--no-reload", "enable", svc2Name},
        {"systemctl", "daemon-reload"},
        {"systemctl", "start", svc2Name},
    })
... obtained [][]string = [][]string(nil)
... expected [][]string = [][]string{[]string{"systemctl", "--no-reload", "enable", "snap.hello-snap.svc2.service"}, []string{"systemctl", "daemon-reload"}, []string{"systemctl", "start", "snap.hello-snap.svc2.service"}}
... Difference:
...     [][]string[0] != [][]string[3]

----------------------------------------------------------------------
FAIL: services_test.go:2867: servicesTestSuite.TestQueryDisabledServices

services_test.go:2924:
    c.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"cannot get unit \"snap.hello-snap.svc2.service\" status: missing Id, UnitFileState, Type, Names, NeedDaemonReload in ‘systemctl show’ output"} ("cannot get unit \"snap.hello-snap.svc2.service\" status: missing Id, UnitFileState, Type, Names, NeedDaemonReload in ‘systemctl show’ output")

----------------------------------------------------------------------
FAIL: services_test.go:2943: servicesTestSuite.TestQueryDisabledServicesActivatedServices

services_test.go:3023:
    c.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"cannot get unit \"snap.hello-snap.svc1.service\" status: missing Id, UnitFileState, Type, Names, NeedDaemonReload in ‘systemctl show’ output"} ("cannot get unit \"snap.hello-snap.svc1.service\" status: missing Id, UnitFileState, Type, Names, NeedDaemonReload in ‘systemctl show’ output")

OOPS: 188 passed, 4 FAILED
--- FAIL: TestWrappers (3.50s)

```

