### PR TITLE
sandbox/apparmor: use internal ABI 3.0 features file

### DIFF
--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -104,6 +104,10 @@ func isContainerWithInternalPolicy() bool {
 }
 
 func loadAppArmorProfiles() error {
+	if err := apparmor_sandbox.WriteInternalABIFiles(); err != nil {
+		return fmt.Errorf("cannot write internal ABI file: %w", err)
+	}
+
 	candidates, err := filepath.Glob(dirs.SnapAppArmorDir + "/*")
 	if err != nil {
 		return fmt.Errorf("Failed to glob profiles from snap apparmor dir %s: %v", dirs.SnapAppArmorDir, err)

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -144,7 +144,7 @@ func (s *mainSuite) TestLoadAppArmorProfiles(c *C) {
 
 	// check arguments to the parser are as expected
 	c.Assert(parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache",
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache",
 			fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", dirs.GlobalRootDir),
 			profile}})
 

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -143,7 +144,7 @@ func (s *mainSuite) TestLoadAppArmorProfiles(c *C) {
 
 	// check arguments to the parser are as expected
 	c.Assert(parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache",
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache",
 			fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", dirs.GlobalRootDir),
 			profile}})
 

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -108,6 +108,12 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 		return fmt.Errorf("cannot read %s: %s", procSelfExe, err)
 	}
 
+	// Write apparmor ABI file that is referenced by apparmor_parser when
+	// using the host apparmor_parser and not snapd-snap re-exec apparmor_parser.
+	if err := apparmor_sandbox.WriteInternalABIFiles(); err != nil {
+		return fmt.Errorf("cannot write internal ABI file: %w", err)
+	}
+
 	if _, err := apparmor_sandbox.SetupSnapConfineSnippets(); err != nil {
 		return err
 	}

--- a/sandbox/apparmor/abi.go
+++ b/sandbox/apparmor/abi.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package apparmor
+
+// textABI30 is a text of the apparmor ABI at version 3.0
+const textABI30 = `
+query {label {multi_transaction {yes
+}
+data {yes
+}
+perms {allow deny audit quiet
+}
+}
+}
+dbus {mask {acquire send receive
+}
+}
+signal {mask {hup int quit ill trap abrt bus fpe kill usr1 segv usr2 pipe alrm term stkflt chld cont stop stp ttin ttou urg xcpu xfsz vtalrm prof winch io pwr sys emt lost
+}
+}
+ptrace {mask {read trace
+}
+}
+caps {mask {chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_module sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap mac_override mac_admin syslog wake_alarm block_suspend audit_read perfmon bpf
+}
+}
+rlimit {mask {cpu fsize data stack core rss nproc nofile memlock as locks sigpending msgqueue nice rtprio rttime
+}
+}
+capability {0xffffff
+}
+namespaces {pivot_root {no
+}
+profile {yes
+}
+}
+mount {mask {mount umount pivot_root
+}
+}
+network {af_unix {yes
+}
+af_mask {unspec unix inet ax25 ipx appletalk netrom bridge atmpvc x25 inet6 rose netbeui security key netlink packet ash econet atmsvc rds sna irda pppox wanpipe llc ib mpls can tipc bluetooth iucv rxrpc isdn phonet ieee802154 caif alg nfc vsock kcm qipcrtr smc xdp
+}
+}
+network_v8 {af_mask {unspec unix inet ax25 ipx appletalk netrom bridge atmpvc x25 inet6 rose netbeui security key netlink packet ash econet atmsvc rds sna irda pppox wanpipe llc ib mpls can tipc bluetooth iucv rxrpc isdn phonet ieee802154 caif alg nfc vsock kcm qipcrtr smc xdp
+}
+}
+file {mask {create read write exec append mmap_exec link lock
+}
+}
+domain {version {1.2
+}
+attach_conditions {xattr {yes
+}
+}
+computed_longest_left {yes
+}
+post_nnp_subset {yes
+}
+fix_binfmt_elf_mmap {yes
+}
+stack {yes
+}
+change_profile {yes
+}
+change_onexec {yes
+}
+change_hatv {yes
+}
+change_hat {yes
+}
+}
+policy {set_load {yes
+}
+versions {v8 {yes
+}
+v7 {yes
+}
+v6 {yes
+}
+v5 {yes
+}
+}
+}
+`

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -511,7 +511,7 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
-			return exec.Command(path), false, nil
+			return exec.Command(path, "--policy-features", InternalABI30File), false, nil
 		}
 	}
 

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -511,7 +511,9 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
-			return exec.Command(path, "--policy-features", InternalABI30File), false, nil
+			// The switch --compile-features is supported all the way back in Debian 11
+			// with AppArmor parser 2.13.6, at least.
+			return exec.Command(path, "--compile-features", InternalABI30File), false, nil
 		}
 	}
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -73,7 +73,7 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 	defer restore()
 	cmd, internal, err := apparmor.AppArmorParser()
 	c.Check(cmd.Path, Equals, mockParserCmd.Exe())
