### PR TITLE
tests/lib/prepare.sh: reflash during shutdown

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1286,56 +1286,12 @@ EOF
     umount /mnt
     kpartx -d "$IMAGE_HOME/$IMAGE"
 
-    # the reflash magic
-    # FIXME: ideally in initrd, but this is good enough for now
-    cat > "$IMAGE_HOME/reflash.sh" << EOF
-#!/tmp/busybox sh
-set -e
-set -x
-
-# blow away everything
-OF=/dev/sda
-if [ -e /dev/vda ]; then
-    OF=/dev/vda
-elif [ -e /dev/nvme0n1 ]; then
-    OF=/dev/nvme0n1
-fi
-dd if=/tmp/$IMAGE of=\$OF bs=4M
-# and reboot
-sync
-echo b > /proc/sysrq-trigger
-
-EOF
-
-    cat > "$IMAGE_HOME/prep-reflash.sh" << EOF
-#!/bin/sh -ex
-mount -t tmpfs none /tmp
-cp /bin/busybox /tmp
-cp $IMAGE_HOME/reflash.sh /tmp
-cp $IMAGE_HOME/$IMAGE /tmp
-sync
-
-# re-exec using busybox from /tmp
-exec /tmp/reflash.sh
-
-EOF
-    chmod +x "$IMAGE_HOME/reflash.sh"
-    chmod +x "$IMAGE_HOME/prep-reflash.sh"
-
-    DEVPREFIX=""
-    if os.query is-core20 || os.query is-core22; then
-        DEVPREFIX="/boot"
+    gzip "${IMAGE_HOME}/${IMAGE}"
+    if os.query is-core16; then
+        "${TESTSLIB}/uc16-reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"
+    else
+        "${TESTSLIB}/reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"
     fi
-    # extract ROOT from /proc/cmdline
-    ROOT=$(sed -e 's/^.*root=//' -e 's/ .*$//' /proc/cmdline)
-    cat >/boot/grub/grub.cfg <<EOF
-set default=0
-set timeout=2
-menuentry 'flash-all-snaps' {
-linux $DEVPREFIX/vmlinuz root=$ROOT ro init=$IMAGE_HOME/prep-reflash.sh console=tty1 console=ttyS0
-initrd $DEVPREFIX/initrd.img
-}
-EOF
 }
 
 # prepare_ubuntu_core will prepare ubuntu-core 16+

--- a/tests/lib/reflash.sh
+++ b/tests/lib/reflash.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# flash.sh: Install a flashing process to reboot to a new disk image
+#
+# Copyright (C) 2023-2024 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# This produces an Ubuntu Core image for testing in file `pc.img.gz`.
+# It will initialize the spread user as well as the project directory
+# (which has to be defined in `PROJECT_PATH`).
+# This is expected to be called from spread.
+
+# This is to reflash a spread runner.
+# This script takes one argument: a gzipped image to be flashed onto the disk.
+# After successfully running this script, a reboot or power down will
+# flash the machine with the given image.
+
+set -eux
+
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends dracut-core busybox-initramfs
+
+[ -d /run/initramfs ] || mkdir -p /run/initramfs
+
+systemd-mount --property=DefaultDependencies=no --options=exec,size=2G none --type=tmpfs /run/initramfs
+
+cp -T "${1}" /run/initramfs/image.gz
+
+for try in /usr/lib/systemd/systemd-shutdown /lib/systemd/systemd-shutdown; do
+    if [ -x "${try}" ]; then
+        systemd_shutdown="${try}"
+    fi
+done
+
+/usr/lib/dracut/dracut-install --ldd -D/run/initramfs -a umount systemctl dd "${systemd_shutdown}"
+/usr/lib/dracut/dracut-install --ldd -D/run/initramfs /usr/lib/initramfs-tools/bin/busybox /bin/busybox
+
+ln -s busybox /run/initramfs/bin/sh
+ln -s busybox /run/initramfs/bin/gunzip
+
+if [ -b /dev/vda ]; then
+    DISK=/dev/vda
+elif [ -b /dev/sda ]; then
+    DISK=/dev/sda
+elif [ -b /dev/nvme0n1 ]; then
+    DISK=/dev/nvme0n1
+else
+    echo "Cannot find disk" 2>&1
+    exit 1
+fi
+
+cat <<EOF >/run/initramfs/shutdown
+#!/bin/sh
+
+echo "SHUTTING DOWN"
+
+set -eu
+
+umount -l /oldroot
+
+gunzip -c /image.gz | dd of='${DISK}' bs=32M
+
+exec '${systemd_shutdown}' "\${@}"
+EOF
+
+chmod +x /run/initramfs/shutdown

--- a/tests/lib/uc16-reflash.sh
+++ b/tests/lib/uc16-reflash.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# old-flash.sh: Install a flashing boot entry to flash a new disk image
+#
+# Copyright (C) 2024 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# This version is only intended to be used on 16.04 where it is
+# difficult to run an initrd during shutdown.
+
+set -eux
+
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends dracut-core busybox-initramfs
+
+mkdir initrd
+
+cp "$1" initrd/to-flash.img
+
+mkdir initrd/proc
+mkdir initrd/dev
+cat > "initrd/init" << EOF
+#!/bin/sh
+
+set -eux
+
+mount -t proc none /proc
+mount -t devtmpfs none /dev
+
+# blow away everything
+OF=/dev/sda
+if [ -e /dev/vda ]; then
+    OF=/dev/vda
+fi
+gunzip -c /to-flash.img | dd of=\$OF bs=4M
+# and reboot
+sync
+echo b > /proc/sysrq-trigger
+EOF
+
+chmod +x "initrd/init"
+
+/usr/lib/dracut/dracut-install --ldd -Dinitrd -a dd sync mount
+/usr/lib/dracut/dracut-install --ldd -Dinitrd /usr/lib/initramfs-tools/bin/busybox /bin/busybox
+[ -d initrd/bin ] || mkdir -p initrd/bin
+ln -s busybox initrd/bin/sh
+ln -s busybox initrd/bin/gunzip
+
+(cd initrd; find . | cpio --create --quiet --format=newc --owner=0:0) >/initrd-reflash.img
+
+cat >/boot/grub/grub.cfg <<EOF
+set default=0
+set timeout=2
+menuentry 'flash-all-snaps' {
+linux /vmlinuz console=tty1 console=ttyS0
+initrd /initrd-reflash.img
+}
+EOF


### PR DESCRIPTION
Originally, to reflash from Classic to Ubuntu Core, we rebooted with a grub entry that would use specific `root=` and `init=` script to reflash the disk.
    
We do not need a full reboot most of the time and we can just instead prepare an initramfs to switch when shutting down. Systemd will switch to `/run/initramfs` and run `/shutdown` in there.
    
However, on 16.04, systemd is unmounting mounts which makes this not as easy. So instead there we still reboot to grub, but instead of using `init=` and mount the root disk, we provide an initrd which can do the flashing, simplifying the method we have been using.
