### PR TITLE
tests: update the snap-system-env test for noble

### DIFF
--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -1,5 +1,7 @@
 summary: Ensure systemd environment generator works
 
+details: Test that the snapd-env-generator works as expected
+
 # systemd environment generators are only supported on 17.10+
 systems: [ubuntu-18.04-*, ubuntu-19*, ubuntu-2*]
 
@@ -20,7 +22,12 @@ execute: |
     systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*/local/.*'
     systemd-run --pty --wait '/usr/bin/env' > env.out
     # ensure PATH is updated (and check full PATH, see LP: #1814355)
-    MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin' < env.out
+
+    if os.query is-ubuntu-ge 24.04; then
+      MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin' < env.out
+    else
+      MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin' < env.out
+    fi
 
     # some unit tests
     SENV=/usr/lib/systemd/system-environment-generators/snapd-env-generator


### PR DESCRIPTION
`/bin` and `/sbin` are not in the PATH generated by systemd in noble (systemd version is 255). I'm not sure if the change comes from another generator but it's likely related to the merging of /bin, /sbin, etc. In any case, the test is still valid and snapd's environment generator still works as expected. If anyone has some insight to share, please feel free to comment