### PR TITLE
daemon: support multiple interfaces in `RemoteAddr` and `interface{Open,Authenticated}Access`

### DIFF
--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -251,7 +251,7 @@ plugs:
 	})
 	defer restore()
 
-	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interface: "snap-themes-control"}
+	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interfaces: []string{"snap-themes-control"}}
 
 	// Access with no ucred data is forbidden
 	c.Check(ac.CheckAccess(d, nil, nil, nil), DeepEquals, errForbidden)
@@ -305,12 +305,12 @@ plugs:
 }
 
 func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
-	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interface: "snap-themes-control"}
+	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interfaces: []string{"snap-themes-control"}}
 
 	s.daemon(c)
 	// interfaceOpenAccess allows access if requireInterfaceApiAccess() succeeds
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return nil
@@ -319,7 +319,7 @@ func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), IsNil)
 
 	// Access is forbidden if requireInterfaceApiAccess() fails
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
 		return errForbidden
 	})
 	defer restore()
@@ -342,7 +342,7 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 
 	// themesAuthenticatedAccess denies access if requireInterfaceApiAccess fails
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return errForbidden
@@ -352,7 +352,7 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
 
 	// If requireInterfaceApiAccess succeeds, root is granted access
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
 		return nil
 	})
 	defer restore()
@@ -374,7 +374,7 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
 
 	s.daemon(c)
-	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return nil

--- a/daemon/api_accessories.go
+++ b/daemon/api_accessories.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -30,7 +30,7 @@ var (
 		Path: "/v2/accessories/changes/{id}",
 		GET:  getAccessoriesChange,
 		// TODO: expand this to other accessories APIs as they appear
-		ReadAccess: interfaceOpenAccess{Interface: "snap-themes-control"},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-themes-control"}},
 	}
 )
 

