### PR TITLE
usersession: Use the app name from .desktop file in notifications

### DIFF
--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -21,15 +21,18 @@ package agent
 
 import (
 	"syscall"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 var (
-	SessionInfoCmd                = sessionInfoCmd
-	ServiceControlCmd             = serviceControlCmd
-	ServiceStatusCmd              = serviceStatusCmd
-	PendingRefreshNotificationCmd = pendingRefreshNotificationCmd
-	FinishRefreshNotificationCmd  = finishRefreshNotificationCmd
-	GuessAppData                  = guessAppData
+	SessionInfoCmd                     = sessionInfoCmd
+	ServiceControlCmd                  = serviceControlCmd
+	ServiceStatusCmd                   = serviceStatusCmd
+	PendingRefreshNotificationCmd      = pendingRefreshNotificationCmd
+	FinishRefreshNotificationCmd       = finishRefreshNotificationCmd
+	GuessAppData                       = guessAppData
+	GetLocalizedAppNameFromDesktopFile = getLocalizedAppNameFromDesktopFile
 )
 
 func MockUcred(ucred *syscall.Ucred, err error) (restore func()) {
@@ -48,5 +51,14 @@ func MockNoBus(agent *SessionAgent) (restore func()) {
 	agent.bus = nil
 	return func() {
 		agent.bus = bus
+	}
+}
+
+func MockCurrentLocale(newLocale string) (restore func()) {
+	currentLocale = func() string {
+		return newLocale
+	}
+	return func() {
+		currentLocale = i18n.CurrentLocale
 	}
 }

--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -29,7 +29,7 @@ var (
 	ServiceStatusCmd              = serviceStatusCmd
 	PendingRefreshNotificationCmd = pendingRefreshNotificationCmd
 	FinishRefreshNotificationCmd  = finishRefreshNotificationCmd
-	GuessAppIcon                  = guessAppIcon
+	GuessAppData                  = guessAppData
 )
 
 func MockUcred(ucred *syscall.Ucred, err error) (restore func()) {

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -463,7 +463,8 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 	return SyncResponse(nil)
 }
 
-func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon string, name string) {
+func guessAppData(si *snap.Info, defaultName string, instanceKey string) (string, string) {
+	var name, icon string
 	parser := goconfigparser.New()
 
 	// trivial heuristic, if the app is named like a snap then

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -479,7 +479,7 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon s
 	}
 
 	if icon != "" {
-		return icon, name
+		return
 	}
 
 	// If it doesn't exist, take the first app in the snap with a DesktopFile with icon
@@ -494,8 +494,7 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon s
 			}
 		}
 	}
-
-	return icon, name
+	return
 }
 
 func combineNameAndKey(name, key string) string {

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -463,8 +463,7 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 	return SyncResponse(nil)
 }
 
-func guessAppData(si *snap.Info, defaultName string, instanceKey string) (string, string) {
-	var icon, name string
+func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon string, name string) {
 	parser := goconfigparser.New()
 
 	// trivial heuristic, if the app is named like a snap then
@@ -474,13 +473,13 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (string
 	if ok && !mainApp.IsService() {
 		// got the main app, grab its desktop file
 		if err := parser.ReadFile(mainApp.DesktopFile()); err == nil {
-			name = getLocalizedAppNameFromDesktopFile(parser, defaultName)
+			name = combineNameAndKey(getLocalizedAppNameFromDesktopFile(parser, defaultName), instanceKey)
 			icon, _ = parser.Get("Desktop Entry", "Icon")
 		}
 	}
 
 	if icon != "" {
-		return icon, combineNameAndKey(name, instanceKey)
+		return icon, name
 	}
 
 	// If it doesn't exist, take the first app in the snap with a DesktopFile with icon
@@ -489,14 +488,14 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (string
 			continue
 		}
 		if err := parser.ReadFile(app.DesktopFile()); err == nil {
-			name = getLocalizedAppNameFromDesktopFile(parser, defaultName)
+			name = combineNameAndKey(getLocalizedAppNameFromDesktopFile(parser, defaultName), instanceKey)
 			if icon, err = parser.Get("Desktop Entry", "Icon"); err == nil && icon != "" {
 				break
 			}
 		}
 	}
 
-	return icon, combineNameAndKey(name, instanceKey)
+	return icon, name
 }
 
 func combineNameAndKey(name, key string) string {

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -463,8 +463,7 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 	return SyncResponse(nil)
 }
 
