### PR TITLE
packaging: wrap-and-sort Debian and Ubuntu packaging

### DIFF
--- a/packaging/debian-sid/control
+++ b/packaging/debian-sid/control
@@ -3,9 +3,9 @@ Section: devel
 Priority: optional
 Maintainer: Michael Hudson-Doyle <mwhudson@debian.org>
 Uploaders: Steve Langasek <vorlon@debian.org>,
-	Zygmunt Krynicki <me@zygoon.pl>,
-	Luke Faraone <lfaraone@debian.org>,
-        Michael Vogt <mvo@debian.org>
+           Zygmunt Krynicki <me@zygoon.pl>,
+           Luke Faraone <lfaraone@debian.org>,
+           Michael Vogt <mvo@debian.org>
 Build-Depends: autoconf,
                autoconf-archive,
                automake,
@@ -20,30 +20,30 @@ Build-Depends: autoconf,
                fakeroot,
                gcc-multilib [amd64],
                gettext,
-               grub-common,
                gnupg2,
-               golang-gopkg-check.v1-dev,
                golang-dbus-dev,
                golang-github-coreos-go-systemd-dev,
-               golang-github-juju-ratelimit-dev,
                golang-github-gorilla-mux-dev,
+               golang-github-jessevdk-go-flags-dev,
+               golang-github-juju-ratelimit-dev,
                golang-github-kr-pretty-dev,
                golang-github-mvo5-goconfigparser-dev,
                golang-github-seccomp-libseccomp-golang-dev,
-               golang-github-jessevdk-go-flags-dev,
+               golang-go (>=2:1.18),
                golang-golang-x-crypto-dev,
                golang-golang-x-xerrors-dev,
-               golang-gopkg-tomb.v2-dev (>= 0.0~git20161208.0.d5d1b58),
-               golang-gopkg-yaml.v2-dev,
+               golang-gopkg-check.v1-dev,
                golang-gopkg-macaroon.v1-dev,
                golang-gopkg-mgo.v2-dev,
                golang-gopkg-retry.v1-dev,
+               golang-gopkg-tomb.v2-dev (>= 0.0~git20161208.0.d5d1b58),
                golang-gopkg-tylerb-graceful.v1-dev,
+               golang-gopkg-yaml.v2-dev,
                golang-gopkg-yaml.v3-dev,
-               golang-go (>=2:1.18),
+               grub-common,
                indent,
-               libcap-dev,
                libapparmor-dev,
+               libcap-dev,
                libglib2.0-dev,
                liblzo2-dev,
                libseccomp-dev,
@@ -78,16 +78,25 @@ Architecture: any
 Depends: adduser,
          apparmor (>= 2.10.95-5),
          ca-certificates,
+         default-dbus-session-bus | dbus-session-bus,
          gnupg1 | gnupg,
          openssh-client,
          squashfs-tools,
          systemd,
          udev,
          ${misc:Depends},
-         ${shlibs:Depends},
-         default-dbus-session-bus | dbus-session-bus
-Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
+         ${shlibs:Depends}
+Replaces: snap-confine (<< 2.23),
+          snapd-xdg-open (<= 0.0.0),
+          ubuntu-core-launcher (<< 2.22),
+          ubuntu-snappy (<< 1.9),
+          ubuntu-snappy-cli (<< 1.9)
+Breaks: snap-confine (<< 2.23),
+        snapd-xdg-open (<= 0.0.0),
+        ubuntu-core-launcher (<< 2.22),
+        ubuntu-snappy (<< 1.9),
+        ubuntu-snappy-cli (<< 1.9),
+        ${snapd:Breaks}
 Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
@@ -114,4 +123,3 @@ Section: oldlibs
 Pre-Depends: dpkg (>= 1.15.7.2)
 Description: Transitional package for snapd
  This is a transitional dummy package. It can safely be removed.
-

--- a/packaging/debian-sid/snapd.dirs
+++ b/packaging/debian-sid/snapd.dirs
@@ -1,6 +1,6 @@
 snap
-var/cache/snapd
 usr/lib/snapd
