### PR TITLE
overlord,systemd: restart mount units when changed

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -10251,7 +10251,7 @@ WantedBy=multi-user.target
 			c.Check(cmd, DeepEquals, []string{"--no-reload", "enable", "snap-snapd-x1.mount"})
 			return nil, nil
 		case 3:
-			c.Check(cmd, DeepEquals, []string{"reload-or-restart", "snap-snapd-x1.mount"})
+			c.Check(cmd, DeepEquals, []string{"restart", "snap-snapd-x1.mount"})
 			return nil, nil
 			// next we get the calls for the rewritten service files after snapd
 			// restarts
@@ -10487,7 +10487,7 @@ WantedBy=multi-user.target
 			c.Check(cmd, DeepEquals, []string{"--no-reload", "enable", "snap-snapd-x1.mount"})
 			return nil, nil
 		case 3:
-			c.Check(cmd, DeepEquals, []string{"reload-or-restart", "snap-snapd-x1.mount"})
+			c.Check(cmd, DeepEquals, []string{"restart", "snap-snapd-x1.mount"})
 			return nil, nil
 			// next we get the calls for the rewritten service files after snapd
 			// restarts

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -364,7 +364,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// mount unit start fails
-		if len(cmd) >= 2 && cmd[0] == "reload-or-restart" && strings.HasSuffix(cmd[1], ".mount") {
+		if len(cmd) >= 2 && cmd[0] == "restart" && strings.HasSuffix(cmd[1], ".mount") {
 			return nil, fmt.Errorf("failed")
 		}
 		return []byte("ActiveState=inactive\n"), nil
@@ -528,7 +528,7 @@ version: 1.0
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// mount unit start fails
-		if len(cmd) >= 2 && cmd[0] == "reload-or-restart" &&
+		if len(cmd) >= 2 && cmd[0] == "restart" &&
 			strings.HasSuffix(cmd[1], ".mount") {
 			return nil, fmt.Errorf("failed")
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -91,7 +91,7 @@ type snapmgrBaseTest struct {
 	user2 *auth.UserState
 	user3 *auth.UserState
 
-	reloadOrRestarts map[string]int
+	restarts map[string]int
 }
 
 // state must be locked by caller
@@ -132,10 +132,10 @@ func (s *snapmgrBaseTest) mockSystemctlCallsUpdateMounts(c *C) (restore func()) 
 		if len(args) == 3 && args[0] == "--no-reload" && args[1] == "enable" {
 			return []byte(""), nil
 		}
-		if len(args) == 2 && args[0] == "reload-or-restart" {
-			value, ok := s.reloadOrRestarts[args[1]]
+		if len(args) == 2 && args[0] == "restart" {
+			value, ok := s.restarts[args[1]]
 			if ok {
-				s.reloadOrRestarts[args[1]] = value + 1
+				s.restarts[args[1]] = value + 1
 			}
 			return []byte(""), nil
 		}
@@ -330,7 +330,7 @@ SNAPD_APPARMOR_REEXEC=1
 	}))
 	s.AddCleanup(osutil.MockMountInfo(""))
 
-	s.reloadOrRestarts = make(map[string]int)
+	s.restarts = make(map[string]int)
 	s.AddCleanup(s.mockSystemctlCallsUpdateMounts(c))
 
 	// mock so the actual notification code isn't called. It races with the SetRootDir
@@ -8899,12 +8899,12 @@ WantedBy=multi-user.target
 	err := os.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
 
-	s.reloadOrRestarts[unitName] = 0
+	s.restarts[unitName] = 0
 
 	err = s.snapmgr.Ensure()
 	c.Assert(err, IsNil)
 
-	c.Assert(s.reloadOrRestarts[unitName], Equals, 1)
+	c.Assert(s.restarts[unitName], Equals, 1)
 
 	expectedContent := fmt.Sprintf(`
 [Unit]
@@ -8976,12 +8976,12 @@ WantedBy=multi-user.target
 	err := os.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
 
-	s.reloadOrRestarts[unitName] = 0
+	s.restarts[unitName] = 0
 
 	err = s.snapmgr.Ensure()
 	c.Assert(err, IsNil)
 
-	c.Assert(s.reloadOrRestarts[unitName], Equals, 0)
+	c.Assert(s.restarts[unitName], Equals, 0)
 
 	c.Assert(mountFile, testutil.FileEquals, mountContent)
 }
@@ -9016,12 +9016,12 @@ apps:
 	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
 	defer restore()
 
-	s.reloadOrRestarts[unitName] = 0
+	s.restarts[unitName] = 0
 
 	err := s.snapmgr.Ensure()
 	c.Assert(err, IsNil)
 
-	c.Assert(s.reloadOrRestarts[unitName], Equals, 1)
+	c.Assert(s.restarts[unitName], Equals, 1)
 
 	expectedContent := fmt.Sprintf(`
 [Unit]

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -92,8 +92,8 @@ func (s *emulation) ReloadOrRestart(services []string) error {
 	return &notImplementedError{"ReloadOrRestart"}
 }
 
-func (s *emulation) RestartAll(service string) error {
-	return &notImplementedError{"RestartAll"}
+func (s *emulation) RestartNoWaitForStop(services []string) error {
+	return &notImplementedError{"RestartNoWaitForStop"}
 }
 
 func (s *emulation) Status(units []string) ([]*UnitStatus, error) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1186,7 +1186,7 @@ WantedBy=multi-user.target
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", rootDir, "enable", "snap-snapname-123.mount"},
-		{"reload-or-restart", "snap-snapname-123.mount"},
+		{"restart", "snap-snapname-123.mount"},
 	})
 }
 
@@ -1310,7 +1310,7 @@ WantedBy=multi-user.target
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", rootDir, "enable", "snap-snapname-123.mount"},
-		{"reload-or-restart", "snap-snapname-123.mount"},
+		{"restart", "snap-snapname-123.mount"},
 	})
 }
 
@@ -1346,7 +1346,7 @@ WantedBy=multi-user.target
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--no-reload", "enable", "snap-snapname-x1.mount"},
-		{"reload-or-restart", "snap-snapname-x1.mount"},
+		{"restart", "snap-snapname-x1.mount"},
 	})
 }
 
@@ -1395,7 +1395,7 @@ X-SnapdOrigin=bar
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", rootDir, "enable", "snap-snapname-345.mount"},
-		{"reload-or-restart", "snap-snapname-345.mount"},
+		{"restart", "snap-snapname-345.mount"},
 	})
 }
 
@@ -1444,7 +1444,7 @@ WantedBy=sysinit.target
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", rootDir, "enable", escapedUnit},
-		{"reload-or-restart", escapedUnit},
+		{"restart", escapedUnit},
 	})
 }
 
@@ -1492,7 +1492,7 @@ WantedBy=sysinit.target
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", rootDir, "enable", escapedUnit},
-		{"reload-or-restart", escapedUnit},
+		{"restart", escapedUnit},
 	})
 }
 


### PR DESCRIPTION
We were doing a reload-or-restart, but we actually need a restart if a mount unit is modified, as reload is relevant only to ask services to reload their (internal) configuration. This was hitting us when updating a component, as they get mounted in the same place as the previous component revision (for a given owner snap revision), and therefore we are rewriting a mount unit that does not change its name. The old component was still showing in that location.
