### PR TITLE
many: remove snap data home directories

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -97,7 +97,7 @@ type managerBackend interface {
 	RemoveSnapData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapCommonData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapSaveData(info *snap.Info, dev snap.Device) error
-	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error
+	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error
 	RemoveComponentDir(cpi snap.ContainerPlaceInfo) error
 	RemoveContainerMountUnits(cpi snap.ContainerPlaceInfo, meter progress.Meter) error
 	DiscardSnapNamespace(snapName string) error

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -68,20 +68,58 @@ func (b Backend) RemoveSnapSaveData(snapInfo *snap.Info, dev snap.Device) error 
 	return os.RemoveAll(saveDir)
 }
 
-// RemoveSnapDataDir removes base snap data directory
-func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error {
+// RemoveSnapDataDir removes base snap data directories
+func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error {
 	if info.InstanceKey != "" {
 		// data directories of snaps with instance key are never used by
 		// other instances
-		if err := os.Remove(snap.BaseDataDir(info.InstanceName())); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove snap %q base directory: %v", info.InstanceName(), err)
+		dirs, err := snapBaseDataDirs(info.InstanceName(), opts)
+		if err != nil {
+			return err
+		}
+		var firstRemoveErr error
+		for _, dir := range dirs {
+			// remove data symlink that could have been created by snap-run
+			// https://bugs.launchpad.net/snapd/+bug/2009617
+			if err := os.Remove(filepath.Join(dir, "current")); err != nil && !os.IsNotExist(err) {
+				if firstRemoveErr == nil {
+					firstRemoveErr = err
+				}
+			}
+			if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
+				if firstRemoveErr == nil {
+					firstRemoveErr = err
+				}
+			}
+		}
+		if firstRemoveErr != nil {
+			return fmt.Errorf("failed to remove snap %q base directory: %v", info.InstanceName(), firstRemoveErr)
 		}
 	}
 	if !hasOtherInstances {
 		// remove the snap base directory only if there are no other
 		// snap instances using it
-		if err := os.Remove(snap.BaseDataDir(info.SnapName())); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove snap %q base directory: %v", info.SnapName(), err)
+		dirs, err := snapBaseDataDirs(info.SnapName(), opts)
+		if err != nil {
+			return err
+		}
+		var firstRemoveErr error
+		for _, dir := range dirs {
+			// remove data symlink that could have been created by snap-run
+			// https://bugs.launchpad.net/snapd/+bug/2009617
+			if err := os.Remove(filepath.Join(dir, "current")); err != nil && !os.IsNotExist(err) {
+				if firstRemoveErr == nil {
+					firstRemoveErr = err
+				}
+			}
+			if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
+				if firstRemoveErr == nil {
+					firstRemoveErr = err
+				}
+			}
+		}
+		if firstRemoveErr != nil {
+			return fmt.Errorf("failed to remove snap %q base directory: %v", info.SnapName(), firstRemoveErr)
 		}
 	}
 
@@ -111,6 +149,27 @@ func removeDirs(dirs []string) error {
 	}
 
 	return nil
+}
+
+// snapDataDirs returns the list of base data directories for the given snap.
+func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, error) {
+	// collect the directories, homes first
+	var found []string
+
+	for _, entry := range snap.BaseDataHomeDirs(snapName, opts) {
+		entryPaths, err := filepath.Glob(entry)
+		if err != nil {
+			return nil, err
+		}
+		found = append(found, entryPaths...)
+	}
+
+	// then the /root user (including GlobalRootDir for tests)
+	found = append(found, snap.UserSnapDir(filepath.Join(dirs.GlobalRootDir, "/root/"), snapName, opts))
+	// then system data
+	found = append(found, snap.BaseDataDir(snapName))
+
+	return found, nil
 }
 
 // snapDataDirs returns the list of data directories for the given snap version

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1282,7 +1282,7 @@ func (f *fakeSnappyBackend) RemoveSnapSaveData(info *snap.Info, _ snap.Device) e
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool) error {
+func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool, opts *dirs.SnapDirOptions) error {
 	f.ops = append(f.ops, fakeOp{
 		op:             "remove-snap-data-dir",
 		name:           info.InstanceName(),

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1663,7 +1663,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) (err error) {
 		}
 		// no other instances of this snap, shared data directory can be
 		// removed now too
-		if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances); err != nil {
+		if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances, dirOpts); err != nil {
 			t.Errorf("cannot undo partial snap %q data copy, failed removing shared directory: %v", snapsup.InstanceName(), err)
 		}
 		return copyDataErr
@@ -1856,7 +1856,7 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 	}
 	// no other instances of this snap and no other revisions, shared data
 	// directory can be removed
-	if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances); err != nil {
+	if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances, dirOpts); err != nil {
 		return err
 	}
 	return nil
@@ -3385,7 +3385,7 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 			return err
 		}
 		// Snap data directory can be removed now too
