### PR TITLE
asserts: move aspect schema to assertion body

### DIFF
--- a/asserts/aspect_bundle.go
+++ b/asserts/aspect_bundle.go
@@ -81,17 +81,13 @@ func assembleAspectBundle(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	v, ok := assert.headers["storage"]
-	if !ok {
-		return nil, fmt.Errorf(`"storage" stanza is mandatory`)
+	if assert.body == nil {
+		return nil, fmt.Errorf(`body must contain aspect schema`)
 	}
-	storageStr, ok := v.(string)
-	if !ok {
-		return nil, fmt.Errorf(`invalid "storage" schema stanza, expected schema text`)
-	}
-	schema, err := aspects.ParseSchema([]byte(storageStr))
+
+	schema, err := aspects.ParseSchema(assert.body)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid "storage" schema stanza: %w`, err)
+		return nil, fmt.Errorf(`invalid schema: %w`, err)
 	}
 
 	bundle, err := aspects.NewBundle(accountID, name, aspectsMap, schema)

--- a/asserts/aspect_bundle.go
+++ b/asserts/aspect_bundle.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"time"
@@ -85,7 +86,17 @@ func assembleAspectBundle(assert assertionBase) (Assertion, error) {
 		return nil, fmt.Errorf(`body must contain aspect schema`)
 	}
 
-	schema, err := aspects.ParseSchema(assert.body)
+	var bodyMap map[string]json.RawMessage
+	if err := json.Unmarshal(assert.body, &bodyMap); err != nil {
+		return nil, err
+	}
+
+	schemaRaw, ok := bodyMap["storage"]
+	if !ok {
+		return nil, fmt.Errorf(`body must contain a "storage" stanza`)
+	}
+
+	schema, err := aspects.ParseSchema(schemaRaw)
 	if err != nil {
 		return nil, fmt.Errorf(`invalid schema: %w`, err)
 	}

--- a/asserts/aspect_bundle.go
+++ b/asserts/aspect_bundle.go
@@ -82,10 +82,6 @@ func assembleAspectBundle(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	if assert.body == nil {
-		return nil, fmt.Errorf(`body must contain aspect schema`)
-	}
-
 	var bodyMap map[string]json.RawMessage
 	if err := json.Unmarshal(assert.body, &bodyMap); err != nil {
 		return nil, err

--- a/asserts/aspect_bundle_test.go
+++ b/asserts/aspect_bundle_test.go
@@ -69,7 +69,7 @@ aspects:
         storage: wifi.{key}
 ` + "TSLINE" +
 		"sign-key-sha3-384: jv8_jihiizjvco9m55ppdqsdwuvuhfdibjus-3vw7f_idjix7ffn5qmxb21zquij\n" +
-		"body-length: 84" +
+		"body-length: 115" +
 		"\n\n" +
 		schema +
 		"\n\n" +
@@ -77,10 +77,12 @@ aspects:
 )
 
 const schema = `{
-  "schema": {
-    "wifi": {
-      "type": "map",
-      "values": "any"
+  "storage": {
+    "schema": {
+      "wifi": {
+        "type": "map",
+        "values": "any"
+      }
     }
   }
 }`
@@ -123,7 +125,8 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 		{"read-write", "update", `cannot define aspect "wifi-setup": cannot create aspect rule:.*`},
 		{body, "body-length: 0", `body must contain aspect schema`},
 		{body, "body-length: 8\n\n  - foo\n", `invalid schema: invalid character ' ' in numeric literal`},
-		{body, "body-length: 2\n\n{}", `invalid schema: cannot parse top level schema: must have a "schema" constraint`},
+		{body, "body-length: 2\n\n{}", `body must contain a "storage" stanza`},
+		{body, "body-length: 14\n\n{\"storage\":{}}", `invalid schema: cannot parse top level schema: must have a "schema" constraint`},
 	}
 
 	for _, test := range invalidTests {
@@ -137,9 +140,9 @@ func (s *aspectBundleSuite) TestDecodeFormatsSchema(c *C) {
 	encoded := strings.Replace(aspectBundleExample, "TSLINE", s.tsLine, 1)
 
 	body := encoded[strings.Index(encoded, "body-length:"):strings.Index(encoded, "\n\nAXN")]
-	compactBody := `body-length: 49
+	compactBody := `body-length: 61
 
-{"schema":{"wifi":{"type":"map","values":"any"}}}`
+{"storage":{"schema":{"wifi":{"type":"map","values":"any"}}}}`
 	input := strings.Replace(encoded, body, compactBody, 1)
 	a, err := asserts.Decode([]byte(input))
 	c.Assert(err, IsNil)
@@ -147,7 +150,7 @@ func (s *aspectBundleSuite) TestDecodeFormatsSchema(c *C) {
 
 }
 
-func (s *aspectBundleSuite) TestAssembleAndSIgnFormatsSchema(c *C) {
+func (s *aspectBundleSuite) TestAssembleAndSignFormatsSchema(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "brand-id1",
 		"account-id":   "brand-id1",
@@ -159,10 +162,10 @@ func (s *aspectBundleSuite) TestAssembleAndSIgnFormatsSchema(c *C) {
 				},
 			},
 		},
-		"body-length": "49",
+		"body-length": "60",
 		"timestamp":   s.ts.Format(time.RFC3339),
 	}
-	acct1, err := asserts.AssembleAndSignInTest(asserts.AspectBundleType, headers, []byte(`{"schema":{"wifi":{"type":"map","values":"any"}}}`), testPrivKey0)
+	acct1, err := asserts.AssembleAndSignInTest(asserts.AspectBundleType, headers, []byte(`{"storage":{"schema":{"wifi":{"type":"map","values":"any"}}}}`), testPrivKey0)
 	c.Assert(err, IsNil)
 	c.Assert(string(acct1.Body()), Equals, schema)
 }

