### PR TITLE
o/i/apparmorprompting: add prompting `common` package

### DIFF
--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap and app")
+	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap")
 	ErrInvalidOutcome             = errors.New(`invalid outcome; must be "allow" or "deny"`)
 	ErrInvalidLifespan            = errors.New("invalid lifespan")
 	ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
@@ -181,18 +181,17 @@ func NewIDAndTimestamp() (id string, timestamp string) {
 	return id, timestamp
 }
 
-// LabelToSnapApp extracts the snap and app names from the given label.
+// LabelToSnap extracts the snap name from the given AppArmor label.
 //
 // If the label is not of the form 'snap.<snap>.<app>', returns an error, and
-// returns the label as both the snap and the app.
-func LabelToSnapApp(label string) (snap string, app string, err error) {
+// returns the label as the snap.
+func LabelToSnap(label string) (string, error) {
 	components := strings.Split(label, ".")
 	if len(components) != 3 || components[0] != "snap" {
-		return label, label, ErrInvalidSnapLabel
+		return label, ErrInvalidSnapLabel
 	}
-	snap = components[1]
-	app = components[2]
-	return snap, app, nil
+	snap := components[1]
+	return snap, nil
 }
 
 var (

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -28,21 +28,25 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/strutil"
 )
 
-var ErrPermissionNotInList = errors.New("permission not found in permissions list")
-var ErrInvalidSnapLabel = errors.New("the given label cannot be converted to snap and app")
-var ErrInvalidOutcome = errors.New(`invalid rule outcome; must be "allow" or "deny"`)
-var ErrInvalidLifespan = errors.New("invalid lifespan")
-var ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
-var ErrInvalidDurationEmpty = fmt.Errorf(`invalid duration: duration must be specified if lifespan is "%v"`, LifespanTimespan)
-var ErrInvalidDurationParseError = errors.New("invalid duration: error parsing duration string")
-var ErrInvalidDurationNegative = errors.New("invalid duration: duration must be greater than zero")
-var ErrUnrecognizedFilePermission = errors.New("file permissions mask contains unrecognized permission")
+var (
+	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap and app")
+	ErrInvalidOutcome             = errors.New(`invalid outcome; must be "allow" or "deny"`)
+	ErrInvalidLifespan            = errors.New("invalid lifespan")
+	ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
+	ErrInvalidDurationEmpty       = fmt.Errorf(`invalid duration: duration must be specified if lifespan is "%v"`, LifespanTimespan)
+	ErrInvalidDurationParseError  = errors.New("invalid duration: error parsing duration string")
+	ErrInvalidDurationNegative    = errors.New("invalid duration: duration must be greater than zero")
+	ErrPermissionNotInList        = errors.New("permission not found in permissions list")
+	ErrPermissionsListEmpty       = errors.New("permissions list empty")
+	ErrUnrecognizedFilePermission = errors.New("file permissions mask contains unrecognized permission")
+)
 
 type Constraints struct {
-	PathPattern string           `json:"path-pattern"`
-	Permissions []PermissionType `json:"permissions"`
+	PathPattern string   `json:"path-pattern"`
+	Permissions []string `json:"permissions"`
 }
 
 // ValidateForInterface returns nil if the constraints are valid for the given
@@ -50,11 +54,18 @@ type Constraints struct {
 func (constraints *Constraints) ValidateForInterface(iface string) error {
 	switch iface {
 	case "home", "camera":
+		// TODO: change to this once PR #13730 is merged:
+		// if err := ValidatePathPattern(constraints.PathPattern); err != nil {
+		//	return err
+		// }
 	default:
 		return fmt.Errorf("constraints incompatible with the given interface: %s", iface)
 	}
-	// TODO: change to this once PR #13730 is merged:
-	// return ValidatePathPattern(constraints.PathPattern)
+	permissions, err := AbstractPermissionsFromList(iface, constraints.Permissions)
+	if err != nil {
+		return err
+	}
+	constraints.Permissions = permissions
 	return nil
 }
 
@@ -70,7 +81,7 @@ func (constraints *Constraints) Match(path string) (bool, error) {
 // RemovePermission removes every instance of the given permission from the
 // permissions list associated with the constraints. If the permission does
 // not exist in the list, returns ErrPermissionNotInList.
-func (constraints *Constraints) RemovePermission(permission PermissionType) error {
+func (constraints *Constraints) RemovePermission(permission string) error {
 	origLen := len(constraints.Permissions)
 	i := 0
 	for i < len(constraints.Permissions) {
@@ -86,6 +97,17 @@ func (constraints *Constraints) RemovePermission(permission PermissionType) erro
 		return ErrPermissionNotInList
 	}
 	return nil
+}
+
+// ContainPermissions returns true if the constraints include every one of the
+// givne permissions.
+func (constraints *Constraints) ContainPermissions(permissions []string) bool {
+	for _, perm := range permissions {
+		if !strutil.ListContains(constraints.Permissions, perm) {
+			return false
+		}
+	}
+	return true
 }
 
 type OutcomeType string
@@ -117,38 +139,6 @@ const (
 	LifespanSingle   LifespanType = "single"
 	LifespanTimespan LifespanType = "timespan"
 )
-
-type PermissionType string
-
-const (
-	PermissionExecute             PermissionType = "execute"
-	PermissionWrite               PermissionType = "write"
-	PermissionRead                PermissionType = "read"
-	PermissionAppend              PermissionType = "append"
-	PermissionCreate              PermissionType = "create"
-	PermissionDelete              PermissionType = "delete"
-	PermissionOpen                PermissionType = "open"
-	PermissionRename              PermissionType = "rename"
-	PermissionSetAttr             PermissionType = "set-attr"
-	PermissionGetAttr             PermissionType = "get-attr"
-	PermissionSetCred             PermissionType = "set-cred"
-	PermissionGetCred             PermissionType = "get-cred"
-	PermissionChangeMode          PermissionType = "change-mode"
-	PermissionChangeOwner         PermissionType = "change-owner"
-	PermissionChangeGroup         PermissionType = "change-group"
-	PermissionLock                PermissionType = "lock"
-	PermissionExecuteMap          PermissionType = "execute-map"
-	PermissionLink                PermissionType = "link"
-	PermissionChangeProfile       PermissionType = "change-profile"
-	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
-)
-
-// If kernel request contains multiple interfaces, one must take priority.
-// Lower value is higher priority, and entries should be in priority order.
-var interfacePriorities = map[string]int{
-	"home":   0,
-	"camera": 1,
-}
 
 // TimestampToTime converts the given timestamp string to a time.Time in Local
 // time. The timestamp string is expected to be of the format time.RFC3339Nano.
@@ -205,6 +195,39 @@ func LabelToSnapApp(label string) (snap string, app string, err error) {
 	return snap, app, nil
 }
 
+var (
+	// If kernel request contains multiple interfaces, one must take priority.
+	// Lower value is higher priority, and entries should be in priority order.
+	interfacePriorities = map[string]int{
+		"home":   0,
+		"camera": 1,
+	}
+
+	// List of permissions available for each interface. This also defines the
+	// order in which the permissions should be presented.
+	interfacePermissionsAvailable = map[string][]string{
+		"home":   {"read", "write", "execute"},
+		"camera": {"access"},
+	}
+
+	// A mapping from interfaces which support AppArmor file permissions to
+	// the map between abstract permissions and those file permissions.
+	//
+	// Never include AA_MAY_OPEN in the maps below; it should always come from
+	// the kernel with another permission (e.g. AA_MAY_READ or AA_MAY_WRITE),
+	// and if it does not, it should be interpreted as AA_MAY_READ.
+	interfaceFilePermissionsMaps = map[string]map[string]notify.FilePermission{
+		"home": {
+			"read":    notify.AA_MAY_READ,
+			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			"execute": notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
+		},
+		"camera": {
+			"access": notify.AA_MAY_WRITE | notify.AA_MAY_READ | notify.AA_MAY_APPEND,
+		},
+	}
+)
+
 // SelectSingleInterface selects the interface with the highest priority from
 // the given list. If none of the given interfaces are included in
 // interfacePriorities, or if the list is empty, return "other".
@@ -224,89 +247,133 @@ func SelectSingleInterface(interfaces []string) string {
 	return bestIface
 }
 
-// PermissionMaskToPermissionsList converts the given aparmor file permission
-// mask into a list of permissions. If the mask contains an unrecognized file
-// permission, returns an error, along with the list of all recognized
-// permissions in the mask.
-func PermissionMaskToPermissionsList(p notify.FilePermission) ([]PermissionType, error) {
-	perms := make([]PermissionType, 0, 1)
-	// Want to be memory efficient, as this list could be stored for a long time.
-	// Most of the time, only one permission bit will be set anyway.
-	if p&notify.AA_MAY_EXEC != 0 {
-		perms = append(perms, PermissionExecute)
+// AvailablePermissions returns the list of available permissions for the given
+// interface.
+func AvailablePermissions(iface string) ([]string, error) {
+	available, exist := interfacePermissionsAvailable[iface]
+	if !exist {
+		return nil, fmt.Errorf("cannot get available permissions: unsupported interface: %s", iface)
 	}
-	if p&notify.AA_MAY_WRITE != 0 {
-		perms = append(perms, PermissionWrite)
-	}
-	if p&notify.AA_MAY_READ != 0 {
-		perms = append(perms, PermissionRead)
-	}
-	if p&notify.AA_MAY_APPEND != 0 {
-		perms = append(perms, PermissionAppend)
-	}
-	if p&notify.AA_MAY_CREATE != 0 {
-		perms = append(perms, PermissionCreate)
-	}
-	if p&notify.AA_MAY_DELETE != 0 {
-		perms = append(perms, PermissionDelete)
-	}
-	if p&notify.AA_MAY_OPEN != 0 {
-		perms = append(perms, PermissionOpen)
-	}
-	if p&notify.AA_MAY_RENAME != 0 {
-		perms = append(perms, PermissionRename)
-	}
-	if p&notify.AA_MAY_SETATTR != 0 {
-		perms = append(perms, PermissionSetAttr)
-	}
-	if p&notify.AA_MAY_GETATTR != 0 {
-		perms = append(perms, PermissionGetAttr)
-	}
-	if p&notify.AA_MAY_SETCRED != 0 {
-		perms = append(perms, PermissionSetCred)
-	}
-	if p&notify.AA_MAY_GETCRED != 0 {
-		perms = append(perms, PermissionGetCred)
-	}
-	if p&notify.AA_MAY_CHMOD != 0 {
-		perms = append(perms, PermissionChangeMode)
-	}
-	if p&notify.AA_MAY_CHOWN != 0 {
-		perms = append(perms, PermissionChangeOwner)
-	}
-	if p&notify.AA_MAY_CHGRP != 0 {
-		perms = append(perms, PermissionChangeGroup)
-	}
-	if p&notify.AA_MAY_LOCK != 0 {
-		perms = append(perms, PermissionLock)
-	}
-	if p&notify.AA_EXEC_MMAP != 0 {
-		perms = append(perms, PermissionExecuteMap)
-	}
-	if p&notify.AA_MAY_LINK != 0 {
-		perms = append(perms, PermissionLink)
-	}
-	if p&notify.AA_MAY_ONEXEC != 0 {
-		perms = append(perms, PermissionChangeProfileOnExec)
-	}
-	if p&notify.AA_MAY_CHANGE_PROFILE != 0 {
-		perms = append(perms, PermissionChangeProfile)
-	}
-	if !p.IsValid() {
-		return perms, ErrUnrecognizedFilePermission
-	}
-	return perms, nil
+	return available, nil
 }
 
-// PermissionsListContains returns true if the given permissions list contains
-// the given permission, else false.
-func PermissionsListContains(list []PermissionType, permission PermissionType) bool {
-	for _, perm := range list {
-		if perm == permission {
-			return true
+// AbstractPermissionsFromAppArmorPermissions returns the list of permissions
+// corresponding to the given AppArmor permissions for the given interface.
+func AbstractPermissionsFromAppArmorPermissions(iface string, permissions interface{}) ([]string, error) {
+	switch iface {
+	case "home", "camera":
+		return abstractPermissionsFromAppArmorFilePermissions(iface, permissions)
+	}
+	return nil, fmt.Errorf("cannot parse AppArmor permissions: unsupported interface: %s", iface)
+}
+
+// abstractPermissionsFromAppArmorFilePermissions returns the list of permissions
+// corresponding to the given AppArmor file permissions for the given interface.
+func abstractPermissionsFromAppArmorFilePermissions(iface string, permissions interface{}) ([]string, error) {
+	filePerms, ok := permissions.(notify.FilePermission)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse the given permissions as file permissions")
+	}
+	abstractPermsAvailable, exists := interfacePermissionsAvailable[iface]
+	if !exists {
+		// This should never happen, since iface is checked in the calling function.
+		return nil, fmt.Errorf("internal error: no permissions list defined for interface: %s", iface)
+	}
+	abstractPermsMap, exists := interfaceFilePermissionsMaps[iface]
+	if !exists {
+		// This should never happen, since iface is checked in the calling function.
+		return nil, fmt.Errorf("internal error: no file permissions map defined for interface: %s", iface)
+	}
+	if filePerms == notify.AA_MAY_OPEN {
+		// Should not occur, but if a request is received for only open, treat it as read.
+		filePerms = notify.AA_MAY_READ
+	}
+	// Discard Open permission; re-add it to the permission mask later
+	filePerms &= ^notify.AA_MAY_OPEN
+	abstractPerms := make([]string, 0, 1) // most requests should only include one permission
+	for _, abstractPerm := range abstractPermsAvailable {
+		aaPermMapping, exists := abstractPermsMap[abstractPerm]
+		if !exists {
+			// This should never happen, since permission mappings are
+			// predefined and should be checked for correctness.
+			return nil, fmt.Errorf("internal error: no permission map defined for abstract permission %s for interface %s", abstractPerm, iface)
+		}
+		if filePerms&aaPermMapping != 0 {
+			abstractPerms = append(abstractPerms, abstractPerm)
+			filePerms &= ^aaPermMapping
 		}
 	}
-	return false
+	if filePerms != notify.FilePermission(0) {
+		return nil, fmt.Errorf("received unexpected permission for interface %s in AppArmor permission mask: %v", iface, filePerms)
+	}
+	if len(abstractPerms) == 0 {
+		origMask := permissions.(notify.FilePermission)
+		return nil, fmt.Errorf("no abstract permissions after parsing AppArmor permissions for interface: %s; original file permissions: %v", iface, origMask)
+	}
+	return abstractPerms, nil
+}
+
+// AbstractPermissionsFromList validates the given permissions list for the
+// given interface and returns a list containing those permissions in the order
+// in which they occur in the list of available permissions for that interface.
+func AbstractPermissionsFromList(iface string, permissions []string) ([]string, error) {
+	availablePerms, ok := interfacePermissionsAvailable[iface]
+	if !ok {
+		return nil, fmt.Errorf("unsupported interface: %s", iface)
+	}
+	permsSet := make(map[string]bool, len(permissions))
+	for _, perm := range permissions {
+		if !strutil.ListContains(availablePerms, perm) {
+			return nil, fmt.Errorf("unsupported permission for %s interface: %s", iface, perm)
+		}
+		permsSet[perm] = true
+	}
+	if len(permsSet) == 0 {
+		return nil, ErrPermissionsListEmpty
+	}
+	permissionsList := make([]string, 0, len(permsSet))
+	for _, perm := range availablePerms {
+		if exists := permsSet[perm]; exists {
+			permissionsList = append(permissionsList, perm)
+		}
+	}
+	return permissionsList, nil
+}
+
+// AbstractPermissionsToAppArmorPermissions returns AppArmor permissions
+// corresponding to the given permissions for the given interface.
+func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (interface{}, error) {
+	switch iface {
+	case "home", "camera":
+		return abstractPermissionsToAppArmorFilePermissions(iface, permissions)
+	}
+	return nil, fmt.Errorf("cannot convert abstract permissions to AppArmor permissions: unsupported interface: %s", iface)
+}
+
+// AbstractPermissionsToAppArmorFilePermissions returns AppArmor file
+// permissions corresponding to the given permissions for the given interface.
+func abstractPermissionsToAppArmorFilePermissions(iface string, permissions []string) (notify.FilePermission, error) {
+	if len(permissions) == 0 {
+		return notify.FilePermission(0), ErrPermissionsListEmpty
+	}
+	filePermsMap, exists := interfaceFilePermissionsMaps[iface]
+	if !exists {
+		// This should never happen, since iface is checked in the calling function
+		return notify.FilePermission(0), fmt.Errorf("internal error: no AppArmor file permissions map defined for interface: %s", iface)
+	}
+	filePerms := notify.FilePermission(0)
+	for _, perm := range permissions {
+		permMask, exists := filePermsMap[perm]
+		if !exists {
+			// Should not occur, since stored permissions list should have been validated
+			return notify.FilePermission(0), fmt.Errorf("no AppArmor file permission mapping for %s interface with abstract permission: %s", iface, perm)
+		}
+		filePerms |= permMask
+	}
+	if filePerms&(notify.AA_MAY_EXEC|notify.AA_MAY_WRITE|notify.AA_MAY_READ|notify.AA_MAY_APPEND|notify.AA_MAY_CREATE) != 0 {
+		filePerms |= notify.AA_MAY_OPEN
+	}
+	return filePerms, nil
 }
 
 // ValidateOutcome returns nil if the given outcome is valid, otherwise an error.

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -83,6 +83,13 @@ const (
 	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
 )
 
+// If kernel request contains multiple interfaces, one must take priority.
+// Lower value is higher priority, and entries should be in priority order.
+var interfacePriorities = map[string]int{
+	"home":   0,
+	"camera": 1,
+}
+
 // TimestampToTime converts the given timestamp string to a time.Time in Local
 // time. The timestamp string is expected to be of the format time.RFC3339Nano.
 // If it cannot be parsed as such, returns an error.
@@ -136,6 +143,25 @@ func LabelToSnapApp(label string) (snap string, app string, err error) {
 	snap = components[1]
 	app = components[2]
 	return snap, app, nil
+}
+
+// SelectSingleInterface selects the interface with the highest priority from
+// the given list. If none of the given interfaces are included in
+// interfacePriorities, or if the list is empty, return "other".
+func SelectSingleInterface(interfaces []string) string {
+	bestIface := "other"
+	bestPriority := len(interfacePriorities)
+	for _, iface := range interfaces {
+		priority, exists := interfacePriorities[iface]
+		if !exists {
+			continue
+		}
+		if priority < bestPriority {
+			bestPriority = priority
+			bestIface = iface
+		}
+	}
+	return bestIface
 }
 
 // PermissionMaskToPermissionsList converts the given aparmor file permission

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -39,8 +39,8 @@ var (
 )
 
 type Constraints struct {
-	PathPattern string   `json:"path-pattern"`
-	Permissions []string `json:"permissions"`
+	PathPattern string   `json:"path-pattern,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 // ValidateForInterface returns nil if the constraints are valid for the given

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -33,12 +33,6 @@ import (
 
 var (
 	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap")
-	ErrInvalidOutcome             = errors.New(`invalid outcome; must be "allow" or "deny"`)
-	ErrInvalidLifespan            = errors.New("invalid lifespan")
-	ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
-	ErrInvalidDurationEmpty       = fmt.Errorf(`invalid duration: duration must be specified if lifespan is "%v"`, LifespanTimespan)
-	ErrInvalidDurationParseError  = errors.New("invalid duration: error parsing duration string")
-	ErrInvalidDurationNegative    = errors.New("invalid duration: duration must be greater than zero")
 	ErrPermissionNotInList        = errors.New("permission not found in permissions list")
 	ErrPermissionsListEmpty       = errors.New("permissions list empty")
 	ErrUnrecognizedFilePermission = errors.New("file permissions mask contains unrecognized permission")
@@ -126,7 +120,7 @@ func (outcome OutcomeType) AsBool() (bool, error) {
 	case OutcomeDeny:
 		return false, nil
 	default:
-		return false, ErrInvalidOutcome
+		return false, fmt.Errorf(`invalid outcome: must be "%v" or "%v": "%v"`, OutcomeAllow, OutcomeDeny, outcome)
 	}
 }
 
@@ -381,14 +375,44 @@ func ValidateOutcome(outcome OutcomeType) error {
 	case OutcomeAllow, OutcomeDeny:
 		return nil
 	default:
-		return ErrInvalidOutcome
+		return fmt.Errorf(`invalid outcome: must be "%v" or "%v": "%v"`, OutcomeAllow, OutcomeDeny, outcome)
 	}
 }
 
+// ValidateLifespanExpiration checks that the given lifespan is valid and that
+// the given expiration is valid for that lifespan.
+//
+// If the lifespan is LifespanTimespan LifespanTimespan, then expiration must
+// be a string parsable as time.Duration with RFC3339 format. Otherwise, it must
+// be empty. Returns an error if any of the above are invalid.
+func ValidateLifespanExpiration(lifespan LifespanType, expiration string, currTime time.Time) error {
+	switch lifespan {
+	case LifespanForever, LifespanSession, LifespanSingle:
+		if expiration != "" {
+			return fmt.Errorf(`invalid expiration: expiration must be empty when lifespan is "%v", but received non-empty expiration: %s`, lifespan, expiration)
+		}
+	case LifespanTimespan:
+		if expiration == "" {
+			return fmt.Errorf(`invalid expiration: expiration must be non-empty when lifespan is "%v", but received empty expiration`, lifespan)
+		}
+		parsedTime, err := time.Parse(time.RFC3339, expiration)
+		if err != nil {
+			return fmt.Errorf("invalid expiration: expiration not parsable as a time in RFC3339 format: %s", expiration)
+		}
+		if currTime.After(parsedTime) {
+			return fmt.Errorf("invalid expiration: expiration time has already passed: %s", expiration)
+		}
+	default:
+		return fmt.Errorf(`invalid lifespan: "%v"`, lifespan)
+	}
+	return nil
+}
+
 // ValidateLifespanParseDuration checks that the given lifespan is valid and
-// that the given duration is valid for that lifespan. If the lifespan is
-// LifespanTimespan, then duration must be a string parsable by
-// time.ParseDuration(), representing the duration of time for which the rule
+// that the given duration is valid for that lifespan.
+//
+// If the lifespan is LifespanTimespan, then duration must be a string parsable
+// by time.ParseDuration(), representing the duration of time for which the rule
 // should be valid. Otherwise, it must be empty. Returns an error if any of the
 // above are invalid, otherwise computes the expiration time of the rule based
 // on the current time and the given duration and returns it.
@@ -397,24 +421,36 @@ func ValidateLifespanParseDuration(lifespan LifespanType, duration string) (stri
 	switch lifespan {
 	case LifespanForever, LifespanSession, LifespanSingle:
 		if duration != "" {
-			return "", ErrInvalidDurationForLifespan
+			return "", fmt.Errorf(`invalid duration: duration must be empty when lifespan is "%v", but received non-empty duration: %s`, lifespan, duration)
 		}
 	case LifespanTimespan:
 		if duration == "" {
-			return "", ErrInvalidDurationEmpty
+			return "", fmt.Errorf(`invalid duration: duration must be non-empty when lifespan is "%v", but received empty expiration`, lifespan)
 		}
 		parsedDuration, err := time.ParseDuration(duration)
 		if err != nil {
-			return "", ErrInvalidDurationParseError
+			return "", fmt.Errorf(`invalid duration: error parsing duration string: %s`, duration)
 		}
 		if parsedDuration <= 0 {
-			return "", ErrInvalidDurationNegative
+			return "", fmt.Errorf(`invalid duration: duration must be greater than zero: %s`, duration)
 		}
 		expirationString = time.Now().Add(parsedDuration).Format(time.RFC3339)
 	default:
-		return "", ErrInvalidLifespan
+		return "", fmt.Errorf(`invalid lifespan: "%v"`, lifespan)
 	}
 	return expirationString, nil
+}
+
+// ValidateConstraintsOutcomeLifespanExpiration returns an error if the given
+// constraints, outcome, lifespan, or duration are invalid, else returns nil.
+func ValidateConstraintsOutcomeLifespanExpiration(iface string, constraints *Constraints, outcome OutcomeType, lifespan LifespanType, expiration string, currTime time.Time) error {
+	if err := constraints.ValidateForInterface(iface); err != nil {
+		return err
+	}
+	if err := ValidateOutcome(outcome); err != nil {
+		return err
+	}
+	return ValidateLifespanExpiration(lifespan, expiration, currTime)
 }
 
 // ValidateConstraintsOutcomeLifespanDuration returns an error if the given

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -1,0 +1,286 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+import (
+	"encoding/base32"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+)
+
+var ErrPermissionNotInList = errors.New("permission not found in permissions list")
+var ErrInvalidSnapLabel = errors.New("the given label cannot be converted to snap and app")
+var ErrInvalidOutcome = errors.New(`invalid rule outcome; must be "allow" or "deny"`)
+var ErrInvalidLifespan = errors.New("invalid lifespan")
+var ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
+var ErrInvalidDurationEmpty = fmt.Errorf(`invalid duration: duration must be specified if lifespan is "%v"`, LifespanTimespan)
+var ErrInvalidDurationParseError = errors.New("invalid duration: error parsing duration string")
+var ErrInvalidDurationNegative = errors.New("invalid duration: duration must be greater than zero")
+var ErrUnrecognizedFilePermission = errors.New("file permissions mask contains unrecognized permission")
+
+type OutcomeType string
+
+const (
+	OutcomeUnset OutcomeType = ""
+	OutcomeAllow OutcomeType = "allow"
+	OutcomeDeny  OutcomeType = "deny"
+)
+
+type LifespanType string
+
+const (
+	LifespanUnset    LifespanType = ""
+	LifespanForever  LifespanType = "forever"
+	LifespanSession  LifespanType = "session"
+	LifespanSingle   LifespanType = "single"
+	LifespanTimespan LifespanType = "timespan"
+)
+
+type PermissionType string
+
+const (
+	PermissionExecute             PermissionType = "execute"
+	PermissionWrite               PermissionType = "write"
+	PermissionRead                PermissionType = "read"
+	PermissionAppend              PermissionType = "append"
+	PermissionCreate              PermissionType = "create"
+	PermissionDelete              PermissionType = "delete"
+	PermissionOpen                PermissionType = "open"
+	PermissionRename              PermissionType = "rename"
+	PermissionSetAttr             PermissionType = "set-attr"
+	PermissionGetAttr             PermissionType = "get-attr"
+	PermissionSetCred             PermissionType = "set-cred"
+	PermissionGetCred             PermissionType = "get-cred"
+	PermissionChangeMode          PermissionType = "change-mode"
+	PermissionChangeOwner         PermissionType = "change-owner"
+	PermissionChangeGroup         PermissionType = "change-group"
+	PermissionLock                PermissionType = "lock"
+	PermissionExecuteMap          PermissionType = "execute-map"
+	PermissionLink                PermissionType = "link"
+	PermissionChangeProfile       PermissionType = "change-profile"
+	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
+)
+
+// TimestampToTime converts the given timestamp string to a time.Time in Local
+// time. The timestamp string is expected to be of the format time.RFC3339Nano.
+// If it cannot be parsed as such, returns an error.
+func TimestampToTime(timestamp string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return t, err
+	}
+	return t.Local(), nil
+}
+
+// CurrentTimestamp returns the current time as a time.RFC3339Nano string.
+func CurrentTimestamp() string {
+	return time.Now().Format(time.RFC3339Nano)
+}
+
+// NewID returns a new unique ID.
+//
+// The ID is the current unix time in nanoseconds encoded as base32.
+func NewID() string {
+	nowUnix := uint64(time.Now().UnixNano())
+	nowBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(nowBytes, nowUnix)
+	id := base32.StdEncoding.EncodeToString(nowBytes)
+	return id
+}
+
+// NewIDAndTimestamp returns a new unique ID and corresponding timestamp.
+//
+// The ID is the current unix time in nanoseconds encoded as a string in base32.
+// The timestamp is the same time, encoded as a string in time.RFC3339Nano.
+func NewIDAndTimestamp() (id string, timestamp string) {
+	now := time.Now()
+	nowUnix := uint64(now.UnixNano())
+	nowBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(nowBytes, nowUnix)
+	id = base32.StdEncoding.EncodeToString(nowBytes)
+	timestamp = now.Format(time.RFC3339Nano)
+	return id, timestamp
+}
+
+// LabelToSnapApp extracts the snap and app names from the given label.
+//
+// If the label is not of the form 'snap.<snap>.<app>', returns an error, and
+// returns the label as both the snap and the app.
+func LabelToSnapApp(label string) (snap string, app string, err error) {
+	components := strings.Split(label, ".")
+	if len(components) != 3 || components[0] != "snap" {
+		return label, label, ErrInvalidSnapLabel
+	}
+	snap = components[1]
+	app = components[2]
+	return snap, app, nil
+}
+
+// PermissionMaskToPermissionsList converts the given aparmor file permission
+// mask into a list of permissions. If the mask contains an unrecognized file
+// permission, returns an error, along with the list of all recognized
+// permissions in the mask.
+func PermissionMaskToPermissionsList(p notify.FilePermission) ([]PermissionType, error) {
+	perms := make([]PermissionType, 0, 1)
+	// Want to be memory efficient, as this list could be stored for a long time.
+	// Most of the time, only one permission bit will be set anyway.
+	if p&notify.AA_MAY_EXEC != 0 {
+		perms = append(perms, PermissionExecute)
+	}
+	if p&notify.AA_MAY_WRITE != 0 {
+		perms = append(perms, PermissionWrite)
+	}
+	if p&notify.AA_MAY_READ != 0 {
+		perms = append(perms, PermissionRead)
+	}
+	if p&notify.AA_MAY_APPEND != 0 {
+		perms = append(perms, PermissionAppend)
+	}
+	if p&notify.AA_MAY_CREATE != 0 {
+		perms = append(perms, PermissionCreate)
+	}
+	if p&notify.AA_MAY_DELETE != 0 {
+		perms = append(perms, PermissionDelete)
+	}
+	if p&notify.AA_MAY_OPEN != 0 {
+		perms = append(perms, PermissionOpen)
+	}
+	if p&notify.AA_MAY_RENAME != 0 {
+		perms = append(perms, PermissionRename)
+	}
+	if p&notify.AA_MAY_SETATTR != 0 {
+		perms = append(perms, PermissionSetAttr)
+	}
+	if p&notify.AA_MAY_GETATTR != 0 {
+		perms = append(perms, PermissionGetAttr)
+	}
+	if p&notify.AA_MAY_SETCRED != 0 {
+		perms = append(perms, PermissionSetCred)
+	}
+	if p&notify.AA_MAY_GETCRED != 0 {
+		perms = append(perms, PermissionGetCred)
+	}
+	if p&notify.AA_MAY_CHMOD != 0 {
+		perms = append(perms, PermissionChangeMode)
+	}
+	if p&notify.AA_MAY_CHOWN != 0 {
+		perms = append(perms, PermissionChangeOwner)
+	}
+	if p&notify.AA_MAY_CHGRP != 0 {
+		perms = append(perms, PermissionChangeGroup)
+	}
+	if p&notify.AA_MAY_LOCK != 0 {
+		perms = append(perms, PermissionLock)
+	}
+	if p&notify.AA_EXEC_MMAP != 0 {
+		perms = append(perms, PermissionExecuteMap)
+	}
+	if p&notify.AA_MAY_LINK != 0 {
+		perms = append(perms, PermissionLink)
+	}
+	if p&notify.AA_MAY_ONEXEC != 0 {
+		perms = append(perms, PermissionChangeProfileOnExec)
+	}
+	if p&notify.AA_MAY_CHANGE_PROFILE != 0 {
+		perms = append(perms, PermissionChangeProfile)
+	}
+	if !p.IsValid() {
+		return perms, ErrUnrecognizedFilePermission
+	}
+	return perms, nil
+}
+
+// PermissionsListContains returns true if the given permissions list contains
+// the given permission, else false.
+func PermissionsListContains(list []PermissionType, permission PermissionType) bool {
+	for _, perm := range list {
+		if perm == permission {
+			return true
+		}
+	}
+	return false
+}
+
+// RemovePermissionFromList returns a new list with all instances of the given
+// permission removed. If the given permission is not found in the list, returns
+// an error, along with the original list.
+func RemovePermissionFromList(list []PermissionType, permission PermissionType) ([]PermissionType, error) {
+	if len(list) == 0 {
+		return list, ErrPermissionNotInList
+	}
+	newList := make([]PermissionType, 0, len(list)-1)
+	found := false
+	for _, perm := range list {
+		if perm == permission {
+			found = true
+			continue
+		}
+		newList = append(newList, perm)
+	}
+	if !found {
+		return list, ErrPermissionNotInList
+	}
+	return newList, nil
+}
+
+// ValidateOutcome returns nil if the given outcome is valid, otherwise an error.
+func ValidateOutcome(outcome OutcomeType) error {
+	switch outcome {
+	case OutcomeAllow, OutcomeDeny:
+		return nil
+	default:
+		return ErrInvalidOutcome
+	}
+}
+
+// ValidateLifespanParseDuration checks that the given lifespan is valid and
+// that the given duration is valid for that lifespan. If the lifespan is
+// LifespanTimespan, then duration must be a string parsable by
+// time.ParseDuration(), representing the duration of time for which the rule
+// should be valid. Otherwise, it must be empty. Returns an error if any of the
+// above are invalid, otherwise computes the expiration time of the rule based
+// on the current time and the given duration and returns it.
+func ValidateLifespanParseDuration(lifespan LifespanType, duration string) (string, error) {
+	expirationString := ""
+	switch lifespan {
+	case LifespanForever, LifespanSession, LifespanSingle:
+		if duration != "" {
+			return "", ErrInvalidDurationForLifespan
+		}
+	case LifespanTimespan:
+		if duration == "" {
+			return "", ErrInvalidDurationEmpty
+		}
+		parsedDuration, err := time.ParseDuration(duration)
+		if err != nil {
+			return "", ErrInvalidDurationParseError
+		}
+		if parsedDuration <= 0 {
+			return "", ErrInvalidDurationNegative
+		}
+		expirationString = time.Now().Add(parsedDuration).Format(time.RFC3339)
+	}
+	return expirationString, nil
+}

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -1,0 +1,371 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common_test
+
+import (
+	"encoding/base32"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type commonSuite struct {
+	tmpdir string
+}
+
+var _ = Suite(&commonSuite{})
+
+func (s *commonSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+}
+
+func (s *commonSuite) TestTimestamps(c *C) {
+	before := time.Now()
+	ts := common.CurrentTimestamp()
+	after := time.Now()
+	parsedTime, err := common.TimestampToTime(ts)
+	c.Assert(err, IsNil)
+	c.Assert(parsedTime.After(before), Equals, true)
+	c.Assert(parsedTime.Before(after), Equals, true)
+}
+
+func (s *commonSuite) TestNewIDAndTimestamp(c *C) {
+	before := time.Now()
+	id := common.NewID()
+	idPaired, timestampPaired := common.NewIDAndTimestamp()
+	after := time.Now()
+	data1, err := base32.StdEncoding.DecodeString(id)
+	c.Assert(err, IsNil)
+	data2, err := base32.StdEncoding.DecodeString(idPaired)
+	c.Assert(err, IsNil)
+	parsedNs := int64(binary.BigEndian.Uint64(data1))
+	parsedNsPaired := int64(binary.BigEndian.Uint64(data2))
+	parsedTime := time.Unix(parsedNs/1000000000, parsedNs%1000000000)
+	parsedTimePaired := time.Unix(parsedNsPaired/1000000000, parsedNsPaired%1000000000)
+	c.Assert(parsedTime.After(before), Equals, true)
+	c.Assert(parsedTime.Before(after), Equals, true)
+	c.Assert(parsedTimePaired.After(before), Equals, true)
+	c.Assert(parsedTimePaired.Before(after), Equals, true)
+	parsedTimestamp, err := common.TimestampToTime(timestampPaired)
+	c.Assert(err, IsNil)
+	c.Assert(parsedTimePaired, Equals, parsedTimestamp)
+}
+
+func (s *commonSuite) TestLabelToSnapAppHappy(c *C) {
+	cases := []struct {
+		label string
+		snap  string
+		app   string
+	}{
+		{
+			label: "snap.nextcloud.occ",
+			snap:  "nextcloud",
+			app:   "occ",
+		},
+		{
+			label: "snap.lxd.lxc",
+			snap:  "lxd",
+			app:   "lxc",
+		},
+		{
+			label: "snap.firefox.firefox",
+			snap:  "firefox",
+			app:   "firefox",
+		},
+	}
+	for _, testCase := range cases {
+		snap, app, err := common.LabelToSnapApp(testCase.label)
+		c.Check(err, IsNil)
+		c.Check(snap, Equals, testCase.snap)
+		c.Check(app, Equals, testCase.app)
+	}
+}
+
+func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
+	cases := []string{
+		"snap",
+		"snap.nextcloud",
+		"nextcloud.occ",
+		"snap.nextcloud.nextcloud.occ",
+		"SNAP.NEXTCLOUD.OCC",
+	}
+	for _, label := range cases {
+		snap, app, err := common.LabelToSnapApp(label)
+		c.Check(err, Equals, common.ErrInvalidSnapLabel)
+		c.Check(snap, Equals, label)
+		c.Check(app, Equals, label)
+	}
+}
+
+func (s *commonSuite) TestPermissionMaskToPermissionsList(c *C) {
+	cases := []struct {
+		mask notify.FilePermission
+		list []common.PermissionType
+	}{
+		{
+			notify.FilePermission(0),
+			[]common.PermissionType{},
+		},
+		{
+			notify.AA_MAY_EXEC,
+			[]common.PermissionType{common.PermissionExecute},
+		},
+		{
+			notify.AA_MAY_WRITE,
+			[]common.PermissionType{common.PermissionWrite},
+		},
+		{
+			notify.AA_MAY_READ,
+			[]common.PermissionType{common.PermissionRead},
+		},
+		{
+			notify.AA_MAY_APPEND,
+			[]common.PermissionType{common.PermissionAppend},
+		},
+		{
+			notify.AA_MAY_CREATE,
+			[]common.PermissionType{common.PermissionCreate},
+		},
+		{
+			notify.AA_MAY_DELETE,
+			[]common.PermissionType{common.PermissionDelete},
+		},
+		{
+			notify.AA_MAY_OPEN,
+			[]common.PermissionType{common.PermissionOpen},
+		},
+		{
+			notify.AA_MAY_RENAME,
+			[]common.PermissionType{common.PermissionRename},
+		},
+		{
+			notify.AA_MAY_SETATTR,
+			[]common.PermissionType{common.PermissionSetAttr},
+		},
+		{
+			notify.AA_MAY_GETATTR,
+			[]common.PermissionType{common.PermissionGetAttr},
+		},
+		{
+			notify.AA_MAY_SETCRED,
+			[]common.PermissionType{common.PermissionSetCred},
+		},
+		{
+			notify.AA_MAY_GETCRED,
+			[]common.PermissionType{common.PermissionGetCred},
+		},
+		{
+			notify.AA_MAY_CHMOD,
+			[]common.PermissionType{common.PermissionChangeMode},
+		},
+		{
+			notify.AA_MAY_CHOWN,
+			[]common.PermissionType{common.PermissionChangeOwner},
+		},
+		{
+			notify.AA_MAY_CHGRP,
+			[]common.PermissionType{common.PermissionChangeGroup},
+		},
+		{
+			notify.AA_MAY_LOCK,
+			[]common.PermissionType{common.PermissionLock},
+		},
+		{
+			notify.AA_EXEC_MMAP,
+			[]common.PermissionType{common.PermissionExecuteMap},
+		},
+		{
+			notify.AA_MAY_LINK,
+			[]common.PermissionType{common.PermissionLink},
+		},
+		{
+			notify.AA_MAY_ONEXEC,
+			[]common.PermissionType{common.PermissionChangeProfileOnExec},
+		},
+		{
+			notify.AA_MAY_CHANGE_PROFILE,
+			[]common.PermissionType{common.PermissionChangeProfile},
+		},
+		{
+			notify.AA_MAY_READ | notify.AA_MAY_WRITE | notify.AA_MAY_EXEC,
+			[]common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead},
+		},
+	}
+	for _, testCase := range cases {
+		perms, err := common.PermissionMaskToPermissionsList(testCase.mask)
+		c.Assert(err, IsNil, Commentf("testCase: %+v", testCase))
+		c.Assert(perms, DeepEquals, testCase.list)
+	}
+
+	unrecognizedFilePerm := notify.FilePermission(1 << 17)
+	perms, err := common.PermissionMaskToPermissionsList(unrecognizedFilePerm)
+	c.Assert(err, Equals, common.ErrUnrecognizedFilePermission)
+	c.Assert(perms, HasLen, 0)
+
+	mixed := unrecognizedFilePerm | notify.AA_MAY_READ | notify.AA_MAY_WRITE
+	expected := []common.PermissionType{common.PermissionWrite, common.PermissionRead}
+	perms, err = common.PermissionMaskToPermissionsList(mixed)
+	c.Assert(err, Equals, common.ErrUnrecognizedFilePermission)
+	c.Assert(perms, DeepEquals, expected)
+}
+
+func (s *commonSuite) TestPermissionsListContains(c *C) {
+	permissionsList := []common.PermissionType{
+		common.PermissionExecute,
+		common.PermissionWrite,
+		common.PermissionRead,
+		common.PermissionAppend,
+		common.PermissionOpen,
+	}
+	for _, perm := range []common.PermissionType{
+		common.PermissionExecute,
+		common.PermissionWrite,
+		common.PermissionRead,
+		common.PermissionAppend,
+		common.PermissionOpen,
+	} {
+		c.Check(common.PermissionsListContains(permissionsList, perm), Equals, true)
+	}
+	for _, perm := range []common.PermissionType{
+		common.PermissionCreate,
+		common.PermissionDelete,
+		common.PermissionRename,
+		common.PermissionChangeOwner,
+		common.PermissionChangeGroup,
+	} {
+		c.Check(common.PermissionsListContains(permissionsList, perm), Equals, false)
+	}
+}
+
+func (s *commonSuite) TestRemovePermissionFromList(c *C) {
+	cases := []struct {
+		initial []common.PermissionType
+		remove  common.PermissionType
+		final   []common.PermissionType
+		err     error
+	}{
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionRead,
+			[]common.PermissionType{common.PermissionWrite, common.PermissionExecute},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionWrite,
+			[]common.PermissionType{common.PermissionRead, common.PermissionExecute},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionExecute,
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{common.PermissionWrite},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionAppend,
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.ErrPermissionNotInList,
+		},
+	}
+	for _, testCase := range cases {
+		result, err := common.RemovePermissionFromList(testCase.initial, testCase.remove)
+		c.Assert(err, Equals, testCase.err)
+		c.Assert(result, DeepEquals, testCase.final)
+	}
+}
+
+func (s *commonSuite) TestValidateOutcome(c *C) {
+	c.Assert(common.ValidateOutcome(common.OutcomeAllow), Equals, nil)
+	c.Assert(common.ValidateOutcome(common.OutcomeDeny), Equals, nil)
+	c.Assert(common.ValidateOutcome(common.OutcomeUnset), Equals, common.ErrInvalidOutcome)
+	c.Assert(common.ValidateOutcome(common.OutcomeType("foo")), Equals, common.ErrInvalidOutcome)
+}
+
+func (s *commonSuite) TestValidateLifespanParseDuration(c *C) {
+	unsetDuration := ""
+	invalidDuration := "foo"
+	negativeDuration := "-5s"
+	validDuration := "10m"
+	parsedValidDuration, err := time.ParseDuration(validDuration)
+	c.Assert(err, IsNil)
+
+	for _, lifespan := range []common.LifespanType{
+		common.LifespanForever,
+		common.LifespanSession,
+		common.LifespanSingle,
+	} {
+		expiration, err := common.ValidateLifespanParseDuration(lifespan, unsetDuration)
+		c.Check(expiration, Equals, "")
+		c.Check(err, IsNil)
+		for _, dur := range []string{invalidDuration, negativeDuration, validDuration} {
+			expiration, err = common.ValidateLifespanParseDuration(lifespan, dur)
+			c.Check(expiration, Equals, "")
+			c.Check(err, Equals, common.ErrInvalidDurationForLifespan)
+		}
+	}
+
+	expiration, err := common.ValidateLifespanParseDuration(common.LifespanTimespan, unsetDuration)
+	c.Check(expiration, Equals, "")
+	c.Check(err, Equals, common.ErrInvalidDurationEmpty)
+
+	expiration, err = common.ValidateLifespanParseDuration(common.LifespanTimespan, invalidDuration)
+	c.Check(expiration, Equals, "")
+	c.Check(err, Equals, common.ErrInvalidDurationParseError)
+
+	expiration, err = common.ValidateLifespanParseDuration(common.LifespanTimespan, negativeDuration)
+	c.Check(expiration, Equals, "")
+	c.Check(err, Equals, common.ErrInvalidDurationNegative)
+
+	expiration, err = common.ValidateLifespanParseDuration(common.LifespanTimespan, validDuration)
+	c.Check(err, Equals, nil)
+	expirationTime, err := time.Parse(time.RFC3339, expiration)
+	c.Check(err, IsNil)
+	c.Check(expirationTime.After(time.Now()), Equals, true)
+	c.Check(expirationTime.Before(time.Now().Add(parsedValidDuration)), Equals, true)
+}

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -123,6 +123,22 @@ func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
 	}
 }
 
+func (s *commonSuite) TestSelectSingleInterface(c *C) {
+	defaultInterface := "other"
+	fakeIface := "foo"
+	c.Check(common.SelectSingleInterface([]string{}), Equals, defaultInterface, Commentf("input: []string{}"))
+	c.Check(common.SelectSingleInterface([]string{""}), Equals, defaultInterface, Commentf(`input: []string{""}`))
+	c.Check(common.SelectSingleInterface([]string{fakeIface}), Equals, defaultInterface, Commentf(`input: []string{""}`))
+	for iface := range common.InterfacePriorities {
+		c.Check(common.SelectSingleInterface([]string{iface}), Equals, iface)
+		fakeList := []string{iface, fakeIface}
+		c.Check(common.SelectSingleInterface(fakeList), Equals, iface)
+		fakeList = []string{fakeIface, iface}
+		c.Check(common.SelectSingleInterface(fakeList), Equals, iface)
+	}
+	c.Check(common.SelectSingleInterface([]string{"home", "camera", "foo"}), Equals, "home")
+}
+
 func (s *commonSuite) TestPermissionMaskToPermissionsList(c *C) {
 	cases := []struct {
 		mask notify.FilePermission

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -313,37 +313,32 @@ func (s *commonSuite) TestNewIDAndTimestamp(c *C) {
 	c.Assert(parsedTimePaired, Equals, parsedTimestamp)
 }
 
-func (s *commonSuite) TestLabelToSnapAppHappy(c *C) {
+func (s *commonSuite) TestLabelToSnapHappy(c *C) {
 	cases := []struct {
 		label string
 		snap  string
-		app   string
 	}{
 		{
 			label: "snap.nextcloud.occ",
 			snap:  "nextcloud",
-			app:   "occ",
 		},
 		{
 			label: "snap.lxd.lxc",
 			snap:  "lxd",
-			app:   "lxc",
 		},
 		{
 			label: "snap.firefox.firefox",
 			snap:  "firefox",
-			app:   "firefox",
 		},
 	}
 	for _, testCase := range cases {
-		snap, app, err := common.LabelToSnapApp(testCase.label)
+		snap, err := common.LabelToSnap(testCase.label)
 		c.Check(err, IsNil)
 		c.Check(snap, Equals, testCase.snap)
-		c.Check(app, Equals, testCase.app)
 	}
 }
 
-func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
+func (s *commonSuite) TestLabelToSnapUnhappy(c *C) {
 	cases := []string{
 		"snap",
 		"snap.nextcloud",
@@ -352,10 +347,9 @@ func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
 		"SNAP.NEXTCLOUD.OCC",
 	}
 	for _, label := range cases {
-		snap, app, err := common.LabelToSnapApp(label)
+		snap, err := common.LabelToSnap(label)
 		c.Check(err, Equals, common.ErrInvalidSnapLabel)
 		c.Check(snap, Equals, label)
-		c.Check(app, Equals, label)
 	}
 }
 

--- a/overlord/ifacestate/apparmorprompting/common/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/export_test.go
@@ -19,4 +19,8 @@
 
 package common
 
-var InterfacePriorities = interfacePriorities
+var (
+	InterfacePriorities           = interfacePriorities
+	InterfacePermissionsAvailable = interfacePermissionsAvailable
+	InterfaceFilePermissionsMaps  = interfaceFilePermissionsMaps
+)

--- a/overlord/ifacestate/apparmorprompting/common/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+var InterfacePriorities = interfacePriorities


### PR DESCRIPTION
This PR has been split into three PRs, some of which have/will be further split into smaller PRs:
1. https://github.com/snapcore/snapd/pull/13849 (common types and helpers)
2. https://github.com/snapcore/snapd/pull/13850 (constraints and abstract permissions)
3. https://github.com/snapcore/snapd/pull/13730 (path patterns -- to be split)

--------

Original description:

Add the `common` package, which provides type definitions and functions which are used by other 
components related to apparmor prompting.

Notably, this package handles:
- Interface-specific constraints
- Abstracted permissions (again, interface-specific)
- ~~Path pattern matching~~ moved to #13730 
- ~~Path pattern validation~~ moved to #13730
- ~~Path pattern precedence~~ moved to #13730
- ~~Expansion of groups in path patterns~~ moved to #13730 

The meta-PR for apparmor prompting can be found here, if it would be helpful to see how this package is used: https://github.com/snapcore/snapd/pull/12964

The bulk of the work to support arbitrary wildcards and groups in path patterns was completed here: https://github.com/olivercalder/snapd/pull/30
There was a very helpful review by @TheSignPainter98 which I addressed as best I could, and I'm hoping any future comments about those components can be consolidated in this PR.