### PR TITLE
tests: use snapcraft and lxd with latest fixes where possible

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -43,7 +43,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
-    LXD_SNAP_CHANNEL: "latest/stable"
+    LXD_SNAP_CHANNEL: "latest/edge"
     UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -55,7 +55,8 @@ run_muinstaller() {
     fi
 
     # build the muinstaller snap
-    snap install snapcraft --candidate --classic
+    # TODO: Consider reverting to latest/candidate when Snapcraft 8.0.5, which includes the fix to deal with LXD 5.21.0 version naming change, becomes available
+    snap install snapcraft --edge --classic
     "${TESTSTOOLS}/lxd-state" prepare-snap
     (cd "${TESTSLIB}/muinstaller" && snapcraft)
 

--- a/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
+++ b/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
@@ -1,6 +1,11 @@
 summary: |
   Test that devmode confined snaps can execute other snaps.
 
+details: |
+  For xenial the test covers running core and non-core based devmode snaps from core based strict snap and
+  and for boinic the test covers running a non-core based devmode snap from a non-core based strict snap as
+  well as running core and non-core based devmode snaps from a core based strict snap.
+
 systems:
   - ubuntu-18.04-64
   - ubuntu-16.04-64

--- a/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
+++ b/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
@@ -21,6 +21,9 @@ environment:
   # build the snap with lxd
   SNAPCRAFT_BUILD_ENVIRONMENT: lxd
 
+  # pin LXD to 5.20/stable to ensure to prevent snapcraft problem with handling new version naming that may include "LTS"
+  LXD_SNAP_CHANNEL: 5.20/stable
+
 prepare: |
   # load the fuse kernel module before installing lxd
   modprobe fuse

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -97,7 +97,8 @@ execute: |
   cp -a ./"$SEED_DIR"/system-seed/ /var/lib/snapd/seed
 
   # build the muinstaller snap
-  snap install snapcraft --candidate --classic
+  # TODO: Consider reverting to latest/candidate when Snapcraft 8.0.5, which includes the fix to deal with LXD 5.21.0 version naming change, becomes available
+  snap install snapcraft --edge --classic
   "$TESTSTOOLS"/lxd-state prepare-snap
   (cd "$TESTSLIB"/muinstaller && snapcraft)
   MUINSTALLER_SNAP="$(find "$TESTSLIB"/muinstaller/ -maxdepth 1 -name '*.snap')"


### PR DESCRIPTION
Use latest (edge) versions of snapcraft and lxd to avoid bugs and ensure compatibility. The LXD bug causes this issue in a few tests: https://paste.ubuntu.com/p/y3RGD2hjb5/, and the snapcraft bug cannot deal with the new LXD version naming that may include "LTS".

lxd bug: https://github.com/canonical/lxd-pkg-snap/pull/379
snapcraft bug: https://chat.canonical.com/canonical/pl/6w13o16npbffup3obepqiig3tr