### PR TITLE
daemon: add "refresh-inhibited" select query to /v2/snaps

### DIFF
--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -120,7 +120,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 		"MountedFrom",
 		"Hold",
 		"GatingHold",
-		"RefreshInhibitProceedTime",
+		"RefreshInhibit",
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {

--- a/client/packages.go
+++ b/client/packages.go
@@ -89,10 +89,8 @@ type Snap struct {
 	Hold *time.Time `json:"hold,omitempty"`
 	// GatingHold is the time until which the snap's refreshes are held by a snap.
 	GatingHold *time.Time `json:"gating-hold,omitempty"`
-	// RefreshInhibitProceedTime is the time after which a pending refresh is forced
-	// for a running snap in the next auto-refresh. If RefreshInhibitProceedTime is
-	// nil, then there are no pending refreshes.
-	RefreshInhibitProceedTime *time.Time `json:"refresh-inhibit-proceed-time,omitempty"`
+	// if RefreshInhibit is nil, then there is no pending refresh.
+	RefreshInhibit *SnapRefreshInhibit `json:"refresh-inhibit,omitempty"`
 }
 
 type SnapHealth struct {
@@ -101,6 +99,15 @@ type SnapHealth struct {
 	Status    string        `json:"status"`
 	Message   string        `json:"message,omitempty"`
 	Code      string        `json:"code,omitempty"`
+}
+
+type SnapRefreshInhibit struct {
+	// ProceedTime is the time after which a pending refresh is forced for a
+	// running snap in the next auto-refresh.
+	//
+	// NOTE: ProceedTime may be in the past, if a refresh is still pending and
+	// the snap applications are being monitored.
+	ProceedTime time.Time `json:"proceed-time"`
 }
 
 // Statuses and types a snap may have.

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -292,7 +292,7 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 	if refreshInhibited {
 		cs.rsp += `
                         "store-url": "https://snapcraft.io/chatroom",
-                        "refresh-inhibit-proceed-time": "2024-02-09T15:04:05Z"`
+                        "refresh-inhibit": { "proceed-time": "2024-02-09T15:04:05Z" }`
 	} else {
 		cs.rsp += `
                         "store-url": "https://snapcraft.io/chatroom"`
@@ -308,10 +308,11 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 	c.Assert(pkg.InstallDate.Equal(time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC)), check.Equals, true)
 	pkg.InstallDate = nil
 
-	var expectedRefreshInhibitProceedTime *time.Time
+	var expectedSnapRefreshInhibit *client.SnapRefreshInhibit
 	if refreshInhibited {
-		t := time.Date(2024, 2, 9, 15, 4, 5, 0, time.UTC)
-		expectedRefreshInhibitProceedTime = &t
+		expectedSnapRefreshInhibit = &client.SnapRefreshInhibit{
+			ProceedTime: time.Date(2024, 2, 9, 15, 4, 5, 0, time.UTC),
+		}
 	}
 	c.Assert(pkg, check.DeepEquals, &client.Snap{
 		ID:            "funky-snap-id",
@@ -352,9 +353,9 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 		Links: map[string][]string{
 			"website": {"http://example.com/funky"},
 		},
-		Website:                   "http://example.com/funky",
-		StoreURL:                  "https://snapcraft.io/chatroom",
-		RefreshInhibitProceedTime: expectedRefreshInhibitProceedTime,
+		Website:        "http://example.com/funky",
+		StoreURL:       "https://snapcraft.io/chatroom",
+		RefreshInhibit: expectedSnapRefreshInhibit,
 	})
 }
 

--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -119,7 +119,7 @@ func appInfosFor(st *state.State, names []string, opts appInfoOptions) ([]*snap.
 		snapNames[name] = true
 	}
 
-	snaps, err := allLocalSnapInfos(st, false, snapNames)
+	snaps, err := allLocalSnapInfos(st, snapSelectNone, snapNames)
 	if err != nil {
 		return nil, InternalError("cannot list local snaps! %v", err)
 	}

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -897,13 +897,16 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	query := r.URL.Query()
-	var all bool
-	sel := query.Get("select")
-	switch sel {
+	var sel snapSelect
+	switch query.Get("select") {
+	case "":
+		sel = snapSelectNone
 	case "all":
-		all = true
-	case "enabled", "":
-		all = false
+		sel = snapSelectAll
+	case "enabled":
+		sel = snapSelectEnabled
+	case "refresh-inhibited":
+		sel = snapSelectRefreshInhibited
 	default:
 		return BadRequest("invalid select parameter: %q", sel)
 	}
@@ -917,7 +920,7 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	st := c.d.overlord.State()
-	found, err := allLocalSnapInfos(st, all, wanted)
+	found, err := allLocalSnapInfos(st, sel, wanted)
 	if err != nil {
 		return InternalError("cannot list local snaps! %v", err)
 	}

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -800,6 +800,11 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 	return false, busyErr
 }
 
+// IsSnapMonitored checks if there's already a goroutine waiting for this snap to close.
+func IsSnapMonitored(st *state.State, snapName string) bool {
+	return monitoringAbort(st, snapName) != nil
+}
+
 // for testing outside of snapstate
 func MockRefreshCandidate(snapSetup *SnapSetup) interface{} {
 	return &refreshCandidate{

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -898,7 +898,7 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 // the user and then triggers an auto-refresh.
 func asyncRefreshOnSnapClose(st *state.State, snapName string, refreshInfo *userclient.PendingSnapRefreshInfo) error {
 	// there's already a goroutine waiting for this snap to close so just notify
-	if isSnapMonitored(st, snapName) {
+	if IsSnapMonitored(st, snapName) {
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 		return nil
 	}
@@ -1079,10 +1079,6 @@ func monitoringAbort(st *state.State, snapName string) context.CancelFunc {
 		logger.Noticef("%v", err)
 	}
 	return aborts[snapName]
-}
-
-func isSnapMonitored(st *state.State, snapName string) bool {
-	return monitoringAbort(st, snapName) != nil
 }
 
 func abortMonitoring(st *state.State, snapName string) {

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -179,7 +179,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
-		monitoring := isSnapMonitored(st, update.InstanceName())
+		monitoring := IsSnapMonitored(st, update.InstanceName())
 		providerContentAttrs := defaultProviderContentAttrs(st, update, nil)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{


### PR DESCRIPTION
This select query allows only showing snaps whose refresh is inhibited which is needed by refresh-app-awareness ux clients as mentioned in the [RAA-UX spec SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.c40tauj2e3fo).
