### PR TITLE
tests/core/kernel-base-gadget-single-reboot-failover: teardown fakestore on restore

### DIFF
--- a/tests/core/kernel-base-gadget-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot-failover/task.yaml
@@ -25,6 +25,7 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
     
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
fakestore that was setup in this test was leaking into other tests causing frequent failures.

This test was caught using this debug PR (#13717).