--- a/asserts/aspect_bundle_test.go
+++ b/asserts/aspect_bundle_test.go
@@ -124,11 +124,11 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 		{aspectsStanza, "", `"aspects" stanza is mandatory`},
 		{"read-write", "update", `cannot define aspect "wifi-setup": cannot create aspect rule:.*`},
 		{body, "body-length: 0", `body must contain JSON`},
-		{body, "body-length: 8\n\n  - foo\n", `invalid JSON: invalid character ' ' in numeric literal`},
+		{body, "body-length: 8\n\n  - foo\n", `invalid JSON in body: invalid character ' ' in numeric literal`},
 		{body, "body-length: 2\n\n{}", `body must contain a "storage" stanza`},
 		{body, "body-length: 19\n\n{\n  \"storage\": {}\n}", `invalid schema: cannot parse top level schema: must have a "schema" constraint`},
 		{body, "body-length: 4\n\nnull", `body must contain a "storage" stanza`},
-		{body, "body-length: 54\n\n{\n\t\"storage\": {\n\t\t\"schema\": {\n\t\t\t\"foo\": \"any\"\n\t\t}\n\t}\n}", `JSON must be indented with 2 spaces and sort object entries by key`},
+		{body, "body-length: 54\n\n{\n\t\"storage\": {\n\t\t\"schema\": {\n\t\t\t\"foo\": \"any\"\n\t\t}\n\t}\n}", `JSON in body must be indented with 2 spaces and sort object entries by key`},
 		{body, `body-length: 79
 
 {
@@ -138,7 +138,7 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
       "a": "any"
     }
   }
-}`, `JSON must be indented with 2 spaces and sort object entries by key`},
+}`, `JSON in body must be indented with 2 spaces and sort object entries by key`},
 	}
 
 	for i, test := range invalidTests {
@@ -197,5 +197,5 @@ func (s *aspectBundleSuite) TestAssembleAndSignChecksSchemaFormatFail(c *C) {
 
 	schema := `{ "storage": { "schema": { "foo": "any" } } }`
 	_, err := asserts.AssembleAndSignInTest(asserts.AspectBundleType, headers, []byte(schema), testPrivKey0)
-	c.Assert(err, ErrorMatches, `assertion aspect-bundle: JSON must be indented with 2 spaces and sort object entries by key`)
+	c.Assert(err, ErrorMatches, `assertion aspect-bundle: JSON in body must be indented with 2 spaces and sort object entries by key`)
 }

--- a/asserts/aspect_bundle_test.go
+++ b/asserts/aspect_bundle_test.go
@@ -67,21 +67,23 @@ aspects:
       -
         request: private.{key}
         storage: wifi.{key}
-storage:
-    {
-      "schema": {
-        "wifi": {
-          "type": "map",
-          "values": "any"
-        }
-      }
-    }
 ` + "TSLINE" +
