### PR TITLE
gadget: if storage traits is zero sized file, assume traits do not exist

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -684,6 +684,12 @@ func LoadDiskVolumesDeviceTraits(dir string) (map[string]DiskVolumeDeviceTraits,
 		return nil, err
 	}
 
+	if len(b) == 0 {
+		// if the file is empty, it is safe to ignore it
+		logger.Noticef("WARNING: ignoring zero sized device traits file\n")
+		return nil, nil
+	}
+
 	if err := json.Unmarshal(b, &mapping); err != nil {
 		return nil, err
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -3920,6 +3920,15 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(m4, DeepEquals, expPiLUKSMap)
+
+	// if disk-mapping.jso is empty file (zero size), we should handle this as device traits are not
+	// available
+	f, err := os.Create(filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"))
+	c.Assert(err, IsNil)
+	f.Close()
+	mAbsent, err = gadget.LoadDiskVolumesDeviceTraits(dirs.SnapDeviceDir)
+	c.Assert(err, IsNil)
+	c.Assert(mAbsent, HasLen, 0)
 }
 
 func (s *gadgetYamlTestSuite) TestOnDiskStructureIsLikelyImplicitSystemDataRoleUC16Implicit(c *C) {


### PR DESCRIPTION
Before unmarshalling storage traits json, check the size of the file, if file is zero size, assume traits do not exist.
This is a safe fallback, as no-existent storage traits is a valid usecase.

This addresses a problem which has occurred on the devices in the field which has been live repartitioned and at the same time those devices were provisioned with snapd version before device traits introduction. This resulted in the creation of zero-sized `disk-mapping.json` as there was non to start with. 