### PR TITLE
features: add experimental.apparmor-prompting feature stub

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,6 +72,8 @@ const (
 	RefreshAppAwarenessUX
 	// AspectsConfiguration enables experimental aspect-based configuration.
 	AspectsConfiguration
+	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
+	AppArmorPrompting
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -115,6 +117,8 @@ var featureNames = map[SnapdFeature]string{
 
 	RefreshAppAwarenessUX: "refresh-app-awareness-ux",
 	AspectsConfiguration:  "aspects-configuration",
+
+	AppArmorPrompting: "apparmor-prompting",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -63,6 +63,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.QuotaGroups, "quota-groups")
 	check(features.RefreshAppAwarenessUX, "refresh-app-awareness-ux")
 	check(features.AspectsConfiguration, "aspects-configuration")
+	check(features.AppArmorPrompting, "apparmor-prompting")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -101,9 +102,10 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.CheckDiskSpaceRefresh, false)
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
+	check(features.QuotaGroups, false)
 	check(features.RefreshAppAwarenessUX, true)
 	check(features.AspectsConfiguration, true)
-	check(features.QuotaGroups, false)
+	check(features.AppArmorPrompting, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -150,9 +152,10 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.CheckDiskSpaceRefresh, false)
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
+	check(features.QuotaGroups, false)
 	check(features.RefreshAppAwarenessUX, false)
 	check(features.AspectsConfiguration, false)
-	check(features.QuotaGroups, false)
+	check(features.AppArmorPrompting, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }


### PR DESCRIPTION
This is a stub version of #13670 , since checking AppArmor kernel and parser support for prompting and passing that information into AppArmor profile regeneration are non-trivial, and not particularly essential in the initial introduction of this feature, while the rest of prompting is not yet merged.

This PR is useful because #13681 exposes the list of supported and/or enabled features on `/v2/system-info`, and we want this feature to be included in that list and marked as unsupported, requiring a newer snapd release.

Whichever of this PR or #13681 get merged second should be responsible for adding a callback to the `featureSupportedCallbacks` which returns false, thus marking this feature as unsupported.