### PR TITLE
cmd/libsnap-confine-private/infofile: support for comments

### DIFF
--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -88,6 +88,11 @@ int sc_infofile_get_ini_section_key(FILE *stream, const char *section, const cha
         /* Replace the trailing newline character with the NUL byte. */
         line_buf[nread - 1] = '\0';
 
+        if (line_buf[0] == '#') {
+            /* A comment, advance to next line. */
+            continue;
+        }
+
         /* Handle ini sections (if requested via non-null section name) */
         if (line_buf[0] == '[') {
             if (section == NULL) {

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -26,10 +26,10 @@
  * sc_infofile_get_key extracts a single value of a key=value pair from a given
  * stream.
  *
- * On success the return value is zero and err_out, if not NULL, is deferences
- * and set to NULL.  On failure the return value is -1 is and detailed error
- * information is stored by dereferencing err_out.  If an error occurs and
- * err_out is NULL then the program dies, printing the error message.
+ * On success the return value is zero and err_out, if not NULL, value is
+ * dereferenced and set to NULL. On failure the return value is -1 is and
+ * detailed error information is stored by dereferencing err_out. If an error
+ * occurs and err_out is NULL then the program dies, printing the error message.
  **/
 int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **err_out);
 
@@ -37,10 +37,10 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
  * sc_infofile_get_ini_section_key extracts a single value of a key=value pair
  * from a given ini section of the stream.
  *
- * On success the return value is zero and err_out, if not NULL, is deferences
- * and set to NULL. On failure the return value is -1 is and detailed error
- * information is stored by dereferencing err_out. If an error occurs and
- * err_out is NULL then the program dies, printing the error message.
+ * On success the return value is zero and err_out, if not NULL, value is
+ * dereferenced and set to NULL. On failure the return value is -1 is and
+ * detailed error information is stored by dereferencing err_out. If an error
+ * occurs and err_out is NULL then the program dies, printing the error message.
  **/
 int sc_infofile_get_ini_section_key(FILE *stream, const char *section, const char *key, char **value,
                                     sc_error **err_out);


### PR DESCRIPTION
Add support for comments spanning the whole line.
