### PR TITLE
tests/main/snapd-snap-transition: increase retries for test robustness

### DIFF
--- a/tests/main/snapd-snap-transition/task.yaml
+++ b/tests/main/snapd-snap-transition/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure the snapd snap transition works
 
+details: |
+    Ensure the snapd snap transition feature works
+
 # ubuntu-core-18+ already has the snapd snap
 # FIXME: ubuntu-core-16 needs special code for the transition
 systems: [-ubuntu-core-18-*, -ubuntu-core-2*, -ubuntu-core-16-*]
@@ -11,7 +14,7 @@ execute: |
     echo "Enable the snapd snap"
     snap set core experimental.snapd-snap=true
 
-    for _ in $(seq 20); do
+    for _ in $(seq 30); do
         snap debug ensure-state-soon
         if snap list snapd; then
             break


### PR DESCRIPTION
`snapd-snap-transition` fails infrequently due to retry timeout, This small PR increases the number of retries from 20 to 30 to increase the test robustness.