### PR TITLE
interfaces: we actually expect snaps to auto-connect to desktop

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -51,10 +51,12 @@ const desktopBaseDeclarationSlots = `
     deny-installation:
       slot-snap-type:
         - app
-    deny-connection:
-      on-classic: false
     deny-auto-connection:
-      on-classic: false
+      slot-snap-type:
+        - app
+    deny-connection:
+      slot-snap-type:
+        - app
 `
 
 const desktopConnectedPlugAppArmor = `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -142,6 +142,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	snowflakes := map[string]bool{
 		"content":            true,
 		"core-support":       true,
+		"desktop":            true,
 		"home":               true,
 		"lxd-support":        true,
 		"microstack-support": true,
@@ -149,6 +150,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"packagekit-control": true,
 		"pkcs11":             true,
 		"snapd-control":      true,
+		"upower-observe":     true,
 		"empty":              true,
 	}
 
@@ -156,7 +158,6 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	autoconnect := map[string]bool{
 		"audio-playback":          true,
 		"browser-support":         true,
-		"desktop":                 true,
 		"desktop-legacy":          true,
 		"gsettings":               true,
 		"media-hub":               true,
@@ -200,6 +201,7 @@ func (s *baseDeclSuite) TestAutoConnectionImplicitSlotOnly(c *C) {
 
 	// these auto-connect only with an implicit slot
 	autoconnect := map[string]bool{
+		"desktop":        true,
 		"upower-observe": true,
 	}
 
@@ -1082,6 +1084,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"content":                   true,
 		"cups":                      true,
 		"custom-device":             true,
+		"desktop":                   true,
 		"docker":                    true,
 		"fwupd":                     true,
 		"location-control":          true,
@@ -1125,6 +1128,7 @@ func (s *baseDeclSuite) TestConnectionImplicitSlotOnly(c *C) {
 
 	// these allow connect only with an implicit slot
 	autoconnect := map[string]bool{
+		"desktop":             true,
 		"qualcomm-ipc-router": true,
 		"upower-observe":      true,
 	}


### PR DESCRIPTION
originally desktop was simply allow auto-connect, making the change to not auto-connect on UC is not that relevant because ultimately there will need to be a snap providing it and that snap will set policy if allowed from its snap-declaration

instead let auto-connection only happen with an implicit slot
