### PR TITLE
many: add experimental.apparmor-prompting

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -72,6 +72,8 @@ const (
 	RefreshAppAwarenessUX
 	// AspectsConfiguration enables experimental aspect-based configuration.
 	AspectsConfiguration
+	// Prompting enables apparmor prompting.
+	AppArmorPrompting
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -115,6 +117,8 @@ var featureNames = map[SnapdFeature]string{
 
 	RefreshAppAwarenessUX: "refresh-app-awareness-ux",
 	AspectsConfiguration:  "aspects-configuration",
+
+	AppArmorPrompting: "apparmor-prompting",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -139,6 +143,8 @@ var featuresExported = map[SnapdFeature]bool{
 
 	RefreshAppAwarenessUX: true,
 	AspectsConfiguration:  true,
+
+	AppArmorPrompting: true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -63,6 +63,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.QuotaGroups, "quota-groups")
 	check(features.RefreshAppAwarenessUX, "refresh-app-awareness-ux")
 	check(features.AspectsConfiguration, "aspects-configuration")
+	check(features.AppArmorPrompting, "apparmor-prompting")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -104,6 +105,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.RefreshAppAwarenessUX, true)
 	check(features.AspectsConfiguration, true)
 	check(features.QuotaGroups, false)
+	check(features.AppArmorPrompting, true)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -153,6 +155,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.RefreshAppAwarenessUX, false)
 	check(features.AspectsConfiguration, false)
 	check(features.QuotaGroups, false)
