### PR TITLE
interfaces/builtin/network_setup_control: allow busctl to bind

### DIFF
--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -45,6 +45,10 @@ const networkSetupControlConnectedPlugAppArmor = `
 # Netplan uses busctl internally, so allow using that as well
 /usr/bin/busctl ixr,
 
+# from systemd 254 onward, busctl binds to a unix socket upon startup to
+# facilitate debugging
+unix (bind) type=stream addr="@[0-9a-fA-F]*/bus/busctl/*",
+
 /etc/netplan/{,**} rw,
 /etc/network/{,**} rw,
 /etc/systemd/network/{,**} rw,

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -46,6 +46,10 @@ const networkSetupObserveConnectedPlugAppArmor = `
 # Netplan uses busctl internally, so allow using that as well
 /usr/bin/busctl ixr,
 
+# from systemd 254 onward, busctl binds to a unix socket upon startup to
+# facilitate debugging
+unix (bind) type=stream addr="@[0-9a-fA-F]*/bus/busctl/*",
+
 /etc/netplan/{,**} r,
 /etc/network/{,**} r,
 /etc/systemd/network/{,**} r,


### PR DESCRIPTION
Starting from systemd 254, busctl will attempt to bind the socket to a known path to facilitate debugging. The change was introduced in https://github.com/systemd/systemd/commit/a0cb33581630a54c89d088d36eb3bf6cf7459cd7 and the path is composed of `@<hex-encoded-u64>/bus/<command>/<description>`.

Actual denial:
```
Feb 29 08:22:04 localhost kernel: audit: type=1400 audit(1709194924.547:213):
apparmor="DENIED" operation="bind" class="net" profile="snap.console-conf.console-conf"
pid=4504 comm="busctl" family="unix" sock_type="stream" protocol=0
requested_mask="bind" denied_mask="bind" addr="@f46ecfc1c63ae80f/bus/busctl/busctl"
```