### PR TITLE
daemon: replace notices "select" param with "users"

### DIFF
--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -62,15 +62,15 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	if len(query["select"]) > 0 {
+	if len(query["users"]) > 0 {
 		if requestUID != 0 {
-			return Forbidden(`only admins may use the "select" filter`)
+			return Forbidden(`only admins may use the "users" filter`)
 		}
 		if len(query["user-id"]) > 0 {
-			return BadRequest(`cannot use both "select" and "user-id" parameters`)
+			return BadRequest(`cannot use both "users" and "user-id" parameters`)
 		}
-		if query.Get("select") != "all" {
-			return BadRequest(`invalid "select" filter: must be "all"`)
+		if query.Get("users") != "all" {
+			return BadRequest(`invalid "users" filter: must be "all"`)
 		}
 		// Clear the userID filter so all notices will be returned.
 		userID = nil

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -338,7 +338,7 @@ func (s *noticesSuite) TestNoticesUserIDNonAdminFilter(c *C) {
 	c.Check(rsp.Status, Equals, 403)
 }
 
-func (s *noticesSuite) TestNoticesSelectAdminFilter(c *C) {
+func (s *noticesSuite) TestNoticesUsersAdminFilter(c *C) {
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -355,8 +355,8 @@ func (s *noticesSuite) TestNoticesSelectAdminFilter(c *C) {
 	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
 	st.Unlock()
 
-	// Test that admin user may get all notices with --select=all filter
-	reqUrl := "/v2/notices?select=all"
+	// Test that admin user may get all notices with --users=all filter
+	reqUrl := "/v2/notices?users=all"
 	req, err := http.NewRequest("GET", reqUrl, nil)
 	c.Check(err, IsNil)
 	req.RemoteAddr = "pid=100;uid=0;socket=;"
@@ -380,7 +380,7 @@ func (s *noticesSuite) TestNoticesSelectAdminFilter(c *C) {
 	c.Assert(n["key"], Equals, "danger")
 }
 
-func (s *noticesSuite) TestNoticesSelectNonAdminFilter(c *C) {
+func (s *noticesSuite) TestNoticesUsersNonAdminFilter(c *C) {
 	s.daemon(c)
 
 	st := s.d.Overlord().State()
@@ -389,8 +389,8 @@ func (s *noticesSuite) TestNoticesSelectNonAdminFilter(c *C) {
 	addNotice(c, st, &nonAdmin, state.WarningNotice, "error1", nil)
 	st.Unlock()
 
-	// Test that non-admin user may not use --select filter
-	reqUrl := "/v2/notices?select=all"
+	// Test that non-admin user may not use --users filter
+	reqUrl := "/v2/notices?users=all"
 	req, err := http.NewRequest("GET", reqUrl, nil)
 	c.Check(err, IsNil)
 	req.RemoteAddr = "pid=100;uid=1000;socket=;"
@@ -499,12 +499,12 @@ func (s *noticesSuite) TestNoticesInvalidUserIDLow(c *C) {
 	s.testNoticesBadRequest(c, "user-id=-1", `invalid "user-id" filter:.*`)
 }
 
-func (s *noticesSuite) TestNoticesInvalidSelect(c *C) {
-	s.testNoticesBadRequest(c, "select=foo", `invalid "select" filter:.*`)
+func (s *noticesSuite) TestNoticesInvalidUsers(c *C) {
+	s.testNoticesBadRequest(c, "users=foo", `invalid "users" filter:.*`)
 }
 
-func (s *noticesSuite) TestNoticesInvalidUserIDWithSelect(c *C) {
-	s.testNoticesBadRequest(c, "user-id=1234&select=all", `cannot use both "select" and "user-id" parameters`)
+func (s *noticesSuite) TestNoticesInvalidUserIDWithUsers(c *C) {
+	s.testNoticesBadRequest(c, "user-id=1234&users=all", `cannot use both "users" and "user-id" parameters`)
 }
 
 func (s *noticesSuite) TestNoticesInvalidAfter(c *C) {


### PR DESCRIPTION
Per discussions with @niemeyer, @pedronis, and @benhoyt, we have decided to rename the `select=all` query parameter for notices. The word "select" should be used when selecting a particular subset of items from a complete set, but in the case of notices, it was being used to extend the original set of notices to include those from all other users.

It has been proposed to rename `select=all` to `users=all`, and since `select=all` and `user-id=1234` were mutually exclusive, it makes sense that a client may choose to use *either* `user-id=1234` or `users=all`, as these are more clearly related.

These changes will need to be backported to pebble, and when doing so, it is important to also change the command-line argument `--select=all` to be `--users=all`, and check for any other uses of the term "select" in similar contexts.