### PR TITLE
o/devicestate: remove unused method

### DIFF
--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -149,24 +149,6 @@ func (m *DeviceManager) recordSeededSystem(st *state.State, whatSeeded *seededSy
 	return nil
 }
 
-func (m *DeviceManager) removeSeededSystem(st *state.State, whatSeeded *seededSystem) error {
-	var seeded []seededSystem
-	if err := st.Get("seeded-systems", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
-		return err
-	}
-
-	for i, sys := range seeded {
-		if sys.sameAs(whatSeeded) {
-			seeded = append(seeded[:i], seeded[i+1:]...)
-			break
-		}
-	}
-
-	st.Set("seeded-systems", seeded)
-
-	return nil
-}
-
 func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()


### PR DESCRIPTION
Remove an unused method that is making golangci fail on master.