### PR TITLE
aspects: empty Get request returns entire aspect

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -799,8 +799,10 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 // Get returns the aspect value identified by the request. If either the named
 // aspect or the corresponding value can't be found, a NotFoundError is returned.
 func (a *Aspect) Get(databag DataBag, request string) (interface{}, error) {
-	if err := validateAspectDottedPath(request, nil); err != nil {
-		return nil, badRequestErrorFrom(a, "get", request, err.Error())
+	if request != "" {
+		if err := validateAspectDottedPath(request, nil); err != nil {
+			return nil, badRequestErrorFrom(a, "get", request, err.Error())
+		}
 	}
 
 	matches, err := a.matchGetRequest(request)
@@ -887,7 +889,11 @@ type requestMatch struct {
 // no entry is an exact match, one or more entries that the request matches a
 // prefix of. If no match is found, a NotFoundError is returned.
 func (a *Aspect) matchGetRequest(request string) (matches []requestMatch, err error) {
-	subkeys := strings.Split(request, ".")
+	var subkeys []string
+	if request != "" {
+		subkeys = strings.Split(request, ".")
+	}
+
 	for _, rule := range a.aspectRules {
 		placeholders, restSuffix, ok := rule.match(subkeys)
 		if !ok {
@@ -998,7 +1004,8 @@ func (p *aspectRule) match(reqSubkeys []string) (placeholders map[string]string,
 
 	placeholders = make(map[string]string)
 	for i, subkey := range reqSubkeys {
-		if !p.request[i].match(subkey, placeholders) {
+		// empty request matches everything
+		if len(reqSubkeys) != 0 && !p.request[i].match(subkey, placeholders) {
 			return nil, nil, false
 		}
 	}

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -1885,3 +1885,43 @@ func (s *aspectSuite) TestAspectSetErrorIfValueContainsUnusedParts(c *C) {
 		}
 	}
 }
+
+func (s *aspectSuite) TestGetEntireAspect(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewBundle("acc", "bundle", map[string]interface{}{
+		"foo": map[string]interface{}{
+			"rules": []interface{}{
+				map[string]interface{}{"request": "foo.{bar}", "storage": "foo-path.{bar}"},
+				map[string]interface{}{"request": "abc", "storage": "abc-path"},
+				map[string]interface{}{"request": "write-only", "storage": "write-only", "access": "write"},
+			},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	asp := aspectBundle.Aspect("foo")
+	c.Assert(asp, NotNil)
+
+	err = asp.Set(databag, "foo", map[string]interface{}{
+		"bar": "value",
+		"baz": "other",
+	})
+	c.Assert(err, IsNil)
+
+	err = asp.Set(databag, "abc", "cba")
+	c.Assert(err, IsNil)
+
+	err = asp.Set(databag, "write-only", "value")
+	c.Assert(err, IsNil)
+
+	result, err := asp.Get(databag, "")
+	c.Assert(err, IsNil)
+
+	c.Assert(result, DeepEquals, map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "value",
+			"baz": "other",
+		},
+		"abc": "cba",
+	})
+}

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -144,7 +144,7 @@ func (s *StorageSchema) Validate(raw []byte) error {
 	return s.topLevel.Validate(raw)
 }
 
-// AtPath returns the types that may be stored at the specified path.
+// SchemaAt returns the types that may be stored at the specified path.
 func (s *StorageSchema) SchemaAt(path []string) ([]Schema, error) {
 	return s.topLevel.SchemaAt(path)
 }
@@ -897,18 +897,14 @@ func (v *anySchema) Validate(raw []byte) (err error) {
 	return nil
 }
 
-func (v *anySchema) parseConstraints(constraints map[string]json.RawMessage) error {
+func (v *anySchema) parseConstraints(map[string]json.RawMessage) error {
 	// no error because we're not explicitly rejecting unsupported keywords (for now)
 	return nil
 }
 
-// SchemaAt returns the any schema if the path terminates here and an error if
+// SchemaAt returns the "any" schema if the path terminates here and an error if
 // not.
-func (v *anySchema) SchemaAt(path []string) ([]Schema, error) {
-	if len(path) != 0 {
-		return nil, schemaAtErrorf(path, `cannot follow path beyond "any" type`)
-	}
-
+func (v *anySchema) SchemaAt([]string) ([]Schema, error) {
 	return []Schema{v}, nil
 }
 

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -902,8 +902,7 @@ func (v *anySchema) parseConstraints(map[string]json.RawMessage) error {
 	return nil
 }
 
-// SchemaAt returns the "any" schema if the path terminates here and an error if
-// not.
+// SchemaAt returns the "any" schema.
 func (v *anySchema) SchemaAt([]string) ([]Schema, error) {
 	return []Schema{v}, nil
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -2236,7 +2236,7 @@ func (*schemaSuite) TestSchemaAtNestedInArray(c *C) {
 }
 
 func (*schemaSuite) TestSchemaAtExceedingSchemaLeafSchema(c *C) {
-	for _, typ := range []string{"int", "number", "bool", "string", "any"} {
+	for _, typ := range []string{"int", "number", "bool", "string"} {
 		cmt := Commentf("type %q test", typ)
 		schemaStr := []byte(fmt.Sprintf(`{
 	"schema": {
@@ -2255,14 +2255,14 @@ func (*schemaSuite) TestSchemaAtExceedingSchemaLeafSchema(c *C) {
 func (*schemaSuite) TestSchemaAtExceedingSchemaContainerSchema(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
-		"foo": {"type": "array", "values": "any"}
+		"foo": {"type": "array", "values": "string"}
 	}
 }`)
 	schema, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
 	schemas, err := schema.SchemaAt([]string{"foo", "0", "bar"})
-	c.Assert(err, ErrorMatches, `cannot follow path beyond "any" type`)
+	c.Assert(err, ErrorMatches, `cannot follow path beyond "string" type`)
 	c.Assert(schemas, IsNil)
 }
 
@@ -2324,4 +2324,18 @@ func (*schemaSuite) TestSchemaAtAlternativesFail(c *C) {
 	schemas, err := schema.SchemaAt([]string{"foo", "bar"})
 	c.Assert(err, ErrorMatches, `cannot follow path beyond "string" type`)
 	c.Assert(schemas, IsNil)
+}
+
+func (*schemaSuite) TestSchemaAtAnyAcceptsLongerPath(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": "any"
+	}
+}`)
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	schemas, err := schema.SchemaAt([]string{"foo", "baz"})
+	c.Assert(err, IsNil)
+	c.Assert(schemas, NotNil)
 }

--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -56,7 +56,12 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 	fields := strutil.CommaSeparatedList(r.URL.Query().Get("fields"))
 
 	if len(fields) == 0 {
-		return BadRequest("missing aspect fields")
+		results, err := aspectstateGetAspect(st, account, bundleName, aspect, nil)
+		if err != nil {
+			return toAPIError(err)
+		}
+
+		return SyncResponse(results["all"])
 	}
 
 	results, err := aspectstateGetAspect(st, account, bundleName, aspect, fields)

--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -53,15 +53,11 @@ func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	vars := muxVars(r)
 	account, bundleName, aspect := vars["account"], vars["bundle"], vars["aspect"]
-	fields := strutil.CommaSeparatedList(r.URL.Query().Get("fields"))
+	fieldStr := r.URL.Query().Get("fields")
 
-	if len(fields) == 0 {
-		results, err := aspectstateGetAspect(st, account, bundleName, aspect, nil)
-		if err != nil {
-			return toAPIError(err)
-		}
-
-		return SyncResponse(results["all"])
+	var fields []string
+	if fieldStr != "" {
+		fields = strutil.CommaSeparatedList(fieldStr)
 	}
 
 	results, err := aspectstateGetAspect(st, account, bundleName, aspect, fields)

--- a/daemon/api_aspects_test.go
+++ b/daemon/api_aspects_test.go
@@ -90,7 +90,7 @@ func (s *aspectsSuite) TestGetAspect(c *C) {
 		{name: "map", value: map[string]int{"foo": 123}},
 	} {
 		cmt := Commentf("%s test", t.name)
-		restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect string, fields []string) (map[string]interface{}, error) {
+		restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect string, fields []string) (interface{}, error) {
 			c.Check(acc, Equals, "system", cmt)
 			c.Check(bundleName, Equals, "network", cmt)
 			c.Check(aspect, Equals, "wifi-setup", cmt)
@@ -113,7 +113,7 @@ func (s *aspectsSuite) TestAspectGetMany(c *C) {
 	s.setFeatureFlag(c)
 
 	var calls int
-	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (interface{}, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -138,7 +138,7 @@ func (s *aspectsSuite) TestAspectGetSomeFieldNotFound(c *C) {
 	s.setFeatureFlag(c)
 
 	var calls int
-	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundle, aspect string, _ []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundle, aspect string, _ []string) (interface{}, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -163,7 +163,7 @@ func (s *aspectsSuite) TestGetAspectNoFieldsFound(c *C) {
 	s.setFeatureFlag(c)
 
 	var calls int
-	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (interface{}, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -194,7 +194,7 @@ func (s *aspectsSuite) TestGetAspectNoFieldsFound(c *C) {
 func (s *aspectsSuite) TestAspectGetDatabagNotFound(c *C) {
 	s.setFeatureFlag(c)
 
-	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (interface{}, error) {
 		return nil, &aspects.NotFoundError{Account: "foo", BundleName: "network", Aspect: "wifi-setup", Operation: "get", Requests: []string{"ssid"}, Cause: "mocked"}
 	})
 	defer restore()
@@ -308,7 +308,7 @@ func (s *aspectsSuite) TestGetAspectError(c *C) {
 		{name: "aspect not found", err: &aspects.NotFoundError{}, code: 404},
 		{name: "internal", err: errors.New("internal"), code: 500},
 	} {
-		restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (map[string]interface{}, error) {
+		restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, _ []string) (interface{}, error) {
 			return nil, t.err
 		})
 
@@ -325,7 +325,7 @@ func (s *aspectsSuite) TestGetAspectMisshapenQuery(c *C) {
 	s.setFeatureFlag(c)
 
 	var calls int
-	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (interface{}, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -502,7 +502,7 @@ func (s *aspectsSuite) TestSetAspectBadRequest(c *C) {
 func (s *aspectsSuite) TestGetBadRequest(c *C) {
 	s.setFeatureFlag(c)
 
-	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect string, fields []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect string, fields []string) (interface{}, error) {
 		return nil, &aspects.BadRequestError{
 			Account:    "acc",
 			BundleName: "bundle",
@@ -589,9 +589,9 @@ func (s *aspectsSuite) TestGetNoFields(c *C) {
 	s.setFeatureFlag(c)
 
 	value := map[string]interface{}{"foo": 1, "bar": "baz", "nested": map[string]interface{}{"a": []interface{}{1, 2}}}
-	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (map[string]interface{}, error) {
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _ string, fields []string) (interface{}, error) {
 		c.Check(fields, IsNil)
-		return map[string]interface{}{"all": value}, nil
+		return value, nil
 	})
 	defer restore()
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -350,7 +350,7 @@ var (
 	MaxReadBuflen = maxReadBuflen
 )
 
-func MockAspectstateGet(f func(st *state.State, account, bundleName, aspect string, field []string) (map[string]interface{}, error)) (restore func()) {
+func MockAspectstateGet(f func(st *state.State, account, bundleName, aspect string, field []string) (interface{}, error)) (restore func()) {
 	old := aspectstateGetAspect
 	aspectstateGetAspect = f
 	return func() {

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -68,8 +68,9 @@ func SetAspect(st *state.State, account, bundleName, aspect string, requests map
 
 // GetAspect finds the aspect identified by the account, bundleName and aspect
 // and uses it to get the values for the specified fields. The results are
-// returned in a map of fields to their values.
-func GetAspect(st *state.State, account, bundleName, aspect string, fields []string) (map[string]interface{}, error) {
+// returned in a map of fields to their values, unless there are no fields in
+// which case the entire aspect is just returned as-is.
+func GetAspect(st *state.State, account, bundleName, aspect string, fields []string) (interface{}, error) {
 	bundleAssert, err := assertstate.AspectBundle(st, account, bundleName)
 	if err != nil {
 		return nil, err
@@ -99,7 +100,7 @@ func GetAspect(st *state.State, account, bundleName, aspect string, fields []str
 			return nil, err
 		}
 
-		return map[string]interface{}{"all": val}, nil
+		return val, nil
 	}
 
 	results := make(map[string]interface{}, len(fields))

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -93,6 +93,15 @@ func GetAspect(st *state.State, account, bundleName, aspect string, fields []str
 		return nil, err
 	}
 
+	if len(fields) == 0 {
+		val, err := asp.Get(tx, "")
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]interface{}{"all": val}, nil
+	}
+
 	results := make(map[string]interface{}, len(fields))
 	for _, field := range fields {
 		value, err := asp.Get(tx, field)

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -192,7 +192,9 @@ func (s *aspectTestSuite) TestAspectstateSetWithExistingState(c *C) {
 
 	results, err := aspectstate.GetAspect(s.state, s.devAccID, "network", "wifi-setup", []string{"ssid"})
 	c.Assert(err, IsNil)
-	c.Assert(results["ssid"], Equals, "bar")
+	resultsMap, ok := results.(map[string]interface{})
+	c.Assert(ok, Equals, true)
+	c.Assert(resultsMap["ssid"], Equals, "bar")
 
 	err = aspectstate.SetAspect(s.state, s.devAccID, "network", "wifi-setup", map[string]interface{}{"ssid": "baz"})
 	c.Assert(err, IsNil)
@@ -263,12 +265,10 @@ func (s *aspectTestSuite) TestAspectstateGetEntireAspect(c *C) {
 	res, err := aspectstate.GetAspect(s.state, s.devAccID, "network", "wifi-setup", nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, DeepEquals, map[string]interface{}{
-		"all": map[string]interface{}{
-			"ssids": []interface{}{"foo", "bar"},
-			"private": map[string]interface{}{
-				"a": float64(1),
-				"b": float64(2),
-			},
+		"ssids": []interface{}{"foo", "bar"},
+		"private": map[string]interface{}{
+			"a": float64(1),
+			"b": float64(2),
 		},
 	})
 }

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -79,7 +79,7 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 				map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
 				map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
 				map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
-				map[string]interface{}{"request": "private.{placeholder}", "storage": "wifi.{placeholder}"},
+				map[string]interface{}{"request": "private.{placeholder}", "storage": "wifi.private.{placeholder}"},
 			},
 		},
 	}
@@ -89,7 +89,7 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 		"account-id":   devAccKey.AccountID(),
 		"name":         "network",
 		"aspects":      rules,
-		"storage":      `{"schema": {"wifi" : {"schema": {"ssids": {"type": "array", "values": "any"}, "ssid": "string"}}}}`,
+		"storage":      `{"schema": {"wifi": {"values": "any"}}}`,
 		"timestamp":    "2030-11-06T09:16:26Z",
 	}
 	as, err := signingDB.Sign(asserts.AspectBundleType, headers, nil, "")
@@ -244,4 +244,31 @@ func (s *aspectTestSuite) TestAspectstateSetWithNoState(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(value, Equals, "bar")
 	}
+}
+
+func (s *aspectTestSuite) TestAspectstateGetEntireAspect(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	err := aspectstate.SetAspect(s.state, s.devAccID, "network", "wifi-setup", map[string]interface{}{
+		"ssids":    []interface{}{"foo", "bar"},
+		"password": "pass",
+		"private": map[string]interface{}{
+			"a": 1,
+			"b": 2,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	res, err := aspectstate.GetAspect(s.state, s.devAccID, "network", "wifi-setup", nil)
+	c.Assert(err, IsNil)
+	c.Assert(res, DeepEquals, map[string]interface{}{
+		"all": map[string]interface{}{
+			"ssids": []interface{}{"foo", "bar"},
+			"private": map[string]interface{}{
+				"a": float64(1),
+				"b": float64(2),
+			},
+		},
+	})
 }


### PR DESCRIPTION
Matches an empty request with the entire aspects i.e., all of the aspect's read rules. The first commit is a small fix to the schema mismatch check for "any" schema to permit longer paths (since "any" can also be a container type).