### PR TITLE
tests: update the configuration used to display the static analysis info

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,6 +12,6 @@ jobs:
         uses: tiobe/tics-github-action@v2
         with:
           projectName: snapd
-          ticsConfiguration: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=config
+          ticsConfiguration: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true


### PR DESCRIPTION
The are switching to the default configuration for the snapd project.

This is to avoid exception raised in prs.