-func guessAppData(si *snap.Info, defaultName string, instanceKey string) (string, string) {
-	var name, icon string
+func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon string, name string) {
 	parser := goconfigparser.New()
 
 	// trivial heuristic, if the app is named like a snap then

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -350,15 +350,17 @@ func serviceStatus(c *Command, r *http.Request) Response {
 	return SyncResponse(unitStatusToClientUnitStatus(stss))
 }
 
+var currentLocale = i18n.CurrentLocale
+
 func getLocalizedAppNameFromDesktopFile(parser *goconfigparser.ConfigParser, defaultName string) string {
 	// First try with full locale string (e.g. es_ES)
-	locale := fmt.Sprintf("Name[%s]", i18n.CurrentLocale())
+	locale := fmt.Sprintf("Name[%s]", currentLocale())
 	if name, err := parser.Get("Desktop Entry", locale); err == nil && name != "" {
 		return name
 	}
 
 	// If not found, try with the country part
-	locale = fmt.Sprintf("Name[%s]", strings.Split(i18n.CurrentLocale(), "_")[0])
+	locale = fmt.Sprintf("Name[%s]", strings.Split(currentLocale(), "_")[0])
 	if name, err := parser.Get("Desktop Entry", locale); err == nil && name != "" {
 		return name
 	}

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -479,7 +479,7 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon s
 	}
 
 	if icon != "" {
-		return
+		return icon, name
 	}
 
 	// If it doesn't exist, take the first app in the snap with a DesktopFile with icon
@@ -494,7 +494,8 @@ func guessAppData(si *snap.Info, defaultName string, instanceKey string) (icon s
 			}
 		}
 	}
-	return
+
+	return icon, name
 }
 
 func combineNameAndKey(name, key string) string {

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -953,7 +953,7 @@ func addAppToSnap(c *C, snapinfo *snap.Info, app string, isService bool, icon st
 func (s *restSuite) TestGuessAppIconNoIconPrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", false, "", "")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "")
 	c.Check(name, Equals, "")
 }
@@ -961,7 +961,7 @@ func (s *restSuite) TestGuessAppIconNoIconPrefixEqualApp(c *C) {
 func (s *restSuite) TestGuessAppIconNoIconPrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "", "")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "")
 	c.Check(name, Equals, "")
 }
@@ -969,7 +969,7 @@ func (s *restSuite) TestGuessAppIconNoIconPrefixDifferentApp(c *C) {
 func (s *restSuite) TestGuessAppIconPrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "iconname", "appname")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "iconname")
 	c.Check(name, Equals, "appname")
 }
@@ -978,7 +978,7 @@ func (s *restSuite) TestGuessAppIconPrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", false, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "iconname1")
 	c.Check(name, Equals, "appname1")
 }
@@ -986,7 +986,7 @@ func (s *restSuite) TestGuessAppIconPrefixEqualApp(c *C) {
 func (s *restSuite) TestGuessAppIconServicePrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname", "appname")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "")
 	c.Check(name, Equals, "")
 }
@@ -994,7 +994,7 @@ func (s *restSuite) TestGuessAppIconServicePrefixEqualApp(c *C) {
 func (s *restSuite) TestGuessAppIconServicePrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", true, "iconname", "appname")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "")
 	c.Check(name, Equals, "")
 }
@@ -1003,7 +1003,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoApps(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "iconname2")
 	c.Check(name, Equals, "appname2")
 }
@@ -1012,7 +1012,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoAppsServices(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", true, "iconname2", "appname2")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "")
 	c.Check(name, Equals, "")
 }
@@ -1021,7 +1021,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoAppsOneServicePrefixDifferent(c *C
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	c.Check(icon, Equals, "iconname2")
 	c.Check(name, Equals, "appname2")
 }
