### PR TITLE
boot: revert bb7d327a36d8fd923126052c32792e1293c1d243

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -616,9 +616,6 @@ func (o *TrustedAssetsUpdateObserver) observeUpdate(bl bootloader.Bootloader, re
 			// content
 			return gadget.ChangeAbort, fmt.Errorf("cannot reuse asset name %q", ta.name)
 		}
-		// The order of assets is important. Changing it would
-		// change assumptions in
-		// bootAssetsToLoadChains
 		(*trustedAssets)[ta.name] = append((*trustedAssets)[ta.name], ta.hash)
 	}
 

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -257,13 +257,7 @@ func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bootCha
 // bootAssetsToLoadChains generates a list of load chains covering given boot
 // assets sequence. At the end of each chain, adds an entry for the kernel boot
 // file.
-// We do not calculate some boot chains because they are impossible as
-// when we update assets we write first the binaries that are used
-// later, that is, if updating both shim and grub, the new grub is
-// copied first to the disk, so booting from the new shim to the old
-// grub is not possible. This is controlled by expectNew, that tells
-// us that the previous step in the chain is from a new asset.
-func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFile, roleToBlName map[bootloader.Role]string, expectNew bool) ([]*secboot.LoadChain, error) {
+func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFile, roleToBlName map[bootloader.Role]string) ([]*secboot.LoadChain, error) {
 	// kernel is added after all the assets
 	addKernelBootFile := len(assets) == 0
 	if addKernelBootFile {
@@ -276,24 +270,7 @@ func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFi
 		return nil, fmt.Errorf("internal error: no bootloader name for boot asset role %q", thisAsset.Role)
 	}
 	var chains []*secboot.LoadChain
-
-	for i, hash := range thisAsset.Hashes {
-		// There should be 1 or 2 assets, and their position has a meaning.
-		// See TrustedAssetsUpdateObserver.observeUpdate
-		if i == 0 {
-			// i == 0 means currently installed asset.
-			// We do not expect this asset to be used as
-			// we have new assets earlier in the chain
-			if len(thisAsset.Hashes) == 2 && expectNew {
-				continue
-			}
-		} else if i == 1 {
-			// i == 1 means new asset
-		} else {
-			// If there is a second asset, it is the next asset to be installed
-			return nil, fmt.Errorf("internal error: did not expect more than 2 hashes for %s", thisAsset.Name)
-		}
-
+	for _, hash := range thisAsset.Hashes {
 		var bf bootloader.BootFile
 		var next []*secboot.LoadChain
 		var err error
@@ -309,7 +286,7 @@ func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFi
 			p,
 			thisAsset.Role,
 		)
-		next, err = bootAssetsToLoadChains(assets[1:], kernelBootFile, roleToBlName, expectNew || i == 1)
+		next, err = bootAssetsToLoadChains(assets[1:], kernelBootFile, roleToBlName)
 		if err != nil {
 			return nil, err
 		}

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -994,7 +994,7 @@ var nbf = bootloader.NewBootFile
 func (s *bootchainSuite) TestBootAssetsToLoadChainTrivialKernel(c *C) {
 	kbl := bootloader.NewBootFile("pc-kernel", "kernel.efi", bootloader.RoleRunMode)
 
-	chains, err := boot.BootAssetsToLoadChains(nil, kbl, nil, false)
+	chains, err := boot.BootAssetsToLoadChains(nil, kbl, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(chains, DeepEquals, []*secboot.LoadChain{
@@ -1016,7 +1016,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 		// missing bootloader name for role "run-mode"
 	}
 	// fails when probing the shim asset in the cache
-	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames, false)
+	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, ErrorMatches, "file .*/recovery-bl/shim-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// make it work now
@@ -1024,7 +1024,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 	c.Assert(os.WriteFile(cPath("recovery-bl/shim-hash0"), nil, 0644), IsNil)
 
 	// nested error bubbled up
-	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames, false)
+	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, ErrorMatches, "file .*/recovery-bl/loader-recovery-hash0 not found in boot assets cache")
 	c.Check(chains, IsNil)
 	// again, make it work
@@ -1032,7 +1032,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 	c.Assert(os.WriteFile(cPath("recovery-bl/loader-recovery-hash0"), nil, 0644), IsNil)
 
 	// fails on missing bootloader name for role "run-mode"
-	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames, false)
+	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, ErrorMatches, `internal error: no bootloader name for boot asset role "run-mode"`)
 	c.Check(chains, IsNil)
 }
@@ -1062,7 +1062,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 		bootloader.RoleRunMode:  "run-bl",
 	}
 
-	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames, false)
+	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, IsNil)
 
 	c.Logf("got:")
@@ -1104,7 +1104,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 		bootloader.RoleRecovery: "recovery-bl",
 		bootloader.RoleRunMode:  "run-bl",
 	}
-	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames, false)
+	chains, err := boot.BootAssetsToLoadChains(assets, kbl, blNames)
 	c.Assert(err, IsNil)
 
 	c.Logf("got:")
@@ -1120,10 +1120,19 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
 					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode)))),
 			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
 				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
 					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))))),
 		secboot.NewLoadChain(nbf("", cPath("recovery-bl/shim-hash1"), bootloader.RoleRecovery),
+			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash0"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode)))),
 			secboot.NewLoadChain(nbf("", cPath("recovery-bl/loader-recovery-hash1"), bootloader.RoleRecovery),
+				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash0"), bootloader.RoleRunMode),
+					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))),
 				secboot.NewLoadChain(nbf("", cPath("run-bl/loader-run-hash1"), bootloader.RoleRunMode),
 					secboot.NewLoadChain(nbf("pc-kernel", "kernel.efi", bootloader.RoleRunMode))))),
 	}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -913,8 +913,7 @@ func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.R
 	for _, bc := range pbc {
 		modelForSealing := bc.modelForSealing()
 		modelID := modelUniqueID(modelForSealing)
-		const expectNew = false
-		loadChains, err := bootAssetsToLoadChains(bc.AssetChain, bc.kernelBootFile, roleToBlName, expectNew)
+		loadChains, err := bootAssetsToLoadChains(bc.AssetChain, bc.kernelBootFile, roleToBlName)
 		if err != nil {
 			return nil, fmt.Errorf("cannot build load chains with current boot assets: %s", err)
 		}

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -717,6 +717,17 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 							runGrub2,
 							possibleRunKernel,
 						})
+						if shimId2 == shimId && grubId2 == grubId {
+							// due to bugs in ordering, sometimes grub2 is old and grub is new, so we need to test
+							// the case shim2 -> grub -> runGrub
+							// this happens only when we do not change the id of the asset (that is the paths are not changed)
+							possibleChains = append(possibleChains, []bootloader.BootFile{
+								shim2,
+								grub,
+								runGrub,
+								possibleRunKernel,
+							})
+						}
 					}
 				} else if shimId2 != "" {
 					// We should not test the case where we half update, to a completely new bootchain.


### PR DESCRIPTION
This reverts #13402.

`tests/nested/manual/uc-update-assets-secure-add-sbat` shows some failures from time to time. It is possible in some context, the wrong hashes are pruned when resealing.
