### PR TITLE
o/hookstate/ctlcmd: introduce --user, --system and --users switches for snap service operations

### DIFF
--- a/client/clientutil/service_scope_test.go
+++ b/client/clientutil/service_scope_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil_test
+
+import (
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
+	. "gopkg.in/check.v1"
+)
+
+type serviceScopeSuite struct{}
+
+var _ = Suite(&serviceScopeSuite{})
+
+func (s *serviceScopeSuite) TestScopes(c *C) {
+	tests := []struct {
+		opts     clientutil.ServiceScopeOptions
+		expected client.ScopeSelector
+	}{
+		// when expected is nil it means both scopes
+		{clientutil.ServiceScopeOptions{}, nil},
+		{clientutil.ServiceScopeOptions{User: true}, client.ScopeSelector{"user"}},
+		{clientutil.ServiceScopeOptions{Usernames: "all"}, client.ScopeSelector{"user"}},
+		{clientutil.ServiceScopeOptions{System: true}, client.ScopeSelector{"system"}},
+		{clientutil.ServiceScopeOptions{User: true, System: true}, nil},
+		{clientutil.ServiceScopeOptions{Usernames: "all", System: true}, nil},
+	}
+
+	for _, t := range tests {
+		c.Check(t.opts.Scope(), DeepEquals, t.expected)
+	}
+}
+
+func (s *serviceScopeSuite) TestUsers(c *C) {
+	tests := []struct {
+		opts     clientutil.ServiceScopeOptions
+		expected client.UserSelector
+	}{
+		{clientutil.ServiceScopeOptions{}, client.UserSelector{Names: []string{}, Selector: client.UserSelectionList}},
+		{clientutil.ServiceScopeOptions{User: true}, client.UserSelector{Selector: client.UserSelectionSelf}},
+		{clientutil.ServiceScopeOptions{Usernames: "all"}, client.UserSelector{Selector: client.UserSelectionAll}},
+		{clientutil.ServiceScopeOptions{System: true}, client.UserSelector{Names: []string{}, Selector: client.UserSelectionList}},
+		{clientutil.ServiceScopeOptions{User: true, System: true}, client.UserSelector{Selector: client.UserSelectionSelf}},
+		{clientutil.ServiceScopeOptions{Usernames: "all", System: true}, client.UserSelector{Selector: client.UserSelectionAll}},
+	}
+
+	for _, t := range tests {
+		c.Check(t.opts.Users(), DeepEquals, t.expected)
+	}
+}
+
+func (s *serviceScopeSuite) TestInvalidOptions(c *C) {
+	tests := []struct {
+		opts     clientutil.ServiceScopeOptions
+		expected string
+	}{
+		{clientutil.ServiceScopeOptions{Usernames: "foo"}, `only "all" is supported as a value for --users`},
+		{clientutil.ServiceScopeOptions{User: true, System: true}, `--system and --user cannot be used in conjunction with each other`},
+		{clientutil.ServiceScopeOptions{Usernames: "all", User: true}, `--user and --users cannot be used in conjunction with each other`},
+	}
+
+	for _, t := range tests {
+		c.Check(t.opts.Validate(), ErrorMatches, t.expected)
+	}
+}

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -38,6 +38,7 @@ func init() {
 
 type restartCommand struct {
 	baseCommand
+	userAndScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -45,12 +46,18 @@ type restartCommand struct {
 }
 
 func (c *restartCommand) Execute(args []string) error {
+	if err := c.validateScopes(); err != nil {
+		return err
+	}
+
 	inst := servicestate.Instruction{
 		Action: "restart",
 		Names:  c.Positional.ServiceNames,
 		RestartOptions: client.RestartOptions{
 			Reload: c.Reload,
 		},
+		Scope: c.serviceScope(),
+		Users: c.serviceUsers(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
 )
@@ -38,7 +39,7 @@ func init() {
 
 type restartCommand struct {
 	baseCommand
-	userAndScopeOptions
+	clientutil.ServiceScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -46,7 +47,7 @@ type restartCommand struct {
 }
 
 func (c *restartCommand) Execute(args []string) error {
-	if err := c.validateScopes(); err != nil {
+	if err := c.Validate(); err != nil {
 		return err
 	}
 
@@ -56,8 +57,8 @@ func (c *restartCommand) Execute(args []string) error {
 		RestartOptions: client.RestartOptions{
 			Reload: c.Reload,
 		},
-		Scope: c.serviceScope(),
-		Users: c.serviceUsers(),
+		Scope: c.Scope(),
+		Users: c.Users(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }

--- a/overlord/hookstate/ctlcmd/service_scope.go
+++ b/overlord/hookstate/ctlcmd/service_scope.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/strutil"
+)
+
+// userAndScopeOptions represents shared options between service operations
+// that change the scope of services affected. This should more or less
+// match what's in cmd/snap.
+type userAndScopeOptions struct {
+	System bool   `long:"system"`
+	User   bool   `long:"user"`
+	Users  string `long:"users"`
+}
+
+func (us *userAndScopeOptions) validateScopes() error {
+	switch {
+	case us.System && us.User:
+		return fmt.Errorf("--system and --user cannot be used in conjunction with each other")
+	case us.Users != "" && us.User:
+		return fmt.Errorf("--user and --users cannot be used in conjunction with each other")
+	case us.Users != "" && us.Users != "all":
+		return fmt.Errorf("only \"all\" is supported as a value for --users")
+	}
+	return nil
+}
+
+func (us *userAndScopeOptions) serviceScope() client.ScopeSelector {
+	switch {
+	case (us.User || us.Users != "") && !us.System:
+		return client.ScopeSelector([]string{"user"})
+	case !(us.User || us.Users != "") && us.System:
+		return client.ScopeSelector([]string{"system"})
+	}
+	return nil
+}
+
+func (us *userAndScopeOptions) serviceUsers() client.UserSelector {
+	switch {
+	case us.User:
+		return client.UserSelector{
+			Selector: client.UserSelectionSelf,
+		}
+	case us.Users == "all":
+		return client.UserSelector{
+			Selector: client.UserSelectionAll,
+		}
+	}
+	return client.UserSelector{
+		Selector: client.UserSelectionList,
+		Names:    strutil.CommaSeparatedList(us.Users),
+	}
+}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -230,6 +230,10 @@ func (s *servicectlSuite) TestStopCommand(c *C) {
 			StopOptions: client.StopOptions{
 				Disable: false,
 			},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
+			},
 		},
 		)
 	})
@@ -277,6 +281,10 @@ func (s *servicectlSuite) TestStartCommand(c *C) {
 			StartOptions: client.StartOptions{
 				Enable: false,
 			},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
+			},
 		},
 		)
 	})