-		"body-length: 0\n" +
-		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"sign-key-sha3-384: jv8_jihiizjvco9m55ppdqsdwuvuhfdibjus-3vw7f_idjix7ffn5qmxb21zquij\n" +
+		"body-length: 84" +
+		"\n\n" +
+		schema +
 		"\n\n" +
 		"AXNpZw=="
 )
+
+const schema = `{
+  "schema": {
+    "wifi": {
+      "type": "map",
+      "values": "any"
+    }
+  }
+}`
 
 func (s *aspectBundleSuite) TestDecodeOK(c *C) {
 	encoded := strings.Replace(aspectBundleExample, "TSLINE", s.tsLine, 1)
@@ -104,8 +106,8 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 
 	encoded := strings.Replace(aspectBundleExample, "TSLINE", s.tsLine, 1)
 
-	aspectsStanza := encoded[strings.Index(encoded, "aspects:") : strings.Index(encoded, "\nstorage:")+1]
-	storageStanza := encoded[strings.Index(encoded, "\nstorage:")+1 : strings.Index(encoded, "timestamp:")]
+	aspectsStanza := encoded[strings.Index(encoded, "aspects:") : strings.Index(encoded, "timestamp:")+1]
+	body := encoded[strings.Index(encoded, "body-length:"):strings.Index(encoded, "\n\nAXN")]
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"account-id: brand-id1\n", "", `"account-id" header is mandatory`},
@@ -119,9 +121,9 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 		{aspectsStanza, "aspects: foo\n", `"aspects" header must be a map`},
 		{aspectsStanza, "", `"aspects" stanza is mandatory`},
 		{"read-write", "update", `cannot define aspect "wifi-setup": cannot create aspect rule:.*`},
