### PR TITLE
tests: remove root user data for pc snap in restore_pc_snap

### DIFF
--- a/tests/lib/core-config.sh
+++ b/tests/lib/core-config.sh
@@ -72,6 +72,7 @@ restore_pc_snap(){
        rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-pc-x1.mount
        rm -f /etc/systemd/system/multi-user.target.wants/snap-pc-x1.mount
        rm -f /var/lib/snapd/snaps/pc_x1.snap
+       rm -rf /root/snap/pc/x1
        systemctl daemon-reload
     fi
     rm -f /var/lib/snapd/seed/snaps/pc_x1.snap


### PR DESCRIPTION
This function, when used in combination with clean_snapd_lib, tried to to make it appear as if the "x1" revision of "pc" was never installed. However, subsequent tests would fail if they removed what appeared to be their last revision of "pc", since that results in an attempt to remove the assumedly empty `/root/snap/pc`, which still contained `/root/snap/pc/x1`.