### PR TITLE
cmd/snap-confine: always set up the device cgroup unless using one of the old bases

### DIFF
--- a/cmd/snap-confine/udev-support.h
+++ b/cmd/snap-confine/udev-support.h
@@ -18,6 +18,15 @@
 #ifndef SNAP_CONFINE_UDEV_SUPPORT_H
 #define SNAP_CONFINE_UDEV_SUPPORT_H
 
-void sc_setup_device_cgroup(const char *security_tag);
+typedef enum {
+	/* Require device cgroup, even if no devices are assigned to the snap */
+	SC_DEVICE_CGROUP_MODE_REQUIRED = 0x0,
+	/* Device cgroup is optional if no devices are assigned to the snap. This is
+	 * to comply with the legacy behavior */
+	SC_DEVICE_CGROUP_MODE_OPTIONAL = 0x1,
+} sc_device_cgroup_mode;
+
+void sc_setup_device_cgroup(const char *security_tag,
+			    sc_device_cgroup_mode mode);
 
 #endif

--- a/tests/main/security-device-cgroups-required-or-optional/task.yaml
+++ b/tests/main/security-device-cgroups-required-or-optional/task.yaml
@@ -1,0 +1,41 @@
+summary: Verify the scenarios when device cgroup is optional or required
+
+details: |
+  Verify scenarios where device cgroup is optional (when using the following
+  base snaps: core, core16, core18, core20, core22, bare) or required (all other
+  bases).
+
+systems:
+  #TODO: bpftool is not available on core22 and tests.device-cgroup needs it for cgroups v2
+  - -ubuntu-core-22-*
+  # no core20 i386
+  - -ubuntu-18.04-32
+
+execute: |
+    echo "Given snap is installed"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core20
+    # XXX explicitly install core24 until there is no release into the stable channel
+    snap install --edge core24
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+
+    echo "No devices are assigned to either snap"
+    udevadm info "/dev/null" | NOMATCH "E: TAGS=.*snap_test-snapd-sh.*"
+    udevadm info "/dev/null" | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh.*"
+
+    # device 'c 1:3' is /dev/null and is among the devices we allow by default
+
+    echo "And no devices are not shown in the snap device list"
+    tests.device-cgroup test-snapd-sh-core20.sh dump | NOMATCH "c 1:3"
+    tests.device-cgroup test-snapd-sh-core24.sh dump | NOMATCH "c 1:3"
+
+    echo "When a snap with optional cgroup command is called"
+    test-snapd-sh-core20.sh -c 'true'
+
+    echo "There is no device set up for it"
+    tests.device-cgroup test-snapd-sh-core20.sh dump | NOMATCH "c 1:3"
+
+    echo "When a snap with required cgroup command is called"
+    test-snapd-sh-core24.sh -c 'true'
+
+    echo "Device is listed as allowed"
+    tests.device-cgroup test-snapd-sh-core24.sh dump | MATCH "c 1:3"


### PR DESCRIPTION
When no devices are tagged for the given snap, snap-confine will not put the current process under a device cgroup. This may lead to the snap having access to more devices than allowed by its connected interfaces. Example case when this happens is input devices, where AppArmor is not expressive enough and selective access is implemented using a device cgroup. On top of this, abusing system-files may accidentally allow a process to access a given device without additional mediation through device cgroup.

Moving forward we will set up device access mediation through cgroups for snaps always, unless the snap is using one of the well-known bases where the old behavior will be preserved for the sake of staying backwards compatible. Right now, snaps using bases:
- core, core16, core18, core20, core22
- base

will be exempt from the new behavior. However, snaps using base core24 onward, or other bases will be a subject to mandatory device cgroup.

This is a second attempt at #6099 