### PR TITLE
boot: do not sort list of hashes for boot assets

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -2554,22 +2554,22 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 		case 1:
 			c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 				secboot.NewLoadChain(shimBf,
-					secboot.NewLoadChain(assetBf,
-						secboot.NewLoadChain(recoveryKernelBf)),
 					secboot.NewLoadChain(beforeAssetBf,
+						secboot.NewLoadChain(recoveryKernelBf)),
+					secboot.NewLoadChain(assetBf,
 						secboot.NewLoadChain(recoveryKernelBf))),
 				secboot.NewLoadChain(shimBf,
-					secboot.NewLoadChain(assetBf,
-						secboot.NewLoadChain(runKernelBf)),
 					secboot.NewLoadChain(beforeAssetBf,
+						secboot.NewLoadChain(runKernelBf)),
+					secboot.NewLoadChain(assetBf,
 						secboot.NewLoadChain(runKernelBf))),
 			})
 		case 2:
 			c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 				secboot.NewLoadChain(shimBf,
-					secboot.NewLoadChain(assetBf,
-						secboot.NewLoadChain(recoveryKernelBf)),
 					secboot.NewLoadChain(beforeAssetBf,
+						secboot.NewLoadChain(recoveryKernelBf)),
+					secboot.NewLoadChain(assetBf,
 						secboot.NewLoadChain(recoveryKernelBf))),
 			})
 		default:

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -105,30 +105,15 @@ func stringListsLess(sl1, sl2 []string) bool {
 	return false
 }
 
-func toPredictableBootAsset(b *bootAsset) *bootAsset {
-	if b == nil {
-		return nil
-	}
-	newB := *b
-	if b.Hashes != nil {
-		newB.Hashes = make([]string, len(b.Hashes))
-		copy(newB.Hashes, b.Hashes)
-		sort.Strings(newB.Hashes)
-	}
-	return &newB
-}
-
 func toPredictableBootChain(b *bootChain) *bootChain {
 	if b == nil {
 		return nil
 	}
 	newB := *b
-	if b.AssetChain != nil {
-		newB.AssetChain = make([]bootAsset, len(b.AssetChain))
-		for i := range b.AssetChain {
-			newB.AssetChain[i] = *toPredictableBootAsset(&b.AssetChain[i])
-		}
-	}
+	// AssetChain is sorted list (by boot order) of sorted list (old to new asset).
+	// So it is already predictable and we can keep it the way it is.
+
+	// However we still need to sort kernel KernelCmdlines
 	if b.KernelCmdlines != nil {
 		newB.KernelCmdlines = make([]string, len(b.KernelCmdlines))
 		copy(newB.KernelCmdlines, b.KernelCmdlines)

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -176,7 +176,6 @@ const (
 )
 
 var (
-	ToPredictableBootAsset              = toPredictableBootAsset
 	ToPredictableBootChain              = toPredictableBootChain
 	ToPredictableBootChains             = toPredictableBootChains
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal


### PR DESCRIPTION
This is needed to re-merge #13402.

Hashes for boot assets are in a list that is already predictable: if there is only one hash, then the asset is not modified; if there are 2 hashes, then the first one is the old asset, and the second is the new asset.

There is no need to re-sort the hashes. And we lose the semantic if we do. We want to keep that semantic so we can prune impossible boot chains.