### PR TITLE
i/builtin: fix newly introduced unit tests after change to Specifications

### DIFF
--- a/interfaces/builtin/ros_opt_data_test.go
+++ b/interfaces/builtin/ros_opt_data_test.go
@@ -79,7 +79,7 @@ func (s *rosOptDataInterfaceSuite) TestAppArmorSpec(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	spec := &apparmor.Specification{}
+	spec := apparmor.NewSpecification(interfaces.NewSnapAppSet(s.plug.Snap()))
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `capability dac_read_search,`)


### PR DESCRIPTION
After merging https://github.com/snapcore/snapd/pull/13281 the unit tests seems to fail due to a conflict between that and https://github.com/snapcore/snapd/pull/13574 (since the former was not rebased after 13574 landed)