### PR TITLE
daemon: allow polkit authentication for `/v2/snaps/{snap}/conf`

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -88,9 +88,10 @@ var api = []*Command{
 }
 
 const (
-	polkitActionLogin            = "io.snapcraft.snapd.login"
-	polkitActionManage           = "io.snapcraft.snapd.manage"
-	polkitActionManageInterfaces = "io.snapcraft.snapd.manage-interfaces"
+	polkitActionLogin               = "io.snapcraft.snapd.login"
+	polkitActionManage              = "io.snapcraft.snapd.manage"
+	polkitActionManageInterfaces    = "io.snapcraft.snapd.manage-interfaces"
+	polkitActionManageConfiguration = "io.snapcraft.snapd.manage-configuration"
 )
 
 // userFromRequest extracts user information from request and return the respective user in state, if valid

--- a/daemon/api_snap_conf.go
+++ b/daemon/api_snap_conf.go
@@ -38,8 +38,8 @@ var (
 		Path:        "/v2/snaps/{name}/conf",
 		GET:         getSnapConf,
 		PUT:         setSnapConf,
-		ReadAccess:  authenticatedAccess{},
-		WriteAccess: authenticatedAccess{},
+		ReadAccess:  authenticatedAccess{Polkit: polkitActionManageConfiguration},
+		WriteAccess: authenticatedAccess{Polkit: polkitActionManageConfiguration},
 	}
 )
 

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -30,6 +30,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/testutil"
@@ -44,7 +45,8 @@ type snapConfSuite struct {
 func (s *snapConfSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
-	s.expectAuthenticatedAccess()
+	s.expectReadAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage-configuration"})
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage-configuration"})
 }
 
 func (s *snapConfSuite) runGetConf(c *check.C, snapName string, keys []string, statusCode int) map[string]interface{} {

--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -37,4 +37,14 @@
     </defaults>
   </action>
 
+  <action id="io.snapcraft.snapd.manage-configuration">
+    <description gettext-domain="snappy">Access or modify snap configuration</description>
+    <message gettext-domain="snappy">Authentication is required to access or modify snap configuration</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>


### PR DESCRIPTION
For prompting, non-root clients need to be able to query and set the `system experimental.apparmor-prompting` option. Previously, there was no good way to do so without a workaround in the client to make a query as root, but using polkit is much preferred. This PR enables polkit authentication on the `/v2/snaps/{snap}/conf` endpoint.

Relevant discussion: https://forum.snapcraft.io/t/get-on-authenticated-endpoints-fail-despite-x-allow-interaction/39067