+var/cache/snapd
 var/lib/snapd/apparmor/snap-confine
 var/lib/snapd/auto-import
 var/lib/snapd/desktop

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -1,40 +1,35 @@
-usr/bin/snap
-usr/bin/snapctl /usr/lib/snapd/
-
-usr/bin/snap-exec /usr/lib/snapd/
-usr/bin/snap-update-ns /usr/lib/snapd/
-usr/bin/snapd /usr/lib/snapd/
-usr/bin/snap-seccomp /usr/lib/snapd/
-usr/bin/snapd-apparmor /usr/lib/snapd/
-
-# bash completion
-data/completion/bash/snap /usr/share/bash-completion/completions
+# apt hook
+data/apt/20snapd.conf /etc/apt/apt.conf.d/
 data/completion/bash/complete.sh /usr/lib/snapd/
 data/completion/bash/etelpmoc.sh /usr/lib/snapd/
+# bash completion
+data/completion/bash/snap /usr/share/bash-completion/completions
 # zsh completion
 data/completion/zsh/_snap /usr/share/zsh/vendor-completions
 # snap/snapd version information
 data/info /usr/lib/snapd/
 # polkit actions
 data/polkit/io.snapcraft.snapd.policy /usr/share/polkit-1/actions/
-# apt hook
-data/apt/20snapd.conf /etc/apt/apt.conf.d/
-
 # snap-confine stuff
 etc/apparmor.d/usr.lib.snapd.snap-confine.real
-usr/lib/snapd/snap-device-helper
-usr/lib/snapd/snap-mgmt
-usr/lib/snapd/snap-confine
-usr/lib/snapd/snap-discard-ns
-usr/share/man/
+usr/bin/snap
+usr/bin/snap-exec /usr/lib/snapd/
+usr/bin/snap-seccomp /usr/lib/snapd/
+usr/bin/snap-update-ns /usr/lib/snapd/
+usr/bin/snapctl /usr/lib/snapd/
+usr/bin/snapd /usr/lib/snapd/
+usr/bin/snapd-apparmor /usr/lib/snapd/
 # for compatibility with ancient snap installs that wrote the shell based
 # wrapper scripts instead of the modern symlinks
 usr/bin/ubuntu-core-launcher
-
+usr/lib/snapd/snap-confine
+usr/lib/snapd/snap-device-helper
+usr/lib/snapd/snap-discard-ns
 # gdb helper
 usr/lib/snapd/snap-gdb-shim
 usr/lib/snapd/snap-gdbserver-shim
-
+usr/lib/snapd/snap-mgmt
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
 usr/lib/systemd/system-generators
+usr/share/man/

--- a/packaging/debian-sid/snapd.links
+++ b/packaging/debian-sid/snapd.links
@@ -1,6 +1,5 @@
 /usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
-usr/lib/snapd/snapctl usr/bin/snapctl
-
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+usr/lib/snapd/snapctl usr/bin/snapctl

--- a/packaging/debian-sid/snapd.maintscript
+++ b/packaging/debian-sid/snapd.maintscript
@@ -1,6 +1,6 @@
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~ snap-confine
 # keep mount point busy
 # we used to ship a custom grub config that is no longer needed
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~ snap-confine
 rm_conffile /etc/sudoers.d/99-snapd.conf 2.50~

--- a/packaging/debian-sid/tests/control
+++ b/packaging/debian-sid/tests/control
@@ -1,12 +1,12 @@
 Tests: integrationtests
 Restrictions: allow-stderr, rw-build-tree, needs-root, breaks-testbed, isolation-machine
-Depends: @builddeps@,
-         bzr,
+Depends: bzr,
          ca-certificates,
          git,
          golang-golang-x-net-dev,
          locales,
-         openssh-server,
-         netcat-openbsd,
          net-tools,
-         snapd
+         netcat-openbsd,
+         openssh-server,
+         snapd,
+         @builddeps@

--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -8,8 +8,8 @@ Build-Depends: autoconf,
                autotools-dev,
                bash-completion,
                ca-certificates,
-               debhelper (>= 9),
                dbus,
+               debhelper (>= 9),
                dh-apparmor,
                dh-autoreconf,
                dh-golang (>=1.7),
@@ -17,13 +17,13 @@ Build-Depends: autoconf,
                fakeroot,
                gcc-multilib [amd64],
                gettext,
-               grub-common,
                gnupg2,
                golang-any (>=2:1.18) | golang-1.18,
+               grub-common,
                indent,
                init-system-helpers,
-               libcap-dev,
                libapparmor-dev,
+               libcap-dev,
                libglib2.0-dev,
                libseccomp-dev (>= 2.1.1-1ubuntu1~trusty4),
                libudev-dev,
