### PR TITLE
test/lib/prepare-restore: skip packages which may be kernel or firmware related during restore

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -724,8 +724,11 @@ restore_suite_each() {
             # shellcheck disable=SC2086
             tests.pkgs remove $packages
         fi
+        # XXX since the package managers rarely have an option to properly
+        # restore kernel or firmware related to their previous versions, use a
+        # simple heuristic to skip them during restore
         # shellcheck disable=SC2002
-        packages="$(cat removed-in-test.pkgs | tr "\n" " ")"
+        packages="$(cat removed-in-test.pkgs | grep -v -e kernel -e '-firmware' | tr "\n" " ")"
         if [ -n "$packages" ]; then
             # shellcheck disable=SC2086
             tests.pkgs install $packages


### PR DESCRIPTION


It is quite common for those packages to replace their previous versions in full and restoring to previous version may not work as expected if we do not plan to take manual steps or reboot the system.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
