### PR TITLE
release: Add OnTouch as a variant of OnClassic & enable Extrausers

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -542,7 +542,7 @@ func checkAndCreateSystemUsernames(si *snap.Info) error {
 
 	// then create
 	// TODO: move user creation to a more appropriate place like "link-snap"
-	extrausers := !release.OnClassic
+	extrausers := !release.OnClassic || release.OnTouch
 	for _, user := range si.SystemUsernames {
 		id := snap.SupportedSystemUsernames[user.Name].Id
 		switch user.Scope {

--- a/release/release.go
+++ b/release/release.go
@@ -187,6 +187,11 @@ var OnClassic bool
 // OnCoreDesktop states whether the process is running inside a Core Desktop image.
 var OnCoreDesktop bool
 
+// OnTouch states whether the process is running inside a Touch image
+// with a classic (but mostly read-only) filesystem layout.
+// It is a narrowed down variant of OnClassic
+var OnTouch bool
+
 // OnWSL states whether the process is running inside the Windows
 // Subsystem for Linux
 var OnWSL bool
@@ -204,6 +209,8 @@ func init() {
 	OnClassic = (ReleaseInfo.ID != "ubuntu-core")
 
 	OnCoreDesktop = (ReleaseInfo.ID == "ubuntu-core" && ReleaseInfo.VariantID == "desktop")
+
+	OnTouch = (OnClassic && ReleaseInfo.VariantID == "touch")
 
 	WSLVersion = getWSLVersion()
 	OnWSL = WSLVersion != 0


### PR DESCRIPTION
Ubuntu Touch as a "read-only by design" OS does need to adapt slightly differently from Ubuntu Desktop & Ubuntu Core.

It isn't a traditional classic rootfs setup, but it isn't a Snap-only environment either, so special precautions need to be taken care of in order to enable certain functionality on it.

Therefore this PR:

- introduces an `OnTouch` property which states the runtime environment to be Ubuntu Touch
- makes use of that to enable multiuser Snaps like for CUPS through extrausers