### PR TITLE
github: mention C source code formatting tools we expect

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -228,10 +228,11 @@ jobs:
           ./autogen.sh
           # apply formatting
           PATH=${{ github.workspace }}/indent-bin/opt/indent/bin:$PATH make fmt
-
+          set +x
           if [ -n "$(git diff --stat)" ]; then
               git diff
               echo "C files are not fomratted correctly, run 'make fmt'"
+              echo "make sure to have clang-format and indent 2.2.13+ installed"
               exit 1
           fi
 


### PR DESCRIPTION
Mention clang-format and indent 2.2.13+ in the error message.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