-		{storageStanza, "", `"storage" stanza is mandatory`},
-		{storageStanza, "storage:\n  - foo\n", `invalid "storage" schema stanza, expected schema text`},
-		{storageStanza, "storage:\n    {}\n", `invalid "storage" schema stanza: cannot parse top level schema: must have a "schema" constraint`},
+		{body, "body-length: 0", `body must contain aspect schema`},
+		{body, "body-length: 8\n\n  - foo\n", `invalid schema: invalid character ' ' in numeric literal`},
+		{body, "body-length: 2\n\n{}", `invalid schema: cannot parse top level schema: must have a "schema" constraint`},
 	}
 
 	for _, test := range invalidTests {
@@ -129,4 +131,38 @@ func (s *aspectBundleSuite) TestDecodeInvalid(c *C) {
 		_, err := asserts.Decode([]byte(invalid))
 		c.Check(err, ErrorMatches, validationSetErrPrefix+test.expectedErr)
 	}
+}
+
+func (s *aspectBundleSuite) TestDecodeFormatsSchema(c *C) {
+	encoded := strings.Replace(aspectBundleExample, "TSLINE", s.tsLine, 1)
+
+	body := encoded[strings.Index(encoded, "body-length:"):strings.Index(encoded, "\n\nAXN")]
+	compactBody := `body-length: 49
+
+{"schema":{"wifi":{"type":"map","values":"any"}}}`
+	input := strings.Replace(encoded, body, compactBody, 1)
+	a, err := asserts.Decode([]byte(input))
+	c.Assert(err, IsNil)
+	c.Assert(string(a.Body()), Equals, schema)
+
+}
+
+func (s *aspectBundleSuite) TestAssembleAndSIgnFormatsSchema(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "brand-id1",
+		"account-id":   "brand-id1",
+		"name":         "my-network",
+		"aspects": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"rules": []interface{}{
+					map[string]interface{}{"request": "wifi", "storage": "wifi"},
+				},
+			},
+		},
+		"body-length": "49",
+		"timestamp":   s.ts.Format(time.RFC3339),
+	}
+	acct1, err := asserts.AssembleAndSignInTest(asserts.AspectBundleType, headers, []byte(`{"schema":{"wifi":{"type":"map","values":"any"}}}`), testPrivKey0)
+	c.Assert(err, IsNil)
+	c.Assert(string(acct1.Body()), Equals, schema)
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -1010,16 +1010,16 @@ func checkJSON(assertType *AssertionType, body []byte) (err error) {
 
 	var val interface{}
 	if err := json.Unmarshal(body, &val); err != nil {
-		return fmt.Errorf("invalid JSON: %v", err)
+		return fmt.Errorf("invalid JSON in body: %v", err)
 	}
 
 	formatted, err := json.MarshalIndent(val, "", "  ")
 	if err != nil {
-		return fmt.Errorf("invalid JSON: %v", err)
+		return fmt.Errorf("invalid JSON in body: %v", err)
 	}
 
 	if !reflect.DeepEqual(body, formatted) {
-		return fmt.Errorf(`JSON must be indented with 2 spaces and sort object entries by key`)
+		return fmt.Errorf(`JSON in body must be indented with 2 spaces and sort object entries by key`)
 	}
 
 	return nil
@@ -1131,6 +1131,12 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 		return nil, fmt.Errorf("assertion body is not utf8")
 	}
 
+	if withJSONBody {
+		if err := checkJSON(assertType, body); err != nil {
+			return nil, err
+		}
+	}
+
 	finalHeaders := copyHeaders(headers)
 	bodyLength := len(body)
 	finalBody := make([]byte, bodyLength)
@@ -1170,12 +1176,6 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 	revision, err := checkRevision(finalHeaders)
 	if err != nil {
 		return nil, err
-	}
-
-	if withJSONBody {
-		if err := checkJSON(assertType, body); err != nil {
-			return nil, err
-		}
 	}
 
 	buf := bytes.NewBufferString("type: ")

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -1210,7 +1210,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 	c.Check(withAuthority, HasLen, asserts.NumAssertionType-3) // excluding device-session-request, serial-request, account-key-request
 	for _, name := range withAuthority {
 		typ := asserts.Type(name)
-		_, err := asserts.AssembleAndSignInTest(typ, nil, nil, testPrivKey1)
+		_, err := asserts.AssembleAndSignInTest(typ, nil, []byte("{}"), testPrivKey1)
 		c.Check(err, ErrorMatches, `"authority-id" header is mandatory`)
 	}
 }

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -72,25 +72,25 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 	c.Check(signingDB, NotNil)
 	c.Assert(storeSigning.Add(devAccKey), IsNil)
 
