### PR TITLE
interfaces/builtin/libvirt: add read permissions to /var/lib/snapd/ho…

### DIFF
--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -33,6 +33,7 @@ const libvirtConnectedPlugAppArmor = `
 /run/libvirt/libvirt-sock-ro rw,
 /run/libvirt/libvirt-sock rw,
 /etc/libvirt/* r,
+/var/lib/snapd/hostfs/var/lib/libvirt/dnsmasq{,**} r,
 `
 
 const libvirtConnectedPlugSecComp = `

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -33,7 +33,7 @@ const libvirtConnectedPlugAppArmor = `
 /run/libvirt/libvirt-sock-ro rw,
 /run/libvirt/libvirt-sock rw,
 /etc/libvirt/* r,
-/var/lib/snapd/hostfs/var/lib/libvirt/dnsmasq{,**} r,
+/var/lib/snapd/hostfs/var/lib/libvirt/dnsmasq/{,**} r,
 `
 
 const libvirtConnectedPlugSecComp = `


### PR DESCRIPTION
Currently [libnss_libvirt and libnss_libvirt_guest](https://libvirt.org/nss.html) which is the official way to get name resolution for libvirt vm, requires access to /var/lib/libvirt/dnsmasq/** (it does not use the libvirt socket). /var/lib/libvirt/dnsmasq/ is used by libvirtd to store vm network related information. 

As libvirt interface is intended to be used with libvirtd running on the host, access to host's  /var/lib/libvirt/dnsmasq/ folder is required. This PR adds one new rule to grant this permission.
