### PR TITLE
cmd/snap-confine: fix exploding homedirs bug

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -927,7 +927,8 @@ static struct sc_mount *sc_homedir_mounts(const struct sc_invocation *inv)
 	for (int i = 0; i < inv->num_homedirs; i++) {
 		debug("Adding homedir: %s", inv->homedirs[i]);
 		mounts[i].path = sc_strdup(inv->homedirs[i]);
-		mounts[i].is_bidirectional = true;
+		// Note that we are not setting bidirectional flag, so anything mounted
+		// here will not propagate to the host.
 	}
 	return mounts;
 }

--- a/tests/regression/exploding-namespace/task.yaml
+++ b/tests/regression/exploding-namespace/task.yaml
@@ -1,0 +1,21 @@
+summary: Ensure that namespaces do not leak through homedirs
+
+details: |
+    Ensure that layouts on /var/lib/subdir coupled with homedirs=/var/lib
+    do not cause hostfs to leak to the initial mount namespace.
+
+systems:
+    - -ubuntu-core-*
+
+prepare: |
+    snap set system homedirs=/var/lib
+    # This snap has a layout for /var/lib/demo, which is relevant here.
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
+
+restore: |
+    snap unset system homedirs
+
+execute: |
+    NOMATCH hostfs </proc/self/mountinfo
+    test-snapd-layout.sh -c "true"
+    NOMATCH hostfs </proc/self/mountinfo


### PR DESCRIPTION
The combination of snap set system homedirs=/var/lib/ and a snap that causes a mimic to be created over /var/lib is sufficient to leak over to the initial mount namespace.

Fixes: https://warthogs.atlassian.net/browse/SNAPDENG-17066
