### PR TITLE
wrappers/core18.go: do not attempt to disable removed units

### DIFF
--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -228,9 +228,6 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 		if err := sysd.Stop(serviceUnits); err != nil {
 			logger.Noticef("failed to stop %q: %v", unit, err)
 		}
-		if err := sysd.DisableNoReload(serviceUnits); err != nil {
-			logger.Noticef("failed to disable %q: %v", unit, err)
-		}
 	}
 
 	// daemon-reload so that we get the new services


### PR DESCRIPTION
This is not valid to try to disable units that do not exist anymore.