### PR TITLE
tests: remove packages marked for auto-removal before running any tests

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -319,6 +319,9 @@ prepare_project() {
     create_test_user
 
     distro_update_package_db
+    # XXX this should be part of the image update in spread-images
+    # remove any packages that are marked for auto removal before running any tests
+    distro_auto_remove_packages
 
     if os.query is-arch-linux; then
         # perform system upgrade on Arch so that we run with most recent kernel


### PR DESCRIPTION
The spread-images is missing a cleanup step after an upgrade which would run auto-removal of obsolete packages. Work around this by removing any outstanding packages that would normally be dropped. This should prevent any package manipulation code in the tests from raising false positives in package cleanup checks running in restore-each.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
