### PR TITLE
release: 2.61.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -382,6 +382,7 @@ jobs:
         - ubuntu-22.04-64
         - ubuntu-23.04-64
         - ubuntu-23.10-64
+        - ubuntu-24.04-64
         - ubuntu-core-16-64
         - ubuntu-core-18-64
         - ubuntu-core-20-64

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.61.3:
+* Install systemd files in correct location for 24.04
+
 # New in snapd 2.61.2:
 * Fix to enable plug/slot sanitization for prepare-image
 * Fix panic when device-service.access=offline

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.61.2
+pkgver=2.61.3
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,10 @@
+snapd (2.61.3-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2039017
+    - Install systemd files in correct location for 24.04
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 06 Mar 2024 23:18:11 +0200
+
 snapd (2.61.2-1) unstable; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.61.2
+Version:        2.61.3
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -991,6 +991,10 @@ fi
 
 
 %changelog
+* Wed Mar 06 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.61.3
+ - Install systemd files in correct location for 24.04
+
 * Fri Feb 16 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.61.2
  - Fix to enable plug/slot sanitization for prepare-image

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Mar 06 21:18:11 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.61.3
+
+-------------------------------------------------------------------
 Fri Feb 16 18:22:23 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.61.2

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.61.2
+Version:        2.61.3
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.61.3~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2039017
+    - Install systemd files in correct location for 24.04
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 06 Mar 2024 23:18:11 +0200
+
 snapd (2.61.2~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.61.3) xenial; urgency=medium
+
+  * New upstream release, LP: #2039017
+    - Install systemd files in correct location for 24.04
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 06 Mar 2024 23:18:11 +0200
+
 snapd (2.61.2) xenial; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -259,7 +259,13 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	$(MAKE) -C cmd check
 endif
 
-override_dh_install:
+
+debian/snapd.install: SYSTEMD_LIBDIR=$(shell pkg-config --variable=systemdutildir systemd)
+debian/snapd.install: debian/snapd.install.in
+	sed 's,@systemd-lib@,$(SYSTEMD_LIBDIR),g' $< >$@.tmp
+	mv $@.tmp $@
+
+override_dh_install: debian/snapd.install
 	# we do not need this in the package, its just needed during build
 	rm -rf ${CURDIR}/debian/tmp/usr/bin/xgettext-go
 	# toolbelt is not shippable

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -49,4 +49,4 @@ c-vendor/squashfuse/snapfuse usr/bin
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
 # but system generators end up in lib
-lib/systemd/system-generators
+@systemd-lib@/system-generators

--- a/spread.yaml
+++ b/spread.yaml
@@ -151,6 +151,9 @@ backends:
             - ubuntu-23.10-64:
                   storage: 12G
                   workers: 8
+            - ubuntu-24.04-64:
+                  storage: 12G
+                  workers: 8
 
             - debian-11-64:
                   workers: 6

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -72,6 +72,9 @@ get_google_image_url_for_vm() {
         ubuntu-23.10-64*)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/mantic-server-cloudimg-amd64.img"
             ;;
+        ubuntu-24.04-64*)
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-amd64.img"
+            ;;
         *)
             echo "unsupported system"
             exit 1
@@ -105,6 +108,9 @@ get_ubuntu_image_url_for_vm() {
             ;;
         ubuntu-23.10-64*)
             echo "https://cloud-images.ubuntu.com/mantic/current/mantic-server-cloudimg-amd64.img"
+            ;;
+        ubuntu-24.04-64*)
+            echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
             ;;
         *)
             echo "unsupported system"

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -616,7 +616,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-22.*|ubuntu-23.*)
+        ubuntu-22.*|ubuntu-23.*|ubuntu-24.*)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session

--- a/tests/main/cgroup-devices-v1/task.yaml
+++ b/tests/main/cgroup-devices-v1/task.yaml
@@ -1,6 +1,6 @@
 summary: measuring basic properties of device cgroup
 
 # Disable the test on all systems that boot with cgroup v2
-systems: [ -fedora-*, -debian-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-22.*, -ubuntu-23.*, -ubuntu-core-22-*, -centos-9-*]
+systems: [ -fedora-*, -debian-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-22.*, -ubuntu-23.*, -ubuntu-24.*, -ubuntu-core-22-*, -centos-9-*]
 
 execute: ./task.sh

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -5,7 +5,7 @@ details: |
     placed into the appropriate hierarchy under the freezer cgroup.
 
 # Disable the test on all systems that boot with cgroup v2
-systems: [ -fedora-*, -debian-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-22.*, -ubuntu-23.*, -ubuntu-core-22-*, -centos-9-*]
+systems: [ -fedora-*, -debian-*, -arch-*, -opensuse-tumbleweed-*, -ubuntu-22.*, -ubuntu-23.*, -ubuntu-24.*, -ubuntu-core-22-*, -centos-9-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -111,7 +111,7 @@ execute: |
             MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
-        ubuntu-22*|ubuntu-23*)
+        ubuntu-22*|ubuntu-23*|ubuntu-24*)
             # Ubuntu > 22 uses unified cgroup hierarchy, where we wait
             # for the systemd to complete the job that creates a transient scope
             MATCH 'DEBUG: using session bus' <debug.txt
