### PR TITLE
o/devicestate: consider the current model's validation sets when creating a recovery system

### DIFF
--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -199,7 +199,7 @@ func TrackedEnforcedValidationSets(st *state.State, extraVss ...*asserts.Validat
 	skip := make(map[string]bool, len(extraVss))
 	for _, extraVs := range extraVss {
 		sets.Add(extraVs)
-		skip[fmt.Sprintf("%s:%s", extraVs.AccountID(), extraVs.Name())] = true
+		skip[ValidationSetKey(extraVs.AccountID(), extraVs.Name())] = true
 	}
 
 	skipSet := func(key string) bool {
@@ -221,7 +221,7 @@ func TrackedEnforcedValidationSets(st *state.State, extraVss ...*asserts.Validat
 func TrackedEnforcedValidationSetsForModel(st *state.State, model *asserts.Model) (*snapasserts.ValidationSets, error) {
 	modelSets := make(map[string]bool, len(model.ValidationSets()))
 	for _, vs := range model.ValidationSets() {
-		modelSets[fmt.Sprintf("%s:%s", vs.AccountID, vs.Name)] = true
+		modelSets[ValidationSetKey(vs.AccountID, vs.Name)] = true
 	}
 
 	skipSet := func(key string) bool {
@@ -249,7 +249,7 @@ func trackedEnforcedValidationSets(st *state.State, skipSet func(string) bool, s
 			continue
 		}
 
-		if skipSet(fmt.Sprintf("%s:%s", vs.AccountID, vs.Name)) {
+		if skipSet(ValidationSetKey(vs.AccountID, vs.Name)) {
 			continue
 		}
 

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -194,12 +194,6 @@ func ValidationSets(st *state.State) (map[string]*ValidationSetTracking, error) 
 // added to the returned set and replaces validation sets with same account/name
 // in case they were tracked already.
 func TrackedEnforcedValidationSets(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
-	valsets, err := ValidationSets(st)
-	if err != nil {
-		return nil, err
-	}
-
-	db := DB(st)
 	sets := snapasserts.NewValidationSets()
 
 	skip := make(map[string]bool, len(extraVss))
@@ -208,14 +202,54 @@ func TrackedEnforcedValidationSets(st *state.State, extraVss ...*asserts.Validat
 		skip[fmt.Sprintf("%s:%s", extraVs.AccountID(), extraVs.Name())] = true
 	}
 
+	skipSet := func(key string) bool {
+		// if extraVs matches an already enforced validation set, then skip that one, extraVs has been added
+		// before the loop.
+		return skip[key]
+	}
+
+	if err := trackedEnforcedValidationSets(st, skipSet, sets); err != nil {
+		return nil, err
+	}
+
+	return sets, nil
+}
+
+// TrackedEnforcedValidationSetsForModel returns a ValidationSets object for
+// currently tracked validation sets that are in enforcing mode and also
+// associated with the specified model.
+func TrackedEnforcedValidationSetsForModel(st *state.State, model *asserts.Model) (*snapasserts.ValidationSets, error) {
+	modelSets := make(map[string]bool, len(model.ValidationSets()))
+	for _, vs := range model.ValidationSets() {
+		modelSets[fmt.Sprintf("%s:%s", vs.AccountID, vs.Name)] = true
+	}
+
+	skipSet := func(key string) bool {
+		return !modelSets[key]
+	}
+
+	sets := snapasserts.NewValidationSets()
+	if err := trackedEnforcedValidationSets(st, skipSet, sets); err != nil {
+		return nil, err
+	}
+
+	return sets, nil
+}
+
+func trackedEnforcedValidationSets(st *state.State, skipSet func(string) bool, sets *snapasserts.ValidationSets) error {
+	valsets, err := ValidationSets(st)
+	if err != nil {
+		return err
+	}
+
+	db := DB(st)
+
 	for _, vs := range valsets {
 		if vs.Mode != Enforce {
 			continue
 		}
 
-		// if extraVs matches an already enforced validation set, then skip that one, extraVs has been added
-		// before the loop.
-		if skip[fmt.Sprintf("%s:%s", vs.AccountID, vs.Name)] {
+		if skipSet(fmt.Sprintf("%s:%s", vs.AccountID, vs.Name)) {
 			continue
 		}
 
@@ -232,16 +266,16 @@ func TrackedEnforcedValidationSets(st *state.State, extraVss ...*asserts.Validat
 
 		as, err := db.Find(asserts.ValidationSetType, headers)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		vsetAssert := as.(*asserts.ValidationSet)
 		if err := sets.Add(vsetAssert); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return sets, err
+	return err
 }
 
 // addCurrentTrackingToValidationSetsHistory stores the current state of validation-sets

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -20,10 +20,13 @@
 package assertstate_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -575,4 +578,56 @@ func (s *validationSetTrackingSuite) TestValidationSetSequence(c *C) {
 	c.Check(tr.Sequence(), Equals, 2)
 	tr.PinnedAt = 1
 	c.Check(tr.Sequence(), Equals, 1)
+}
+
+func (s *validationSetTrackingSuite) TestTrackedEnforcedValidationSets(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	a := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"architecture": "amd64",
+		"store":        "my-brand-store",
+		"gadget":       "gadget",
+		"kernel":       "krnl",
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": s.dev1acct.AccountID(),
+				"name":       "foo",
+				"mode":       "enforce",
+				"sequence":   "9",
+			},
+			map[string]interface{}{
+				"account-id": s.dev1acct.AccountID(),
+				"name":       "bar",
+				"mode":       "prefer-enforce",
+				"sequence":   "9",
+			},
+		},
+	})
+
+	model := a.(*asserts.Model)
+
+	for _, name := range []string{"foo", "bar", "baz"} {
+		assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+			AccountID: s.dev1acct.AccountID(),
+			Name:      name,
+			Mode:      assertstate.Enforce,
+			Current:   9,
+		})
+		vs := s.mockAssert(c, name, "9", "required")
+		c.Assert(assertstate.Add(s.st, vs), IsNil)
+	}
+
+	sets, err := assertstate.TrackedEnforcedValidationSetsForModel(s.st, model)
+	c.Assert(err, IsNil)
+
+	keys := sets.Keys()
+	c.Check(keys, testutil.Contains, snapasserts.ValidationSetKey(fmt.Sprintf("16/%s/%s/9", s.dev1acct.AccountID(), "foo")))
+	c.Check(keys, testutil.Contains, snapasserts.ValidationSetKey(fmt.Sprintf("16/%s/%s/9", s.dev1acct.AccountID(), "bar")))
+	c.Check(keys, Not(testutil.Contains), snapasserts.ValidationSetKey(fmt.Sprintf("16/%s/%s/9", s.dev1acct.AccountID(), "baz")))
 }

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1601,11 +1601,18 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 		return nil, fmt.Errorf("cannot create new recovery systems until fully seeded")
 	}
 
-	valsets := snapasserts.NewValidationSets()
+	model, err := findModel(st)
+	if err != nil {
+		return nil, err
+	}
+
+	valsets, err := assertstate.TrackedEnforcedValidationSetsForModel(st, model)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, vs := range opts.ValidationSets {
-		if err := valsets.Add(vs); err != nil {
-			return nil, err
-		}
+		valsets.Add(vs)
 	}
 
 	if err := valsets.Conflict(); err != nil {
@@ -1613,11 +1620,6 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 	}
 
 	revisions, err := valsets.Revisions()
-	if err != nil {
-		return nil, err
-	}
-
-	model, err := findModel(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2957,6 +2957,106 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 	c.Check(vSetErr.Snaps[fakeSnapID("pc")].Error(), Equals, `cannot constrain snap "pc" at different revisions 12 (canonical/vset-1), 13 (canonical/vset-2)`)
 }
 
+func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValidationSetsConflictWithModel(c *C) {
+	devicestate.SetBootOkRan(s.mgr, true)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		"grade":        "dangerous",
+		"base":         "core20",
+		"revision":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.ss.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.ss.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "core20",
+				"id":   s.ss.AssertedSnapID("core20"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "snapd",
+				"id":   s.ss.AssertedSnapID("snapd"),
+				"type": "snapd",
+			},
+		},
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": "canonical",
+				"name":       "vset-model",
+				"mode":       "enforce",
+			},
+		},
+	})
+
+	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "canonical",
+		"series":       "16",
+		"account-id":   "canonical",
+		"name":         "vset-model",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "pc",
+				"id":       fakeSnapID("pc"),
+				"revision": "12",
+				"presence": "required",
+			},
+		},
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	assertstatetest.AddMany(s.state, vsetModel)
+	assertstate.UpdateValidationSet(s.state, &assertstate.ValidationSetTracking{
+		AccountID: "canonical",
+		Name:      "vset-model",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	})
+
+	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "canonical",
+		"series":       "16",
+		"account-id":   "canonical",
+		"name":         "vset-1",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "pc",
+				"id":       fakeSnapID("pc"),
+				"revision": "13",
+				"presence": "required",
+			},
+		},
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	_, err = devicestate.CreateRecoverySystem(s.state, "1234", devicestate.CreateRecoverySystemOptions{
+		ValidationSets: []*asserts.ValidationSet{vset1.(*asserts.ValidationSet)},
+	})
+	c.Assert(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
+
+	vSetErr := &snapasserts.ValidationSetsConflictError{}
+	c.Check(errors.As(err, &vSetErr), Equals, true)
+	c.Check(vSetErr.Snaps[fakeSnapID("pc")].Error(), Equals, `cannot constrain snap "pc" at different revisions 12 (canonical/vset-model), 13 (canonical/vset-1)`)
+}
+
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemNoTestSystemMarkCurrent(c *C) {
 	const markCurrent = true
 	s.testDeviceManagerCreateRecoverySystemNoTestSystem(c, markCurrent)
@@ -3066,6 +3166,73 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 
 func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValidationSetsHappy(c *C, markCurrent bool) {
 	devicestate.SetBootOkRan(s.mgr, true)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		"grade":        "dangerous",
+		"base":         "core20",
+		"revision":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.ss.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.ss.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "core20",
+				"id":   s.ss.AssertedSnapID("core20"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "snapd",
+				"id":   s.ss.AssertedSnapID("snapd"),
+				"type": "snapd",
+			},
+		},
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": "canonical",
+				"name":       "vset-model",
+				"mode":       "enforce",
+			},
+		},
+	})
+
+	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "canonical",
+		"series":       "16",
+		"account-id":   "canonical",
+		"name":         "vset-model",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "pc",
+				"id":       fakeSnapID("pc"),
+				"presence": "required",
+			},
+		},
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	assertstatetest.AddMany(s.state, vsetModel)
+	assertstate.UpdateValidationSet(s.state, &assertstate.ValidationSetTracking{
+		AccountID: "canonical",
+		Name:      "vset-model",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	})
 
 	snapRevisions := map[string]snap.Revision{
 		"pc":        snap.R(10),
@@ -3210,9 +3377,6 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		ts.MarkEdge(tValidate, snapstate.LastBeforeLocalModificationsEdge)
 		return ts, info, nil
 	})
-
-	s.state.Lock()
-	defer s.state.Unlock()
 
 	s.state.Set("refresh-privacy-key", "some-privacy-key")
 	s.mockStandardSnapsModeenvAndBootloaderState(c)


### PR DESCRIPTION
I forgot to consider the current model's validation sets in the first PR. This change makes creating a recovery system respect the validation sets in the current model. The main effect of this change is that you cannot create recovery systems with validation sets that conflict with the validation sets of the current model.