### PR TITLE
interfaces/apparmor/template: add read access to /etc/default/keyboard

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -250,6 +250,7 @@ var templateCommon = `
   /dev/{,u}random w,
   /etc/machine-id r,
   /etc/mime.types r,
+  /etc/default/keyboard r,
   @{PROC}/ r,
   @{PROC}/version r,
   @{PROC}/version_signature r,


### PR DESCRIPTION
This PR adds read access to /etc/default/keyboard to apparmor tempplate per suggestion of @alexmurray in https://forum.snapcraft.io/t/auto-connect-and-alias-request-for-uncomplicated-vm-tools/39029