-		if err := m.backend.RemoveSnapDataDir(info, otherInstances); err != nil {
+		if err := m.backend.RemoveSnapDataDir(info, otherInstances, dirOpts); err != nil {
 			return err
 		}
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -264,6 +264,16 @@ func snapDataDir(opts *dirs.SnapDirOptions) string {
 	return dirs.UserHomeSnapDir
 }
 
+// BaseDataHomeDirs returns the per user base data directories of the snap across multiple
+// home directories.
+func BaseDataHomeDirs(name string, opts *dirs.SnapDirOptions) []string {
+	var dataHomeGlob []string
+	for _, glob := range dirs.DataHomeGlobs(opts) {
+		dataHomeGlob = append(dataHomeGlob, filepath.Join(glob, name))
+	}
+	return dataHomeGlob
+}
+
 // UserDataDir returns the user-specific data directory for given snap name. The
 // name can be either a snap name or snap instance name.
 func UserDataDir(home string, name string, revision Revision, opts *dirs.SnapDirOptions) string {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1245,6 +1245,20 @@ func (s *infoSuite) TestDataHomeDirs(c *C) {
 	c.Check(info.CommonDataHomeDirs(opts), DeepEquals, hiddenCommonHomeDirs)
 }
 
+func (s *infoSuite) TestBaseDataHomeDirs(c *C) {
+	dirs.SetSnapHomeDirs("/home,/home/group1,/home/group2,/home/group3")
+
+	homeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/snap/name"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/snap/name"),
+		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/snap/name"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/snap/name")}
+	c.Check(snap.BaseDataHomeDirs("name", nil), DeepEquals, homeDirs)
+
+	// Same test but with a hidden snap directory
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	hiddenHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/.snap/data/name"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/.snap/data/name"),
+		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/.snap/data/name"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/.snap/data/name")}
+	c.Check(snap.BaseDataHomeDirs("name", opts), DeepEquals, hiddenHomeDirs)
+}
+
 func BenchmarkTestParsePlaceInfoFromSnapFileName(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		for _, sn := range []string{
@@ -1775,6 +1789,7 @@ func (s *infoSuite) TestDirAndFileHelpers(c *C) {
 	c.Check(snap.MountDir("name", snap.R(1)), Equals, fmt.Sprintf("%s/name/1", dirs.SnapMountDir))
 	c.Check(snap.MountFile("name", snap.R(1)), Equals, "/var/lib/snapd/snaps/name_1.snap")
 	c.Check(snap.HooksDir("name", snap.R(1)), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapMountDir))
+	c.Check(snap.BaseDataDir("name"), Equals, "/var/snap/name")
 	c.Check(snap.DataDir("name", snap.R(1)), Equals, "/var/snap/name/1")
 	c.Check(snap.CommonDataDir("name"), Equals, "/var/snap/name/common")
 	c.Check(snap.CommonDataSaveDir("name"), Equals, "/var/lib/snapd/save/snap/name")
@@ -1786,6 +1801,7 @@ func (s *infoSuite) TestDirAndFileHelpers(c *C) {
 	c.Check(snap.MountDir("name_instance", snap.R(1)), Equals, fmt.Sprintf("%s/name_instance/1", dirs.SnapMountDir))
 	c.Check(snap.MountFile("name_instance", snap.R(1)), Equals, "/var/lib/snapd/snaps/name_instance_1.snap")
 	c.Check(snap.HooksDir("name_instance", snap.R(1)), Equals, fmt.Sprintf("%s/name_instance/1/meta/hooks", dirs.SnapMountDir))
+	c.Check(snap.BaseDataDir("name_instance"), Equals, "/var/snap/name_instance")
 	c.Check(snap.DataDir("name_instance", snap.R(1)), Equals, "/var/snap/name_instance/1")
 	c.Check(snap.CommonDataDir("name_instance"), Equals, "/var/snap/name_instance/common")
 	c.Check(snap.CommonDataSaveDir("name_instance"), Equals, "/var/lib/snapd/save/snap/name_instance")

--- a/tests/main/snapd-homedirs/task.yaml
+++ b/tests/main/snapd-homedirs/task.yaml
@@ -88,6 +88,5 @@ execute: |
 
     echo "Then all user data and root data is gone"
     for h in "${homes[@]}"; do
-        test ! -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
-        test ! -e "${h}snap/test-snapd-sh/$rev/mock-data"
+        test ! -e "${h}snap/test-snapd-sh"
     done


### PR DESCRIPTION
`RemoveSnapDataDir` is leaving behind empty snap home data directories after the snap is removed (leaving a broken symlink behind).

Fixes: https://bugs.launchpad.net/snapd/+bug/2009617

This PR is a follow-up to https://github.com/snapcore/snapd/pull/13145.

This is an older PR https://github.com/snapcore/snapd/pull/13083 attempting the same thing, linking it here because the discussions are relevant.