### PR TITLE
client,daemon,features: expose feature flags supported/enabled info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Added API route for creating recovery systems: POST to `/v2/systems` with action `create`
 * Added API route for removing recovery systems: POST to `/v2/systems/{label}` with action `remove`
 * Support for user daemons by introducing new control switches --user/--system/--users for service start/stop/restart
+* client,daemon: expose features supported/enabled in `/v2/system-info`
 
 # New in snapd 2.61.3:
 * Install systemd files in correct location for 24.04

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/jsonutil"
 )
@@ -688,6 +689,8 @@ type SysInfo struct {
 	Refresh         RefreshInfo         `json:"refresh,omitempty"`
 	Confinement     string              `json:"confinement"`
 	SandboxFeatures map[string][]string `json:"sandbox-features,omitempty"`
+
+	Features map[string]features.FeatureInfo `json:"features,omitempty"`
 }
 
 func (rsp *response) err(cli *Client, statusCode int) error {

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -30,10 +30,12 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -105,6 +107,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	deviceMgr := c.d.overlord.DeviceManager()
 	st.Lock()
 	defer st.Unlock()
+	tr := config.NewTransaction(st)
 	nextRefresh := snapMgr.NextRefresh()
 	lastRefresh, _ := snapMgr.LastRefresh()
 	refreshHold, _ := snapMgr.EffectiveRefreshHold()
@@ -143,6 +146,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"refresh":      refreshInfo,
 		"architecture": arch.DpkgArchitecture(),
 		"system-mode":  deviceMgr.SystemMode(devicestate.SysAny),
+		"features":     features.All(tr),
 	}
 	if systemdVirt != "" {
 		m["virtualization"] = systemdVirt

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,12 +35,14 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
+	"github.com/snapcore/snapd/systemd"
 )
 
 var _ = check.Suite(&generalSuite{})
@@ -90,6 +92,8 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	tr := config.NewTransaction(st)
 	tr.Set("core", "refresh.schedule", "00:00-9:00/12:00-13:00")
 	tr.Set("core", "refresh.timer", "8:00~9:00/2")
+	tr.Set("core", "experimental.parallel-instances", "false")
+	tr.Set("core", "experimental.quota-groups", "true")
 	tr.Commit()
 	st.Unlock()
 
@@ -102,6 +106,9 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	// reload dirs for release info to have effect
 	dirs.SetRootDir(dirs.GlobalRootDir)
 	restore = daemon.MockSystemdVirt("magic")
+	defer restore()
+	// Set systemd version <230 so QuotaGroups feature unsupported
+	restore = systemd.MockSystemdVersion(229, nil)
 	defer restore()
 
 	buildID := "this-is-my-build-id"
@@ -145,7 +152,48 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	const kernelVersionKey = "kernel-version"
 	c.Check(rsp.Result.(map[string]interface{})[kernelVersionKey], check.Not(check.Equals), "")
 	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	// Extract "features" field and remove it from result; check it later.
+	const featuresKey = "features"
+	resultFeatures := rsp.Result.(map[string]interface{})[featuresKey]
+	c.Check(resultFeatures, check.Not(check.Equals), "")
+	delete(rsp.Result.(map[string]interface{}), featuresKey)
+
 	c.Check(rsp.Result, check.DeepEquals, expected)
+
+	// Check that "features" is map
+	featuresAll, ok := resultFeatures.(map[string]interface{})
+	c.Assert(ok, check.Equals, true)
+	// Ensure that Layouts exists and is feature.FeatureInfo
+	layoutsInfoRaw, exists := featuresAll[features.Layouts.String()]
+	c.Assert(exists, check.Equals, true)
+	layoutsInfo, ok := layoutsInfoRaw.(map[string]interface{})
+	c.Assert(ok, check.Equals, true, check.Commentf("%+v", layoutsInfoRaw))
+	// Ensure that Layouts is supported and enabled
+	c.Check(layoutsInfo["supported"], check.Equals, true)
+	_, exists = layoutsInfo["unsupported-reason"]
+	c.Check(exists, check.Equals, false)
+	c.Check(layoutsInfo["enabled"], check.Equals, true)
+	// Ensure that ParallelInstances exists and is a feature.FeatureInfo
+	parallelInstancesInfoRaw, exists := featuresAll[features.ParallelInstances.String()]
+	c.Assert(exists, check.Equals, true)
+	parallelInstancesInfo, ok := parallelInstancesInfoRaw.(map[string]interface{})
+	c.Assert(ok, check.Equals, true)
+	// Ensure that ParallelInstances is supported and not enabled
+	c.Check(parallelInstancesInfo["supported"], check.Equals, true)
+	_, exists = parallelInstancesInfo["unsupported-reason"]
+	c.Check(exists, check.Equals, false)
+	c.Check(parallelInstancesInfo["enabled"], check.Equals, false)
+	// Ensure that QuotaGroups exists and is a feature.FeatureInfo
+	quotaGroupsInfoRaw, exists := featuresAll[features.QuotaGroups.String()]
+	c.Assert(exists, check.Equals, true)
+	quotaGroupsInfo, ok := quotaGroupsInfoRaw.(map[string]interface{})
+	c.Assert(ok, check.Equals, true)
+	// Ensure that QuotaGroups is unsupported but enabled
+	c.Check(quotaGroupsInfo["supported"], check.Equals, false)
+	unsupportedReason, exists := quotaGroupsInfo["unsupported-reason"]
+	c.Check(exists, check.Equals, true)
+	c.Check(unsupportedReason, check.Not(check.Equals), "")
+	c.Check(quotaGroupsInfo["enabled"], check.Equals, true)
 }
 
 func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
@@ -224,6 +272,8 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	const kernelVersionKey = "kernel-version"
 	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	const featuresKey = "features"
+	delete(rsp.Result.(map[string]interface{}), featuresKey)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
@@ -302,6 +352,8 @@ func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	const kernelVersionKey = "kernel-version"
 	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	const featuresKey = "features"
+	delete(rsp.Result.(map[string]interface{}), featuresKey)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 


### PR DESCRIPTION
Adds `features.All()` to return a map from feature flag names to a struct indicating whether that feature is supported and/or enabled. A callback functions may be defined for a feature flag which returns `true` if that feature flag is supported by the system, otherwise `false`.

Features which are set to a value other than `true` or `false` are not included in the map, as these are not feature flags.

If no callback function is defined for a given feature flag, it is assumed that that feature flag is supported. Currently, callbacks are defined for `QuotaGroups` (check that systemd version >= 230) and `UserDaemons` (check that user units are supported).

Features may be enabled but not supported. In this case, the feature flag has been set to true, but the underlying feature is not supported by the system.

This information is now included in the response to the `/v2/system-info` endpoint under a new `"features"` field. This lets clients get information about which features are supported and/or enabled without querying `/v2/snaps/system/conf`, which requires authentication.