+	check(features.AppArmorPrompting, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -21,9 +21,12 @@ package builtin
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	apparmor_prompting "github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -52,29 +55,29 @@ const homeConnectedPlugAppArmor = `
 # Note, @{HOME} is the user's $HOME, not the snap's $HOME
 
 # Allow read access to toplevel $HOME for the user
-owner @{HOME}/ r,
+###PROMPT###owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snap and toplevel hidden directories in @{HOME}.
-owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
-owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
-owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
-owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
-owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
 
 # Allow creating a few files not caught above
-owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
 
 # Allow access to @{HOME}/snap/ to allow directory traversals from
 # @{HOME}/snap/@{SNAP_INSTANCE_NAME} through @{HOME}/snap to @{HOME}.
 # While this leaks snap names, it fixes usability issues for snaps
 # that require this transitional interface.
-owner @{HOME}/snap/ r,
+###PROMPT###owner @{HOME}/snap/ r,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).
-owner /run/user/[0-9]*/gvfs/{,**} r,
-owner /run/user/[0-9]*/gvfs/*/**  w,
+###PROMPT###owner /run/user/[0-9]*/gvfs/{,**} r,
+###PROMPT###owner /run/user/[0-9]*/gvfs/*/**  w,
 
 # Disallow writes to the well-known directory included in
 # the user's PATH on several distributions
@@ -84,13 +87,13 @@ audit deny @{HOME}/bin/{,**} wl,
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
 capability dac_read_search,
-@{HOME}/               r,
-@{HOME}/[^s.]**        r,
-@{HOME}/s[^n]**        r,
-@{HOME}/sn[^a]**       r,
-@{HOME}/sna[^p]**      r,
-@{HOME}/snap[^/]**     r,
-@{HOME}/{s,sn,sna}{,/} r,
+###PROMPT### @{HOME}/               r,
+###PROMPT### @{HOME}/[^s.]**        r,
+###PROMPT### @{HOME}/s[^n]**        r,
+###PROMPT### @{HOME}/sn[^a]**       r,
+###PROMPT### @{HOME}/sna[^p]**      r,
+###PROMPT### @{HOME}/snap[^/]**     r,
+###PROMPT### @{HOME}/{s,sn,sna}{,/} r,
 `
 
 type homeInterface struct {
@@ -107,16 +110,25 @@ func (iface *homeInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	return nil
 }
 
+func evalPrompting(s string) string {
+	repl := ""
+	if features.AppArmorPrompting.IsEnabled() && apparmor_prompting.SupportAvailable() {
+		repl = "prompt "
+	}
+	return strings.Replace(s, "###PROMPT###", repl, -1)
+}
+
 func (iface *homeInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	var read string
 	_ = plug.Attr("read", &read)
+
 	// 'owner' is the standard policy
-	spec.AddSnippet(homeConnectedPlugAppArmor)
+	spec.AddSnippet(evalPrompting(homeConnectedPlugAppArmor))
 
 	// 'all' grants standard policy plus read access to home without owner
 	// match
 	if read == "all" {
-		spec.AddSnippet(homeConnectedPlugAppArmorWithAllRead)
+		spec.AddSnippet(evalPrompting(homeConnectedPlugAppArmorWithAllRead))
 	}
 	return nil
 }

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+// +build !nomanagers
+
+/*
+ * Copyright (C) 2017-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+)
+
+func doExperimentalApparmorPromptProfileRegeneration(c RunTransaction, opts *fsOnlyContext) error {
+	st := c.State()
+
+	var prompting bool
+	err := c.Get("core", "experimental."+features.AppArmorPrompting.String(), &prompting)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	var prevPrompting bool
+	err = c.GetPristine("core", "experimental."+features.AppArmorPrompting.String(), &prevPrompting)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if prompting == prevPrompting {
+		return nil
+	}
+
+	st.Lock()
+	regenerateProfilesChg := st.NewChange("regenerate-all-security-profiles",
+		i18n.G("Regenerate all profiles due to change in prompting"))
+	t := st.NewTask("regenerate-all-security-profiles", i18n.G("Regenerate all profiles due to change in prompting"))
+	regenerateProfilesChg.AddTask(t)
+	st.Unlock()
+	st.EnsureBefore(0)
+
+	select {
+	case <-regenerateProfilesChg.Ready():
+		st.Lock()
+		defer st.Unlock()
+		return regenerateProfilesChg.Err()
+	case <-time.After(10 * time.Minute):
+		// profile generate may take some time
+		return fmt.Errorf("%s is taking too long", regenerateProfilesChg.Kind())
+	}
+}

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -66,6 +66,10 @@ func init() {
 
 	// kernel.{,dangerous-}cmdline-append
 	addWithStateHandler(validateCmdlineAppend, handleCmdlineAppend, &flags{modeenvOnlyConfig: true})
+
+	// experimental.apparmor-prompting
+	addWithStateHandler(nil, doExperimentalApparmorPromptProfileRegeneration, nil)
+
 }
 
 // RunTransaction is an interface describing how to access

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1960,3 +1960,19 @@ func (m *InterfaceManager) doHotplugSeqWait(task *state.Task, _ *tomb.Tomb) erro
 	// no conflicting change for same hotplug key found
 	return nil
 }
+
+func (m *InterfaceManager) doRegenerateAllSecurityProfiles(task *state.Task, _ *tomb.Tomb) error {
+	// XXX: this will make snapd unusable for a long time :(
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(task)
+	defer perfTimings.Save(task.State())
+
+	if err := m.regenerateAllSecurityProfiles(perfTimings); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -114,6 +114,9 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	// helper for ubuntu-core -> core
 	addHandler("transition-ubuntu-core", m.doTransitionUbuntuCore, m.undoTransitionUbuntuCore)
 
+	// helper for apparmor prompting backend
+	addHandler("regenerate-all-security-profiles", m.doRegenerateAllSecurityProfiles, nil)
+
 	// interface tasks might touch more than the immediate task target snap, serialize them
 	runner.AddBlocked(func(t *state.Task, running []*state.Task) bool {
 		if !taskKinds[t.Kind()] {

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -10,3 +10,5 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 	restore = func() { doSyscall = old }
 	return restore
 }
+
+var ExplicitlyUnsupported = &explicitlyUnsupported

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -10,10 +10,16 @@ import (
 
 var SysPath string
 
+// Until other prompting components are in place, mark support as unavailable
+// explicitly, even if the kernel has support.
+// TODO: Delete this or set to false once the necessary AppArmor Prompting
+// components are in place.
+var explicitlyUnsupported = true
+
 // SupportAvailable returns true if SysPath exists, indicating that apparmor
 // prompting messages may be received from SysPath.
 func SupportAvailable() bool {
-	return osutil.FileExists(SysPath)
+	return !explicitlyUnsupported && osutil.FileExists(SysPath)
 }
 
 func setupSysPath(newrootdir string) {

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -35,6 +35,7 @@ func (*notifySuite) TestSysPathBehavior(c *C) {
 }
 
 func (*notifySuite) TestSupportAvailable(c *C) {
+	*notify.ExplicitlyUnsupported = false
 	newRoot := c.MkDir()
 	dirs.SetRootDir(newRoot)
 	c.Assert(notify.SupportAvailable(), Equals, false)
@@ -44,4 +45,6 @@ func (*notifySuite) TestSupportAvailable(c *C) {
 	_, err = os.Create(notify.SysPath)
 	c.Assert(err, IsNil)
 	c.Assert(notify.SupportAvailable(), Equals, true)
+	*notify.ExplicitlyUnsupported = true
+	c.Assert(notify.SupportAvailable(), Equals, false)
 }


### PR DESCRIPTION
Add `experimental.apparmor-prompting` feature. Enabling this feature regenerates AppArmor profiles for relevant interfaces to add the `prompt` prefix to AppArmor rules. AppArmor then knows to send a prompt request via the notify socket, which will be received by the prompting listener (defined in `sandbox/apparmor/notify/listener`).

For now, this PR explicitly marks notify support as unavailable, so it will have no effect on AppArmor rules yet. Once the other prompting components are merged into snapd master, the commit which marks notify unsupported should be reverted.

The PR configures the home interface to use the `prompt` in its rules if `experimental.apparmor-prompting` is enabled. In the future, this may be extended to other interfaces.