### PR TITLE
o/snapstate: record `change-update` notice on forced refresh

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1371,7 +1371,15 @@ func onRefreshInhibitionTimeout(chg *state.Change, snapName string) error {
 
 	chg.Set("api-data", data)
 
-	// TODO: record a change-update notice here
+	// record a change-update notice on forced snap refresh
+	opts := &state.AddNoticeOptions{
+		Data: map[string]string{"kind": chg.Kind()},
+	}
+	_, err = chg.State().AddNotice(nil, state.ChangeUpdateNotice, chg.ID(), opts)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -10963,7 +10963,14 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 		return refreshForced[i].(string) < refreshForced[j].(string)
 	})
 	c.Check(refreshForced, DeepEquals, []interface{}{"some-other-snap", "some-snap"})
-	// TODO: Check that change-update notice is added
+
+	notices := s.state.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "change-update")
+	c.Check(n["key"], Equals, chg.ID())
+	// 3 status changes (Default -> Doing -> Done) + 2 forced refreshes
+	c.Check(n["occurrences"], Equals, 5.0)
 
 	c.Check(notified, Equals, 2)
 	c.Check(check["some-snap"], Equals, 2)


### PR DESCRIPTION
This change records a notice when a snap refresh is forced due to inhibition timeout as mentioned in the [RAA-UX spec SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.c40tauj2e3fo).