### PR TITLE
steam_support: Allow mounting of hostfs and snap for Pressure Vessel

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -186,6 +186,7 @@ mount options=(rw, rbind) /bindfile* -> /newroot/run/host/container-manager,
 # Allow mounting Nvidia drivers into the sandbox
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/**,
 
+# Allow PV to access driver information and features necessary for some games to run
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/share/** -> /newroot/**,
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/ -> /newroot/var/lib/snapd/hostfs/,
 

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -210,6 +210,7 @@ deny /usr/bin/{chfn,chsh,gpasswd,mount,newgrp,passwd,su,sudo,umount} x,
 /run/host/usr/bin/localedef ixr,
 /var/cache/ldconfig/** rw,
 /sys/module/nvidia/version r,
+/var/lib/snapd/hostfs/usr/share/nvidia/** mr,
 /etc/debian_chroot r,
 
 capability sys_admin,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -135,7 +135,7 @@ mount options=(rw, rbind) /oldroot/opt/ -> /newroot/opt/,
 mount options=(rw, rbind) /oldroot/srv/ -> /newroot/srv/,
 mount options=(rw, rbind) /oldroot/run/udev/ -> /newroot/run/udev/,
 mount options=(rw, rbind) /oldroot/home/{,**} -> /newroot/home/{,**},
-mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
+mount options=(rw, rbind) /oldroot/snap/{,**} -> /newroot/snap/{,**},
 mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/** -> /newroot/etc/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.cache,
@@ -188,7 +188,6 @@ mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** 
 
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/share/** -> /newroot/**,
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/ -> /newroot/var/lib/snapd/hostfs/,
-mount options=(rw, rbind) /oldroot/snap/ -> /newroot/snap/,
 
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -186,6 +186,10 @@ mount options=(rw, rbind) /bindfile* -> /newroot/run/host/container-manager,
 # Allow mounting Nvidia drivers into the sandbox
 mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/**,
 
+mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/share/** -> /newroot/**,
+mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/ -> /newroot/var/lib/snapd/hostfs/,
+mount options=(rw, rbind) /oldroot/snap/ -> /newroot/snap/,
+
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/run/pressure-vessel/ldso/,


### PR DESCRIPTION
Based on https://github.com/canonical/steam-snap/issues/359, [Pressure Vessel](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/main/pressure-vessel?ref_type=heads) would like access to the same data that Steam itself has access to from within the Snap environment. Namely being the `/snap/` directory and `hostfs` directories. These are the same directories that are already available to Steam itself, so allowing them to be mounted into Pressure Vessel shouldn't increase attack surface as far as I'm aware.

I've tested these changes in my own app armor profile alongside the modified build of Pressure Vessel provided in https://github.com/canonical/steam-snap/issues/359 and I successfully can access the files required for https://github.com/canonical/steam-snap/issues/359.

For this change to actually be useful, https://github.com/snapcore/snapd/pull/13489 still needs to be merged. However, this PR doesn't rely on it itself, so this can be merged as soon as possible.

Fixes https://github.com/canonical/steam-snap/issues/359