### PR TITLE
i/builtin/power-control: add paths for battery charging thresholds to power-control interface

### DIFF
--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -57,7 +57,8 @@ const powerControlConnectedPlugAppArmor = `
 /sys/devices/**/power_supply/BAT[0-9]*/type r,
 /sys/devices/**/power_supply/BAT[0-9]*/status r,
 /sys/devices/**/power_supply/AC/type r,
-/sys/devices/**/power_supply/AC/online r,`
+/sys/devices/**/power_supply/AC/online r,
+`
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -57,8 +57,7 @@ const powerControlConnectedPlugAppArmor = `
 /sys/devices/**/power_supply/BAT[0-9]*/type r,
 /sys/devices/**/power_supply/BAT[0-9]*/status r,
 /sys/devices/**/power_supply/AC/type r,
-/sys/devices/**/power_supply/AC/online r,
-@{PROC}/@{pid}/cmdline r,
+/sys/devices/**/power_supply/AC/online r,`
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -49,6 +49,10 @@ const powerControlConnectedPlugAppArmor = `
 
 # for android kernels, see https://android.googlesource.com/kernel/msm/+/android-msm-bullhead-3.10-marshmallow-dr/Documentation/devicetree/bindings/arm/msm/lpm-levels.txt
 /sys/module/lpm_levels/parameters/sleep_disabled rw,
+
+# Needed for ACPI modules to read and set values for battery charging thresholds
+/sys/class/power_supply/BAT{,*}/charge_start_threshold rw,
+/sys/class/power_supply/BAT{,*}/charge_stop_threshold rw,
 `
 
 func init() {

--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -51,8 +51,8 @@ const powerControlConnectedPlugAppArmor = `
 /sys/module/lpm_levels/parameters/sleep_disabled rw,
 
 # Needed for ACPI modules to read and set values for battery charging thresholds
-/sys/class/power_supply/BAT{,*}/charge_start_threshold rw,
-/sys/class/power_supply/BAT{,*}/charge_stop_threshold rw,
+/sys/devices/**/power_supply/BAT[0-9]*/charge_start_threshold rw,
+/sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw,
 `
 
 func init() {

--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -50,10 +50,15 @@ const powerControlConnectedPlugAppArmor = `
 # for android kernels, see https://android.googlesource.com/kernel/msm/+/android-msm-bullhead-3.10-marshmallow-dr/Documentation/devicetree/bindings/arm/msm/lpm-levels.txt
 /sys/module/lpm_levels/parameters/sleep_disabled rw,
 
-# Needed for ACPI modules to read and set values for battery charging thresholds
-/sys/devices/**/power_supply/BAT[0-9]*/charge_start_threshold rw,
-/sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw,
-`
+# Needed for ACPI modules to read and set values for battery charging thresholds & other functionality
+# required by auto-cpufreq, reference: https://github.com/snapcore/snapd/pull/13722
+/sys/devices/**/power_supply/BAT[0-9]*/charge_start_threshold rw, 
+/sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw, 
+/sys/devices/**/power_supply/BAT[0-9]*/type r,
+/sys/devices/**/power_supply/BAT[0-9]*/status r,
+/sys/devices/**/power_supply/AC/type r,
+/sys/devices/**/power_supply/AC/online r,
+@{PROC}/@{pid}/cmdline r,
 
 func init() {
 	registerIface(&commonInterface{


### PR DESCRIPTION
[auto-cpufreq project](https://github.com/AdnanHodzic/auto-cpufreq) has had snap package for few years now, and with [release of 2.2.0](https://github.com/AdnanHodzic/auto-cpufreq/releases) which adds functionality to set battery charging thresholds, its snap package is in broken state since. 

Reason for this is because `hardware-observe` interface doesn't have ability to write to `/sys/class/power_supply/`. This was discussion and this PR was suggested as part of [Snapcraft forum: Request for kernel-module-control interface for auto-cpufreq](https://forum.snapcraft.io/t/request-for-kernel-module-control-interface-for-auto-cpufreq/38953) by @alexmurray 

Currently only 2 locations auto-cpufreq will need to write to are:

```
/sys/class/power_supply/BAT*/charge_start_threshold
/sys/class/power_supply/BAT*/charge_stop_threshold
```

but this list might extended in future. 

Since this is my first contribution to snapd, I hope I've made the right changes, as this is how I interpreted where & how changes should be made. If not please let me know what I need to fix/improve.

Thanks!

Adnan