@@ -298,6 +306,10 @@ func (s *servicectlSuite) TestRestartCommand(c *C) {
 			Names:  []string{"test-snap.test-service"},
 			RestartOptions: client.RestartOptions{
 				Reload: false,
+			},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
 			},
 		},
 		)
@@ -354,6 +366,15 @@ func (s *servicectlSuite) TestServiceCommandsScope(c *C) {
 			Action: c,
 			Names:  names,
 			Scope:  []string{"user"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionAll,
+			},
+		}, "")
+
+		// check combined cases
+		checkInvocation(c, names, []string{"--system", "--users=all"}, &servicestate.Instruction{
+			Action: c,
+			Names:  names,
 			Users: client.UserSelector{
 				Selector: client.UserSelectionAll,
 			},

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -309,6 +309,70 @@ func (s *servicectlSuite) TestRestartCommand(c *C) {
 	c.Assert(serviceChangeFuncCalled, Equals, true)
 }
 
+func (s *servicectlSuite) TestServiceCommandsScope(c *C) {
+	checkInvocation := func(action string, names, args []string, expected *servicestate.Instruction, expectedErr string) {
+		var serviceChangeFuncCalled bool
+		restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+			serviceChangeFuncCalled = true
+			c.Check(appInfos, HasLen, 1)
+			c.Check(appInfos[0].Name, Equals, "test-service")
+			c.Check(inst, DeepEquals, expected)
+		})
+		defer restore()
+		_, _, err := ctlcmd.Run(s.mockContext, append([]string{action}, append(names, args...)...), 0)
+		c.Check(err, NotNil)
+		if expectedErr != "" {
+			c.Check(err, ErrorMatches, expectedErr)
+			c.Check(serviceChangeFuncCalled, Equals, false)
+		} else {
+			// bit weird we are always returning an error in the test code
+			c.Check(err, ErrorMatches, "forced error")
+			c.Check(serviceChangeFuncCalled, Equals, true)
+		}
+	}
+
+	for _, c := range []string{"start", "stop", "restart"} {
+		names := []string{"test-snap.test-service"}
+		checkInvocation(c, names, []string{"--system"}, &servicestate.Instruction{
+			Action: c,
+			Names:  names,
+			Scope:  []string{"system"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
+			},
+		}, "")
+		checkInvocation(c, names, []string{"--user"}, &servicestate.Instruction{
+			Action: c,
+			Names:  names,
+			Scope:  []string{"user"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionSelf,
+			},
+		}, "")
+		checkInvocation(c, names, []string{"--users=all"}, &servicestate.Instruction{
+			Action: c,
+			Names:  names,
+			Scope:  []string{"user"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionAll,
+			},
+		}, "")
+
+		// we *must* provide a value for --users
+		checkInvocation(c, names, []string{"--users"}, nil, "expected argument for flag `--users'")
+
+		// that value must only be 'all'
+		checkInvocation(c, names, []string{"--users=foo"}, nil, "only \"all\" is supported as a value for --users")
+
+		// --system and --user not allowed together
+		checkInvocation(c, names, []string{"--system", "--user"}, nil, "--system and --user cannot be used in conjunction with each other")
+
+		// --user and --users not allowed together
+		checkInvocation(c, names, []string{"--users=all", "--user"}, nil, "--user and --users cannot be used in conjunction with each other")
+	}
+}
+
 func (s *servicectlSuite) TestConflictingChange(c *C) {
 	s.st.Lock()
 	task := s.st.NewTask("link-snap", "conflicting task")

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
 )