@@ -183,7 +183,7 @@ execute: |
     SNAPD_DEBUG=1 tests.session -u root exec snap run test-snapd-sh.sh -c 'exec cat /proc/self/cgroup' >cgroup.txt 2>debug.txt
     tests.session -u root restore
     case "$SPREAD_SYSTEM" in
-        ubuntu-23.10*)
+        ubuntu-23.10*|ubuntu-24*)
             # Ubuntu >= 23.10 uses systemd-run instead of busctl to run commands using tests.session
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
@@ -240,7 +240,7 @@ execute: |
             MATCH 'DEBUG: transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-12345.slice/user@12345.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
-        ubuntu-23.10*)
+        ubuntu-23.10*|ubuntu-24*)
             # Ubuntu >= 23.10 uses systemd-run instead of busctl to run commands using tests.session
             MATCH '0::/user.slice/user-12345.slice/user@12345.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -22,15 +22,13 @@ execute: |
         core_snap=core22
     fi
 
-    # There isn't an official image for mantic yet, let's use the community one
-    if os.query is-ubuntu 23.10; then
-        CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-        lxc launch --quiet "images:ubuntu/$CODENAME" ubuntu
-        core_snap=core22
-    else
-        VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-        lxd.lxc launch --quiet "ubuntu:$VERSION_ID" ubuntu
+    REMOTE=ubuntu
+    # There isn't an official image for noble yet, let's use the daily one
+    if os.query is-ubuntu 24.04; then
+        REMOTE=ubuntu-daily
     fi
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "$REMOTE:$VERSION_ID" ubuntu
 
     echo "Setting up proxy *inside* the container"
     if [ -n "${http_proxy:-}" ]; then
@@ -47,9 +45,9 @@ execute: |
     DEB=$(basename "$GOHOME"/snapd_*.deb)
     
     lxd.lxc exec ubuntu -- apt update
-    # As for ubuntu mantic it is not using the official image, snapd is not installed by default
+    # As for ubuntu noble it is not using the official image, snapd is not installed by default
     # This should be removed once the official image is released
-    if os.query is-ubuntu 23.10; then
+    if os.query is-ubuntu 24.04; then
         lxd.lxc exec ubuntu -- apt install -y snapd
         lxd.lxc exec ubuntu -- snap install "$core_snap"
     fi

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that package remove and purge works inside LXD containers
 
+details: |
+    Verifies that the snapd package can be removed from inside a LXD container.
+    Also check that potentially problematic directories are gone.
+
 # Since it's only apt remove --purge and lxd tests are rather long, limit to a
 # couple of systems only. The postrm purge is more thoroughly checked in
 # tests/main/postrm-purge.
@@ -22,14 +26,13 @@ prepare: |
     echo "Install lxd"
     "$TESTSTOOLS"/lxd-state prepare-snap
 
-    # There isn't an official image for mantic yet, let's use the community one
-    if os.query is-ubuntu 23.10; then
-        CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-        lxc launch --quiet "images:ubuntu/$CODENAME" my-ubuntu
-    else
-        VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-        lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
+    REMOTE=ubuntu
+    # There isn't an official image for noble yet, let's use the daily one
+    if os.query is-ubuntu 24.04; then
+      REMOTE=ubuntu-daily
     fi
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "$REMOTE:$VERSION_ID" my-ubuntu
 
     # precondition check
     if os.query is-pc-amd64 && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -1,19 +1,21 @@
 summary: Check that try command works inside lxd container
 
+details: |
+  Verifies that the `snap try` command works inside a LXD container.
+
 systems: [ubuntu-2*]
 
 prepare: |
   echo "Install lxd"
   "$TESTSTOOLS"/lxd-state prepare-snap
 
-  # There isn't an official image for mantic yet, let's use the community one
-  if os.query is-ubuntu 23.10; then
-      CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-      lxc launch --quiet "images:ubuntu/$CODENAME" ubuntu
-  else
-      VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-      lxd.lxc launch --quiet "ubuntu:$VERSION_ID" ubuntu
+  REMOTE=ubuntu
+  # There isn't an official image for noble yet, let's use the daily one
+  if os.query is-ubuntu 24.04; then
+      REMOTE=ubuntu-daily
   fi
+  VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+  lxd.lxc launch --quiet "$REMOTE:$VERSION_ID" ubuntu
 
   echo "Setting up proxy *inside* the container"
   if [ -n "${http_proxy:-}" ]; then

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -1,5 +1,13 @@
 summary: Ensure that lxd works
 
+details: |
+    Verifies lxd snap works properly. Ensure we can run things inside lxd
+    container, we can use snapd inside lxd snd we can run snaps as regular
+    users. Check that we can run lxd as a snap inside a container to create
+    a nested container and we can use lxd as a snap inside lxd. Finally 
+    exercise the lxd interface and check that snaps in containers don't
+    prevent refreshes in the host.
+
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
 backends: [-autopkgtest]