@@ -1030,7 +1030,7 @@ func (s *restSuite) TestGuessAppIconTwoAppsPrefixDifferent(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
-	icon, name := agent.GuessAppData(si, "")
+	icon, name := agent.GuessAppData(si, "", "")
 	if (icon != "iconname1") && (icon != "iconname2") {
 		c.Fail()
 	}
@@ -1040,6 +1040,14 @@ func (s *restSuite) TestGuessAppIconTwoAppsPrefixDifferent(c *C) {
 	if (icon == "iconname2") && (name != "appname2") {
 		c.Fail()
 	}
+}
+
+func (s *restSuite) TestGuessAppIconWithKey(c *C) {
+	si := createSnapInfo("snap1")
+	addAppToSnap(c, si, "app1", false, "iconname", "appname")
+	icon, name := agent.GuessAppData(si, "", "akey")
+	c.Check(icon, Equals, "iconname")
+	c.Check(name, Equals, "appname (akey)")
 }
 
 func (s *restSuite) TestPostCloseRefreshNotificationWithIconDefault(c *C) {

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -950,7 +950,7 @@ func addAppToSnap(c *C, snapinfo *snap.Info, app string, isService bool, icon st
 	createDesktopFile(c, newInfo.DesktopFile(), icon, name, nil)
 }
 
-func (s *restSuite) TestGuessAppIconNoIconPrefixEqualApp(c *C) {
+func (s *restSuite) TestGuessAppDataNoIconPrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", false, "", "")
 	icon, name := agent.GuessAppData(si, "", "")
@@ -958,7 +958,7 @@ func (s *restSuite) TestGuessAppIconNoIconPrefixEqualApp(c *C) {
 	c.Check(name, Equals, "")
 }
 
-func (s *restSuite) TestGuessAppIconNoIconPrefixDifferentApp(c *C) {
+func (s *restSuite) TestGuessAppDataNoIconPrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "", "")
 	icon, name := agent.GuessAppData(si, "", "")
@@ -966,7 +966,7 @@ func (s *restSuite) TestGuessAppIconNoIconPrefixDifferentApp(c *C) {
 	c.Check(name, Equals, "")
 }
 
-func (s *restSuite) TestGuessAppIconPrefixDifferentApp(c *C) {
+func (s *restSuite) TestGuessAppDataPrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "iconname", "appname")
 	icon, name := agent.GuessAppData(si, "", "")
@@ -974,7 +974,7 @@ func (s *restSuite) TestGuessAppIconPrefixDifferentApp(c *C) {
 	c.Check(name, Equals, "appname")
 }
 
-func (s *restSuite) TestGuessAppIconPrefixEqualApp(c *C) {
+func (s *restSuite) TestGuessAppDataPrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", false, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
@@ -983,7 +983,7 @@ func (s *restSuite) TestGuessAppIconPrefixEqualApp(c *C) {
 	c.Check(name, Equals, "appname1")
 }
 
-func (s *restSuite) TestGuessAppIconServicePrefixEqualApp(c *C) {
+func (s *restSuite) TestGuessAppDataServicePrefixEqualApp(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname", "appname")
 	icon, name := agent.GuessAppData(si, "", "")
@@ -991,7 +991,7 @@ func (s *restSuite) TestGuessAppIconServicePrefixEqualApp(c *C) {
 	c.Check(name, Equals, "")
 }
 
-func (s *restSuite) TestGuessAppIconServicePrefixDifferentApp(c *C) {
+func (s *restSuite) TestGuessAppDataServicePrefixDifferentApp(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", true, "iconname", "appname")
 	icon, name := agent.GuessAppData(si, "", "")
@@ -999,7 +999,7 @@ func (s *restSuite) TestGuessAppIconServicePrefixDifferentApp(c *C) {
 	c.Check(name, Equals, "")
 }
 
-func (s *restSuite) TestGuessAppIconServiceTwoApps(c *C) {
+func (s *restSuite) TestGuessAppDataServiceTwoApps(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
@@ -1008,7 +1008,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoApps(c *C) {
 	c.Check(name, Equals, "appname2")
 }
 
-func (s *restSuite) TestGuessAppIconServiceTwoAppsServices(c *C) {
+func (s *restSuite) TestGuessAppDataServiceTwoAppsServices(c *C) {
 	si := createSnapInfo("app1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", true, "iconname2", "appname2")
@@ -1017,7 +1017,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoAppsServices(c *C) {
 	c.Check(name, Equals, "")
 }
 
-func (s *restSuite) TestGuessAppIconServiceTwoAppsOneServicePrefixDifferent(c *C) {
+func (s *restSuite) TestGuessAppDataServiceTwoAppsOneServicePrefixDifferent(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", true, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
@@ -1026,7 +1026,7 @@ func (s *restSuite) TestGuessAppIconServiceTwoAppsOneServicePrefixDifferent(c *C
 	c.Check(name, Equals, "appname2")
 }
 
-func (s *restSuite) TestGuessAppIconTwoAppsPrefixDifferent(c *C) {
+func (s *restSuite) TestGuessAppDataTwoAppsPrefixDifferent(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "iconname1", "appname1")
 	addAppToSnap(c, si, "app2", false, "iconname2", "appname2")
@@ -1042,7 +1042,7 @@ func (s *restSuite) TestGuessAppIconTwoAppsPrefixDifferent(c *C) {
 	}
 }
 
-func (s *restSuite) TestGuessAppIconWithKey(c *C) {
+func (s *restSuite) TestGuessAppDataWithKey(c *C) {
 	si := createSnapInfo("snap1")
 	addAppToSnap(c, si, "app1", false, "iconname", "appname")
 	icon, name := agent.GuessAppData(si, "", "akey")


### PR DESCRIPTION
Currently, when a notification is shown to the user to inform they that there is an update for an open snap, the snap name is used, which can be misleading to the user.

This PR uses the application name from the .desktop file, taking into account the current locale of the user.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
