### PR TITLE
spread.yaml: make lxd-state install latest/stable instead of latest/candidate

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -42,7 +42,8 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
+    LXD_SNAP_CHANNEL: "latest/stable"
     UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod


### PR DESCRIPTION
LXD from [v5.21 adds "LTS"](https://docs.google.com/document/d/1UZqKQjbfE9ZTJyOmJCtZHwYgo1E2jlirsyDDB5tIWLM/edit#heading=h.fgvrz5f63wo) after version number for LTS versions when calling `lxd --version` which breaks snapcraft due to a snapcraft bug discussed [here](https://chat.canonical.com/canonical/pl/jkqk5b98hfrhzrrdptfodp4uew) 

The error: https://paste.ubuntu.com/p/2vwwkkw5Ty/

Where the error happens: https://github.com/snapcore/snapd/blob/master/tests/nested/manual/muinstaller-core/task.yaml#L99-L104

This fix proposal is to use latest/stable instead for all our testing. This impacts:
```
regression/lp-1871652/task.yaml:    lxc exec bionic -- snap install lxd --channel="$LXD_SNAP_CHANNEL"
main/lxd/task.yaml:    lxd.lxc exec my-nesting-ubuntu -- snap install lxd --channel="$LXD_SNAP_CHANNEL"

regression/lp-1867193/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
regression/lp-1867752/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
regression/lp-1815869/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
regression/lp-1871652/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
nested/manual/muinstaller-core/task.yaml:  "$TESTSTOOLS"/lxd-state prepare-snap
nested/manual/devmode-snaps-can-run-other-snaps/task.yaml:  "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd-snapfuse/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd-no-fuse/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
main/selinux-lxd/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
main/snapd-snap/task.yaml:        "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd-postrm-purge/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd-try/task.yaml:  "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap
main/lxd-mount-units/task.yaml:    "$TESTSTOOLS"/lxd-state prepare-snap`