-	rules := map[string]interface{}{
-		"wifi-setup": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
-				map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
-				map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
-				map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
-				map[string]interface{}{"request": "private.{placeholder}", "storage": "private.{placeholder}"},
-			},
-		},
-	}
-
 	headers := map[string]interface{}{
 		"authority-id": devAccKey.AccountID(),
 		"account-id":   devAccKey.AccountID(),
 		"name":         "network",
-		"aspects":      rules,
-		"storage": `{
-		"schema": {
+		"aspects": map[string]interface{}{
+			"wifi-setup": map[string]interface{}{
+				"rules": []interface{}{
+					map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
+					map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
+					map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
+					map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
+					map[string]interface{}{"request": "private.{placeholder}", "storage": "private.{placeholder}"},
+				},
+			},
+		},
+		"timestamp": "2030-11-06T09:16:26Z",
+	}
+	body := []byte(`{
+	"schema": {
 		"wifi" : {
 			"schema": {
 				"ssids": {"type": "array", "values": "any"},
@@ -103,10 +103,9 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 			"values": "any"
 		}
 	}
-}`,
-		"timestamp": "2030-11-06T09:16:26Z",
-	}
-	as, err := signingDB.Sign(asserts.AspectBundleType, headers, nil, "")
+}`)
+
+	as, err := signingDB.Sign(asserts.AspectBundleType, headers, body, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(s.state, as), IsNil)
 

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -90,21 +90,24 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 		"timestamp": "2030-11-06T09:16:26Z",
 	}
 	body := []byte(`{
-	"storage": {
-		"schema": {
-			"wifi" : {
-				"schema": {
-					"ssids": {"type": "array", "values": "any"},
-					"ssid": "string",
-					"psk": "string",
-					"status":"string"
-				}
-			},
-			"private": {
-				"values": "any"
-			}
-		}
-	}
+  "storage": {
+    "schema": {
+      "private": {
+        "values": "any"
+      },
+      "wifi": {
+        "schema": {
+          "psk": "string",
+          "ssid": "string",
+          "ssids": {
+            "type": "array",
+            "values": "any"
+          },
+          "status": "string"
+        }
+      }
+    }
+  }
 }`)
 
 	as, err := signingDB.Sign(asserts.AspectBundleType, headers, body, "")

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -90,17 +90,19 @@ func (s *aspectTestSuite) SetUpTest(c *C) {
 		"timestamp": "2030-11-06T09:16:26Z",
 	}
 	body := []byte(`{
-	"schema": {
-		"wifi" : {
-			"schema": {
-				"ssids": {"type": "array", "values": "any"},
-				"ssid": "string",
-				"psk": "string",
-				"status":"string"
+	"storage": {
+		"schema": {
+			"wifi" : {
+				"schema": {
+					"ssids": {"type": "array", "values": "any"},
+					"ssid": "string",
+					"psk": "string",
+					"status":"string"
+				}
+			},
+			"private": {
+				"values": "any"
 			}
-		},
-		"private": {
-			"values": "any"
 		}
 	}
 }`)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5148,8 +5148,14 @@ func (s *assertMgrSuite) TestAspectBundle(c *C) {
 			},
 		},
 	},
-		`{"storage": {"schema": {"a": "string", "b": "string"}}}`,
-	)
+		`{
+  "storage": {
+    "schema": {
+      "a": "string",
+      "b": "string"
+    }
+  }
+}`)
 	err = assertstate.Add(s.state, aspectBundleFoo)
 	c.Assert(err, IsNil)
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5148,7 +5148,7 @@ func (s *assertMgrSuite) TestAspectBundle(c *C) {
 			},
 		},
 	},
-		`{"schema": {"a": "string", "b": "string"}}`,
+		`{"storage": {"schema": {"a": "string", "b": "string"}}}`,
 	)
 	err = assertstate.Add(s.state, aspectBundleFoo)
 	c.Assert(err, IsNil)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5109,7 +5109,7 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
 }
 
