### PR TITLE
tests: isolate lp-2044335 regression test kernel packaging

### DIFF
--- a/tests/regression/lp-2044335/task.yaml
+++ b/tests/regression/lp-2044335/task.yaml
@@ -23,8 +23,18 @@ prepare: |
     rm -f test-snapd-busybox-static*.snap
     snap connect test-snapd-busybox-static:system-packages-doc
 
+    if [ ! -e "/usr/share/doc/linux-image-$(uname -r)/changelog.Debian.gz" ]; then
+      # We do not care about packaging, more about mount namespaces working.
+      mkdir -p "/usr/share/doc/linux-image-$(uname -r)/"
+      touch "/usr/share/doc/linux-image-$(uname -r)/FAKE"
+      touch "/usr/share/doc/linux-image-$(uname -r)/changelog.Debian.gz"
+    fi
+
 restore: |
     snap remove --purge test-snapd-busybox-static
+    if [ -f "/usr/share/doc/linux-image-$(uname -r)/FAKE" ]; then
+      rm -rf "/usr/share/doc/linux-image-$(uname -r)/"
+    fi
 
 execute: |
     snap run test-snapd-busybox-static.busybox-static stat "/usr/share/doc/linux-image-$(uname -r)/changelog.Debian.gz"


### PR DESCRIPTION
In certain cases, the kernel packaging may not contain the directory /usr/share/linux-image-$(uname -r). Since we do not precisely care about kernel packaging or special kernel packages for the cloud, isolate the test from this factor by automatically creating the directory if required.