@@ -78,16 +86,15 @@ execute: |
     # prep two containers, the my-ubuntu normal container and the
     # my-nesting-ubuntu nesting container
 
-    # There isn't an official image for mantic yet, let's use the community one
-    if os.query is-ubuntu 23.10; then
-        CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-        lxc launch --quiet "images:ubuntu/$CODENAME" my-ubuntu
-        lxc launch --quiet "images:ubuntu/$CODENAME" my-nesting-ubuntu -c security.nesting=true
-    else
-        VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-        lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
-        lxc launch --quiet "ubuntu:$VERSION_ID" my-nesting-ubuntu -c security.nesting=true
+    # There isn't an official image for noble yet, let's use the community one
+    REMOTE=ubuntu
+    # There isn't an official image for noble yet, let's use the daily one
+    if os.query is-ubuntu 24.04; then
+        REMOTE=ubuntu-daily
     fi
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "$REMOTE:$VERSION_ID" my-ubuntu
+    lxc launch --quiet "$REMOTE:$VERSION_ID" my-nesting-ubuntu -c security.nesting=true
 
     if os.query is-pc-amd64 && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
         echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
@@ -161,14 +168,7 @@ execute: |
     lxd.lxc exec my-nesting-ubuntu -- lxd waitready
     lxd.lxc exec my-nesting-ubuntu -- lxd init --auto
 
-    # There isn't an official image for mantic yet, let's use the community one
-    if os.query is-ubuntu 23.10; then
-      CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-      lxd.lxc exec my-nesting-ubuntu -- lxc launch --quiet "images:ubuntu/$CODENAME" my-inner-ubuntu
-    else
-      VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-      lxd.lxc exec my-nesting-ubuntu -- lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-inner-ubuntu
-    fi
+    lxd.lxc exec my-nesting-ubuntu -- lxd.lxc launch --quiet "$REMOTE:$VERSION_ID" my-inner-ubuntu
     lxd.lxc exec my-nesting-ubuntu -- lxd.lxc exec my-inner-ubuntu -- echo "from-the-INSIDE-inside" | MATCH from-the-INSIDE-inside
 
     echo "Install lxd-demo server to exercise the lxd interface"

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,7 +1,13 @@
 summary: Test that vendored apparmor does not break any system tunables
 
+details: |
+    Verifies that on systems where we have an older snapd (pre vendored apparmor)
+    deb package, and the snap itself is upgraded to vendored apparmor, apparmor
+    snippets continue to work.
+
 # On ubuntu 18 and below snapd-internal is not available
-systems: [ubuntu-18*, ubuntu-2*]
+# ubuntu-24*: the snapd deb is version 2.60.4 which is post-vendored apparmor.
+systems: [ubuntu-18*, ubuntu-20*, ubuntu-22*, ubuntu-23*]
 
 environment:
     USERNAME: home-sweet-home

--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -1,5 +1,9 @@
 summary: Ensure upgrades from release version of snap works
 
+details: |
+    Verifies that when we upgrade snap from a release version to
+    the latest version, snapd and the installed snaps still work.
+
 systems: [ubuntu-1*-64, ubuntu-2*-64]
 
 prepare: |
@@ -13,8 +17,8 @@ restore: |
     distro_install_build_snapd
 
 execute: |
-    if os.query is-ubuntu 23.10; then
-        echo "Ubuntu mantic is skipped until it is released."
+    if os.query is-ubuntu 24.04; then
+        echo "Ubuntu noble is skipped until it is released."
         exit
     fi
 
@@ -44,6 +48,7 @@ execute: |
     fi
 
     declare -A EXPECTED_SNAPD_VERSIONS=(
+        ["23.10"]='2.60.4\+23.10'
         ["23.04"]='2.59.1\+23.04'
         ["22.04"]='2.55.3\+22.04'
         ["20.04"]='2.44.3\+20.04'


### PR DESCRIPTION
This release is a followup on 2.61.2 which [failed to build for noble](https://launchpad.net/~snappy-dev/+archive/ubuntu/image/+packages?field.name_filter=snapd&field.status_filter=published&field.series_filter=noble).
It was agreed to be a deb only release.

Cherry-picked the noble build fix and enabling of tests for 24.04:

- [packaging/ubuntu-16.04: install systemd files in correct place on 24.04](https://github.com/snapcore/snapd/pull/13597)
- [tests: add spread tests support for ubuntu-24.04](https://github.com/snapcore/snapd/pull/13426)

Labelled all cherry-picked PRs and generated changelogs with:
DEBEMAIL="Ernest Lotter <ernest.lotter@canonical.com>" release-tools/changelog.py 2.61.3 2039017 NEWS.md

NEWS.md and changelogs was updated in the final commit: [release: 2.61.3](https://github.com/snapcore/snapd/pull/13671/commits/6510c98c19ac4e5b27650bd736e48ca044735d90)