--- a/daemon/api_accessories_test.go
+++ b/daemon/api_accessories_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,7 +35,7 @@ type accessoriesSuite struct {
 }
 
 func (s *accessoriesSuite) expectThemesAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-themes-control"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-themes-control"}})
 }
 
 func (s *accessoriesSuite) TestChangeInfo(c *C) {

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -61,14 +61,14 @@ var (
 		Path:        "/v2/changes/{id}",
 		GET:         getChange,
 		POST:        abortChange,
-		ReadAccess:  interfaceOpenAccess{Interface: "snap-refresh-observe"},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
 	stateChangesCmd = &Command{
 		Path:       "/v2/changes",
 		GET:        getChanges,
-		ReadAccess: interfaceOpenAccess{Interface: "snap-refresh-observe"},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 	}
 
 	warningsCmd = &Command{

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -52,7 +52,7 @@ type generalSuite struct {
 }
 
 func (s *generalSuite) expectChangesReadAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-refresh-observe"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
 
 func (s *generalSuite) TestRoot(c *check.C) {

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -37,13 +37,13 @@ var (
 	noticesCmd = &Command{
 		Path:       "/v2/notices",
 		GET:        getNotices,
-		ReadAccess: interfaceOpenAccess{Interface: "snap-refresh-observe"},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 	}
 
 	noticeCmd = &Command{
 		Path:       "/v2/notices/{id}",
 		GET:        getNotice,
-		ReadAccess: interfaceOpenAccess{Interface: "snap-refresh-observe"},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 	}
 )
 

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Canonical Ltd
+// Copyright (c) 2023-2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -143,7 +143,7 @@ func (s *noticesSuite) TestNoticesFilterMultipleTypes(c *C) {
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	st.Unlock()
 
-	req, err := http.NewRequest("GET", "/v2/notices?types=change-update&types=warning&types=refresh-inhibit", nil)
+	req, err := http.NewRequest("GET", "/v2/notices?types=change-update&types=warning,warning&types=refresh-inhibit", nil)
 	c.Assert(err, IsNil)
 	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;", dirs.SnapdSocket)
 	rsp := s.syncReq(c, req, nil)
@@ -661,6 +661,131 @@ func (s *noticesSuite) testNoticesBadRequest(c *C, query, errorMatch string) {
 	rsp := s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 400)
 	c.Assert(rsp.Message, Matches, errorMatch)
+}
+
+// Check that duplicate explicitly-given notice types are removed from filter.
+func (s *noticesSuite) TestSanitizeNoticeTypesFilterDuplicateGivenTypes(c *C) {
+	typeStrs := []string{
+		string(state.ChangeUpdateNotice),
+		fmt.Sprintf(
+			"%s,%s,%s",
+			state.WarningNotice,
+			state.ChangeUpdateNotice,
+			state.RefreshInhibitNotice,
+		),
+		string(state.WarningNotice),
+		string(state.RefreshInhibitNotice),
+		string(state.WarningNotice),
+		string(state.ChangeUpdateNotice),
+	}
+	types := []state.NoticeType{
+		state.ChangeUpdateNotice,
+		state.WarningNotice,
+		state.RefreshInhibitNotice,
+	}
+	// Request unnecessary since explicitly-specified types are validated later.
+	result, err := daemon.SanitizeNoticeTypesFilter(typeStrs, nil)
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, types)
+}
+
+// Check that notice types granted by default by multiple connected interfaces
+// are only included once in the filter.
+func (s *noticesSuite) TestSanitizeNoticeTypesFilterDuplicateDefaultTypes(c *C) {
+	types := []state.NoticeType{
+		state.NoticeType("foo"),
+		state.NoticeType("bar"),
+		state.NoticeType("baz"),
+	}
+	ifaces := []string{
+		"abc",
+		"xyz",
+		"123",
+	}
+	fakeNoticeReadInterfaces := map[state.NoticeType][]string{
+		types[0]: {ifaces[0], ifaces[1]},
+		types[1]: {ifaces[1], ifaces[2]},
+		types[2]: {ifaces[2]},
+	}
+	restore := daemon.MockNoticeReadInterfaces(fakeNoticeReadInterfaces)
+	defer restore()
+
+	// Check that multiple interfaces which grant the same notice type do not
+	// result in duplicates of that type
+	req, err := http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=%s&%s;", dirs.SnapSocket, ifaces[0], ifaces[1])
+	result, err := daemon.SanitizeNoticeTypesFilter(nil, req)
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, types[:2])
+}
+
+// Check that requests for notice types granted by multiple connected interfaces
+// behave correctly.
+func (s *noticesSuite) TestNoticeTypesViewableBySnap(c *C) {
+	types := []state.NoticeType{
+		state.NoticeType("foo"),
+		state.NoticeType("bar"),
+		state.NoticeType("baz"),
+	}
+	ifaces := []string{
+		"abc",
+		"xyz",
+		"123",
+	}
+	fakeNoticeReadInterfaces := map[state.NoticeType][]string{
+		types[0]: {ifaces[0], ifaces[1]},
+		types[1]: {ifaces[1], ifaces[2]},
+		types[2]: {ifaces[2]},
+	}
+	restore := daemon.MockNoticeReadInterfaces(fakeNoticeReadInterfaces)
+	defer restore()
+
+	// Check notice types granted by different connected interfaces.
+	req, err := http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=%s&%s;", dirs.SnapSocket, ifaces[0], ifaces[2])
+	requestedTypes := []state.NoticeType{types[0], types[1], types[2]}
+	viewable := daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, true)
+
+	// Check notice types granted by the same connected interface.
+	req, err = http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=%s&%s;", dirs.SnapSocket, ifaces[0], ifaces[1])
+	// Types viewable by both interfaces
+	requestedTypes = []state.NoticeType{types[0]}
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, true)
+	// Types viewable by at least one interface
+	requestedTypes = []state.NoticeType{types[0], types[1]}
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, true)
+	// Type not viewable by any interface
+	requestedTypes = []state.NoticeType{types[2]}
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, false)
+	// Mix of viewable and unviewable types
+	requestedTypes = []state.NoticeType{types[0], types[2]}
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, false)
+
+	// Check no types results in not viewable, no matter what
+	requestedTypes = make([]state.NoticeType, 0)
+	req, err = http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	// No "iface=" field given
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;", dirs.SnapSocket)
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, false)
+	// Empty "iface=" field
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=;", dirs.SnapSocket)
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, false)
+	// Non-empty "iface=" field
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-refresh-observe;", dirs.SnapSocket)
+	viewable = daemon.NoticeTypesViewableBySnap(requestedTypes, req)
+	c.Check(viewable, Equals, false)
 }
 
 func (s *noticesSuite) TestNotice(c *C) {

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -40,7 +40,7 @@ type noticesSuite struct {
 func (s *noticesSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-refresh-observe"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
 
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2022 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -59,7 +59,7 @@ var (
 		Path:        "/v2/snaps",
 		GET:         getSnapsInfo,
 		POST:        postSnaps,
-		ReadAccess:  interfaceOpenAccess{Interface: "snap-refresh-observe"},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 )

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2022 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -69,7 +69,7 @@ func (s *snapsSuite) SetUpTest(c *check.C) {
 }
 
 func (s *snapsSuite) expectSnapsReadAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-refresh-observe"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
 
 func (s *snapsSuite) TestSnapsInfoIntegration(c *check.C) {

--- a/daemon/api_themes.go
+++ b/daemon/api_themes.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2020-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -45,8 +45,8 @@ var (
 		Path:        "/v2/accessories/themes",
 		GET:         checkThemes,
 		POST:        installThemes,
-		ReadAccess:  interfaceOpenAccess{Interface: "snap-themes-control"},
-		WriteAccess: interfaceAuthenticatedAccess{Interface: "snap-themes-control", Polkit: polkitActionManage},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-themes-control"}},
+		WriteAccess: interfaceAuthenticatedAccess{Interfaces: []string{"snap-themes-control"}, Polkit: polkitActionManage},
 	}
 )
 

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2020-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,8 +72,8 @@ func (s *themesSuite) daemon(c *C) *daemon.Daemon {
 }
 
 func (s *themesSuite) expectThemesAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-themes-control"})
-	s.expectWriteAccess(daemon.InterfaceAuthenticatedAccess{Interface: "snap-themes-control", Polkit: "io.snapcraft.snapd.manage"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-themes-control"}})
+	s.expectWriteAccess(daemon.InterfaceAuthenticatedAccess{Interfaces: []string{"snap-themes-control"}, Polkit: "io.snapcraft.snapd.manage"})
 }
 
 func (s *themesSuite) TestInstalledThemes(c *C) {

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -64,7 +64,7 @@ func MockCgroupSnapNameFromPid(new func(pid int) (string, error)) (restore func(
 
 var RequireInterfaceApiAccessImpl = requireInterfaceApiAccessImpl
 
-func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, interfaceName string) *apiError) (restore func()) {
+func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, interfaceNames []string) *apiError) (restore func()) {
 	old := requireInterfaceApiAccess
 	requireInterfaceApiAccess = new
 	return func() {

--- a/daemon/export_api_notices_test.go
+++ b/daemon/export_api_notices_test.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var (
+	SanitizeNoticeTypesFilter = sanitizeNoticeTypesFilter
+	NoticeTypesViewableBySnap = noticeTypesViewableBySnap
+)
+
+func MockNoticeReadInterfaces(newMap map[state.NoticeType][]string) (restore func()) {
+	old := noticeReadInterfaces
+	noticeReadInterfaces = newMap
+	return func() {
+		noticeReadInterfaces = old
+	}
+}

--- a/daemon/ucrednet.go
+++ b/daemon/ucrednet.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,8 +25,11 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	sys "syscall"
+
+	"github.com/snapcore/snapd/strutil"
 )
 
 var errNoID = errors.New("no pid/uid found")
@@ -39,14 +42,14 @@ const (
 var raddrRegexp = regexp.MustCompile(`^pid=(\d+);uid=(\d+);socket=([^;]*);(iface=([^;]*);)?$`)
 
 var ucrednetGet = ucrednetGetImpl
-var ucrednetGetWithInterface = ucrednetGetWithInterfaceImpl
+var ucrednetGetWithInterfaces = ucrednetGetWithInterfacesImpl
 
 func ucrednetGetImpl(remoteAddr string) (*ucrednet, error) {
-	uc, _, err := ucrednetGetWithInterface(remoteAddr)
+	uc, _, err := ucrednetGetWithInterfaces(remoteAddr)
 	return uc, err
 }
 
-func ucrednetGetWithInterfaceImpl(remoteAddr string) (ucred *ucrednet, iface string, err error) {
+func ucrednetGetWithInterfacesImpl(remoteAddr string) (ucred *ucrednet, ifaces []string, err error) {
 	// NOTE treat remoteAddr at one point included a user-controlled
 	// string. In case that happens again by accident, treat it as tainted,
 	// and be very suspicious of it.
@@ -62,20 +65,42 @@ func ucrednetGetWithInterfaceImpl(remoteAddr string) (ucred *ucrednet, iface str
 		if v, err := strconv.ParseUint(subs[2], 10, 32); err == nil {
 			u.Uid = uint32(v)
 		}
+		// group: ([^;]*) - socket path following socket=
 		u.Socket = subs[3]
-		if len(subs) == 6 {
-			iface = subs[5]
+		// group: (iface=([^;]*);)
+		if len(subs[4]) > 0 {
+			// group: ([^;]*) - actual interfaces joined together with & separator
+			ifaces = strings.Split(subs[5], "&")
 		}
 	}
 	if u.Pid == ucrednetNoProcess || u.Uid == ucrednetNobody {
-		return nil, "", errNoID
+		return nil, nil, errNoID
 	}
 
-	return u, iface, nil
+	return u, ifaces, nil
 }
 
 func ucrednetAttachInterface(remoteAddr, iface string) string {
-	return fmt.Sprintf("%siface=%s;", remoteAddr, iface)
+	inds := raddrRegexp.FindStringSubmatchIndex(remoteAddr)
+	if inds == nil {
+		// This should only occur if remoteAddr is invalid.
+		return fmt.Sprintf("%siface=%s;", remoteAddr, iface)
+	}
+	// start of string matching group "(iface=([^;]*);)"
+	ifaceSubStart := inds[8]
+	ifaceSubEnd := inds[9]
+	if ifaceSubStart == ifaceSubEnd {
+		// "(iface=([^;]*);)" not present.
+		return fmt.Sprintf("%siface=%s;", remoteAddr, iface)
+	}
+	// string matching group "([^;]*)" within "(iface=([^;]*);)"
+	ifacesStr := remoteAddr[inds[10]:inds[11]]
+	ifaces := strings.Split(ifacesStr, "&")
+	if strutil.ListContains(ifaces, iface) {
+		return remoteAddr
+	}
+	ifaces = append(ifaces, iface)
+	return fmt.Sprintf("%siface=%s;", remoteAddr[:ifaceSubStart], strings.Join(ifaces, "&"))
 }
 
 type ucrednet struct {


### PR DESCRIPTION
For the some endpoints, including `/v2/notices`, we need to allow multiple interfaces to grant snaps access via `interfaceOpenAccess` or `interfaceAuthenticatedAccess`. Thus, the `Interface string` field in these structs should be replaced with `Interfaces []string`.

Accordingly, the optional `iface=` field in `RemoteAddr` should also support multiple interfaces. To do so, the relevant functions in `daemon/ucrednet.go` now support values of the form `iface=foo&bar&baz;`, which are added/parsed as `"foo"`, `"bar"`, and `"baz"`. That is, `ucrednetGetWithInterface(remoteAddr)` now returns `ifaces []string` instead of `iface string`, in case `remoteAddr` has an `iface=` value with multiple `'&'`-separated interfaces.

Importantly, `ucrednetAttachInterface` is now idempotent. Regardless of the initial state, calling `ucrednetAttachInterface(remoteAddr, iface)` will ensure that there is an `iface=` field and that it contains the value `iface` exactly once. Any other interfaces which were already values to `iface=` will still be included exactly as before.