### PR TITLE
tests/main/cgroup-devices-v2, tests/main/microk8s-smoke: collect debus, stop all microk8s processes

### DIFF
--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -54,6 +54,8 @@ debug: |
         echo "cgroup devices after restarting the service:"
         cat "cgroup_device.progs-4"
     fi
+    systemctl status snap.test-snapd-service.test-snapd-service.service || true
+    journalctl -u snap.test-snapd-service.test-snapd-service.service || true
 
 execute: |
     dump_cgroup_device_progs() {

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -47,6 +47,12 @@ prepare: |
     tests.cleanup defer systemctl restart snapd.socket
 
 restore: |
+    # microk8s does not clean up services/pods/nodes nor additional services
+    # during remove
+    microk8s kubectl delete pods --all
+    microk8s kubectl delete nodes --all
+    microk8s stop
+    # now we're ready for remove
     snap remove --purge microk8s
 
     # TODO: remove handling of snap_daemon user once microk8s is updated not


### PR DESCRIPTION
The test was observed to be unstable on certain systems. Try to collect more debug info.


Edit: Turns out it's microk8s leaving processes behind and interfering with tests that follow. I've pushed another patch which stops all microk8s processes and any pods we may have started during the test. I was able to successfully run the spread tests such that microk8s runs first, followed by cgroup-devices-v2

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
