### PR TITLE
aspects: check path type mismatch when creating aspect

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -278,6 +278,22 @@ func newAspect(bundle *Bundle, name string, aspectRules []interface{}) (*Aspect,
 		aspect.aspectRules = append(aspect.aspectRules, rule)
 	}
 
+	// check that the rules matching a given request can be satisfied with some
+	// data type (otherwise, no data can ever be written there)
+	pathToRules := make(map[string][]*aspectRule)
+	for _, rule := range aspect.aspectRules {
+		// TODO: once the paths support list index placeholders, also add mapping
+		// for the prefixes of each path and their implied types (Map or Array)
+		path := rule.originalRequest
+		pathToRules[path] = append(pathToRules[path], rule)
+	}
+
+	for _, rules := range pathToRules {
+		if err := checkSchemaMismatch(bundle.Schema, rules); err != nil {
+			return nil, err
+		}
+	}
+
 	return aspect, nil
 }
 
@@ -466,12 +482,6 @@ func (a *Aspect) Set(databag DataBag, request string, value interface{}) error {
 		return badRequestErrorFrom(a, "set", request, err.Error())
 	}
 
-	if value != nil {
-		if err := checkSchemaMismatch(a.bundle.Schema, expandedMatches); err != nil {
-			return err
-		}
-	}
-
 	for _, match := range expandedMatches {
 		if err := databag.Set(match.storagePath, match.value); err != nil {
 			return err
@@ -493,11 +503,13 @@ func (a *Aspect) Set(databag DataBag, request string, value interface{}) error {
 	return nil
 }
 
-func checkSchemaMismatch(schema Schema, matches []expandedMatch) error {
+// checkSchemaMismatch checks whether the rules accept compatible schema types.
+// If not, then no data can satisfy these rules and the aspect should be rejected.
+func checkSchemaMismatch(schema Schema, rules []*aspectRule) error {
 	pathTypes := make(map[string][]SchemaType)
 out:
-	for _, match := range matches {
-		path := match.storagePath
+	for _, rule := range rules {
+		path := rule.originalStorage
 		pathParts := strings.Split(path, ".")
 		schemas, err := schema.SchemaAt(pathParts)
 		if err != nil {
@@ -507,8 +519,8 @@ out:
 				subParts := parts[:len(parts)-serr.left]
 				subPath := strings.Join(subParts, ".")
 
-				return fmt.Errorf(`path %q for request %q is invalid after %q: %w`,
-					path, match.request, subPath, serr.err)
+				return fmt.Errorf(`storage path %q for request %q is invalid after %q: %w`,
+					path, rule.originalRequest, subPath, serr.err)
 			}
 
 			return fmt.Errorf(`internal error: unexpected error finding schema at %q: %w`, path, err)
@@ -547,7 +559,7 @@ out:
 			if !pathMatch {
 				oldSetStr, newSetStr := schemaTypesStr(oldTypes), schemaTypesStr(newTypes)
 				return fmt.Errorf(`storage paths %q and %q for request %q require incompatible types: %s != %s`,
-					oldPath, path, match.request, oldSetStr, newSetStr)
+					oldPath, path, rule.originalRequest, oldSetStr, newSetStr)
 			}
 		}
 
@@ -974,6 +986,7 @@ func newAspectRule(request, storage, accesstype string) (*aspectRule, error) {
 
 	return &aspectRule{
 		originalRequest: request,
+		originalStorage: storage,
 		request:         requestMatchers,
 		storage:         pathWriters,
 		access:          accType,
@@ -989,9 +1002,11 @@ func isPlaceholder(part string) bool {
 // placeholders filled in.
 type aspectRule struct {
 	originalRequest string
-	request         []requestMatcher
-	storage         []storageWriter
-	access          accessType
+	originalStorage string
+
+	request []requestMatcher
+	storage []storageWriter
+	access  accessType
 }
 
 // match returns true if the subkeys match the pattern exactly or as a prefix.

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -79,7 +79,7 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 				map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
 				map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
 				map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
-				map[string]interface{}{"request": "private.{placeholder}", "storage": "wifi.{placeholder}"},
+				map[string]interface{}{"request": "private.{placeholder}", "storage": "private.{placeholder}"},
 			},
 		},
 	}
@@ -89,8 +89,22 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 		"account-id":   devAccKey.AccountID(),
 		"name":         "network",
 		"aspects":      rules,
-		"storage":      `{"schema": {"wifi" : {"schema": {"ssids": {"type": "array", "values": "any"}, "ssid": "string"}}}}`,
-		"timestamp":    "2030-11-06T09:16:26Z",
+		"storage": `{
+	"schema": {
+		"wifi" : {
+			"schema": {
+				"ssids": {"type": "array", "values": "any"},
+				"ssid": "string",
+				"psk": "string",
+				"status":"string"
+			}
+		},
+		"private": {
+			"values": "any"
+		}
+	}
+}`,
+		"timestamp": "2030-11-06T09:16:26Z",
 	}
 	as, err := signingDB.Sign(asserts.AspectBundleType, headers, nil, "")
 	c.Assert(err, IsNil)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5139,7 +5139,7 @@ func (s *assertMgrSuite) TestAspectBundle(c *C) {
 	c.Assert(err, IsNil)
 
 	aspectBundleFoo := s.aspectBundle(c, "foo", map[string]interface{}{
-		"storage": `{"schema": { "a": "any"}}`,
+		"storage": `{"schema": {"a": "string", "b": "string"}}`,
 		"aspects": map[string]interface{}{
 			"an-aspect": map[string]interface{}{
 				"rules": []interface{}{


### PR DESCRIPTION
Previously the path type mismatch check was done on Set, this PR moves the check to the aspect creation so this is done as early as possible. This check ensures that the assertion doesn't declare requests that can't be satisfied by some data type, per the schema. In the future, we'll have to include request prefixes in this check (since we can get/set those as well) considering that path prefixes are implicitly Map/Array types. However, since we requests still don't support index placeholders it makes sense to do this later.