### PR TITLE
tests: support testflinger

### DIFF
--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -71,7 +71,7 @@ execute: |
     # ensure that our the-tool (and thus our snap-bootstrap ran)
     # for external backend the initramfs is not rebuilt
     echo "Check that we booted with the rebuilt initramfs in the kernel snap"
-    if [ "$SPREAD_BACKEND" != "external" ]; then
+    if [ "$SPREAD_BACKEND" != "external" ] && [ "$SPREAD_BACKEND" != "testflinger" ]; then
         test -e /writable/system-data/the-tool-ran
     fi
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -289,7 +289,6 @@ prepare_project() {
     fi
 
     if [ "$SPREAD_BACKEND" = "testflinger" ]; then
-        groupadd --gid 12345 test
         adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
         echo test:ubuntu | sudo chpasswd
         echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -283,7 +283,7 @@ prepare_project() {
 
     # declare the "quiet" wrapper
 
-    if [ "$SPREAD_BACKEND" = external ]; then
+    if [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "testflinger" ]; then
         chown test.test -R "$PROJECT_PATH"
         exit 0
     fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -283,7 +283,16 @@ prepare_project() {
 
     # declare the "quiet" wrapper
 
-    if [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "testflinger" ]; then
+    if [ "$SPREAD_BACKEND" = "external" ]; then
+        chown test.test -R "$PROJECT_PATH"
+        exit 0
+    fi
+
+    if [ "$SPREAD_BACKEND" = "testflinger" ]; then
+        groupadd --gid 12345 test
+        adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
+        echo test:ubuntu | sudo chpasswd
+        echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test
         chown test.test -R "$PROJECT_PATH"
         exit 0
     fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1359,7 +1359,7 @@ prepare_ubuntu_core() {
     fi
 
     # Wait for the snap command to become available.
-    if [ "$SPREAD_BACKEND" != "external" ]; then
+    if [ "$SPREAD_BACKEND" != "external" ] && [ "$SPREAD_BACKEND" != "testflinger" ]; then
         # shellcheck disable=SC2016
         retry -n 120 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap && snap version | grep -E -q "snapd +1337.*"'
     fi
@@ -1440,7 +1440,7 @@ prepare_ubuntu_core() {
         # this is needed just for external devices because those could be using
         # custom images with pre-installed snaps which cannot be removed, such
         # as the network-manager.
-        if [ "$SPREAD_BACKEND" == "external" ]; then
+        if [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "testflinger" ]; then
             PREINSTALLED_SNAPS="$(snap list | tail -n +2 | awk '{print $1}' | tr '\n' ' ')"
             tests.env set initial PREINSTALLED_SNAPS "$PREINSTALLED_SNAPS"
         fi

--- a/tests/lib/uc20-recovery.sh
+++ b/tests/lib/uc20-recovery.sh
@@ -49,7 +49,7 @@ transition_to_recover_mode(){
     # the test, we need to add a .ssh/rc script which copies all of the data
     # from /host/ubuntu-data in recover mode to the tmpfs /home, see
     # sshd(8) for details on the ~/.ssh/rc script
-    if [ "$SPREAD_BACKEND" = "external" ]; then
+    if [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "testflinger" ]; then
         mkdir -p /home/external/.ssh
         chown external:external /home/external/.ssh
         touch /home/external/.ssh/rc


### PR DESCRIPTION
Add changes to the spread tests to support edge and beta validation using testflinger backend

This works even not having the testflinger backend merged in spread. 