### PR TITLE
usersession/client: add missing parameters (enable, disable, reload, disabled-services)

### DIFF
--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -448,7 +448,7 @@ func (s *restSuite) TestServicesRestartReportsError(c *C) {
 }
 
 func (s *restSuite) TestServicesRestartOrReload(c *C) {
-	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"reload-or-restart","services":["snap.foo.service", "snap.bar.service"]}`))
+	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"restart", "reload":true,"services":["snap.foo.service", "snap.bar.service"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
@@ -467,7 +467,7 @@ func (s *restSuite) TestServicesRestartOrReload(c *C) {
 }
 
 func (s *restSuite) TestServicesRestartOrReloadNonSnap(c *C) {
-	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"reload-or-restart","services":["snap.foo.service", "not-snap.bar.service"]}`))
+	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"restart", "reload":true,"services":["snap.foo.service", "not-snap.bar.service"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
@@ -499,7 +499,7 @@ func (s *restSuite) TestServicesRestartOrReloadReportsError(c *C) {
 	})
 	defer restore()
 
-	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"reload-or-restart","services":["snap.foo.service", "snap.bar.service"]}`))
+	req := httptest.NewRequest("POST", "/v1/service-control", bytes.NewBufferString(`{"action":"restart", "reload":true,"services":["snap.foo.service", "snap.bar.service"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
@@ -511,7 +511,7 @@ func (s *restSuite) TestServicesRestartOrReloadReportsError(c *C) {
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
 	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
 		"kind":    "service-control",
-		"message": "some user services failed to restart or reload",
+		"message": "some user services failed to restart",
 		"value": map[string]interface{}{
 			"restart-errors": map[string]interface{}{
 				"snap.bar.service": "mock systemctl error",

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -53,7 +52,7 @@ func dialSessionAgent(network, address string) (net.Conn, error) {
 
 type Client struct {
 	doer *http.Client
-	uids []int
+	uids map[int]bool
 }
 
 func New() *Client {
@@ -67,7 +66,10 @@ func New() *Client {
 // only.
 func NewForUids(uids ...int) *Client {
 	cli := New()
-	cli.uids = append(cli.uids, uids...)
+	cli.uids = make(map[int]bool, len(uids))
+	for _, uid := range uids {
+		cli.uids[uid] = true
+	}
 	return cli
 }
 
@@ -104,20 +106,12 @@ func (resp *response) checkError() {
 	}
 }
 
-func (client *Client) sendRequest(ctx context.Context, socket string, method, urlpath string, query url.Values, headers map[string]string, body []byte) *response {
-	uidStr := filepath.Base(filepath.Dir(socket))
-	uid, err := strconv.Atoi(uidStr)
-	if err != nil {
-		// Ignore directories that do not
-		// appear to be valid XDG runtime dirs
-		// (i.e. /run/user/NNNN).
-		return nil
-	}
+func (client *Client) sendRequest(ctx context.Context, uid int, method, urlpath string, query url.Values, headers map[string]string, body []byte) *response {
 	response := &response{uid: uid}
 
 	u := url.URL{
 		Scheme:   "http",
-		Host:     uidStr,
+		Host:     fmt.Sprintf("%d", uid),
 		Path:     urlpath,
 		RawQuery: query.Encode(),
 	}
@@ -142,13 +136,45 @@ func (client *Client) sendRequest(ctx context.Context, socket string, method, ur
 	return response
 }
 
+func (client *Client) uidIsValidAsTarget(uid int) bool {
+	// if uids are provided (i.e there must be entries, otherwise
+	// no list is there), then there must be an entry
+	if len(client.uids) > 0 {
+		return client.uids[uid]
+	}
+	return true
+}
+
+func (client *Client) sessionTargets() ([]int, error) {
+	sockets, err := filepath.Glob(filepath.Join(dirs.XdgRuntimeDirGlob, "snapd-session-agent.socket"))
+	if err != nil {
+		return nil, err
+	}
+
+	uids := make([]int, 0, len(client.uids))
+	for _, sock := range sockets {
+		uidStr := filepath.Base(filepath.Dir(sock))
+		uid, err := strconv.Atoi(uidStr)
+		if err != nil {
+			// Ignore directories that do not
+			// appear to be valid XDG runtime dirs
+			// (i.e. /run/user/NNNN).
+			continue
+		}
+		if client.uidIsValidAsTarget(uid) {
+			uids = append(uids, uid)
+		}
+	}
+	return uids, nil
+}
+
 // doMany sends the given request to all active user sessions or a subset of them
 // defined by optional client.uids field. Please be careful when using this
 // method, because it is not aware of the physical user who triggered the request
 // and blindly forwards it to all logged in users. Some of them might not have
 // the right to see the request (let alone to respond to it).
 func (client *Client) doMany(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body []byte) ([]*response, error) {
-	sockets, err := filepath.Glob(filepath.Join(dirs.XdgRuntimeDirGlob, "snapd-session-agent.socket"))
+	uids, err := client.sessionTargets()
 	if err != nil {
 		return nil, err
 	}
@@ -158,35 +184,17 @@ func (client *Client) doMany(ctx context.Context, method, urlpath string, query 
 		responses []*response
 	)
 
-	var uids map[string]bool
-	if len(client.uids) > 0 {
-		uids = make(map[string]bool)
-		for _, uid := range client.uids {
-			uids[fmt.Sprintf("%d", uid)] = true
-		}
-	}
-
-	for _, socket := range sockets {
-		// filter out sockets based on uids
-		if len(uids) > 0 {
-			// XXX: alternatively we could Stat() the socket and
-			// and check Uid field of stat.Sys().(*syscall.Stat_t), but it's
-			// more annyoing to unit-test.
-			userPart := filepath.Base(filepath.Dir(socket))
-			if !uids[userPart] {
-				continue
-			}
-		}
+	for _, uid := range uids {
 		wg.Add(1)
-		go func(socket string) {
+		go func(uid int) {
 			defer wg.Done()
-			response := client.sendRequest(ctx, socket, method, urlpath, query, headers, body)
+			response := client.sendRequest(ctx, uid, method, urlpath, query, headers, body)
 			if response != nil {
 				mu.Lock()
 				defer mu.Unlock()
 				responses = append(responses, response)
 			}
-		}(socket)
+		}(uid)
 	}
 	wg.Wait()
 	return responses, nil
@@ -196,7 +204,7 @@ func decodeInto(reader io.Reader, v interface{}) error {
 	dec := json.NewDecoder(reader)
 	if err := dec.Decode(v); err != nil {
 		r := dec.Buffered()
-		buf, err1 := ioutil.ReadAll(r)
+		buf, err1 := io.ReadAll(r)
 		if err1 != nil {
 			buf = []byte(fmt.Sprintf("error reading buffered response body: %s", err1))
 		}
@@ -265,19 +273,25 @@ func decodeServiceErrors(uid int, errorValue map[string]interface{}, kind string
 	return failures, err
 }
 
-func (client *Client) serviceControlCall(ctx context.Context, action string, services []string) (startFailures, stopFailures []ServiceFailure, err error) {
-	headers := map[string]string{"Content-Type": "application/json"}
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"action":   action,
-		"services": services,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	responses, err := client.doMany(ctx, "POST", "/v1/service-control", nil, headers, reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
+// ServiceInstruction is the json representation of possible arguments
+// for the user session rest api to control services. Arguments allowed for
+// start/stop/restart are all listed here, and closely reflect possible arguments
+// for similar options in the wrappers package.
+type ServiceInstruction struct {
+	Action   string   `json:"action"`
+	Services []string `json:"services,omitempty"`
+
+	// StartServices options
+	Enable bool `json:"enable,omitempty"`
+
+	// StopServices options
+	Disable bool `json:"disable,omitempty"`
+
+	// RestartServices options
+	Reload bool `json:"reload,omitempty"`
+}
+
+func (client *Client) decodeControlResponses(responses []*response) (startFailures, stopFailures []ServiceFailure, err error) {
 	for _, resp := range responses {
 		if agentErr, ok := resp.err.(*Error); ok && agentErr.Kind == "service-control" {
 			if errorValue, ok := agentErr.Value.(map[string]interface{}); ok {
@@ -298,27 +312,127 @@ func (client *Client) serviceControlCall(ctx context.Context, action string, ser
 	return startFailures, stopFailures, err
 }
 
+func (client *Client) serviceControlCall(ctx context.Context, inst *ServiceInstruction) (startFailures, stopFailures []ServiceFailure, err error) {
+	headers := map[string]string{"Content-Type": "application/json"}
+	reqBody, err := json.Marshal(inst)
+	if err != nil {
+		return nil, nil, err
+	}
+	responses, err := client.doMany(ctx, "POST", "/v1/service-control", nil, headers, reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client.decodeControlResponses(responses)
+}
+
 func (client *Client) ServicesDaemonReload(ctx context.Context) error {
-	_, _, err := client.serviceControlCall(ctx, "daemon-reload", nil)
+	_, _, err := client.serviceControlCall(ctx, &ServiceInstruction{
+		Action: "daemon-reload",
+	})
 	return err
 }
 
-func (client *Client) ServicesStart(ctx context.Context, services []string) (startFailures, stopFailures []ServiceFailure, err error) {
-	return client.serviceControlCall(ctx, "start", services)
+func filterDisabledServices(all, disabled []string) []string {
+	var filtered []string
+ServiceLoop:
+	for _, svc := range all {
+		for _, disabledSvc := range disabled {
+			if strings.Contains(svc, disabledSvc) {
+				continue ServiceLoop
+			}
+		}
+		filtered = append(filtered, svc)
+	}
+	return filtered
 }
 
-func (client *Client) ServicesStop(ctx context.Context, services []string) (stopFailures []ServiceFailure, err error) {
-	_, stopFailures, err = client.serviceControlCall(ctx, "stop", services)
+type ClientServicesStartOptions struct {
+	// Enable determines whether the service should be enabled before
+	// its being started.
+	Enable bool
+	// DisabledServices is a list of services per-uid that can be provided
+	// which will then be ignored for the start or enable operation.
+	DisabledServices map[int][]string
+}
+
+// ServicesStop attempts to start the services in `services`.
+// If the enable flag is provided, then services listed will also be
+// enabled.
+// If the map of disabled services is set, then on a per-uid basis the services
+// listed in `services` can be filtered out.
+func (client *Client) ServicesStart(ctx context.Context, services []string, opts ClientServicesStartOptions) (startFailures, stopFailures []ServiceFailure, err error) {
+	// If no disabled services lists are provided, then we do not need to filter out services
+	// per-user. In this case lets
+	if len(opts.DisabledServices) == 0 {
+		return client.serviceControlCall(ctx, &ServiceInstruction{
+			Action:   "start",
+			Services: services,
+			Enable:   opts.Enable,
+		})
+	}
+
+	// Otherwise we do a bit of manual request building based on the uids we need to filter
+	// services out for.
+	uids, err := client.sessionTargets()
+	if err != nil {
+		return nil, nil, err
+	}
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		responses []*response
+	)
+
+	for _, uid := range uids {
+		headers := map[string]string{"Content-Type": "application/json"}
+		filtered := filterDisabledServices(services, opts.DisabledServices[uid])
+		if len(filtered) == 0 {
+			// Save an expensive call
+			continue
+		}
+		reqBody, err := json.Marshal(&ServiceInstruction{
+			Action:   "start",
+			Services: filtered,
+			Enable:   opts.Enable,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		wg.Add(1)
+		go func(uid int) {
+			defer wg.Done()
+			response := client.sendRequest(ctx, uid, "POST", "/v1/service-control", nil, headers, reqBody)
+			if response != nil {
+				mu.Lock()
+				defer mu.Unlock()
+				responses = append(responses, response)
+			}
+		}(uid)
+	}
+	wg.Wait()
+	return client.decodeControlResponses(responses)
+}
+
+// ServicesStop attempts to stop the services in `services`.
+// If the disable flag is set then the services listed also will
+// be disabled.
+func (client *Client) ServicesStop(ctx context.Context, services []string, disable bool) (stopFailures []ServiceFailure, err error) {
+	_, stopFailures, err = client.serviceControlCall(ctx, &ServiceInstruction{
+		Action:   "stop",
+		Services: services,
+		Disable:  disable,
+	})
 	return stopFailures, err
 }
 
-func (client *Client) ServicesRestart(ctx context.Context, services []string) (restartFailures []ServiceFailure, err error) {
-	restartFailures, _, err = client.serviceControlCall(ctx, "restart", services)
-	return restartFailures, err
-}
-
-func (client *Client) ServicesReloadOrRestart(ctx context.Context, services []string) (restartFailures []ServiceFailure, err error) {
-	restartFailures, _, err = client.serviceControlCall(ctx, "reload-or-restart", services)
+// ServicesRestart attempts to restart or reload active services in `services`.
+// If the reload flag is set then "systemctl reload-or-restart" is attempted.
+func (client *Client) ServicesRestart(ctx context.Context, services []string, reload bool) (restartFailures []ServiceFailure, err error) {
+	restartFailures, _, err = client.serviceControlCall(ctx, &ServiceInstruction{
+		Action:   "restart",
+		Services: services,
+		Reload:   reload,
+	})
 	return restartFailures, err
 }
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -132,7 +132,9 @@ func newUserServiceClientNames(users []string, inter Interacter) (*userServiceCl
 func (c *userServiceClient) stopServices(services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
-	failures, err := c.cli.ServicesStop(ctx, services)
+
+	const disable = false
+	failures, err := c.cli.ServicesStop(ctx, services, disable)
 	for _, f := range failures {
 		c.inter.Notify(fmt.Sprintf("Could not stop service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
@@ -142,7 +144,8 @@ func (c *userServiceClient) stopServices(services ...string) error {
 func (c *userServiceClient) startServices(services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
-	startFailures, stopFailures, err := c.cli.ServicesStart(ctx, services)
+
+	startFailures, stopFailures, err := c.cli.ServicesStart(ctx, services, client.ClientServicesStartOptions{})
 	for _, f := range startFailures {
 		c.inter.Notify(fmt.Sprintf("Could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
@@ -155,13 +158,7 @@ func (c *userServiceClient) startServices(services ...string) error {
 func (c *userServiceClient) restartServices(reload bool, services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
-	var failures []client.ServiceFailure
-	var err error
-	if reload {
-		failures, err = c.cli.ServicesReloadOrRestart(ctx, services)
-	} else {
-		failures, err = c.cli.ServicesRestart(ctx, services)
-	}
+	failures, err := c.cli.ServicesRestart(ctx, services, reload)
 	for _, f := range failures {
 		c.inter.Notify(fmt.Sprintf("Could not restart service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -4765,7 +4765,7 @@ NeedDaemonReload=no
 
 	flags := wrappers.RestartServicesFlags{Reload: true, AlsoEnabledNonActive: true}
 	err = wrappers.RestartServices(info.Services(), nil, &flags, progress.Null, s.perfTimings)
-	c.Assert(err, ErrorMatches, `some user services failed to restart or reload`)
+	c.Assert(err, ErrorMatches, `some user services failed to restart`)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--user", "daemon-reload"},
 		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},


### PR DESCRIPTION
This PR simplifies reload-or-restart into just restart with `reload` parameter as well

This adds support for:
- enable+disabledServices to StartServices
- disable to StopServices
- reload to RestartServices and then remove "restart-or-reload"

This is not being used yet as I plan to do some cleanup and refactoring around the usession client / rest-api. This simply introduces new parameters, but nothing uses them yet.

I plan to cleanup and refactor how we return errors first.