### PR TITLE
many: generate security profiles from component hooks

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -617,12 +617,10 @@ var (
 
 func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState) {
 	runnables := appSet.Runnables()
-
 	content = make(map[string]osutil.FileState, len(runnables))
-
 	snapInfo := appSet.Info()
 
-	// Add profile for each app.
+	// Add profile for apps and hooks.
 	for _, r := range runnables {
 		b.addContent(r.SecurityTag, snapInfo, r.CommandName, opts, spec.SnippetForTag(r.SecurityTag), content, spec)
 	}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -310,7 +310,7 @@ func nsProfile(snapName string) string {
 // apps and hooks while the second profile describes the snap-update-ns profile
 // for the whole snap.
 func profileGlobs(snapName string) []string {
-	return []string{interfaces.SecurityTagGlob(snapName), nsProfile(snapName)}
+	return append(interfaces.SecurityTagGlobs(snapName), nsProfile(snapName))
 }
 
 // Determine if a profile filename is removable during core refresh/rollback.
@@ -399,10 +399,12 @@ func (b *Backend) prepareProfiles(appSet *interfaces.SnapAppSet, opts interfaces
 	content := b.deriveContent(spec.(*Specification), appSet, opts)
 
 	dir := dirs.SnapAppArmorDir
-	globs := profileGlobs(snapInfo.InstanceName())
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("cannot create directory for apparmor profiles %q: %s", dir, err)
 	}
+
+	globs := profileGlobs(snapInfo.InstanceName())
+
 	changed, removedPaths, errEnsure := osutil.EnsureDirStateGlobs(dir, globs, content)
 	// XXX: in the old code this error was reported late, after doing load/removeCached.
 	if errEnsure != nil {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2227,7 +2227,7 @@ func (s *backendSuite) TestCasperOverlaySnippets(c *C) {
 
 func (s *backendSuite) TestProfileGlobs(c *C) {
 	globs := apparmor.ProfileGlobs("foo")
-	c.Assert(globs, DeepEquals, []string{"snap.foo.*", "snap-update-ns.foo"})
+	c.Assert(globs, DeepEquals, []string{"snap.foo.*", "snap.foo+*.hook.*", "snap-update-ns.foo"})
 }
 
 func (s *backendSuite) TestNsProfile(c *C) {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -322,7 +322,8 @@ func (spec *Specification) emitLayout(si *snap.Info, layout *snap.Layout) {
 //
 // Importantly, the above mount operations are happening within the per-snap
 // mount namespace.
-func (spec *Specification) AddLayout(snapInfo *snap.Info) {
+func (spec *Specification) AddLayout(appSet *interfaces.SnapAppSet) {
+	snapInfo := appSet.Info()
 	if len(snapInfo.Layout) == 0 {
 		return
 	}
@@ -334,13 +335,11 @@ func (spec *Specification) AddLayout(snapInfo *snap.Info) {
 	}
 	sort.Strings(paths)
 
-	// Get tags describing all apps and hooks.
-	tags := make([]string, 0, len(snapInfo.Apps)+len(snapInfo.Hooks))
-	for _, app := range snapInfo.Apps {
-		tags = append(tags, app.SecurityTag())
-	}
-	for _, hook := range snapInfo.Hooks {
-		tags = append(tags, hook.SecurityTag())
+	// Get tags describing all runnables (apps, hooks, component hooks)
+	runnables := appSet.Runnables()
+	tags := make([]string, 0, len(runnables))
+	for _, r := range runnables {
+		tags = append(tags, r.SecurityTag)
 	}
 
 	// Append layout snippets to all tags; the layout applies equally to the

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -295,7 +295,10 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.vanguard.vanguard"})
 	defer restore()
 
-	s.spec.AddLayout(snapInfo)
+	appSet, err := interfaces.NewSnapAppSet(snapInfo, nil)
+	c.Assert(err, IsNil)
+
+	s.spec.AddLayout(appSet)
 
 	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
 		"snap.vanguard.vanguard": {

--- a/interfaces/ifacetest/backendtest.go
+++ b/interfaces/ifacetest/backendtest.go
@@ -245,7 +245,9 @@ func (s *BackendSuite) InstallSnapWithComponents(c *C, opts interfaces.Confineme
 
 	componentInfos := make([]*snap.ComponentInfo, 0, len(componentYamls))
 	for _, componentYaml := range componentYamls {
-		componentInfos = append(componentInfos, snaptest.MockComponent(c, componentYaml, snapInfo))
+		componentInfos = append(componentInfos, snaptest.MockComponent(c, componentYaml, snapInfo, snap.ComponentSideInfo{
+			Revision: snap.R(1),
+		}))
 	}
 
 	appSet, err := interfaces.NewSnapAppSet(snapInfo, componentInfos)
@@ -266,7 +268,9 @@ func (s *BackendSuite) UpdateSnapWithComponents(c *C, oldSnapInfo *snap.Info, op
 
 	componentInfos := make([]*snap.ComponentInfo, 0, len(componentYamls))
 	for _, componentYaml := range componentYamls {
-		componentInfos = append(componentInfos, snaptest.MockComponent(c, componentYaml, snapInfo))
+		componentInfos = append(componentInfos, snaptest.MockComponent(c, componentYaml, snapInfo, snap.ComponentSideInfo{
+			Revision: snap.R(1),
+		}))
 	}
 
 	appSet, err := interfaces.NewSnapAppSet(snapInfo, componentInfos)

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -73,13 +73,13 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 func (b *Backend) setupModules(appSet *interfaces.SnapAppSet, spec *Specification) error {
 	content, modules := deriveContent(spec, appSet)
 	// synchronize the content with the filesystem
-	glob := interfaces.SecurityTagGlob(appSet.InstanceName())
+	globs := interfaces.SecurityTagGlobs(appSet.InstanceName())
 	dir := dirs.SnapKModModulesDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for kmod files %q: %s", dir, err)
 	}
 
-	changed, _, err := osutil.EnsureDirState(dirs.SnapKModModulesDir, glob, content)
+	changed, _, err := osutil.EnsureDirStateGlobs(dirs.SnapKModModulesDir, globs, content)
 	if err != nil {
 		return err
 	}
@@ -102,9 +102,9 @@ func (b *Backend) setupModprobe(appSet *interfaces.SnapAppSet, spec *Specificati
 		return fmt.Errorf("cannot create directory for kmod files %q: %s", dir, err)
 	}
 
-	glob := interfaces.SecurityTagGlob(appSet.InstanceName())
+	globs := interfaces.SecurityTagGlobs(appSet.InstanceName())
 	dirContents := prepareModprobeDirContents(spec, appSet)
-	_, _, err := osutil.EnsureDirState(dirs.SnapKModModprobeDir, glob, dirContents)
+	_, _, err := osutil.EnsureDirStateGlobs(dirs.SnapKModModprobeDir, globs, dirContents)
 	if err != nil {
 		return err
 	}
@@ -146,13 +146,13 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, confinement interfaces.Co
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
 func (b *Backend) Remove(snapName string) error {
-	glob := interfaces.SecurityTagGlob(snapName)
+	globs := interfaces.SecurityTagGlobs(snapName)
 	var errors []error
-	if _, _, err := osutil.EnsureDirState(dirs.SnapKModModulesDir, glob, nil); err != nil {
+	if _, _, err := osutil.EnsureDirStateGlobs(dirs.SnapKModModulesDir, globs, nil); err != nil {
 		errors = append(errors, err)
 	}
 
-	if _, _, err := osutil.EnsureDirState(dirs.SnapKModModprobeDir, glob, nil); err != nil {
+	if _, _, err := osutil.EnsureDirStateGlobs(dirs.SnapKModModprobeDir, globs, nil); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/interfaces/naming.go
+++ b/interfaces/naming.go
@@ -20,11 +20,16 @@
 package interfaces
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/snap"
 )
 
-// SecurityTagGlob returns a pattern that matches all security tags belonging to
+// SecurityTagGlobs returns patterns that match all security tags belonging to
 // the same snap as the given app.
-func SecurityTagGlob(snapName string) string {
-	return snap.AppSecurityTag(snapName, "*")
+func SecurityTagGlobs(snapName string) []string {
+	return []string{
+		snap.AppSecurityTag(snapName, "*"),
+		fmt.Sprintf("snap.%s+*.hook.*", snapName),
+	}
 }

--- a/interfaces/naming.go
+++ b/interfaces/naming.go
@@ -20,8 +20,6 @@
 package interfaces
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -30,6 +28,6 @@ import (
 func SecurityTagGlobs(snapName string) []string {
 	return []string{
 		snap.AppSecurityTag(snapName, "*"),
-		fmt.Sprintf("snap.%s+*.hook.*", snapName),
+		snap.ComponentHookSecurityTag(snapName, "*", "*"),
 	}
 }

--- a/interfaces/naming_test.go
+++ b/interfaces/naming_test.go
@@ -30,5 +30,8 @@ type NamingSuite struct{}
 var _ = Suite(&NamingSuite{})
 
 func (s *NamingSuite) TestSecurityTagGlob(c *C) {
-	c.Check(SecurityTagGlob("http"), Equals, "snap.http.*")
+	c.Check(SecurityTagGlobs("http"), DeepEquals, []string{
+		"snap.http.*",
+		"snap.http+*.hook.*",
+	})
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -261,11 +261,16 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.Confineme
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
 
-	glob := interfaces.SecurityTagGlob(snapName) + ".src"
 	dir := dirs.SnapSeccompDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for seccomp profiles %q: %s", dir, err)
 	}
+
+	var globs []string
+	for _, g := range interfaces.SecurityTagGlobs(snapName) {
+		globs = append(globs, fmt.Sprintf("%s.src", g))
+	}
+
 	// There is a delicate interaction between `snap run`, `snap-confine`
 	// and compilation of profiles:
 	// - whenever profiles need to be rebuilt due to system-key change,
@@ -275,7 +280,7 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.Confineme
 	// - whenever the binary file does not exist, `snap-confine` will poll
 	//   and wait for SNAP_CONFINE_MAX_PROFILE_WAIT, if the profile does not
 	//   appear in that time, `snap-confine` will fail and die
-	changed, removed, err := osutil.EnsureDirState(dir, glob, content)
+	changed, removed, err := osutil.EnsureDirStateGlobs(dir, globs, content)
 	if err != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}
@@ -291,8 +296,8 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.Confineme
 
 // Remove removes seccomp profiles of a given snap.
 func (b *Backend) Remove(snapName string) error {
-	glob := interfaces.SecurityTagGlob(snapName)
-	_, _, err := osutil.EnsureDirState(dirs.SnapSeccompDir, glob, nil)
+	globs := interfaces.SecurityTagGlobs(snapName)
+	_, _, err := osutil.EnsureDirStateGlobs(dirs.SnapSeccompDir, globs, nil)
 	if err != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -327,31 +327,17 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 		uidGidChownSyscalls.WriteString(rootSetUidGidSyscalls)
 	}
 
-	for _, hookInfo := range snapInfo.Hooks {
+	for _, r := range appSet.Runnables() {
 		if content == nil {
 			content = make(map[string]osutil.FileState)
 		}
-		securityTag := hookInfo.SecurityTag()
 
-		path := securityTag + ".src"
+		path := r.SecurityTag + ".src"
 		content[path] = &osutil.MemoryFileState{
-			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
+			Content: generateContent(opts, spec.SnippetForTag(r.SecurityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
 			Mode:    0644,
 		}
 	}
-	for _, appInfo := range snapInfo.Apps {
-		if content == nil {
-			content = make(map[string]osutil.FileState)
-		}
-		securityTag := appInfo.SecurityTag()
-		path := securityTag + ".src"
-		content[path] = &osutil.MemoryFileState{
-			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
-			Mode:    0644,
-		}
-	}
-
-	// TODO: something with component hooks will need to happen here
 
 	return content, nil
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -178,7 +178,7 @@ func (s *backendSuite) testInstallingComponentWritesHookProfiles(c *C, instanceN
 
 		// and got compiled
 		c.Check(s.snapSeccomp.Calls(), testutil.DeepContains, []string{
-			"snap-seccomp", "compile", componentHookProfile + ".src", componentHookProfile + ".bin",
+			"snap-seccomp", "compile", componentHookProfile + ".src", componentHookProfile + ".bin2",
 		})
 
 		s.RemoveSnap(c, info)
@@ -321,7 +321,7 @@ func (s *backendSuite) testUpdatingSnapToOneWithMoreComponents(c *C, instanceNam
 		c.Check(profile+".src", testutil.FilePresent)
 
 		// and got compiled
-		c.Check(s.snapSeccomp.Calls(), testutil.DeepContains, []string{"snap-seccomp", "compile", profile + ".src", profile + ".bin"})
+		c.Check(s.snapSeccomp.Calls(), testutil.DeepContains, []string{"snap-seccomp", "compile", profile + ".src", profile + ".bin2"})
 		s.snapSeccomp.ForgetCalls()
 
 		s.RemoveSnap(c, info)

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -149,6 +149,43 @@ func (s *backendSuite) TestInstallingSnapWritesHookProfiles(c *C) {
 	})
 }
 
+func (s *backendSuite) TestInstallingComponentWritesHookProfiles(c *C) {
+	const instanceName = ""
+	s.testInstallingComponentWritesHookProfiles(c, instanceName)
+}
+
+func (s *backendSuite) TestInstallingComponentWritesHookProfilesInstance(c *C) {
+	const instanceName = "snap_instance"
+	s.testInstallingComponentWritesHookProfiles(c, instanceName)
+}
+
+func (s *backendSuite) testInstallingComponentWritesHookProfiles(c *C, instanceName string) {
+	testedConfinementOpts := []interfaces.ConfinementOptions{
+		{},
+	}
+
+	for _, opts := range testedConfinementOpts {
+		info := s.InstallSnapWithComponents(c, opts, instanceName, ifacetest.SnapWithComponentsYaml, 0, []string{ifacetest.ComponentYaml})
+
+		expectedName := info.InstanceName()
+
+		componentHookProfile := filepath.Join(dirs.SnapSeccompDir, fmt.Sprintf("snap.%s+comp.hook.install", expectedName))
+		appProfile := filepath.Join(dirs.SnapSeccompDir, fmt.Sprintf("snap.%s.app", expectedName))
+
+		// verify that profiles were created
+		c.Check(componentHookProfile+".src", testutil.FilePresent)
+		c.Check(appProfile+".src", testutil.FilePresent)
+
+		// and got compiled
+		c.Check(s.snapSeccomp.Calls(), testutil.DeepContains, []string{
+			"snap-seccomp", "compile", componentHookProfile + ".src", componentHookProfile + ".bin",
+		})
+
+		s.RemoveSnap(c, info)
+		s.snapSeccomp.ForgetCalls()
+	}
+}
+
 func (s *backendSuite) TestInstallingSnapWritesProfilesWithReexec(c *C) {
 	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
 		// simulate that we run snapd from core
@@ -209,6 +246,27 @@ func (s *backendSuite) TestRemovingSnapRemovesHookProfiles(c *C) {
 	}
 }
 
+func (s *backendSuite) TestRemovingSnapRemovesComponentProfiles(c *C) {
+	const instanceName = ""
+	s.testRemovingSnapRemovesComponentProfiles(c, instanceName)
+}
+
+func (s *backendSuite) TestRemovingSnapRemovesComponentProfilesInstance(c *C) {
+	const instanceName = "snap_instance"
+	s.testRemovingSnapRemovesComponentProfiles(c, instanceName)
+}
+
+func (s *backendSuite) testRemovingSnapRemovesComponentProfiles(c *C, instanceName string) {
+	for _, opts := range testedConfinementOpts {
+		info := s.InstallSnapWithComponents(c, opts, instanceName, ifacetest.SnapWithComponentsYaml, 0, []string{ifacetest.ComponentYaml})
+		s.RemoveSnap(c, info)
+
+		expectedName := info.InstanceName()
+		profile := filepath.Join(dirs.SnapSeccompDir, fmt.Sprintf("snap.%s+comp.hook.install", expectedName))
+		c.Check(profile+".src", testutil.FileAbsent)
+	}
+}
+
 func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 	for _, opts := range testedConfinementOpts {
 		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 0)
@@ -239,6 +297,58 @@ func (s *backendSuite) TestUpdatingSnapToOneWithHooks(c *C) {
 		s.snapSeccomp.ForgetCalls()
 
 		s.RemoveSnap(c, snapInfo)
+	}
+}
+
+func (s *backendSuite) TestUpdatingSnapToOneWithMoreComponents(c *C) {
+	const instanceName = ""
+	s.testUpdatingSnapToOneWithMoreComponents(c, instanceName)
+}
+
+func (s *backendSuite) TestUpdatingSnapToOneWithMoreComponentsInstance(c *C) {
+	const instanceName = "snap_instance"
+	s.testUpdatingSnapToOneWithMoreComponents(c, instanceName)
+}
+
+func (s *backendSuite) testUpdatingSnapToOneWithMoreComponents(c *C, instanceName string) {
+	for _, opts := range testedConfinementOpts {
+		info := s.InstallSnap(c, opts, instanceName, ifacetest.SnapWithComponentsYaml, 0)
+		info = s.UpdateSnapWithComponents(c, info, opts, ifacetest.SnapWithComponentsYaml, 0, []string{ifacetest.ComponentYaml})
+
+		expectedName := info.InstanceName()
+
+		profile := filepath.Join(dirs.SnapSeccompDir, fmt.Sprintf("snap.%s+comp.hook.install", expectedName))
+		c.Check(profile+".src", testutil.FilePresent)
+
+		// and got compiled
+		c.Check(s.snapSeccomp.Calls(), testutil.DeepContains, []string{"snap-seccomp", "compile", profile + ".src", profile + ".bin"})
+		s.snapSeccomp.ForgetCalls()
+
+		s.RemoveSnap(c, info)
+	}
+}
+
+func (s *backendSuite) TestUpdatingSnapToOneWithFewerComponents(c *C) {
+	const instanceName = ""
+	s.testUpdatingSnapToOneWithFewerComponents(c, instanceName)
+}
+
+func (s *backendSuite) TestUpdatingSnapToOneWithFewerComponentsInstance(c *C) {
+	const instanceName = "snap_instance"
+	s.testUpdatingSnapToOneWithFewerComponents(c, instanceName)
+}
+
+func (s *backendSuite) testUpdatingSnapToOneWithFewerComponents(c *C, instanceName string) {
+	for _, opts := range testedConfinementOpts {
+		info := s.InstallSnapWithComponents(c, opts, instanceName, ifacetest.SnapWithComponentsYaml, 0, []string{ifacetest.ComponentYaml})
+		info = s.UpdateSnapWithComponents(c, info, opts, ifacetest.SnapWithComponentsYaml, 0, nil)
+
+		expectedName := info.InstanceName()
+
+		profile := filepath.Join(dirs.SnapSeccompDir, fmt.Sprintf("snap.%s+comp.hook.install", expectedName))
+		c.Check(profile+".src", testutil.FileAbsent)
+
+		s.RemoveSnap(c, info)
 	}
 }
 

--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -157,9 +157,6 @@ type Runnable struct {
 	// tags are used by various security subsystems as "profile names" and
 	// sometimes also as a part of the file name.
 	SecurityTag string
-	// Type is the type of the runnable, either an app, a hook, or a component
-	// hook.
-	Type RunnableType
 }
 
 // Runnables returns a list of all runnables known by the app set.
@@ -170,7 +167,6 @@ func (a *SnapAppSet) Runnables() []Runnable {
 		runnables = append(runnables, Runnable{
 			CommandName: app.Name,
 			SecurityTag: app.SecurityTag(),
-			Type:        RunnableApp,
 		})
 	}
 
@@ -178,7 +174,6 @@ func (a *SnapAppSet) Runnables() []Runnable {
 		runnables = append(runnables, Runnable{
 			CommandName: fmt.Sprintf("hook.%s", hook.Name),
 			SecurityTag: hook.SecurityTag(),
-			Type:        RunnableHook,
 		})
 	}
 
@@ -187,17 +182,9 @@ func (a *SnapAppSet) Runnables() []Runnable {
 			runnables = append(runnables, Runnable{
 				CommandName: fmt.Sprintf("%s.hook.%s", component.Component, hook.Name),
 				SecurityTag: hook.SecurityTag(),
-				Type:        RunnableComponentHook,
 			})
 		}
 	}
-
-	sort.Slice(runnables, func(i, j int) bool {
-		if runnables[i].Type != runnables[j].Type {
-			return runnables[i].Type < runnables[j].Type
-		}
-		return runnables[i].CommandName < runnables[j].CommandName
-	})
 
 	return runnables
 }

--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -54,6 +54,10 @@ func (a *SnapAppSet) SecurityTagsForPlug(plug *snap.PlugInfo) ([]string, error) 
 	apps := a.info.AppsForPlug(plug)
 	hooks := a.info.HooksForPlug(plug)
 
+	for _, component := range a.components {
+		hooks = append(hooks, component.HooksForPlug(plug)...)
+	}
+
 	tags := make([]string, 0, len(apps)+len(hooks))
 	for _, app := range apps {
 		tags = append(tags, app.SecurityTag())

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -181,7 +181,9 @@ plugs:
 slots:
   slot:`
 	info, connectedPlug := mockInfoAndConnectedPlug(c, yaml, nil, "plug")
-	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1", info)
+	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1", info, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	set, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{compInfo})
 	c.Assert(err, IsNil)
@@ -267,7 +269,9 @@ components:
 `
 	info := snaptest.MockInfo(c, yaml, nil)
 
-	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1.0", info)
+	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1.0", info, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	set, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{compInfo})
 	c.Assert(err, IsNil)

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -276,26 +276,22 @@ components:
 	set, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{compInfo})
 	c.Assert(err, IsNil)
 
-	c.Check(set.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(set.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app1",
 			SecurityTag: "snap.name.app1",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "app2",
 			SecurityTag: "snap.name.app2",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "hook.install",
 			SecurityTag: "snap.name.hook.install",
-			Type:        interfaces.RunnableHook,
 		},
 		{
 			CommandName: "name+comp.hook.install",
 			SecurityTag: "snap.name+comp.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -179,10 +179,7 @@ hooks:
 plugs:
   plug:
 slots:
-  slot:
-components:
-  comp:
-    type: test`
+  slot:`
 	info, connectedPlug := mockInfoAndConnectedPlug(c, yaml, nil, "plug")
 	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1", info)
 
@@ -191,7 +188,12 @@ components:
 
 	tags, err := set.SecurityTagsForConnectedPlug(connectedPlug)
 	c.Assert(err, IsNil)
-	c.Assert(tags, DeepEquals, []string{"snap.name.app1", "snap.name.app2", "snap.name.hook.install"})
+	c.Assert(tags, DeepEquals, []string{
+		"snap.name+comp.hook.install",
+		"snap.name.app1",
+		"snap.name.app2",
+		"snap.name.hook.install",
+	})
 }
 
 func (s *snapAppSetSuite) TestPlugSecurityTagsWrongSnap(c *C) {

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -179,7 +179,10 @@ hooks:
 plugs:
   plug:
 slots:
-  slot:`
+  slot:
+components:
+  comp:
+    type: test`
 	info, connectedPlug := mockInfoAndConnectedPlug(c, yaml, nil, "plug")
 	compInfo := snaptest.MockComponent(c, "component: name+comp\ntype: test\nversion: 1", info)
 
@@ -256,6 +259,7 @@ hooks:
   install:
 components:
   comp:
+    type: test
     hooks:
       install:
 `

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -42,7 +42,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
-	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -201,41 +200,6 @@ func setPendingProfilesSideInfo(st *state.State, instanceName string, si *snap.S
 	}
 	snapstate.Set(st, instanceName, &snapst)
 	return nil
-}
-
-func componentSetupsForTask(t *state.Task) ([]*snapstate.ComponentSetup, error) {
-	switch {
-	case t.Has("component-setup") || t.Has("component-setup-task"):
-		// task comes from a component installation
-		compsup, _, err := snapstate.TaskComponentSetup(t)
-		if err != nil {
-			return nil, err
-		}
-		return []*snapstate.ComponentSetup{compsup}, nil
-	case t.Has("component-setups") || t.Has("component-setups-task"):
-		// TODO: test this branch once we know more about refreshing snaps with
-		// components
-		// task comes from a snap refresh
-		compsups, _, err := snapstate.TaskComponentSetups(t)
-		if err != nil {
-			return nil, err
-		}
-		return compsups, nil
-	default:
-		// task comes from a snap installation
-		return nil, nil
-	}
-}
-
-func componentInfoFromComponentSetup(compsup *snapstate.ComponentSetup, info *snap.Info) (*snap.ComponentInfo, error) {
-	cpi := snap.MinimalComponentContainerPlaceInfo(
-		compsup.ComponentName(),
-		compsup.CompSideInfo.Revision,
-		info.InstanceName(),
-	)
-
-	container := snapdir.New(cpi.MountDir())
-	return snap.ReadComponentInfoFromContainer(container, info)
 }
 
 func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, snapInfo *snap.Info, opts interfaces.ConfinementOptions, tm timings.Measurer) error {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -238,60 +238,6 @@ func componentInfoFromComponentSetup(compsup *snapstate.ComponentSetup, info *sn
 	return snap.ReadComponentInfoFromContainer(container, info)
 }
 
-func appSetForTask(t *state.Task, info *snap.Info) (*interfaces.SnapAppSet, error) {
-	compsups, err := componentSetupsForTask(t)
-	if err != nil {
-		return nil, err
-	}
-
-	compInfos := make([]*snap.ComponentInfo, 0, len(compsups))
-	for _, compsup := range compsups {
-		compInfo, err := componentInfoFromComponentSetup(compsup, info)
-		if err != nil {
-			return nil, err
-		}
-		compInfos = append(compInfos, compInfo)
-	}
-
-	st := t.State()
-
-	var snapst snapstate.SnapState
-	if err := snapstate.Get(st, info.InstanceName(), &snapst); err != nil {
-		// if the snap isn't in the state, then we know that there aren't any
-		// pre-existing components to consider
-		if errors.Is(err, state.ErrNoState) {
-			return interfaces.NewSnapAppSet(info, compInfos)
-		}
-		return nil, err
-	}
-
-	// if we're installing/refreshing a component then we need to consider the
-	// components that are already installed
-	if snapst.LastIndex(info.Revision) != -1 {
-		compsForRevision, err := snapst.ComponentInfosForRevision(info.Revision)
-		if err != nil {
-			return nil, err
-		}
-		compInfos = append(compInfos, compsForRevision...)
-	}
-
-	return interfaces.NewSnapAppSet(info, compInfos)
-}
-
-func appSetForSnapRevision(st *state.State, info *snap.Info) (*interfaces.SnapAppSet, error) {
-	var snapst snapstate.SnapState
-	if err := snapstate.Get(st, info.InstanceName(), &snapst); err != nil {
-		return nil, err
-	}
-
-	compInfos, err := snapst.ComponentInfosForRevision(info.Revision)
-	if err != nil {
-		return nil, err
-	}
-
-	return interfaces.NewSnapAppSet(info, compInfos)
-}
-
 func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, snapInfo *snap.Info, opts interfaces.ConfinementOptions, tm timings.Measurer) error {
 	st := task.State()
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1392,3 +1392,57 @@ func hasActiveConnection(st *state.State, iface string) (bool, error) {
 	}
 	return false, nil
 }
+
+func appSetForTask(t *state.Task, info *snap.Info) (*interfaces.SnapAppSet, error) {
+	compsups, err := componentSetupsForTask(t)
+	if err != nil {
+		return nil, err
+	}
+
+	compInfos := make([]*snap.ComponentInfo, 0, len(compsups))
+	for _, compsup := range compsups {
+		compInfo, err := componentInfoFromComponentSetup(compsup, info)
+		if err != nil {
+			return nil, err
+		}
+		compInfos = append(compInfos, compInfo)
+	}
+
+	st := t.State()
+
+	var snapst snapstate.SnapState
+	if err := snapstate.Get(st, info.InstanceName(), &snapst); err != nil {
+		// if the snap isn't in the state, then we know that there aren't any
+		// pre-existing components to consider
+		if errors.Is(err, state.ErrNoState) {
+			return interfaces.NewSnapAppSet(info, compInfos)
+		}
+		return nil, err
+	}
+
+	// if we're installing/refreshing a component then we need to consider the
+	// components that are already installed
+	if snapst.LastIndex(info.Revision) != -1 {
+		compsForRevision, err := snapst.ComponentInfosForRevision(info.Revision)
+		if err != nil {
+			return nil, err
+		}
+		compInfos = append(compInfos, compsForRevision...)
+	}
+
+	return interfaces.NewSnapAppSet(info, compInfos)
+}
+
+func appSetForSnapRevision(st *state.State, info *snap.Info) (*interfaces.SnapAppSet, error) {
+	var snapst snapstate.SnapState
+	if err := snapstate.Get(st, info.InstanceName(), &snapst); err != nil {
+		return nil, err
+	}
+
+	compInfos, err := snapst.ComponentInfosForRevision(info.Revision)
+	if err != nil {
+		return nil, err
+	}
+
+	return interfaces.NewSnapAppSet(info, compInfos)
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1394,14 +1394,14 @@ func hasActiveConnection(st *state.State, iface string) (bool, error) {
 }
 
 func appSetForTask(t *state.Task, info *snap.Info) (*interfaces.SnapAppSet, error) {
-	compsups, err := componentSetupsForTask(t)
+	compsups, err := snapstate.ComponentSetupsForTask(t)
 	if err != nil {
 		return nil, err
 	}
 
 	compInfos := make([]*snap.ComponentInfo, 0, len(compsups))
 	for _, compsup := range compsups {
-		compInfo, err := componentInfoFromComponentSetup(compsup, info)
+		compInfo, err := snapstate.ComponentInfoFromComponentSetup(compsup, info)
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -175,11 +175,10 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 	// TODO: should snapsWithSecurityProfiles return app sets instead of snap infos?
 	appSets := make([]*interfaces.SnapAppSet, 0, len(snaps))
 	for _, sn := range snaps {
-		set, err := interfaces.NewSnapAppSet(sn, nil)
+		set, err := appSetForSnapRevision(m.state, sn)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot build app set for snap %q: %v", sn.InstanceName(), err)
 		}
-
 		appSets = append(appSets, set)
 	}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1707,11 +1707,11 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 
 	consumerAppSet := s.secBackend.SetupCalls[0].AppSet
 	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
-	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+	c.Check(consumerAppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 
 	producerAppSet := s.secBackend.SetupCalls[1].AppSet
 	c.Check(producerAppSet.InstanceName(), Equals, "producer")
-	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+	c.Check(producerAppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
 
 }
 
@@ -1809,21 +1809,19 @@ components:
 
 	producerAppSet := s.secBackend.SetupCalls[2].AppSet
 	c.Check(producerAppSet.InstanceName(), Equals, "producer")
-	c.Check(producerAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(producerAppSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "producer+comp.hook.install",
 			SecurityTag: "snap.producer+comp.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 
 	consumerAppSet := s.secBackend.SetupCalls[3].AppSet
 	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
-	c.Check(consumerAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(consumerAppSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "consumer+comp.hook.install",
 			SecurityTag: "snap.consumer+comp.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }
@@ -2508,47 +2506,38 @@ var consumerRunnablesFullSet = []interfaces.Runnable{
 	{
 		CommandName: "hook.connect-plug-otherplug",
 		SecurityTag: "snap.consumer.hook.connect-plug-otherplug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.connect-plug-plug",
 		SecurityTag: "snap.consumer.hook.connect-plug-plug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.disconnect-plug-otherplug",
 		SecurityTag: "snap.consumer.hook.disconnect-plug-otherplug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.disconnect-plug-plug",
 		SecurityTag: "snap.consumer.hook.disconnect-plug-plug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.prepare-plug-otherplug",
 		SecurityTag: "snap.consumer.hook.prepare-plug-otherplug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.prepare-plug-plug",
 		SecurityTag: "snap.consumer.hook.prepare-plug-plug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.unprepare-plug-otherplug",
 		SecurityTag: "snap.consumer.hook.unprepare-plug-otherplug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.unprepare-plug-plug",
 		SecurityTag: "snap.consumer.hook.unprepare-plug-plug",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "consumer+comp.hook.install",
 		SecurityTag: "snap.consumer+comp.hook.install",
-		Type:        interfaces.RunnableComponentHook,
 	},
 }
 
@@ -2601,27 +2590,22 @@ var producerRunnablesFullSet = []interfaces.Runnable{
 	{
 		CommandName: "hook.connect-slot-slot",
 		SecurityTag: "snap.producer.hook.connect-slot-slot",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.disconnect-slot-slot",
 		SecurityTag: "snap.producer.hook.disconnect-slot-slot",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.prepare-slot-slot",
 		SecurityTag: "snap.producer.hook.prepare-slot-slot",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "hook.unprepare-slot-slot",
 		SecurityTag: "snap.producer.hook.unprepare-slot-slot",
-		Type:        interfaces.RunnableHook,
 	},
 	{
 		CommandName: "producer+comp.hook.install",
 		SecurityTag: "snap.producer+comp.hook.install",
-		Type:        interfaces.RunnableComponentHook,
 	},
 }
 
@@ -4040,16 +4024,14 @@ version: 1.0
 
 	// the snap defines another component, comp2. note that it is not listed
 	// here because it is not installed.
-	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(appSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app",
 			SecurityTag: "snap.snap.app",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "snap+comp1.hook.install",
 			SecurityTag: "snap.snap+comp1.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }
@@ -4124,21 +4106,18 @@ version: 1.0
 
 	// the snap defines another component, comp2. note that it is not listed
 	// here because it is not installed.
-	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(appSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app",
 			SecurityTag: "snap.snap.app",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "snap+comp1.hook.install",
 			SecurityTag: "snap.snap+comp1.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 		{
 			CommandName: "snap+comp2.hook.pre-refresh",
 			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }
@@ -4190,21 +4169,18 @@ version: 1.0
 
 	// the snap defines another component, comp2. note that it is not listed
 	// here because it is not installed.
-	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(appSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app",
 			SecurityTag: "snap.snap.app",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "snap+comp1.hook.install",
 			SecurityTag: "snap.snap+comp1.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 		{
 			CommandName: "snap+comp2.hook.pre-refresh",
 			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }
@@ -4303,47 +4279,40 @@ version: 1.0
 
 	// the snap defines another component, comp2. note that it is not listed
 	// here because it is not installed.
-	c.Check(firstAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(firstAppSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app",
 			SecurityTag: "snap.snap.app",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "snap+comp1.hook.install",
 			SecurityTag: "snap.snap+comp1.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 		{
 			CommandName: "snap+comp2.hook.pre-refresh",
 			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 
-	c.Check(secondAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(secondAppSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "app",
 			SecurityTag: "snap.snap.app",
-			Type:        interfaces.RunnableApp,
 		},
 		{
 			CommandName: "snap+comp1.hook.install",
 			SecurityTag: "snap.snap+comp1.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 		{
 			CommandName: "snap+comp2.hook.pre-refresh",
 			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 
-	c.Check(thirdAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+	c.Check(thirdAppSet.Runnables(), testutil.DeepUnsortedMatches, []interfaces.Runnable{
 		{
 			CommandName: "ubuntu-core+comp.hook.install",
 			SecurityTag: "snap.ubuntu-core+comp.hook.install",
-			Type:        interfaces.RunnableComponentHook,
 		},
 	})
 }
@@ -4861,8 +4830,8 @@ func (s *interfaceManagerSuite) TestConnectWithComponentsSetsUpSecurity(c *C) {
 	c.Check(producerAppSet.InstanceName(), Equals, "producer")
 	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
 
-	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
-	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+	c.Check(producerAppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
+	c.Check(consumerAppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
@@ -6095,16 +6064,16 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[0].AppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
-	c.Check(s.secBackend.SetupCalls[1].AppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[0].AppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[1].AppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 
 	// by undo
 	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[3].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[2].AppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
-	c.Check(s.secBackend.SetupCalls[3].AppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[2].AppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[3].AppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
@@ -6154,11 +6123,11 @@ func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
 
 	producerAppSet := s.secBackend.SetupCalls[2].AppSet
 	c.Check(producerAppSet.InstanceName(), Equals, "producer")
-	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+	c.Check(producerAppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
 
 	consumerAppSet := s.secBackend.SetupCalls[3].AppSet
 	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
-	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+	c.Check(consumerAppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectNoSetupProfilesWithDelayedSetupProfiles(c *C) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4006,7 +4006,9 @@ component: snap+comp1
 type: test
 version: 1.0
 `
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	// initialize the manager
 	_ = s.manager(c)
@@ -4053,7 +4055,9 @@ version: 1.0
 }
 
 func (s *interfaceManagerSuite) mockComponentForSnap(c *C, compName string, compYaml string, snapInfo *snap.Info) *snap.ComponentInfo {
-	compInfo := snaptest.MockComponent(c, compYaml, snapInfo)
+	compInfo := snaptest.MockComponent(c, compYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -4085,7 +4089,9 @@ component: snap+comp1
 type: test
 version: 1.0
 `
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	// initialize the manager
 	_ = s.manager(c)
@@ -4149,7 +4155,9 @@ component: snap+comp1
 type: test
 version: 1.0
 `
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	// initialize the manager
 	_ = s.manager(c)
@@ -4205,12 +4213,16 @@ func (s *interfaceManagerSuite) TestSetupProfilesOfAffectedSnapWithComponents(c 
 	s.MockModel(c, nil)
 
 	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
-	snaptest.MockComponent(c, "component: snap+comp2\ntype: test", snapInfo)
+	snaptest.MockComponent(c, "component: snap+comp2\ntype: test", snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	// core snap is here so that it appears as an affected snap when "snap" has
 	// its profiles setup
 	coreSnapInfo := s.mockSnap(c, ubuntuCoreSnapWithComponentYaml)
-	snaptest.MockComponent(c, "component: ubuntu-core+comp\ntype: test", coreSnapInfo)
+	snaptest.MockComponent(c, "component: ubuntu-core+comp\ntype: test", coreSnapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	s.state.Lock()
 	var snapst snapstate.SnapState
@@ -4248,7 +4260,9 @@ component: snap+comp1
 type: test
 version: 1.0
 `
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	// initialize the manager
 	_ = s.manager(c)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
@@ -1639,8 +1640,11 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	// Put two snaps in place They consumer has an plug that can be connected
 	// to slot on the producer.
 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
-	s.mockSnap(c, consumerYaml)
-	s.mockSnap(c, producerYaml)
+	consumer := s.mockSnap(c, consumerWithComponentYaml)
+	producer := s.mockSnap(c, producerWithComponentYaml)
+
+	s.mockComponentForSnap(c, "comp", "component: consumer+comp\ntype: test", consumer)
+	s.mockComponentForSnap(c, "comp", "component: producer+comp\ntype: test", producer)
 
 	// Put a connection in the state so that it automatically gets set up when
 	// we create the manager.
@@ -1697,11 +1701,18 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	// Ensure that the backend was used to setup security of both snaps
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
-	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "producer")
 
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+
+	consumerAppSet := s.secBackend.SetupCalls[0].AppSet
+	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
+	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
+
+	producerAppSet := s.secBackend.SetupCalls[1].AppSet
+	c.Check(producerAppSet.InstanceName(), Equals, "producer")
+	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+
 }
 
 func (s *interfaceManagerSuite) TestDisconnectUndo(c *C) {
@@ -1713,6 +1724,15 @@ plugs:
  plug:
   interface: test
   static: plug-static-value
+components:
+ comp:
+  type: test
+  hooks:
+   install:
+ not-installed:
+  type: test
+  hooks:
+   install:
 `
 	var producerYaml = `
 name: producer
@@ -1721,9 +1741,21 @@ slots:
  slot:
   interface: test
   static: slot-static-value
+components:
+ comp:
+  type: test
+  hooks:
+   install:
+ not-installed:
+  type: test
+  hooks:
+   install:
 `
-	s.mockSnap(c, consumerYaml)
-	s.mockSnap(c, producerYaml)
+	consumer := s.mockSnap(c, consumerYaml)
+	producer := s.mockSnap(c, producerYaml)
+
+	s.mockComponentForSnap(c, "comp", "component: consumer+comp\ntype: test", consumer)
+	s.mockComponentForSnap(c, "comp", "component: producer+comp\ntype: test", producer)
 
 	connState := map[string]interface{}{
 		"consumer:plug producer:slot": map[string]interface{}{
@@ -1772,6 +1804,28 @@ slots:
 	c.Assert(conns, DeepEquals, connState)
 
 	_ = s.getConnection(c, "consumer", "plug", "producer", "slot")
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 4)
+
+	producerAppSet := s.secBackend.SetupCalls[2].AppSet
+	c.Check(producerAppSet.InstanceName(), Equals, "producer")
+	c.Check(producerAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "producer+comp.hook.install",
+			SecurityTag: "snap.producer+comp.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+
+	consumerAppSet := s.secBackend.SetupCalls[3].AppSet
+	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
+	c.Check(consumerAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "consumer+comp.hook.install",
+			SecurityTag: "snap.consumer+comp.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
 }
 
 func (s *interfaceManagerSuite) TestForgetUndo(c *C) {
@@ -2147,6 +2201,83 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapsup *snapst
 	return s.addSetupSnapSecurityChangeWithOptions(c, snapsup, setupSnapSecurityChangeOptions{active: false})
 }
 
+func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, snapsup *snapstate.SnapSetup, compsup *snapstate.ComponentSetup) *state.Change {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.o.TaskRunner().AddHandler("mock-link-component-n-witness", func(task *state.Task, tomb *tomb.Tomb) error { // do handler
+		s.state.Lock()
+		defer s.state.Unlock()
+
+		var snapst snapstate.SnapState
+		err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+
+		info, err := snapst.CurrentInfo()
+		if err != nil {
+			return err
+		}
+
+		cs := sequence.NewComponentState(compsup.CompSideInfo, compsup.CompType)
+
+		if err := snapst.Sequence.AddComponentForRevision(info.Revision, cs); err != nil {
+			return fmt.Errorf("internal error while linking component: %w", err)
+		}
+
+		snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+
+		return nil
+	}, func(task *state.Task, tomb *tomb.Tomb) error { // undo handler
+		s.state.Lock()
+		defer s.state.Unlock()
+		var snapst snapstate.SnapState
+		err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+
+		info, err := snapst.CurrentInfo()
+		if err != nil {
+			return err
+		}
+
+		snapst.Sequence.RemoveComponentForRevision(
+			info.Revision, compsup.CompSideInfo.Component,
+		)
+
+		snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+
+		return nil
+	})
+
+	// snap should already be installed if calling this function
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+	c.Assert(err, IsNil)
+
+	change := s.state.NewChange("test", "")
+
+	task1 := s.state.NewTask("setup-profiles", "")
+	task1.Set("snap-setup", snapsup)
+	task1.Set("component-setup", compsup)
+	change.AddTask(task1)
+
+	task2 := s.state.NewTask("mock-link-component-n-witness", "")
+	task2.Set("snap-setup", snapsup)
+	task2.Set("component-setup", compsup)
+	task2.WaitFor(task1)
+	change.AddTask(task2)
+
+	task3 := s.state.NewTask("auto-connect", "")
+	task3.Set("snap-setup", snapsup)
+	task3.WaitFor(task2)
+	change.AddTask(task3)
+
+	return change
+}
+
 func (s *interfaceManagerSuite) addSetupSnapSecurityChangeWithOptions(c *C, snapsup *snapstate.SnapSetup, opts setupSnapSecurityChangeOptions) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -2271,6 +2402,14 @@ version: 1
 type: os
 `
 
+var ubuntuCoreSnapWithComponentYaml = ubuntuCoreSnapYaml + `
+components:
+  comp:
+    type: test
+    hooks:
+      install:
+`
+
 var ubuntuCoreSnapYaml2 = `
 name: ubuntu-core
 version: 1
@@ -2302,6 +2441,18 @@ plugs:
   interface: network
  unrelated:
   interface: unrelated
+`
+
+var sampleSnapWithComponentsYaml = sampleSnapYaml + `
+components:
+  comp1:
+    type: test
+    hooks:
+      install:
+  comp2:
+    type: test
+    hooks:
+      pre-refresh:
 `
 
 var sampleSnapYamlManyPlugs = `
@@ -2341,6 +2492,66 @@ hooks:
  disconnect-plug-otherplug:
 `
 
+var consumerWithComponentYaml = consumerYaml + `
+components:
+  comp:
+    type: test
+    hooks:
+      install:
+  not-installed-comp:
+    type: test
+    hooks:
+      install:
+`
+
+var consumerRunnablesFullSet = []interfaces.Runnable{
+	{
+		CommandName: "hook.connect-plug-otherplug",
+		SecurityTag: "snap.consumer.hook.connect-plug-otherplug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.connect-plug-plug",
+		SecurityTag: "snap.consumer.hook.connect-plug-plug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.disconnect-plug-otherplug",
+		SecurityTag: "snap.consumer.hook.disconnect-plug-otherplug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.disconnect-plug-plug",
+		SecurityTag: "snap.consumer.hook.disconnect-plug-plug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.prepare-plug-otherplug",
+		SecurityTag: "snap.consumer.hook.prepare-plug-otherplug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.prepare-plug-plug",
+		SecurityTag: "snap.consumer.hook.prepare-plug-plug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.unprepare-plug-otherplug",
+		SecurityTag: "snap.consumer.hook.unprepare-plug-otherplug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.unprepare-plug-plug",
+		SecurityTag: "snap.consumer.hook.unprepare-plug-plug",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "consumer+comp.hook.install",
+		SecurityTag: "snap.consumer+comp.hook.install",
+		Type:        interfaces.RunnableComponentHook,
+	},
+}
+
 var consumer2Yaml = `
 name: consumer2
 version: 1
@@ -2373,6 +2584,46 @@ hooks:
   connect-slot-slot:
   disconnect-slot-slot:
 `
+
+var producerWithComponentYaml = producerYaml + `
+components:
+  comp:
+    type: test
+    hooks:
+      install:
+  not-installed-comp:
+    type: test
+    hooks:
+      install:
+`
+
+var producerRunnablesFullSet = []interfaces.Runnable{
+	{
+		CommandName: "hook.connect-slot-slot",
+		SecurityTag: "snap.producer.hook.connect-slot-slot",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.disconnect-slot-slot",
+		SecurityTag: "snap.producer.hook.disconnect-slot-slot",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.prepare-slot-slot",
+		SecurityTag: "snap.producer.hook.prepare-slot-slot",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "hook.unprepare-slot-slot",
+		SecurityTag: "snap.producer.hook.unprepare-slot-slot",
+		Type:        interfaces.RunnableHook,
+	},
+	{
+		CommandName: "producer+comp.hook.install",
+		SecurityTag: "snap.producer+comp.hook.install",
+		Type:        interfaces.RunnableComponentHook,
+	},
+}
 
 var producer2Yaml = `
 name: producer2
@@ -3221,8 +3472,8 @@ slots:
 	// just the first version of both in the state.
 	s.mockSnap(c, producerV1Yaml)
 	s.mockSnap(c, consumerV1Yaml)
-	snaptest.MockSnapInstance(c, "", consumerV2Yaml, &snap.SideInfo{Revision: snap.R(2)})
-	snaptest.MockSnapInstance(c, "", producerV2Yaml, &snap.SideInfo{Revision: snap.R(2)})
+	snaptest.MockSnapInstance(c, "", consumerV2Yaml, &snap.SideInfo{Revision: snap.R(2), RealName: "consumer"})
+	snaptest.MockSnapInstance(c, "", producerV2Yaml, &snap.SideInfo{Revision: snap.R(2), RealName: "producer"})
 
 	// Mock two unrelated snaps, those will show that the state of unrelated
 	// snaps is not clobbered by the refresh process.
@@ -3289,8 +3540,11 @@ slots:
 	s.state.Lock()
 	for _, snapName := range []string{"producer", "consumer"} {
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Active:   true,
-			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}}),
+			Active: true,
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+				{Revision: snap.R(1), RealName: snapName},
+				{Revision: snap.R(2), RealName: snapName},
+			}),
 			Current:  snap.R(2),
 			SnapType: string("app"),
 		})
@@ -3310,6 +3564,7 @@ slots:
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Logf("change failure: %v", change.Err())
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// We expect our security backend to be invoked for both snaps. See above
@@ -3393,8 +3648,11 @@ slots:
 	s.state.Lock()
 	for _, snapName := range []string{"producer", "consumer"} {
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Active:   true,
-			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}}),
+			Active: true,
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+				{Revision: snap.R(1), RealName: snapName},
+				{Revision: snap.R(2), RealName: snapName},
+			}),
 			Current:  snap.R(2),
 			SnapType: string("app"),
 		})
@@ -3738,6 +3996,344 @@ func (s *interfaceManagerSuite) TestSetupProfilesOnInstall(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].AppSet.Info().Revision, Equals, installSnapInfo.Revision)
 }
 
+func (s *interfaceManagerSuite) TestSetupProfilesInstallComponent(c *C) {
+	s.MockModel(c, nil)
+
+	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
+
+	const compomentYaml = `
+component: snap+comp1
+type: test
+version: 1.0
+`
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+
+	// initialize the manager
+	_ = s.manager(c)
+
+	change := s.addSetupSnapSecurityChangeFromComponent(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	}, &snapstate.ComponentSetup{
+		CompSideInfo: &snap.ComponentSideInfo{
+			Component: compInfo.Component,
+			Revision:  snap.R(1),
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
+
+	appSet := s.secBackend.SetupCalls[0].AppSet
+	c.Check(appSet.InstanceName(), Equals, snapInfo.InstanceName())
+	c.Check(appSet.Info().Revision, Equals, snapInfo.Revision)
+
+	// the snap defines another component, comp2. note that it is not listed
+	// here because it is not installed.
+	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+			Type:        interfaces.RunnableApp,
+		},
+		{
+			CommandName: "snap+comp1.hook.install",
+			SecurityTag: "snap.snap+comp1.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+}
+
+func (s *interfaceManagerSuite) mockComponentForSnap(c *C, compName string, compYaml string, snapInfo *snap.Info) *snap.ComponentInfo {
+	compInfo := snaptest.MockComponent(c, compYaml, snapInfo)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapInfo.InstanceName(), &snapst), IsNil)
+
+	snapst.Sequence.AddComponentForRevision(snapInfo.Revision, &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapInfo.SnapName(), compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	snapstate.Set(s.state, snapInfo.InstanceName(), &snapst)
+
+	return compInfo
+}
+
+func (s *interfaceManagerSuite) TestSetupProfilesInstallComponentSnapHasPreexistingComponent(c *C) {
+	s.MockModel(c, nil)
+
+	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
+	s.mockComponentForSnap(c, "comp2", "component: snap+comp2\ntype: test", snapInfo)
+
+	const compomentYaml = `
+component: snap+comp1
+type: test
+version: 1.0
+`
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+
+	// initialize the manager
+	_ = s.manager(c)
+
+	change := s.addSetupSnapSecurityChangeFromComponent(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	}, &snapstate.ComponentSetup{
+		CompSideInfo: &snap.ComponentSideInfo{
+			Component: compInfo.Component,
+			Revision:  snap.R(1),
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure that the task succeeded.
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
+
+	appSet := s.secBackend.SetupCalls[0].AppSet
+	c.Check(appSet.InstanceName(), Equals, snapInfo.InstanceName())
+	c.Check(appSet.Info().Revision, Equals, snapInfo.Revision)
+
+	// the snap defines another component, comp2. note that it is not listed
+	// here because it is not installed.
+	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+			Type:        interfaces.RunnableApp,
+		},
+		{
+			CommandName: "snap+comp1.hook.install",
+			SecurityTag: "snap.snap+comp1.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+		{
+			CommandName: "snap+comp2.hook.pre-refresh",
+			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+}
+
+func (s *interfaceManagerSuite) TestSetupProfilesUpdateSnapWithComponents(c *C) {
+	s.MockModel(c, nil)
+
+	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
+
+	s.mockComponentForSnap(c, "comp2", "component: snap+comp2\ntype: test", snapInfo)
+
+	const compomentYaml = `
+component: snap+comp1
+type: test
+version: 1.0
+`
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+
+	// initialize the manager
+	_ = s.manager(c)
+
+	change := s.addSetupSnapSecurityChangeFromComponent(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	}, &snapstate.ComponentSetup{
+		CompSideInfo: &snap.ComponentSideInfo{
+			Component: compInfo.Component,
+			Revision:  snap.R(1),
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure that the task succeeded.
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
+
+	appSet := s.secBackend.SetupCalls[0].AppSet
+	c.Check(appSet.InstanceName(), Equals, snapInfo.InstanceName())
+	c.Check(appSet.Info().Revision, Equals, snapInfo.Revision)
+
+	// the snap defines another component, comp2. note that it is not listed
+	// here because it is not installed.
+	c.Check(appSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+			Type:        interfaces.RunnableApp,
+		},
+		{
+			CommandName: "snap+comp1.hook.install",
+			SecurityTag: "snap.snap+comp1.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+		{
+			CommandName: "snap+comp2.hook.pre-refresh",
+			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+}
+
+func (s *interfaceManagerSuite) TestSetupProfilesOfAffectedSnapWithComponents(c *C) {
+	s.MockModel(c, nil)
+
+	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
+	snaptest.MockComponent(c, "component: snap+comp2\ntype: test", snapInfo)
+
+	// core snap is here so that it appears as an affected snap when "snap" has
+	// its profiles setup
+	coreSnapInfo := s.mockSnap(c, ubuntuCoreSnapWithComponentYaml)
+	snaptest.MockComponent(c, "component: ubuntu-core+comp\ntype: test", coreSnapInfo)
+
+	s.state.Lock()
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapInfo.InstanceName(), &snapst), IsNil)
+
+	// add a preexisting component to make sure that we create an app set that
+	// includes it
+	snapst.Sequence.AddComponentForRevision(snapInfo.Revision, &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapInfo.SnapName(), "comp2"),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	// add a component to the affected snap, we should see this in the final
+	// call to Setup in the backend
+	var coreSnapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, coreSnapInfo.InstanceName(), &coreSnapst), IsNil)
+	coreSnapst.Sequence.AddComponentForRevision(snapInfo.Revision, &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapInfo.SnapName(), "comp"),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	snapstate.Set(s.state, snapInfo.InstanceName(), &snapst)
+	snapstate.Set(s.state, coreSnapInfo.InstanceName(), &coreSnapst)
+
+	s.state.Unlock()
+
+	const compomentYaml = `
+component: snap+comp1
+type: test
+version: 1.0
+`
+	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo)
+
+	// initialize the manager
+	_ = s.manager(c)
+
+	change := s.addSetupSnapSecurityChangeFromComponent(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	}, &snapstate.ComponentSetup{
+		CompSideInfo: &snap.ComponentSideInfo{
+			Component: compInfo.Component,
+			Revision:  snap.R(1),
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure that the task succeeded.
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 3)
+
+	firstAppSet := s.secBackend.SetupCalls[0].AppSet
+	c.Check(firstAppSet.InstanceName(), Equals, snapInfo.InstanceName())
+	c.Check(firstAppSet.Info().Revision, Equals, snapInfo.Revision)
+
+	secondAppSet := s.secBackend.SetupCalls[1].AppSet
+	c.Check(secondAppSet.InstanceName(), Equals, snapInfo.InstanceName())
+	c.Check(secondAppSet.Info().Revision, Equals, snapInfo.Revision)
+
+	thirdAppSet := s.secBackend.SetupCalls[2].AppSet
+	c.Check(thirdAppSet.InstanceName(), Equals, coreSnapInfo.InstanceName())
+	c.Check(thirdAppSet.Info().Revision, Equals, coreSnapInfo.Revision)
+
+	// the snap defines another component, comp2. note that it is not listed
+	// here because it is not installed.
+	c.Check(firstAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+			Type:        interfaces.RunnableApp,
+		},
+		{
+			CommandName: "snap+comp1.hook.install",
+			SecurityTag: "snap.snap+comp1.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+		{
+			CommandName: "snap+comp2.hook.pre-refresh",
+			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+
+	c.Check(secondAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+			Type:        interfaces.RunnableApp,
+		},
+		{
+			CommandName: "snap+comp1.hook.install",
+			SecurityTag: "snap.snap+comp1.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+		{
+			CommandName: "snap+comp2.hook.pre-refresh",
+			SecurityTag: "snap.snap+comp2.hook.pre-refresh",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+
+	c.Check(thirdAppSet.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "ubuntu-core+comp.hook.install",
+			SecurityTag: "snap.ubuntu-core+comp.hook.install",
+			Type:        interfaces.RunnableComponentHook,
+		},
+	})
+}
+
 func (s *interfaceManagerSuite) TestSetupProfilesKeepsUndesiredConnection(c *C) {
 	undesired := true
 	byGadget := false
@@ -3885,6 +4481,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityForConnectedSlots(c 
 	// 1st call is for initial setup-profiles, 2nd call is for setup-profiles after connect task.
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, snapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[0].AppSet.Info().Revision, Equals, snapInfo.Revision)
+
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, snapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[1].AppSet.Info().Revision, Equals, snapInfo.Revision)
 
@@ -4203,6 +4800,55 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+}
+
+func (s *interfaceManagerSuite) TestConnectWithComponentsSetsUpSecurity(c *C) {
+	s.MockModel(c, nil)
+
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+
+	consumerInfo := s.mockSnap(c, consumerWithComponentYaml)
+	producerInfo := s.mockSnap(c, producerWithComponentYaml)
+	s.mockComponentForSnap(c, "comp", "component: consumer+comp\ntype: test", consumerInfo)
+	s.mockComponentForSnap(c, "comp", "component: producer+comp\ntype: test", producerInfo)
+
+	_ = s.manager(c)
+
+	s.state.Lock()
+	ts, err := ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
+	c.Assert(err, IsNil)
+	ts.Tasks()[0].Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "consumer",
+		},
+	})
+
+	change := s.state.NewChange("connect", "")
+	change.AddAll(ts)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
+
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+
+	producerAppSet := s.secBackend.SetupCalls[0].AppSet
+	consumerAppSet := s.secBackend.SetupCalls[1].AppSet
+
+	c.Check(producerAppSet.InstanceName(), Equals, "producer")
+	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
+
+	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
@@ -5359,8 +6005,11 @@ func (s *interfaceManagerSuite) mockConnectForUndo(c *C, conns map[string]interf
 
 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.manager(c)
-	producer := s.mockSnap(c, producerYaml)
-	consumer := s.mockSnap(c, consumerYaml)
+	producer := s.mockSnap(c, producerWithComponentYaml)
+	consumer := s.mockSnap(c, consumerWithComponentYaml)
+
+	s.mockComponentForSnap(c, "comp", "component: consumer+comp\ntype: test", consumer)
+	s.mockComponentForSnap(c, "comp", "component: producer+comp\ntype: test", producer)
 
 	repo := s.manager(c).Repository()
 	err := repo.AddPlug(&snap.PlugInfo{
@@ -5432,12 +6081,16 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].AppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[1].AppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
 
 	// by undo
 	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[3].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{})
 	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[2].AppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+	c.Check(s.secBackend.SetupCalls[3].AppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
@@ -5482,6 +6135,16 @@ func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
 	_, err := s.manager(c).Repository().Connection(cref)
 	notConnected, _ := err.(*interfaces.NotConnectedError)
 	c.Check(notConnected, NotNil)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 4)
+
+	producerAppSet := s.secBackend.SetupCalls[2].AppSet
+	c.Check(producerAppSet.InstanceName(), Equals, "producer")
+	c.Check(producerAppSet.Runnables(), DeepEquals, producerRunnablesFullSet)
+
+	consumerAppSet := s.secBackend.SetupCalls[3].AppSet
+	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
+	c.Check(consumerAppSet.Runnables(), DeepEquals, consumerRunnablesFullSet)
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectNoSetupProfilesWithDelayedSetupProfiles(c *C) {

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -168,6 +168,11 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 		addTask(unlink)
 	}
 
+	// security
+	setupSecurity := st.NewTask("setup-profiles", fmt.Sprintf(i18n.G("Setup component %q%s security profiles"), compSi.Component, revisionStr))
+	addTask(setupSecurity)
+	prev = setupSecurity
+
 	// finalize (sets SnapState)
 	linkSnap := st.NewTask("link-component",
 		fmt.Sprintf(i18n.G("Make component %q%s available to the system"),

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -65,6 +65,9 @@ func expectedComponentInstallTasks(opts int) []string {
 	if opts&compOptIsActive != 0 {
 		startTasks = append(startTasks, "unlink-current-component")
 	}
+
+	startTasks = append(startTasks, "setup-profiles")
+
 	// link-component is always present
 	startTasks = append(startTasks, "link-component")
 	if opts&compOptIsActive != 0 {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -67,37 +67,6 @@ func TaskComponentSetup(t *state.Task) (*ComponentSetup, *SnapSetup, error) {
 	return &compSetup, snapsup, nil
 }
 
-func TaskComponentSetups(t *state.Task) ([]*ComponentSetup, *SnapSetup, error) {
-	snapsup, err := TaskSnapSetup(t)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var setups []*ComponentSetup
-	err = t.Get("component-setups", &setups)
-	if err != nil && !errors.Is(err, state.ErrNoState) {
-		return nil, nil, err
-	}
-
-	if err == nil {
-		return setups, snapsup, nil
-	}
-
-	var id string
-	if err := t.Get("component-setups-task", &id); err != nil {
-		return nil, nil, err
-	}
-
-	ts := t.State().Task(id)
-	if ts == nil {
-		return nil, nil, fmt.Errorf("internal error: tasks are being pruned")
-	}
-	if err := ts.Get("component-setups", &setups); err != nil {
-		return nil, nil, err
-	}
-	return setups, snapsup, nil
-}
-
 func compSetupAndState(t *state.Task) (*ComponentSetup, *SnapSetup, *SnapState, error) {
 	csup, ssup, err := TaskComponentSetup(t)
 	if err != nil {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -67,6 +67,37 @@ func TaskComponentSetup(t *state.Task) (*ComponentSetup, *SnapSetup, error) {
 	return &compSetup, snapsup, nil
 }
 
+func TaskComponentSetups(t *state.Task) ([]*ComponentSetup, *SnapSetup, error) {
+	snapsup, err := TaskSnapSetup(t)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var setups []*ComponentSetup
+	err = t.Get("component-setups", &setups)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return nil, nil, err
+	}
+
+	if err == nil {
+		return setups, snapsup, nil
+	}
+
+	var id string
+	if err := t.Get("component-setups-task", &id); err != nil {
+		return nil, nil, err
+	}
+
+	ts := t.State().Task(id)
+	if ts == nil {
+		return nil, nil, fmt.Errorf("internal error: tasks are being pruned")
+	}
+	if err := ts.Get("component-setups", &setups); err != nil {
+		return nil, nil, err
+	}
+	return setups, snapsup, nil
+}
+
 func compSetupAndState(t *state.Task) (*ComponentSetup, *SnapSetup, *SnapState, error) {
 	csup, ssup, err := TaskComponentSetup(t)
 	if err != nil {

--- a/overlord/snapstate/handlers_components_test.go
+++ b/overlord/snapstate/handlers_components_test.go
@@ -139,7 +139,6 @@ func (s *handlersComponentsSuite) TestComponentSetupsForTaskSnapWithoutComponent
 	defer s.state.Unlock()
 	t := s.state.NewTask("prepare-component", "test")
 
-	const snapName = "mysnap"
 	t.Set("snap-setup", snapstate.SnapSetup{
 		Version: "1.0",
 	})

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -223,27 +223,22 @@ func (compsu *ComponentSetup) Revision() snap.Revision {
 //
 // The task could originate from:
 // * Installing a singular component for an already installed snap
+// * Installing multiple components for an already installed snap
 // * Installing/refreshing a snap with components
 // * Installing/refreshing a snap without any components
 func ComponentSetupsForTask(t *state.Task) ([]*ComponentSetup, error) {
+	// TODO: handle remaining cases in this switch:
+	// * installing multiple components for an already installed snap
+	// * installing/refreshing a snap with components
 	switch {
 	case t.Has("component-setup") || t.Has("component-setup-task"):
-		// task comes from a component installation
+		// task comes from a singular component installation for an already
+		// installed snap
 		compsup, _, err := TaskComponentSetup(t)
 		if err != nil {
 			return nil, err
 		}
 		return []*ComponentSetup{compsup}, nil
-	case t.Has("component-setups") || t.Has("component-setups-task"):
-		// TODO: test this branch once we know more about refreshing/installing
-		// snaps with components
-
-		// task comes from a snap refresh/install that contains components
-		compsups, _, err := TaskComponentSetups(t)
-		if err != nil {
-			return nil, err
-		}
-		return compsups, nil
 	default:
 		// task comes from a snap installation that doesn't contain any
 		// components

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -537,7 +537,7 @@ func (snapst *SnapState) ComponentInfosForRevision(rev snap.Revision) ([]*snap.C
 	compInfos := make([]*snap.ComponentInfo, 0, len(revState.Components))
 	for _, comp := range revState.Components {
 		cpi := snap.MinimalComponentContainerPlaceInfo(comp.SideInfo.Component.ComponentName,
-			comp.SideInfo.Revision, si.InstanceName(), si.SnapRevision())
+			comp.SideInfo.Revision, si.InstanceName())
 
 		compInfo, err := readComponentInfo(cpi.MountDir(), si)
 		if err != nil {

--- a/snap/component.go
+++ b/snap/component.go
@@ -250,6 +250,12 @@ func (ci *ComponentInfo) FullName() string {
 	return ci.Component.String()
 }
 
+// HooksForPlug returns the component hooks that are associated with the given
+// plug.
+func (ci *ComponentInfo) HooksForPlug(plug *PlugInfo) []*HookInfo {
+	return hooksForPlug(plug, ci.Hooks)
+}
+
 // Validate performs some basic validations on component.yaml values.
 func (ci *ComponentInfo) validate() error {
 	if ci.Component.SnapName == "" {

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -477,3 +477,45 @@ components:
 	_, err = snap.ReadComponentInfoFromContainer(compf, snapInfo)
 	c.Assert(err, ErrorMatches, `inconsistent component type \("kernel-modules" in snap, "test" in component\)`)
 }
+
+func (s *componentSuite) TestHooksForPlug(c *C) {
+	const snapYaml = `
+name: snap
+version: 1
+apps:
+ one:
+   command: one
+   plugs: [app-plug]
+components:
+  comp:
+    type: test
+    hooks:
+      install:
+        plugs: [scoped-plug]
+      pre-refresh:
+plugs:
+  unscoped-plug:
+  app-plug:
+`
+	const componentYaml = `
+component: snap+comp
+type: test
+version: 1
+`
+
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+
+	componentInfo := snaptest.MockComponent(c, componentYaml, info)
+
+	scoped := info.Plugs["scoped-plug"]
+	c.Assert(scoped, NotNil)
+
+	scopedHooks := componentInfo.HooksForPlug(scoped)
+	c.Assert(scopedHooks, testutil.DeepUnsortedMatches, []*snap.HookInfo{componentInfo.Hooks["install"]})
+
+	unscoped := info.Plugs["unscoped-plug"]
+	c.Assert(unscoped, NotNil)
+
+	unscopedHooks := componentInfo.HooksForPlug(unscoped)
+	c.Assert(unscopedHooks, testutil.DeepUnsortedMatches, []*snap.HookInfo{componentInfo.Hooks["install"], componentInfo.Hooks["pre-refresh"]})
+}

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -505,7 +505,9 @@ version: 1
 
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
 
-	componentInfo := snaptest.MockComponent(c, componentYaml, info)
+	componentInfo := snaptest.MockComponent(c, componentYaml, info, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
 
 	scoped := info.Plugs["scoped-plug"]
 	c.Assert(scoped, NotNil)

--- a/snap/info.go
+++ b/snap/info.go
@@ -846,22 +846,26 @@ func (s *Info) AppsForSlot(slot *SlotInfo) []*AppInfo {
 // HooksForPlug returns the list of hooks that are associated with the given
 // plug. If the plug is unscoped, then all hooks are returned.
 func (s *Info) HooksForPlug(plug *PlugInfo) []*HookInfo {
+	return hooksForPlug(plug, s.Hooks)
+}
+
+func hooksForPlug(plug *PlugInfo, hooks map[string]*HookInfo) []*HookInfo {
 	if plug.Unscoped {
-		hooks := make([]*HookInfo, 0, len(s.Hooks))
-		for _, hook := range s.Hooks {
-			hooks = append(hooks, hook)
+		plugHooks := make([]*HookInfo, 0, len(hooks))
+		for _, hook := range hooks {
+			plugHooks = append(plugHooks, hook)
 		}
-		return hooks
+		return plugHooks
 	}
 
-	var hooks []*HookInfo
-	for _, hook := range s.Hooks {
+	var plugHooks []*HookInfo
+	for _, hook := range hooks {
 		if _, ok := hook.Plugs[plug.Name]; ok {
-			hooks = append(hooks, hook)
+			plugHooks = append(plugHooks, hook)
 		}
 	}
 
-	return hooks
+	return plugHooks
 }
 
 // HooksForSlot returns the list of hooks that are associated with the given

--- a/snap/info.go
+++ b/snap/info.go
@@ -218,6 +218,11 @@ func AppSecurityTag(snapName, appName string) string {
 	return fmt.Sprintf("%s.%s", SecurityTag(snapName), appName)
 }
 
+// ComponentSecurityTag returns a snap component's hook-specific security tag.
+func ComponentHookSecurityTag(snapInstance, componentName, hookName string) string {
+	return ScopedSecurityTag(fmt.Sprintf("%s+%s", snapInstance, componentName), "hook", hookName)
+}
+
 // HookSecurityTag returns the hook-specific security tag.
 func HookSecurityTag(snapName, hookName string) string {
 	return ScopedSecurityTag(snapName, "hook", hookName)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2339,3 +2339,8 @@ func (s *infoSuite) TestComponentMountDir(c *C) {
 	dir := snap.ComponentMountDir("comp", snap.R(1), "snap")
 	c.Check(dir, Equals, filepath.Join(dirs.SnapMountDir, "snap", "components", "mnt", "comp", "1"))
 }
+
+func (s *infoSuite) TestComponentHookSecurityTag(c *C) {
+	c.Check(snap.ComponentHookSecurityTag("snap", "comp", "install"), Equals, "snap.snap+comp.hook.install")
+	c.Check(snap.ComponentHookSecurityTag("snap_name", "comp", "install"), Equals, "snap.snap_name+comp.hook.install")
+}

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -90,14 +90,13 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 //
 // The caller is responsible for mocking root directory with dirs.SetRootDir()
 // and for altering the overlord state if required.
-func MockComponent(c *check.C, yamlText string, info *snap.Info) *snap.ComponentInfo {
+func MockComponent(c *check.C, yamlText string, info *snap.Info, csi snap.ComponentSideInfo) *snap.ComponentInfo {
 	infoForName, err := snap.InfoFromComponentYaml([]byte(yamlText))
 	c.Assert(err, check.IsNil)
 
-	componentName := infoForName.Component.ComponentName
-
-	// Put the YAML on disk, in the right spot.
-	metaDir := filepath.Join(snap.BaseDir(info.InstanceName()), "components", info.Revision.String(), componentName, "meta")
+	// Put the component.yaml on disk, in the right spot.
+	mountDir := snap.ComponentMountDir(infoForName.Component.ComponentName, csi.Revision, info.InstanceName())
+	metaDir := filepath.Join(mountDir, "meta")
 	err = os.MkdirAll(metaDir, 0755)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
This PR does some of the work for creating security profiles for component hooks. First relevant commit is 3a7d9f9349296f845ad2fa587b72498bc754fb5a, based on https://github.com/snapcore/snapd/pull/13837.