### PR TITLE
osutil: extend nfs-based home to support cifs

### DIFF
--- a/osutil/nfs_linux.go
+++ b/osutil/nfs_linux.go
@@ -37,8 +37,11 @@ var isHomeUsingNFS = func() (bool, error) {
 		return false, fmt.Errorf("cannot parse mountinfo: %s", err)
 	}
 	for _, entry := range mountinfo {
-		if (entry.FsType == "nfs4" || entry.FsType == "nfs" || entry.FsType == "autofs") && (strings.HasPrefix(entry.MountDir, "/home/") || entry.MountDir == "/home") {
-			return true, nil
+		switch entry.FsType {
+		case "nfs4", "nfs", "autofs", "cifs":
+			if strings.HasPrefix(entry.MountDir, "/home/") || entry.MountDir == "/home" {
+				return true, nil
+			}
 		}
 	}
 	fstab, err := LoadMountProfile(etcFstab)
@@ -46,8 +49,11 @@ var isHomeUsingNFS = func() (bool, error) {
 		return false, fmt.Errorf("cannot parse %s: %s", etcFstab, err)
 	}
 	for _, entry := range fstab.Entries {
-		if (entry.Type == "nfs4" || entry.Type == "nfs") && (strings.HasPrefix(entry.Dir, "/home/") || entry.Dir == "/home") {
-			return true, nil
+		switch entry.Type {
+		case "nfs4", "nfs", "autofs", "cifs":
+			if strings.HasPrefix(entry.Dir, "/home/") || entry.Dir == "/home" {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/osutil/nfs_linux_test.go
+++ b/osutil/nfs_linux_test.go
@@ -80,6 +80,16 @@ func (s *nfsSuite) TestIsHomeUsingNFS(c *C) {
 		// autofs that is mounted at /home.
 		mountinfo: "137 29 0:50 / /home rw,relatime shared:87 - autofs /etc/auto.master.d/home rw,fd=7,pgrp=22588,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=173399",
 		nfs:       true,
+	}, {
+		// cifs that is mounted at /home
+		// This is not real data, it is made-up.
+		mountinfo: "0 0 0:0 / /home rw,relatime shared:0 - cifs //sub.example.org/path$/all-users irrelevant-options",
+		nfs:       true,
+	}, {
+		// cifs that is mounted at /home/$USERNAME
+		// This is not real data, it is made-up.
+		mountinfo: "0 0 0:0 / /home/some-user rw,relatime shared:0 - cifs //sub.example.org/path$/some-user irrelevant-options",
+		nfs:       true,
 	}}
 	for _, tc := range cases {
 		restore := osutil.MockMountInfo(tc.mountinfo)


### PR DESCRIPTION
NFS and CIFS share the same shortcoming, that on kernels older than 6.8 (but I could be wrong on the version number), accessing files there causes apparmor to require network permissions even though the process performing the access is entirely unaware of the fact that network file system is in use.

Snapd contained a work-around for this behavior, with specific detection logic looking for NFS file system mounted or declared at a specific place. Extend the logic to handle NFS and CIFS equally, to give better support to SAMBA or Windows Server-based home directories.

Follows on https://github.com/snapcore/snapd/pull/13758
