### PR TITLE
build-aux: add libzstd to snapd snap for snap pack

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -120,6 +120,14 @@ parts:
       - zlib1g
     stage:
       - lib/*
+  # Also needed by squashfs-tools
+  zstd:
+    plugin: nil
+    stage-packages:
+      - libzstd1
+    stage:
+      - usr/lib/*
+      - lib/*
   # libc6 is part of core but we need it in the snapd snap for
   # CommandFromSystemSnap
   libc6:


### PR DESCRIPTION
It seems that squashfs-tools is pulling in libzstd1 from the host when executing snap pack, and that causes an mismatch with libc that is bundled in snapd. So bundle in libzstd to avoid using the host library.

```
Pack command: ['snap', 'pack', '--filename', 'core24_20240229_riscv64.snap', '--compression', 'xz', PosixPath('/home/ubuntu/core-base/prime'), PosixPath('/home/ubuntu/core-base')]    
2024-02-29 11:30:35.888 Command '['snap', 'pack', '--filename', 'core24_20240229_riscv64.snap', '--compression', 'xz', PosixPath('/home/ubuntu/core-base/prime'), PosixPath('/home/ubuntu/core-base')]' returned non-zero exit status 20.                                                                              
2024-02-29 11:30:35.891 Detailed information: error: cannot pack "/home/ubuntu/core-base/prime": mksquashfs call failed: /snap/snapd/current/usr/bin/mksquashfs: /snap/snapd/current/lib/riscv64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /lib/riscv64-linux-gnu/libzstd.so.1
```