-func (s *assertMgrSuite) aspectBundle(c *C, name string, extraHeaders map[string]interface{}) *asserts.AspectBundle {
+func (s *assertMgrSuite) aspectBundle(c *C, name string, extraHeaders map[string]interface{}, body string) *asserts.AspectBundle {
 	headers := map[string]interface{}{
 		"series":       "16",
 		"account-id":   s.dev1AcctKey.AccountID(),
@@ -5121,7 +5121,7 @@ func (s *assertMgrSuite) aspectBundle(c *C, name string, extraHeaders map[string
 		headers[h] = v
 	}
 
-	as, err := s.dev1Signing.Sign(asserts.AspectBundleType, headers, nil, "")
+	as, err := s.dev1Signing.Sign(asserts.AspectBundleType, headers, []byte(body), "")
 	c.Assert(err, IsNil)
 
 	return as.(*asserts.AspectBundle)
@@ -5139,7 +5139,6 @@ func (s *assertMgrSuite) TestAspectBundle(c *C) {
 	c.Assert(err, IsNil)
 
 	aspectBundleFoo := s.aspectBundle(c, "foo", map[string]interface{}{
-		"storage": `{"schema": {"a": "string", "b": "string"}}`,
 		"aspects": map[string]interface{}{
 			"an-aspect": map[string]interface{}{
 				"rules": []interface{}{
@@ -5148,7 +5147,9 @@ func (s *assertMgrSuite) TestAspectBundle(c *C) {
 				},
 			},
 		},
-	})
+	},
+		`{"schema": {"a": "string", "b": "string"}}`,
+	)
 	err = assertstate.Add(s.state, aspectBundleFoo)
 	c.Assert(err, IsNil)
 

--- a/tests/lib/assertions/developer1-network-aspect-bundle.json
+++ b/tests/lib/assertions/developer1-network-aspect-bundle.json
@@ -14,6 +14,6 @@
 			]
 		}
 	},
-	"body": "{ \"schema\": { \"wifi\" : { \"values\": \"any\" } } }",
+	"body": "{\"storage\": { \"schema\": { \"wifi\" : { \"values\": \"any\" } } } }",
 	"timestamp": "2024-02-09T17:11:32Z"
 }

--- a/tests/lib/assertions/developer1-network-aspect-bundle.json
+++ b/tests/lib/assertions/developer1-network-aspect-bundle.json
@@ -14,6 +14,6 @@
 			]
 		}
 	},
-	"storage": "{ \"schema\": { \"wifi\" : { \"values\": \"any\" } } }",
+	"body": "{ \"schema\": { \"wifi\" : { \"values\": \"any\" } } }",
 	"timestamp": "2024-02-09T17:11:32Z"
 }

--- a/tests/lib/assertions/developer1-network-aspect-bundle.json
+++ b/tests/lib/assertions/developer1-network-aspect-bundle.json
@@ -14,6 +14,6 @@
 			]
 		}
 	},
-	"body": "{\"storage\": { \"schema\": { \"wifi\" : { \"values\": \"any\" } } } }",
+	"body": "{\n  \"storage\": {\n    \"schema\": {\n      \"wifi\": {\n        \"values\": \"any\"\n      }\n    }\n  }\n}\n",
 	"timestamp": "2024-02-09T17:11:32Z"
 }

--- a/tests/lib/assertions/developer1-network.aspect-bundle
+++ b/tests/lib/assertions/developer1-network.aspect-bundle
@@ -74,17 +74,25 @@ aspects:
       -
         request: private.{placeholder}
         storage: wifi.{placeholder}
-storage: { "schema": { "wifi" : { "values": "any" } } }
 timestamp: 2024-02-09T17:11:32Z
+body-length: 63
 sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 
