### PR TITLE
overlord,systemd: do not restart mount units on snapd start

### DIFF
--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -36,7 +36,8 @@ func addMountUnit(c snap.ContainerPlaceInfo, preseed bool, meter progress.Meter)
 	} else {
 		sysd = systemd.New(systemd.SystemMode, meter)
 	}
-	_, err := sysd.EnsureMountUnitFile(c.MountDescription(), squashfsPath, whereDir, "squashfs")
+	_, err := sysd.EnsureMountUnitFile(c.MountDescription(), squashfsPath, whereDir, "squashfs",
+		systemd.EnsureMountUnitFlags{})
 	return err
 }
 

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -55,7 +55,7 @@ type FakeSystemd struct {
 	ListMountUnitsResult ResultForListMountUnits
 }
 
-func (s *FakeSystemd) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
+func (s *FakeSystemd) EnsureMountUnitFile(description, what, where, fstype string, flags systemd.EnsureMountUnitFlags) (string, error) {
 	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls,
 		ParamsForEnsureMountUnitFile{description, what, where, fstype})
 	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8789,6 +8789,14 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorWithInvalidS
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMounts(c *C) {
+	s.testEnsureSnapStateRewriteMounts(c, "app")
+}
+
+func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMountsSnapdSnap(c *C) {
+	s.testEnsureSnapStateRewriteMounts(c, "snapd")
+}
+
+func (s *snapmgrTestSuite) testEnsureSnapStateRewriteMounts(c *C, snapType string) {
 	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
 	defer restore()
 
@@ -8797,7 +8805,7 @@ func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMounts(c *C) {
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{testSnapSideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
-		SnapType: "app",
+		SnapType: snapType,
 	}
 	testYaml := `name: test-snap
 version: v1
@@ -8841,7 +8849,8 @@ WantedBy=multi-user.target
 	err = s.snapmgr.Ensure()
 	c.Assert(err, IsNil)
 
-	c.Assert(s.restarts[unitName], Equals, 1)
+	// no restarts of mount unit expected even if changed
+	c.Assert(s.restarts[unitName], Equals, 0)
 
 	expectedContent := fmt.Sprintf(`
 [Unit]

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -124,7 +124,7 @@ func (s *emulation) LogReader(services []string, n int, follow, namespaces bool)
 	return nil, fmt.Errorf("LogReader")
 }
 
-func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
+func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string, flags EnsureMountUnitFlags) (string, error) {
 	// We don't build the options in exactly the same way as in the systemd
 	// type because these options will be written in a unit that is used in
 	// a host different to where this is running (the one used while
@@ -132,12 +132,13 @@ func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string)
 	// target is not a container.
 	mountUnitOptions := append(fsMountOptions(fstype), squashfs.StandardOptions()...)
 	return s.EnsureMountUnitFileWithOptions(&MountUnitOptions{
-		Lifetime:    Persistent,
-		Description: description,
-		What:        what,
-		Where:       where,
-		Fstype:      fstype,
-		Options:     mountUnitOptions,
+		Lifetime:                 Persistent,
+		Description:              description,
+		What:                     what,
+		Where:                    where,
+		Fstype:                   fstype,
+		Options:                  mountUnitOptions,
+		PreventRestartIfModified: flags.PreventRestartIfModified,
 	})
 }
 

--- a/tests/main/snapd-update-services/task.yaml
+++ b/tests/main/snapd-update-services/task.yaml
@@ -1,5 +1,9 @@
 summary: systemd units get regenerated when snapd is refreshed
 
+details: |
+  Check that updating snapd does not remount already installed
+  snaps.
+
 systems:
   # there seems to be some kernel issue with duplicated mounts in
   # /proc/*/mounts on 14.04 so it makes it more difficult to test
@@ -71,9 +75,13 @@ execute: |
   systemctl is-active snap.test-snapd-service.test-snapd-service.service
   systemctl show -p TimeoutStopUSec snap.test-snapd-service.test-snapd-service.service | MATCH 'TimeoutStopUSec=30s'
 
-  # Check the mounts have been updated
+  # Check the mounts have been updated and that we have option "nodev"
+  # XXX Actually, check that the mounts *have not* been updated
+  # because we are not reloading the mount units for installed snaps anymore,
+  # as it is not clear we should change things for running processes.
+  # But leaving the test around in case we change our mind.
   for unit in "${mount_units[@]}"; do
     what="$(systemctl show -p What "${unit}")"
     what="${what#What=}"
-    findmnt -o OPTIONS -n "${what}" | MATCH nodev
+    findmnt -o OPTIONS -n "${what}" | NOMATCH nodev
   done


### PR DESCRIPTION
Do not restart the mount units when starting snapd even if the file
itself has been modified. This is to prevent systemd stopping services
when the mount unit gets restarted, as there are required dependencies
in the mount path for services defined in snaps.