### PR TITLE
release-tools: skip flake8 on 24.04

### DIFF
--- a/release-tools/test/test_flake8.py
+++ b/release-tools/test/test_flake8.py
@@ -3,7 +3,13 @@ import subprocess
 import unittest
 
 
+def is_24_04():
+    with open("/etc/os-release") as inf:
+        return "VERSION_ID=\"24.04\"" in inf.read()
+
+
 class TestFlake8(unittest.TestCase):
+    @unittest.skipIf(is_24_04(), "flake8 is broken on 24.04")
     def test_flake8(self):
         p = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
         subprocess.check_call(["flake8", "--ignore=E501", p])


### PR DESCRIPTION
flake8 is broken on 24.04, this outright fails:

```
$ flake8 --ignore=E501 release-tools
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/flake8/plugins/finder.py", line 296, in _load_plugin
    obj = plugin.entry_point.load()
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3/dist-packages/flake8/plugins/pycodestyle.py", line 25, in <module>
    from pycodestyle import missing_whitespace_around_operator as _missing_whitespace_around_operator  # noqa: E501
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: cannot import name 'missing_whitespace_around_operator' from 'pycodestyle' (/usr/lib/python3/dist-packages/pycodestyle.py)
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