-AcLBUgQAAQoABgUCZco8VQAAiYQQAGTov6k+cKmPX+lfNdYMoPjb+laRqEi6wUzGvlTqs6og8fxz
-W3p0jUOcZNSUvRC75jHhdlJWBkzatGUmQqkSruMlSS5+tj+8AWBOSGt8vrNXbXo65r3zPN0yuyFQ
-+80qnbEg8I5EQaMOtvkLfBjgRf0yRe99fS1uaM+MP2xZzhqFv7XliNDLn2vwmUOSg7lu6AmHhRvE
-tgqBeQtdwt3U+1cloWZqlgOwGen/eciUHom0Wkqe8UEfvNGf4iX0sah2oWn1eKODtxowx4urqRjf
-IqhHzv14RlBBAhibnbIorRoMuD/jdb0HkCdVrWJRKMN2go/vGsGd4ZQYFLDu66D7aydztkV2g9MT
-Akm/l1YqsJmUTysNkjU6etNZ7Th5fZzgn8/6KWNuQEw00Coe2OiIsK3ejTalyDuusv6WG2aDWdAa
-MM0J+SLHPMyoyFW9walU6d+JdVxj1SwWTGgWqx+yJNnu29zDKtLQ4LnRGoZdjz2fYUi/4LRpgAxC
-xMBDSESj4IA/JoEUMHzeZ2WfJcdPEVTcYvcYCmNMl6b64FCQ0TcGWoLAGf6CxvtkYexqfAIZrlco
-ClR6UiAAiWwpwAOnywBlFRRFF41DFFoZyWHVchJinMTsZFUCoCHoj5O4U3xRmg4QrpKTpt/gdOcN
-tKFWDSNGkFKhLFS1h86BU2m8Wuw7
+{
+  "schema": {
+    "wifi": {
+      "values": "any"
+    }
+  }
+}
+
+AcLBUgQAAQoABgUCZecNIwAAyxMQAGApyR/4d+rzjYDGrjZIXjJ9MovgqRlYVsF6w0ytEWh6jgGT
+1FQGz27wDpjZmxJmMatPxmFjNR8MKsMgP9hW/foqYE/SIkN5heLTUdghecUlxs+9DFBBrBFMrAxC
+jiSJSCEY/QYY89NP82QnzRDFW8i1OAtsof0hjW2ChYLjS9zq9GhHibFzobD4haMIS6vKpLnrV57A
+Mdbz46fArg8eG6+z3f4u9HlXjvY0l8SOsBE4GHIktFTx0VJYiVgVdtpLiXn66z4gzJUrhwH+HD9Z
+ELGwVYQAoHqWwd4PAiXyoV9L3LmPUe1HE8MjAZy8l/JKfcMEJgGlf6ht/LvSxMtdBD197GAJLblV
+Mlpk80xqFSNtOStWmZlSDmRQzfUkFAmA4IYz09pJ06S3oZ//jLQhRCULKIf5v7KASP9gZhEnndbr
+5GsEWjbB8J/XNJm0I3VuyEEGzNMK2xMYq8z1FyfnJRvLJcQlzRUXsO5NlMX7Qa75O8021lqIR2bR
+6gwYVGXjczt1VFZ3ygiV/hPVLjkGfU/FgqeVe5IXdpMpHzx7z8C4ml+EYtc7Ye0YoQ2plFNCqLjH
+2TACLBfx6XF3qIRem4+mR4hLAvUiiCedIlLlk9/EKRutKz6FNhwrFWfIck5HXUTMUdQzrWV7azcv
+bJS3bgWX4umx43KgkuHdyJ9YoecV

--- a/tests/lib/assertions/developer1-network.aspect-bundle
+++ b/tests/lib/assertions/developer1-network.aspect-bundle
@@ -75,24 +75,26 @@ aspects:
         request: private.{placeholder}
         storage: wifi.{placeholder}
 timestamp: 2024-02-09T17:11:32Z
