### PR TITLE
tests/lib/tools/tests.invariant: ignore session for user ubuntu

### DIFF
--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -104,6 +104,11 @@ check_stray_dbus_daemon() {
 			if [ "$user" = "external" ]; then
 				continue
 			fi
+                        # On qemu backend, sudo from user "ubuntu" is used. So the session
+                        # for user "ubuntu" is expected to exist.
+			if [ "$user" = "ubuntu" ]; then
+				continue
+			fi
 			# Report stray dbus-daemon.
 			failed+=("pid:$pid user:$user cmdline:$cmdline")
 		done


### PR DESCRIPTION
On qemu backend, user "ubuntu" is used to call sudo. So while this script is called, user "ubuntu" is logged in.