@@ -77,9 +77,17 @@ Depends: adduser,
          ${misc:Depends},
          ${shlibs:Depends}
 # recommends because of LP: #1675900
-Recommends: linux-generic-lts-xenial,
-Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<< 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<< 0.0.0)
+Recommends: linux-generic-lts-xenial
+Replaces: snap-confine (<< 2.23),
+          snapd-xdg-open (<< 0.0.0),
+          ubuntu-core-launcher (<< 2.22),
+          ubuntu-snappy (<< 1.9),
+          ubuntu-snappy-cli (<< 1.9)
+Breaks: snap-confine (<< 2.23),
+        snapd-xdg-open (<< 0.0.0),
+        ubuntu-core-launcher (<< 2.22),
+        ubuntu-snappy (<< 1.9),
+        ubuntu-snappy-cli (<< 1.9)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${Built-Using} ${misc:Built-Using}
 Description: Daemon and tooling that enable snap packages

--- a/packaging/ubuntu-14.04/snapd.dirs
+++ b/packaging/ubuntu-14.04/snapd.dirs
@@ -1,10 +1,10 @@
 snap
-var/cache/snapd
 usr/lib/snapd
+var/cache/snapd
 var/lib/snapd/apparmor/snap-confine
-var/lib/snapd/desktop/applications
 var/lib/snapd/auto-import
 var/lib/snapd/desktop
+var/lib/snapd/desktop/applications
 var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/hostfs

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -1,43 +1,39 @@
-usr/bin/snap
-usr/bin/snapctl /usr/lib/snapd/
-usr/lib/snapd/system-shutdown
-usr/bin/snap-exec /usr/lib/snapd/
-usr/bin/snap-repair /usr/lib/snapd/
-usr/bin/snap-failure /usr/lib/snapd/
-usr/bin/snap-update-ns /usr/lib/snapd/
-usr/bin/snapd /usr/lib/snapd/
-usr/bin/snap-seccomp /usr/lib/snapd/
-usr/bin/snap-preseed /usr/lib/snapd/
-
-# bash completion
-data/completion/bash/snap /usr/share/bash-completion/completions
 data/completion/bash/complete.sh /usr/lib/snapd/
 data/completion/bash/etelpmoc.sh /usr/lib/snapd/
+# bash completion
+data/completion/bash/snap /usr/share/bash-completion/completions
 # zsh completion
 data/completion/zsh/_snap /usr/share/zsh/vendor-completions
-# udev, must be installed before 80-udisks
-data/udev/rules.d/66-snapd-autoimport.rules /lib/udev/rules.d
 # snap/snapd version information
 data/info /usr/lib/snapd/
 # polkit actions
 data/polkit/io.snapcraft.snapd.policy /usr/share/polkit-1/actions/
-
+# udev, must be installed before 80-udisks
+data/udev/rules.d/66-snapd-autoimport.rules /lib/udev/rules.d
 # snap-confine stuff
 etc/apparmor.d/usr.lib.snapd.snap-confine
-usr/lib/snapd/snap-device-helper
-usr/lib/snapd/snap-confine
-usr/lib/snapd/snap-discard-ns
-usr/lib/snapd/snap-mgmt
-usr/share/man/
+# but system generators end up in lib
+lib/systemd/system-generators
+usr/bin/snap
+usr/bin/snap-exec /usr/lib/snapd/
+usr/bin/snap-failure /usr/lib/snapd/
+usr/bin/snap-preseed /usr/lib/snapd/
+usr/bin/snap-repair /usr/lib/snapd/
+usr/bin/snap-seccomp /usr/lib/snapd/
+usr/bin/snap-update-ns /usr/lib/snapd/
+usr/bin/snapctl /usr/lib/snapd/
+usr/bin/snapd /usr/lib/snapd/
 # for compatibility with ancient snap installs that wrote the shell based
 # wrapper scripts instead of the modern symlinks
 usr/bin/ubuntu-core-launcher
-
+usr/lib/snapd/snap-confine
+usr/lib/snapd/snap-device-helper
+usr/lib/snapd/snap-discard-ns
 # gdb helper
 usr/lib/snapd/snap-gdb-shim
 usr/lib/snapd/snap-gdbserver-shim
-
+usr/lib/snapd/snap-mgmt
+usr/lib/snapd/system-shutdown
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
-# but system generators end up in lib
-lib/systemd/system-generators
+usr/share/man/