-body-length: 63
+body-length: 92
 sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 
 {
-  "schema": {
-    "wifi": {
-      "values": "any"
+  "storage": {
+    "schema": {
+      "wifi": {
+        "values": "any"
+      }
     }
   }
 }
 
-AcLBUgQAAQoABgUCZecNIwAAyxMQAGApyR/4d+rzjYDGrjZIXjJ9MovgqRlYVsF6w0ytEWh6jgGT
-1FQGz27wDpjZmxJmMatPxmFjNR8MKsMgP9hW/foqYE/SIkN5heLTUdghecUlxs+9DFBBrBFMrAxC
-jiSJSCEY/QYY89NP82QnzRDFW8i1OAtsof0hjW2ChYLjS9zq9GhHibFzobD4haMIS6vKpLnrV57A
-Mdbz46fArg8eG6+z3f4u9HlXjvY0l8SOsBE4GHIktFTx0VJYiVgVdtpLiXn66z4gzJUrhwH+HD9Z
-ELGwVYQAoHqWwd4PAiXyoV9L3LmPUe1HE8MjAZy8l/JKfcMEJgGlf6ht/LvSxMtdBD197GAJLblV
-Mlpk80xqFSNtOStWmZlSDmRQzfUkFAmA4IYz09pJ06S3oZ//jLQhRCULKIf5v7KASP9gZhEnndbr
-5GsEWjbB8J/XNJm0I3VuyEEGzNMK2xMYq8z1FyfnJRvLJcQlzRUXsO5NlMX7Qa75O8021lqIR2bR
-6gwYVGXjczt1VFZ3ygiV/hPVLjkGfU/FgqeVe5IXdpMpHzx7z8C4ml+EYtc7Ye0YoQ2plFNCqLjH
-2TACLBfx6XF3qIRem4+mR4hLAvUiiCedIlLlk9/EKRutKz6FNhwrFWfIck5HXUTMUdQzrWV7azcv
-bJS3bgWX4umx43KgkuHdyJ9YoecV
+AcLBUgQAAQoABgUCZen+ywAA8mAQADL8tlQHe2QKIqK7Mt3CkXfAOsG8lRoTOulPIzctYpJu7XOG
+kFW1BGrRPwDZSKFf4qZXwO0SH4QbuQ4ykuw1qMO+JTFTmUcEw5JLrdSrGG21fGaZjfK/XXVsmUXA
+d1IzGTa3PYWwBptt1x4D1f/mXidxt26e8WBWzNJ1eih9q5XeOsvXuA7r4ekGjHr2epkNE8TO1wc6
+7j4QDs3KvN/jz6ivtH+fV9jY+23cVO1L45k+Odwgh/O0/hQIg9VxPZYvQIJi8FQTQabFJ1ncRdwp
+kZjP/Az053D8IuQLecFRJ7vpa2/plbtg1qLm/ptnGEmPa1szehJfH4tLjQXXukjwuTTryVjv+525
+OQYXHCcdtmqhh/0u2AAXz7VJj0M3sxCzBX16nEbSB0oErBSBrBFGl41htCzByFp3lGSkCSYVqwSH
++8oMyp7ucu3EQyaIt/qLPvgFP1pXABFi9ho2b4hRxojbsMvZs/cuLDhUCA86qQ2UmG/yinPH88JV
+xTumdsfzOUy+NjVe5x8Ag/VBEEHLNpM1mXFR8k3C85eh81EzSGPjXIOALM3z+xIV3jKQ3SFoSmjX
+M550G/Vagy2H/ue+vzqltawuJ+iInIcjXs5jhHNH6ekcfvaRciKHov1RayhQ2+D2mzVOUBKSkO64
+yTDDkGYoI+VuKP/pFxiZZ1gBIOh+

--- a/tests/lib/gendeveloper1/main.go
+++ b/tests/lib/gendeveloper1/main.go
@@ -77,7 +77,17 @@ func main() {
 		assertType = asserts.Type(assertTypeStr)
 	}
 
-	clModel, err := devSigning.Sign(assertType, headers, nil, "")
+	var body []byte
+	if bodyHeader, ok := headers["body"]; ok {
+		bodyStr, ok := bodyHeader.(string)
+		if !ok {
+			log.Fatalf("failed to decode body: expected string but got %T", bodyHeader)
+		}
+		body = []byte(bodyStr)
+		delete(headers, "body")
+	}
+
+	clModel, err := devSigning.Sign(assertType, headers, body, "")
 	if err != nil {
 		log.Fatalf("failed to sign the model: %v", err)
 	}


### PR DESCRIPTION
Move the aspect schema from a "storage" stanza to the assertion body. Also format parse and re-encode the JSON with two spaces for indentation and map ordered map keys. This should make the schema uniform and easy to read while still using a format that can be emulated by other tools. `jq -S` indents with 2 spaces and sorts maps by key, python's `json.dump` can be configured to do the same and Go's `json.MarshalIndent` sorts by default. For posterity, `jq` can also be used to escape newlines and quotes into a string that can be used in snap sign's expected input: `echo '{"storage":{"schema":{"foo":{"values":"any"}}}}' | jq -S | jq -sR`