-	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe()})
+	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--policy-features", apparmor.InternalABI30File})
 	c.Check(internal, Equals, false)
 	c.Check(err, Equals, nil)
 }
@@ -279,7 +279,7 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 			} else {
 				code = 1
 			}
-			expectedCalls = append(expectedCalls, []string{"apparmor_parser", "--preprocess"})
+			expectedCalls = append(expectedCalls, []string{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--preprocess"})
 			contents += fmt.Sprintf("%d ", code)
 		}
 		// probeParserFeatures() sorts the features

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -73,7 +73,7 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 	defer restore()
 	cmd, internal, err := apparmor.AppArmorParser()
 	c.Check(cmd.Path, Equals, mockParserCmd.Exe())
-	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--policy-features", apparmor.InternalABI30File})
+	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--compile-features", apparmor.InternalABI30File})
 	c.Check(internal, Equals, false)
 	c.Check(err, Equals, nil)
 }
@@ -279,7 +279,7 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 			} else {
 				code = 1
 			}
-			expectedCalls = append(expectedCalls, []string{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--preprocess"})
+			expectedCalls = append(expectedCalls, []string{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--preprocess"})
 			contents += fmt.Sprintf("%d ", code)
 		}
 		// probeParserFeatures() sorts the features

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -63,7 +63,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplace(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -75,7 +75,7 @@ func (s *appArmorSuite) TestLoadProfilesMany(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd", "/path/to/another.profile"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
 	})
 }
 
@@ -99,7 +99,7 @@ func (s *appArmorSuite) TestLoadProfilesReportsErrors(c *C) {
 apparmor_parser output:
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -114,7 +114,7 @@ apparmor_parser output:
 parser error
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -128,7 +128,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplaceWithSnapdDebug(
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
 	})
 }
 

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -63,7 +63,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplace(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -75,7 +75,7 @@ func (s *appArmorSuite) TestLoadProfilesMany(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd", "/path/to/another.profile"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
 	})
 }
 
@@ -99,7 +99,7 @@ func (s *appArmorSuite) TestLoadProfilesReportsErrors(c *C) {
 apparmor_parser output:
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -114,7 +114,7 @@ apparmor_parser output:
 parser error
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -128,7 +128,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplaceWithSnapdDebug(
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--policy-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--compile-features", apparmor.InternalABI30File, "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
 	})
 }
 


### PR DESCRIPTION
The introduction of AppArmor 4.0 to Ubuntu 24.04 has uncovered a weakness in how we call `apparmor_parser`. It is still unclear if this is a bug in the parser or a mistake in our assumptions, but we are observing confinement changes with the new stack, leading to ineffective network rules.

For context this only happens when snapd snap is _not_ installed, as its presence enables apparmor "re-execution" from the snapd snap, and the version used there is moving independently from the version in any distribution. At present it is still at version 3.x but we have work-in-progress to update that to 4.x, which would presumably hit the same issues (in https://github.com/snapcore/snapd/pull/13354).

To attempt to avoid the problem tell the parser to use the 3.0 feature ABI even if the kernel and parser both support 4.0. This method was chosen as an alternative over the `abi <abi/3.0>,` syntax in actual profiles, as that is not compatible with `apparmor_parser` in Debian 11.