@@ -38,7 +39,7 @@ func init() {
 
 type startCommand struct {
 	baseCommand
-	userAndScopeOptions
+	clientutil.ServiceScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -46,7 +47,7 @@ type startCommand struct {
 }
 
 func (c *startCommand) Execute(args []string) error {
-	if err := c.validateScopes(); err != nil {
+	if err := c.Validate(); err != nil {
 		return err
 	}
 
@@ -56,8 +57,8 @@ func (c *startCommand) Execute(args []string) error {
 		StartOptions: client.StartOptions{
 			Enable: c.Enable,
 		},
-		Scope: c.serviceScope(),
-		Users: c.serviceUsers(),
+		Scope: c.Scope(),
+		Users: c.Users(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -38,6 +38,7 @@ func init() {
 
 type startCommand struct {
 	baseCommand
+	userAndScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -45,12 +46,18 @@ type startCommand struct {
 }
 
 func (c *startCommand) Execute(args []string) error {
+	if err := c.validateScopes(); err != nil {
+		return err
+	}
+
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  c.Positional.ServiceNames,
 		StartOptions: client.StartOptions{
 			Enable: c.Enable,
 		},
+		Scope: c.serviceScope(),
+		Users: c.serviceUsers(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,6 +27,7 @@ import (
 
 type stopCommand struct {
 	baseCommand
+	userAndScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -45,12 +46,18 @@ func init() {
 }
 
 func (c *stopCommand) Execute(args []string) error {
+	if err := c.validateScopes(); err != nil {
+		return err
+	}
+
 	inst := servicestate.Instruction{
 		Action: "stop",
 		Names:  c.Positional.ServiceNames,
 		StopOptions: client.StopOptions{
 			Disable: c.Disable,
 		},
+		Scope: c.serviceScope(),
+		Users: c.serviceUsers(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -21,13 +21,14 @@ package ctlcmd
 
 import (
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
 )
 
 type stopCommand struct {
 	baseCommand
-	userAndScopeOptions
+	clientutil.ServiceScopeOptions
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
@@ -46,7 +47,7 @@ func init() {
 }
 
 func (c *stopCommand) Execute(args []string) error {
-	if err := c.validateScopes(); err != nil {
+	if err := c.Validate(); err != nil {
 		return err
 	}
 
@@ -56,8 +57,8 @@ func (c *stopCommand) Execute(args []string) error {
 		StopOptions: client.StopOptions{
 			Disable: c.Disable,
 		},
-		Scope: c.serviceScope(),
-		Users: c.serviceUsers(),
+		Scope: c.Scope(),
+		Users: c.Users(),
 	}
 	return runServiceCommand(c.context(), &inst)
 }


### PR DESCRIPTION
This is the snapctl version of https://github.com/snapcore/snapd/pull/13368 and based on top of it to reuse some of the code from that PR.