--- a/packaging/ubuntu-14.04/tests/control
+++ b/packaging/ubuntu-14.04/tests/control
@@ -1,11 +1,11 @@
 Tests: integrationtests
 Restrictions: allow-stderr, isolation-container, rw-build-tree, needs-root, breaks-testbed
-Depends: @builddeps@,
-         bzr,
+Depends: bzr,
          ca-certificates,
          git,
          openssh-server,
          snapd,
          unity,
          x11-utils,
-         xvfb
+         xvfb,
+         @builddeps@

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -8,19 +8,19 @@ Build-Depends: autoconf,
                autotools-dev,
                bash-completion,
                ca-certificates,
-               debhelper (>= 9),
                dbus,
+               debhelper (>= 9),
+               debhelper (>= 9.20160709~) | dh-systemd,
                dh-apparmor,
                dh-autoreconf,
                dh-golang (>=1.7),
-               debhelper (>= 9.20160709~) | dh-systemd,
                fakeroot,
                flake8,
                gcc-multilib [amd64],
                gettext,
-               grub-common,
                gnupg2,
                golang-go (>=2:1.18~)  [!powerpc] | golang-1.18 [!powerpc],
+               grub-common,
                indent,
                init-system-helpers,
                libapparmor-dev,
@@ -74,11 +74,20 @@ Depends: adduser,
          squashfs-tools,
          systemd,
          udev,
+         ${dbussession:Depends},
          ${misc:Depends},
-         ${shlibs:Depends},
-         ${dbussession:Depends}
-Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
+         ${shlibs:Depends}
+Replaces: snap-confine (<< 2.23),
+          snapd-xdg-open (<= 0.0.0),
+          ubuntu-core-launcher (<< 2.22),
+          ubuntu-snappy (<< 1.9),
+          ubuntu-snappy-cli (<< 1.9)
+Breaks: snap-confine (<< 2.23),
+        snapd-xdg-open (<= 0.0.0),
+        ubuntu-core-launcher (<< 2.22),
+        ubuntu-snappy (<< 1.9),
+        ubuntu-snappy-cli (<< 1.9),
+        ${snapd:Breaks}
 Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -1,15 +1,15 @@
 snap
-var/cache/snapd
 usr/lib/snapd
 usr/share/dbus-1/session.d
 usr/share/dbus-1/system.d
+var/cache/snapd
 var/lib/snapd/apparmor/snap-confine
-var/lib/snapd/desktop/applications
 var/lib/snapd/auto-import
 var/lib/snapd/dbus-1
 var/lib/snapd/dbus-1/services
 var/lib/snapd/dbus-1/system-services
 var/lib/snapd/desktop
+var/lib/snapd/desktop/applications
 var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/hostfs
@@ -18,7 +18,7 @@ var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
 var/lib/snapd/lib/glvnd
 var/lib/snapd/lib/vulkan
-var/lib/snapd/ssl/store-certs
 var/lib/snapd/snaps/partial
+var/lib/snapd/ssl/store-certs
 var/lib/snapd/void
 var/snap

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,6 +1,5 @@
 /usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
-usr/lib/snapd/snapctl usr/bin/snapctl
-
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+usr/lib/snapd/snapctl usr/bin/snapctl

--- a/packaging/ubuntu-16.04/snapd.maintscript
+++ b/packaging/ubuntu-16.04/snapd.maintscript
@@ -1,6 +1,6 @@
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~
 # keep mount point busy
 # we used to ship a custom grub config that is no longer needed
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~
 rm_conffile /etc/sudoers.d/99-snapd.conf 2.50~

--- a/packaging/ubuntu-16.04/tests/control
+++ b/packaging/ubuntu-16.04/tests/control
@@ -1,12 +1,12 @@
 Tests: integrationtests
 Restrictions: allow-stderr, rw-build-tree, needs-root, breaks-testbed, isolation-machine
-Depends: @builddeps@,
-         bzr,
+Depends: bzr,
          ca-certificates,
          git,
          golang-golang-x-net-dev,
          locales,
-         openssh-server,
-         netcat-openbsd,
          net-tools,
-         snapd
+         netcat-openbsd,
+         openssh-server,
+         snapd,
+         @builddeps@


### PR DESCRIPTION
This is the go fmt equivalent of debian control files.