### PR TITLE
overlord: create the drivers tree only if it will be mounted

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2796,7 +2796,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	// set a model assertion
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
-		"base":         "core20",
+		"base":         "core24",
 		"grade":        "dangerous",
 		"snaps": []interface{}{
 			map[string]interface{}{
@@ -2821,10 +2821,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	})
 
 	// install snaps for current model
-	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", nil, nil)
+	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
 	// install snaps that will be needed for new model
-	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", nil, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core24-new", nil, &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-new"),
 		Revision: snap.R(222),
 		RealName: "pc-new",
@@ -2838,10 +2838,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 		Channel:  "20/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", nil, &snap.SideInfo{
-		SnapID:   snaptest.AssertedSnapID("core20-new"),
+	snapstatetest.InstallSnap(c, s.state, "name: core24-new\nversion: 1\ntype: base\n", nil, &snap.SideInfo{
+		SnapID:   snaptest.AssertedSnapID("core24-new"),
 		Revision: snap.R(222),
-		RealName: "core20-new",
+		RealName: "core24-new",
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
@@ -2857,7 +2857,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
-		"base":     "core20-new",
+		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
 		"snaps": []interface{}{
@@ -2936,10 +2936,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateAssetsKernel.Summary(), Equals, `Update assets from kernel "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareBase.Kind(), Equals, "prepare-snap")
-	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core20-new" (222) for remodel`)
+	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core24-new" (222) for remodel`)
 	c.Assert(tPrepareBase.WaitTasks(), HasLen, 1)
 	c.Assert(tLinkBase.Kind(), Equals, "link-snap")
-	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core20-new" (222) available to the system during remodel`)
+	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core24-new" (222) available to the system during remodel`)
 	c.Assert(tPrepareGadget.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareGadget.Summary(), Equals, `Prepare snap "pc-new" (222) for remodel`)
 	c.Assert(tPrepareGadget.WaitTasks(), HasLen, 1)
@@ -3053,7 +3053,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	// set a model assertion
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
-		"base":         "core20",
+		"base":         "core24",
 		"grade":        "dangerous",
 		"snaps": []interface{}{
 			map[string]interface{}{
@@ -3078,10 +3078,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	})
 
 	// install snaps for current model
-	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", nil, nil)
+	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
 	// install snaps that will be needed for new model
-	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new", nil, &snap.SideInfo{
+	snapstatetest.InstallSnap(c, s.state, "name: pc-new\nversion: 1\ntype: gadget\nbase: core24-new", nil, &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("pc-new"),
 		Revision: snap.R(222),
 		RealName: "pc-new",
@@ -3095,10 +3095,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 		Channel:  "20/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	snapstatetest.InstallSnap(c, s.state, "name: core20-new\nversion: 1\ntype: base\n", nil, &snap.SideInfo{
-		SnapID:   snaptest.AssertedSnapID("core20-new"),
+	snapstatetest.InstallSnap(c, s.state, "name: core24-new\nversion: 1\ntype: base\n", nil, &snap.SideInfo{
+		SnapID:   snaptest.AssertedSnapID("core24-new"),
 		Revision: snap.R(222),
-		RealName: "core20-new",
+		RealName: "core24-new",
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
@@ -3114,7 +3114,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
-		"base":     "core20-new",
+		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
 		"snaps": []interface{}{
@@ -3193,10 +3193,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateAssetsKernel.Summary(), Equals, `Update assets from kernel "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareBase.Kind(), Equals, "prepare-snap")
-	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core20-new" (222) for remodel`)
+	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core24-new" (222) for remodel`)
 	c.Assert(tPrepareBase.WaitTasks(), HasLen, 1)
 	c.Assert(tLinkBase.Kind(), Equals, "link-snap")
-	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core20-new" (222) available to the system during remodel`)
+	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core24-new" (222) available to the system during remodel`)
 	c.Assert(tSwitchGadget.Kind(), Equals, "switch-snap")
 	c.Assert(tSwitchGadget.Summary(), Equals, `Switch snap "pc-new" from channel "20/stable" to "20/edge"`)
 	c.Assert(tSwitchGadget.WaitTasks(), HasLen, 1)
@@ -3311,7 +3311,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	// set a model assertion
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
-		"base":         "core20",
+		"base":         "core24",
 		"grade":        "dangerous",
 		"snaps": []interface{}{
 			map[string]interface{}{
@@ -3362,15 +3362,15 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		TrackingChannel: "20/stable",
 	})
 	// new gadget, base and kernel which are already installed
-	for _, alreadyInstalledName := range []string{"pc-new", "pc-kernel-new", "core20-new"} {
+	for _, alreadyInstalledName := range []string{"pc-new", "pc-kernel-new", "core24-new"} {
 		snapYaml := "name: pc-kernel-new\nversion: 1\ntype: kernel\n"
 		channel := "20/stable"
 		switch alreadyInstalledName {
-		case "core20-new":
-			snapYaml = "name: core20-new\nversion: 1\ntype: base\n"
+		case "core24-new":
+			snapYaml = "name: core24-new\nversion: 1\ntype: base\n"
 			channel = "latest/stable"
 		case "pc-new":
-			snapYaml = "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new\n"
+			snapYaml = "name: pc-new\nversion: 1\ntype: gadget\nbase: core24-new\n"
 		}
 		si := &snap.SideInfo{
 			RealName: alreadyInstalledName,
@@ -3390,7 +3390,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
-		"base":     "core20-new",
+		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
 		"snaps": []interface{}{
@@ -3453,10 +3453,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateAssetsKernel.Summary(), Equals, `Update assets from kernel "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareBase.Kind(), Equals, "prepare-snap")
-	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core20-new" (222) for remodel`)
+	c.Assert(tPrepareBase.Summary(), Equals, `Prepare snap "core24-new" (222) for remodel`)
 	c.Assert(tPrepareBase.WaitTasks(), HasLen, 1)
 	c.Assert(tLinkBase.Kind(), Equals, "link-snap")
-	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core20-new" (222) available to the system during remodel`)
+	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core24-new" (222) available to the system during remodel`)
 	c.Assert(tPrepareGadget.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareGadget.Summary(), Equals, `Prepare snap "pc-new" (222) for remodel`)
 	c.Assert(tPrepareGadget.WaitTasks(), HasLen, 1)
@@ -3560,7 +3560,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	callsToMockedUpdate := 0
 	restore := devicestate.MockSnapstateUpdateWithDeviceContext(func(st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, prqt snapstate.PrereqTracker, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
-		c.Assert(strutil.ListContains([]string{"core20-new", "pc-kernel-new", "pc-new"}, name), Equals, true,
+		c.Assert(strutil.ListContains([]string{"core24-new", "pc-kernel-new", "pc-new"}, name), Equals, true,
 			Commentf("unexpected snap %q", name))
 		callsToMockedUpdate++
 		c.Check(flags.Required, Equals, false)
@@ -3572,7 +3572,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		tSwitchChannel := s.state.NewTask("switch-snap-channel", fmt.Sprintf("Switch %s channel to %s", name, opts.Channel))
 		typ := "kernel"
 		rev := snap.R(222)
-		if name == "core20-new" {
+		if name == "core24-new" {
 			typ = "base"
 			rev = snap.R(223)
 		} else if name == "pc-new" {
@@ -3597,7 +3597,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	callsToMockedUpdatePath := 0
 	restore = devicestate.MockSnapstateUpdatePathWithDeviceContext(func(st *state.State, si *snap.SideInfo, path, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, prqt snapstate.PrereqTracker, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
 		callsToMockedUpdatePath++
-		c.Assert(strutil.ListContains([]string{"core20-new", "pc-kernel-new", "pc-new"}, name), Equals, true,
+		c.Assert(strutil.ListContains([]string{"core24-new", "pc-kernel-new", "pc-new"}, name), Equals, true,
 			Commentf("unexpected snap %q", name))
 		c.Check(flags.Required, Equals, false)
 		c.Check(flags.NoReRefresh, Equals, true)
@@ -3608,7 +3608,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		// switch channel using SideInfo from the local snap
 		tSwitchChannel := s.state.NewTask("switch-snap-channel", fmt.Sprintf("Switch %s channel to %s", name, opts.Channel))
 		typ := "kernel"
-		if name == "core20-new" {
+		if name == "core24-new" {
 			typ = "base"
 		} else if name == "pc-new" {
 			typ = "gadget"
@@ -3638,7 +3638,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	// set a model assertion
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
-		"base":         "core20",
+		"base":         "core24",
 		"grade":        "dangerous",
 		"snaps": []interface{}{
 			map[string]interface{}{
@@ -3689,13 +3689,13 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		TrackingChannel: "20/stable",
 	})
 	// new gadget and kernel which are already installed
-	for _, alreadyInstalledName := range []string{"pc-kernel-new", "core20-new", "pc-new"} {
+	for _, alreadyInstalledName := range []string{"pc-kernel-new", "core24-new", "pc-new"} {
 		snapYaml := "name: pc-kernel-new\nversion: 1\ntype: kernel\n"
 		channel := "other/edge"
-		if alreadyInstalledName == "core20-new" {
-			snapYaml = "name: core20-new\nversion: 1\ntype: base\n"
+		if alreadyInstalledName == "core24-new" {
+			snapYaml = "name: core24-new\nversion: 1\ntype: base\n"
 		} else if alreadyInstalledName == "pc-new" {
-			snapYaml = "name: pc-new\nversion: 1\ntype: gadget\nbase: core20-new\n"
+			snapYaml = "name: pc-new\nversion: 1\ntype: gadget\nbase: core24-new\n"
 		}
 		si := &snap.SideInfo{
 			RealName: alreadyInstalledName,
@@ -3715,7 +3715,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
-		"base":     "core20-new",
+		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
 		"snaps": []interface{}{
@@ -3736,8 +3736,8 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 			},
 			map[string]interface{}{
 				// similar case for the base snap
-				"name":            "core20-new",
-				"id":              snaptest.AssertedSnapID("core20-new"),
+				"name":            "core24-new",
+				"id":              snaptest.AssertedSnapID("core24-new"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
@@ -3747,7 +3747,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	var localSnaps []*snap.SideInfo
 	var paths []string
 	if opts.localSnaps {
-		for i, name := range []string{"pc-kernel-new", "core20-new", "pc-new"} {
+		for i, name := range []string{"pc-kernel-new", "core24-new", "pc-new"} {
 			si, path := createLocalSnap(c, name, snaptest.AssertedSnapID(name), 222+i, "", "", nil)
 			localSnaps = append(localSnaps, si)
 			paths = append(paths, path)
@@ -3808,9 +3808,9 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tSwitchChannelBase.Kind(), Equals, "switch-snap-channel")
-	c.Assert(tSwitchChannelBase.Summary(), Equals, `Switch core20-new channel to latest/stable`)
+	c.Assert(tSwitchChannelBase.Summary(), Equals, `Switch core24-new channel to latest/stable`)
 	c.Assert(tLinkBase.Kind(), Equals, "link-snap")
-	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core20-new" (223) available to the system during remodel`)
+	c.Assert(tLinkBase.Summary(), Equals, `Make snap "core24-new" (223) available to the system during remodel`)
 	c.Assert(tSwitchChannelGadget.Kind(), Equals, "switch-snap-channel")
 	c.Assert(tSwitchChannelGadget.Summary(), Equals, `Switch pc-new channel to 20/stable`)
 	c.Assert(tUpdateAssetsFromGadget.Kind(), Equals, "update-gadget-assets")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4922,7 +4922,7 @@ const (
 	noConfigure = 1 << iota
 	isGadget
 	isKernel
-	hasModeenv
+	needsKernelSetup
 )
 
 func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags int) int {
@@ -4934,7 +4934,7 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 		if flags&isKernel != 0 {
 			what = "kernel"
 		}
-		if flags&isKernel != 0 && flags&hasModeenv != 0 {
+		if flags&isKernel != 0 && flags&needsKernelSetup != 0 {
 			c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup kernel driver tree for "%s" (%s)`, name, revno))
 			i++
 		}
@@ -4951,7 +4951,7 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Make snap "%s" (%s) available to the system`, name, revno))
 	i++
-	if flags&isKernel != 0 && flags&hasModeenv != 0 {
+	if flags&isKernel != 0 && flags&needsKernelSetup != 0 {
 		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Cleanup kernel driver tree for "%s" (%s)`, name, revno))
 		i++
 	}
@@ -4995,7 +4995,7 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 		if flags&isKernel != 0 {
 			what = "kernel"
 		}
-		if flags&isKernel != 0 && flags&hasModeenv != 0 {
+		if flags&isKernel != 0 && flags&needsKernelSetup != 0 {
 			c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup kernel driver tree for "%s" (%s)`, name, revno))
 			i++
 		}
@@ -5014,7 +5014,7 @@ func validateRefreshTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
 	i++
-	if flags&isKernel != 0 && flags&hasModeenv != 0 {
+	if flags&isKernel != 0 && flags&needsKernelSetup != 0 {
 		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Cleanup kernel driver tree for "%s" (%s)`, name, revno))
 		i++
 	}
@@ -8025,7 +8025,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all installs in sequential order
-	validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
+	validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
 }
 
 func (s *mgrsSuiteCore) TestRemodelUC20DifferentGadgetChannel(c *C) {
@@ -9681,7 +9681,7 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all refreshes and install in sequential order (no configure hooks for bases though)
-	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
+	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
 	i += validateInstallTasks(c, tasks[i:], "core22", "1", noConfigure)
 	i += validateRefreshTasks(c, tasks[i:], "pc", "34", isGadget)
 	// finally new model assertion
@@ -9993,7 +9993,7 @@ func (s *mgrsSuiteCore) testRemodelUC20ToUC22(c *C, mockSnapdRefresh bool) {
 	// then create recovery
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then all refreshes and install in sequential order (no configure hooks for bases though)
-	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel|hasModeenv)
+	i += validateRefreshTasks(c, tasks[i:], "pc-kernel", "33", isKernel)
 	i += validateInstallTasks(c, tasks[i:], "core22", "1", noConfigure)
 	i += validateRefreshTasks(c, tasks[i:], "pc", "34", isGadget)
 	// finally new model assertion

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -541,16 +542,17 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 
 	// we need to know some of the characteristics of the device - it is
-	// expected to always have a model/device context at this point. Note
-	// that in a remodel this would use the old model, but that does not
-	// matter for the information we want to extract from deviceCtx here.
+	// expected to always have a model/device context at this point.
+	// TODO in a remodel this would use the old model, we need to fix this
+	// as needsKernelSetup needs to know the new model for UC2{0,2} -> UC24
+	// remodel case.
 	deviceCtx, err := DeviceCtx(st, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// This task is necessary only for UC20+ and hybrid
-	if deviceCtx.HasModeenv() && snapsup.Type == snap.TypeKernel {
+	if snapsup.Type == snap.TypeKernel && needsKernelSetup(deviceCtx) {
 		setupKernel := st.NewTask("setup-kernel-snap", fmt.Sprintf(i18n.G("Setup kernel driver tree for %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(setupKernel)
 		prev = setupKernel
@@ -614,7 +616,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	addTask(autoConnect)
 	prev = autoConnect
 
-	if deviceCtx.HasModeenv() && snapsup.Type == snap.TypeKernel {
+	if snapsup.Type == snap.TypeKernel && needsKernelSetup(deviceCtx) {
 		// This task needs to run after we're back and running the new
 		// kernel after a reboot was requested in link-snap handler.
 		setupKernel := st.NewTask("remove-old-kernel-snap-setup", fmt.Sprintf(i18n.G("Cleanup kernel driver tree for %q%s"), snapsup.InstanceName(), revisionStr))
@@ -790,6 +792,54 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	installSet.MarkEdge(healthCheck, EndEdge)
 
 	return installSet, nil
+}
+
+func needsKernelSetup(devCtx DeviceContext) bool {
+	// Must be UC20+ or hybrid
+	if !devCtx.HasModeenv() {
+		return false
+	}
+
+	// Check that we have a snapd-generator that will create mount
+	// units for the drivers tree, for both classic & UC
+	if devCtx.Classic() {
+		// We run the generator from the deb package, so check its version
+		snapdInfoDir := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir)
+		debVersion, _, err := snapdtool.SnapdVersionFromInfoFile(snapdInfoDir)
+		if err != nil {
+			return false
+		}
+
+		res, err := strutil.VersionCompare(debVersion, "2.62")
+		if err != nil {
+			logger.Noticef("cannot compare %q to 2.62: %v", debVersion, err)
+			return false
+		}
+		if res >= 0 {
+			return true
+		}
+	} else {
+		// We assume core24 onwards has the generator, for older boot bases
+		// we return false.
+		// TODO this won't work for a UC2{0,2} -> UC24+ remodel as we
+		// need the context created from the new model. Get to this
+		// ASAP after snapd 2.62 release.
+		baseSn := devCtx.Model().BaseSnap()
+		if baseSn == nil {
+			logger.Noticef("internal error: no base in model")
+			return false
+		}
+		// TODO in remodeling we are not getting the right answer,
+		// how to fix that?
+		switch baseSn.SnapName() {
+		case "core20", "core22", "core22-desktop":
+			return false
+		default:
+			return true
+		}
+	}
+
+	return false
 }
 
 func findTasksMatchingKindAndSnap(st *state.State, kind string, snapName string, revision snap.Revision) ([]*state.Task, error) {
@@ -3078,14 +3128,14 @@ func LinkNewBaseOrKernel(st *state.State, name string, fromChange string) (*stat
 	ts := state.NewTaskSet(prepareSnap)
 	// preserve the same order as during the update
 	if info.Type() == snap.TypeKernel {
-		// Note that in a remodel this would use the old model, but
-		// that does not matter for the information we want to extract
-		// from deviceCtx here.
+		// TODO in a remodel this would use the old model, we need to fix this
+		// as needsKernelSetup needs to know the new model for UC2{0,2} -> UC24
+		// remodel case.
 		deviceCtx, err := DeviceCtx(st, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-		if deviceCtx.HasModeenv() {
+		if needsKernelSetup(deviceCtx) {
 			setupKernel := st.NewTask("setup-kernel-snap", fmt.Sprintf(i18n.G("Setup kernel driver tree for %q (%s) for remodel"), snapsup.InstanceName(), snapst.Current))
 			ts.AddTask(setupKernel)
 			setupKernel.Set("snap-setup-task", prepareSnap.ID())
@@ -3137,14 +3187,14 @@ func AddLinkNewBaseOrKernel(st *state.State, ts *state.TaskSet) (*state.TaskSet,
 	prev := allTasks[len(allTasks)-1]
 	// preserve the same order as during the update
 	if snapsup.Type == snap.TypeKernel {
-		// Note that in a remodel this would use the old model, but
-		// that does not matter for the information we want to extract
-		// from deviceCtx here.
+		// TODO in a remodel this would use the old model, we need to fix this
+		// as needsKernelSetup needs to know the new model for UC2{0,2} -> UC24
+		// remodel case.
 		deviceCtx, err := DeviceCtx(st, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-		if deviceCtx.HasModeenv() {
+		if needsKernelSetup(deviceCtx) {
 			setupKernel := st.NewTask("setup-kernel-snap", fmt.Sprintf(i18n.G("Setup kernel driver tree for %q (%s) for remodel"), snapsup.InstanceName(), snapsup.Revision()))
 			setupKernel.Set("snap-setup-task", snapSetupTask.ID())
 			setupKernel.WaitFor(prev)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -64,7 +64,7 @@ import (
 )
 
 func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []string, filterOut map[string]bool) []string {
-	if !release.OnClassic {
+	if !release.OnClassic || opts&isHybrid != 0 {
 		switch typ {
 		case snap.TypeGadget:
 			opts |= updatesGadget
@@ -99,7 +99,7 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 		)
 		expected = append(expected, "unlink-current-snap")
 	}
-	if opts&updatesGadgetAssets != 0 && opts&hasModeenv != 0 {
+	if opts&updatesGadgetAssets != 0 && opts&needsKernelSetup != 0 {
 		expected = append(expected, "setup-kernel-snap")
 	}
 	if opts&(updatesGadget|updatesGadgetAssets) != 0 {
@@ -113,7 +113,7 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 		"setup-profiles",
 		"link-snap",
 		"auto-connect")
-	if opts&updatesGadgetAssets != 0 && opts&hasModeenv != 0 {
+	if opts&updatesGadgetAssets != 0 && opts&needsKernelSetup != 0 {
 		expected = append(expected, "remove-old-kernel-snap-setup")
 	}
 	expected = append(expected,

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -12402,8 +12402,6 @@ type: snapd
 
 	s.settle(c)
 
-	fmt.Printf("Settle returned\n")
-
 	didDownloadCore22 := false
 
 	for _, fakeOp := range s.fakeBackend.ops {


### PR DESCRIPTION
Create the kernel setup tasks that create the drivers tree only if a version of snapd-generator that creates mount units for this tree is installed in the system. This will happen if this is a UC24+ system or a hybrid system with snapd debian package version 2.62 or more modern.