### PR TITLE
interfaces/backend: update sandbox features to account for cgroup v2 device filtering

### DIFF
--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -169,18 +169,17 @@ func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet) interfaces.Spe
 // SandboxFeatures returns the list of features supported by snapd for mediating access to kernel devices.
 func (b *Backend) SandboxFeatures() []string {
 	commonFeatures := []string{
-		"tagging", /* Tagging dynamically associates new devices with specific snaps */
-	}
-	cgroupv1Features := []string{
+		"tagging",          /* Tagging dynamically associates new devices with specific snaps */
 		"device-filtering", /* Snapd can limit device access for each snap */
-		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
 	}
 
 	if cgroup.IsUnified() {
-		// TODO: update v2 device cgroup is supported
-		return commonFeatures
+		return append(commonFeatures,
+			"device-cgroup-v2", /* Snapd creates a device group (v2) for each snap */
+		)
+	} else {
+		return append(commonFeatures,
+			"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
+		)
 	}
-
-	features := append(cgroupv1Features, commonFeatures...)
-	return features
 }

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -522,14 +522,16 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 	defer restore()
 
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
+		"tagging",
 		"device-filtering",
 		"device-cgroup-v1",
-		"tagging",
 	})
 
 	restore = cgroup.MockVersion(cgroup.V2, nil)
 	defer restore()
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"tagging",
+		"device-filtering",
+		"device-cgroup-v2",
 	})
 }


### PR DESCRIPTION
Add device-cgroup-v2 sandbox feature flag which was forgotten when we landed cgroup v2 device filtering support.
