### PR TITLE
o/devicestate: do not try to unmount early kernel mount if there isn't one

### DIFF
--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -50,7 +50,9 @@ execute: |
   SNAPD_SNAP=$(ls /tmp/snapd*.snap)
 
   # XXX: confusingly, the name of our test key is actually " (test)".
-  snap prepare-image --preseed --preseed-sign-key=" (test)" --channel=stable --snap="$SNAPD_SNAP" --snap systemusers-snap_1.0_all.snap "$TESTSLIB"/assertions/developer1-20-dangerous.model "$PREPARE_IMAGE_DIR" > preseed.log 2>&1
+  SNAPD_DEBUG=1 snap prepare-image --preseed --preseed-sign-key=" (test)" --channel=stable \
+      --snap="$SNAPD_SNAP" --snap systemusers-snap_1.0_all.snap \
+      "$TESTSLIB"/assertions/developer1-20-dangerous.model "$PREPARE_IMAGE_DIR" > preseed.log 2>&1
 
   echo "Make sure no umount errors were reported during preseeding cleanup"
   NOMATCH "umount.*failed" < preseed.log

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -147,6 +147,9 @@ execute: |
   # TODO add a preseed core24 test and check these mounts:
   # MATCH '^etc/systemd/system/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
   # MATCH '^etc/systemd/system/sysinit.target.wants/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
+  # TODO and these entries:
+  # MATCH "^var/lib/snapd/kernel/.*/lib/modules/.*" < files.log
+  # MATCH "^var/lib/snapd/kernel/.*/lib/firmware/.*" < files.log
 
   MATCH "^snap/pc-kernel/current" < files.log
   MATCH "^snap/core20/current" < files.log
@@ -176,9 +179,6 @@ execute: |
   MATCH "^var/lib/snapd/assertions/asserts-v0/model/16/developer1/testkeys-snapd-dangerous-core-20-amd64/" < files.log
   MATCH "^var/lib/snapd/assertions/asserts-v0/snap-revision/.*" < files.log
   MATCH "^var/lib/snapd/assertions/asserts-v0/account-key/.*" < files.log
-
-  MATCH "^var/lib/snapd/kernel/.*/lib/modules/.*" < files.log
-  MATCH "^var/lib/snapd/kernel/.*/lib/firmware/.*" < files.log
 
   MATCH "^var/lib/extrausers/group" < files.log
   MATCH "^var/lib/extrausers/passwd" < files.log

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -144,8 +144,9 @@ execute: |
   MATCH "^etc/systemd/system/snapd.failure.service" < files.log
 
   # tar tf already escapes '\', so we need to double escape it here
-  MATCH '^etc/systemd/system/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
-  MATCH '^etc/systemd/system/sysinit.target.wants/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
+  # TODO add a preseed core24 test and check these mounts:
+  # MATCH '^etc/systemd/system/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
+  # MATCH '^etc/systemd/system/sysinit.target.wants/run-mnt-kernel\\\\x2dsnaps-pc\\\\x2dkernel.*.mount' < files.log
 
   MATCH "^snap/pc-kernel/current" < files.log
   MATCH "^snap/core20/current" < files.log


### PR DESCRIPTION
Do not attempt to unmount early kernel mount point if one wasn't created during
preseeding. Normally, we conditionally add a setup-kernel-snap, which sets up
the mount where we have more device context information, but for the teardown in
mark-preseeded, it should be enough to just check if the mount was indeed
created.