### PR TITLE
daemon, client: Set error kind when can't refresh snap that is busy.

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -142,6 +142,9 @@ const (
 
 	// ErrorKindValidationSetNotFound: validation set cannot be found.
 	ErrorKindValidationSetNotFound ErrorKind = "validation-set-not-found"
+
+	// ErrorKindBusySnap: cannot do action as snap is currently busy.
+	ErrorKindBusySnap ErrorKind = "busy"
 )
 
 // Maintenance error kinds.

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -342,6 +342,8 @@ func errToResponse(err error, snaps []string, fallback errorResponder, format st
 			snapName = err.Snap
 		case *snapstate.InsufficientSpaceError:
 			return InsufficientSpace(err)
+		case *snapstate.BusySnapError:
+			kind = client.ErrorKindBusySnap
 		case net.Error:
 			if err.Timeout() {
 				kind = client.ErrorKindNetworkTimeout


### PR DESCRIPTION
This is a normal use case for a client, so we want to be able to distinguish this from other refresh errors.
