### PR TITLE
i/builtin: fix issue with for loop variable reference

### DIFF
--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -150,9 +150,9 @@ func (iface *polkitInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 }
 
 func isPathMountedWritable(mntProfile *osutil.MountProfile, fsPath string) bool {
-	mntMap := make(map[string]*osutil.MountEntry, len(mntProfile.Entries))
+	mntMap := make(map[string]osutil.MountEntry, len(mntProfile.Entries))
 	for _, mnt := range mntProfile.Entries {
-		mntMap[mnt.Dir] = &mnt
+		mntMap[mnt.Dir] = mnt
 	}
 
 	// go backwards in path until we hit a match

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -150,8 +150,9 @@ func (iface *polkitInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 }
 
 func isPathMountedWritable(mntProfile *osutil.MountProfile, fsPath string) bool {
-	mntMap := make(map[string]osutil.MountEntry, len(mntProfile.Entries))
-	for _, mnt := range mntProfile.Entries {
+	mntMap := make(map[string]*osutil.MountEntry, len(mntProfile.Entries))
+	for i := range mntProfile.Entries {
+		mnt := &mntProfile.Entries[i]
 		mntMap[mnt.Dir] = mnt
 	}
 

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -348,6 +348,24 @@ rpool/ROOT/ubuntu/usr/share /usr/share zfs rw,relatime,xattr,posixacl,casesensit
 			"/usr/share/",
 			true,
 		},
+		// Test an more real example
+		{
+			`/dev/sda3 /run/mnt/ubuntu-boot ext4 rw,relatime 0 0
+/dev/sda2 /run/mnt/ubuntu-seed vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro[7m>[27m
+/dev/sda5 /run/mnt/data ext4 rw,nosuid,relatime 0 0
+/dev/sda4 /run/mnt/ubuntu-save ext4 rw,relatime,stripe=4 0 0
+/dev/loop0 /run/mnt/base squashfs ro,relatime,errors=continue 0 0
+/dev/loop1 /run/mnt/gadget squashfs ro,relatime,errors=continue 0 0
+/dev/loop2 /run/mnt/kernel squashfs ro,relatime,errors=continue 0 0
+/dev/loop3 /run/mnt/snapd squashfs ro,relatime,errors=continue 0 0
+/dev/loop0 / squashfs ro,relatime,errors=continue 0 0
+/dev/loop5 /snap/test-snapd-rsync-core22/1 squashfs ro,nodev,relatime,errors=continue 0 0
+/dev/loop6 /snap/jq-core22/1 squashfs ro,nodev,relatime,errors=continue 0 0
+nsfs /run/snapd/ns/jq-core22.mnt nsfs rw 0 0
+`,
+			"/usr/share/polkit-1/actions",
+			false,
+		},
 	}
 
 	for _, t := range tests {


### PR DESCRIPTION
I was taking the address of the local variable in the for-loop, causing the mnt entry to point to the last inserted entry every time. This caused unstable results when running it live.