### PR TITLE
release: 2.62

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,77 @@
-# In progress:
-* Installation of local snap components
-* Started support for snap services to show real status of user daemons
-
-# Next:
-* state: add support for notices (from pebble)
-* daemon: add notices to the snapd API under `/v2/notices` and `/v2/notice`
-* Mandatory device cgroup for all snaps using bare and core24 base as well as future bases
-* Added API route for creating recovery systems: POST to `/v2/systems` with action `create`
-* Added API route for removing recovery systems: POST to `/v2/systems/{label}` with action `remove`
-* Support for user daemons by introducing new control switches --user/--system/--users for service start/stop/restart
-* client,daemon: expose features supported/enabled in `/v2/system-info`
+# New in snapd 2.62:
+* Aspects based configuration schema support (experimental)
+* Refresh app awareness support for UI (experimental)
+* Support for user daemons by introducing new control switches --user/--system/--users for service start/stop/restart (experimental)
+* Add AppArmor prompting experimental flag (feature currently unsupported)
+* Expose experimental features supported/enabled in snapd REST API endpoint /v2/system-info
+* Support creating and removing recovery systems for use by factory reset
+* Enable API route for creating and removing recovery systems using /v2/systems with action create and /v2/systems/{label} with action remove
+* Lift requirements for fde-setup hook for single boot install
+* Enable single reboot gadget update for UC20+
+* Allow core to be removed on classic systems
+* Support for remodeling on hybrid systems
+* Install desktop files on Ubuntu Core and update after snapd upgrade
+* Upgrade sandbox features to account for cgroup v2 device filtering
+* Support snaps to manage their own cgroups
+* Add support for AppArmor 4.0 unconfined profile mode
+* Add AppArmor based read access to /etc/default/keyboard
+* Upgrade to squashfuse 0.5.0
+* Support useradd utility to enable removing Perl dependency for UC24+
+* Support for recovery-chooser to use console-conf snap
+* Add support for --uid/--gid using strace-static
+* Add support for notices (from pebble) and expose via the snapd REST API endpoints /v2/notices and /v2/notice
+* Add polkit authentication for snapd REST API endpoints /v2/snaps/{snap}/conf and /v2/apps
+* Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
+* Take into account validation sets during remodeling
+* Improve offline remodeling to use installed revisions of snaps to fulfill the remodel revision requirement
+* Add rpi configuration option sdtv_mode
+* When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if present on host
+* Fix gadget zero-sized disk mapping caused by not ignoring zero sized storage traits
+* Fix gadget install case where size of existing partition was not correctly taken into account
+* Fix trying to unmount early kernel mount if it does not exist
+* Fix restarting mount units on snapd start
+* Fix call to udev in preseed mode
+* Fix to ensure always setting up the device cgroup for base bare and core24+
+* Fix not copying data from newly set homedirs on revision change
+* Fix leaving behind empty snap home directories after snap is removed (resulting in broken symlink)
+* Fix to avoid using libzstd from host by adding to snapd snap
+* Fix autorefresh to correctly handle forever refresh hold
+* Fix username regex allowed for system-user assertion to not allow '+'
+* Fix incorrect application icon for notification after autorefresh completion
+* Fix to restart mount units when changed
+* Fix to support AppArmor running under incus
+* Fix case of snap-update-ns dropping synthetic mounts due to failure to match  desired mount dependencies
+* Fix parsing of base snap version to enable pre-seeding of Ubuntu Core Desktop
+* Fix packaging and tests for various distributions
+* Add remoteproc interface to allow developers to interact with Remote Processor Framework which enables snaps to load firmware to ARM Cortex microcontrollers
+* Add kernel-control interface to enable controlling the kernel firmware search path
+* Add nfs-mount interface to allow mounting of NFS shares
+* Add ros-opt-data interface to allow snaps to access the host /opt/ros/ paths
+* Add snap-refresh-observe interface that provides refresh-app-awareness clients access to relevant snapd API endpoints
+* steam-support interface: generalize Pressure Vessel root paths and allow access to driver information, features and container versions
+* steam-support interface: make implicit on Ubuntu Core Desktop
+* desktop interface: improved support for Ubuntu Core Desktop and limit autoconnection to implicit slots
+* cups-control interface: make autoconnect depend on presence of cupsd on host to ensure it works on classic systems
+* opengl interface: allow read access to /usr/share/nvidia
+* personal-files interface: extend to support automatic creation of missing parent directories in write paths
+* network-control interface: allow creating /run/resolveconf
+* network-setup-control and network-setup-observe interfaces: allow busctl bind as required for systemd 254+
+* libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-ro and read access to /var/lib/libvirt/dnsmasq/**
+* fwupd interface: allow access to IMPI devices (including locking of device nodes), sysfs attributes needed by amdgpu and the COD capsule update directory
+* uio interface: allow configuring UIO drivers from userspace libraries
+* serial-port interface: add support for NXP Layerscape SoC
+* lxd-support interface: add attribute enable-unconfined-mode to require LXD to opt-in to run unconfined
+* block-devices interface: add support for ZFS volumes
+* system-packages-doc interface: add support for reading jquery and sphinx documentation
+* system-packages-doc interface: workaround to prevent autoconnect failure for snaps using base bare
+* microceph-support interface: allow more types of block devices to be added as an OSD
+* mount-observe interface: allow read access to /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
+* polkit interface: changed to not be implicit on core because installing policy files is not possible
+* upower-observe interface: allow stats refresh
+* gpg-public-keys interface: allow creating lock file for certain gpg operations
+* shutdown interface: allow access to SetRebootParameter method
+* media-control interface: allow device file locking
+* u2f-devices interface: support for Trustkey G310H, JaCarta U2F, Kensington VeriMark Guard, RSA DS100, Google Titan v2
 
 # New in snapd 2.61.3:
 * Install systemd files in correct location for 24.04

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -684,6 +684,12 @@ func LoadDiskVolumesDeviceTraits(dir string) (map[string]DiskVolumeDeviceTraits,
 		return nil, err
 	}
 
+	if len(b) == 0 {
+		// if the file is empty, it is safe to ignore it
+		logger.Noticef("WARNING: ignoring zero sized device traits file\n")
+		return nil, nil
+	}
+
 	if err := json.Unmarshal(b, &mapping); err != nil {
 		return nil, err
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -3920,6 +3920,15 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(m4, DeepEquals, expPiLUKSMap)
+
+	// if disk-mapping.jso is empty file (zero size), we should handle this as device traits are not
+	// available
+	f, err := os.Create(filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"))
+	c.Assert(err, IsNil)
+	f.Close()
+	mAbsent, err = gadget.LoadDiskVolumesDeviceTraits(dirs.SnapDeviceDir)
+	c.Assert(err, IsNil)
+	c.Assert(mAbsent, HasLen, 0)
 }
 
 func (s *gadgetYamlTestSuite) TestOnDiskStructureIsLikelyImplicitSystemDataRoleUC16Implicit(c *C) {

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.61.3
+pkgver=2.62
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,126 @@
+snapd (2.62-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2058277
+    - Aspects based configuration schema support (experimental)
+    - Refresh app awareness support for UI (experimental)
+    - Support for user daemons by introducing new control switches
+      --user/--system/--users for service start/stop/restart
+      (experimental)
+    - Add AppArmor prompting experimental flag (feature currently
+      unsupported)
+    - Expose experimental features supported/enabled in snapd REST API
+      endpoint /v2/system-info
+    - Support creating and removing recovery systems for use by factory
+      reset
+    - Enable API route for creating and removing recovery systems using
+      /v2/systems with action create and /v2/systems/{label} with action
+      remove
+    - Lift requirements for fde-setup hook for single boot install
+    - Enable single reboot gadget update for UC20+
+    - Allow core to be removed on classic systems
+    - Support for remodeling on hybrid systems
+    - Install desktop files on Ubuntu Core and update after snapd
+      upgrade
+    - Upgrade sandbox features to account for cgroup v2 device filtering
+    - Support snaps to manage their own cgroups
+    - Add support for AppArmor 4.0 unconfined profile mode
+    - Add AppArmor based read access to /etc/default/keyboard
+    - Upgrade to squashfuse 0.5.0
+    - Support useradd utility to enable removing Perl dependency for
+      UC24+
+    - Support for recovery-chooser to use console-conf snap
+    - Add support for --uid/--gid using strace-static
+    - Add support for notices (from pebble) and expose via the snapd
+      REST API endpoints /v2/notices and /v2/notice
+    - Add polkit authentication for snapd REST API endpoints
+      /v2/snaps/{snap}/conf and /v2/apps
+    - Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
+    - Take into account validation sets during remodeling
+    - Improve offline remodeling to use installed revisions of snaps to
+      fulfill the remodel revision requirement
+    - Add rpi configuration option sdtv_mode
+    - When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if
+      present on host
+    - Fix gadget zero-sized disk mapping caused by not ignoring zero
+      sized storage traits
+    - Fix gadget install case where size of existing partition was not
+      correctly taken into account
+    - Fix trying to unmount early kernel mount if it does not exist
+    - Fix restarting mount units on snapd start
+    - Fix call to udev in preseed mode
+    - Fix to ensure always setting up the device cgroup for base bare
+      and core24+
+    - Fix not copying data from newly set homedirs on revision change
+    - Fix leaving behind empty snap home directories after snap is
+      removed (resulting in broken symlink)
+    - Fix to avoid using libzstd from host by adding to snapd snap
+    - Fix autorefresh to correctly handle forever refresh hold
+    - Fix username regex allowed for system-user assertion to not allow
+      '+'
+    - Fix incorrect application icon for notification after autorefresh
+      completion
+    - Fix to restart mount units when changed
+    - Fix to support AppArmor running under incus
+    - Fix case of snap-update-ns dropping synthetic mounts due to
+      failure to match  desired mount dependencies
+    - Fix parsing of base snap version to enable pre-seeding of Ubuntu
+      Core Desktop
+    - Fix packaging and tests for various distributions
+    - Add remoteproc interface to allow developers to interact with
+      Remote Processor Framework which enables snaps to load firmware to
+      ARM Cortex microcontrollers
+    - Add kernel-control interface to enable controlling the kernel
+      firmware search path
+    - Add nfs-mount interface to allow mounting of NFS shares
+    - Add ros-opt-data interface to allow snaps to access the host
+      /opt/ros/ paths
+    - Add snap-refresh-observe interface that provides refresh-app-
+      awareness clients access to relevant snapd API endpoints
+    - steam-support interface: generalize Pressure Vessel root paths and
+      allow access to driver information, features and container
+      versions
+    - steam-support interface: make implicit on Ubuntu Core Desktop
+    - desktop interface: improved support for Ubuntu Core Desktop and
+      limit autoconnection to implicit slots
+    - cups-control interface: make autoconnect depend on presence of
+      cupsd on host to ensure it works on classic systems
+    - opengl interface: allow read access to /usr/share/nvidia
+    - personal-files interface: extend to support automatic creation of
+      missing parent directories in write paths
+    - network-control interface: allow creating /run/resolveconf
+    - network-setup-control and network-setup-observe interfaces: allow
+      busctl bind as required for systemd 254+
+    - libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-
+      ro and read access to /var/lib/libvirt/dnsmasq/**
+    - fwupd interface: allow access to IMPI devices (including locking
+      of device nodes), sysfs attributes needed by amdgpu and the COD
+      capsule update directory
+    - uio interface: allow configuring UIO drivers from userspace
+      libraries
+    - serial-port interface: add support for NXP Layerscape SoC
+    - lxd-support interface: add attribute enable-unconfined-mode to
+      require LXD to opt-in to run unconfined
+    - block-devices interface: add support for ZFS volumes
+    - system-packages-doc interface: add support for reading jquery and
+      sphinx documentation
+    - system-packages-doc interface: workaround to prevent autoconnect
+      failure for snaps using base bare
+    - microceph-support interface: allow more types of block devices to
+      be added as an OSD
+    - mount-observe interface: allow read access to
+      /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
+    - polkit interface: changed to not be implicit on core because
+      installing policy files is not possible
+    - upower-observe interface: allow stats refresh
+    - gpg-public-keys interface: allow creating lock file for certain
+      gpg operations
+    - shutdown interface: allow access to SetRebootParameter method
+    - media-control interface: allow device file locking
+    - u2f-devices interface: support for Trustkey G310H, JaCarta U2F,
+      Kensington VeriMark Guard, RSA DS100, Google Titan v2
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 21 Mar 2024 15:31:15 +0200
+
 snapd (2.61.3-1) unstable; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.61.3
+Version:        2.62
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -1004,6 +1004,126 @@ fi
 
 
 %changelog
+* Thu Mar 21 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.62
+ - Aspects based configuration schema support (experimental)
+ - Refresh app awareness support for UI (experimental)
+ - Support for user daemons by introducing new control switches
+   --user/--system/--users for service start/stop/restart
+   (experimental)
+ - Add AppArmor prompting experimental flag (feature currently
+   unsupported)
+ - Expose experimental features supported/enabled in snapd REST API
+   endpoint /v2/system-info
+ - Support creating and removing recovery systems for use by factory
+   reset
+ - Enable API route for creating and removing recovery systems using
+   /v2/systems with action create and /v2/systems/{label} with action
+   remove
+ - Lift requirements for fde-setup hook for single boot install
+ - Enable single reboot gadget update for UC20+
+ - Allow core to be removed on classic systems
+ - Support for remodeling on hybrid systems
+ - Install desktop files on Ubuntu Core and update after snapd
+   upgrade
+ - Upgrade sandbox features to account for cgroup v2 device filtering
+ - Support snaps to manage their own cgroups
+ - Add support for AppArmor 4.0 unconfined profile mode
+ - Add AppArmor based read access to /etc/default/keyboard
+ - Upgrade to squashfuse 0.5.0
+ - Support useradd utility to enable removing Perl dependency for
+   UC24+
+ - Support for recovery-chooser to use console-conf snap
+ - Add support for --uid/--gid using strace-static
+ - Add support for notices (from pebble) and expose via the snapd
+   REST API endpoints /v2/notices and /v2/notice
+ - Add polkit authentication for snapd REST API endpoints
+   /v2/snaps/{snap}/conf and /v2/apps
+ - Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
+ - Take into account validation sets during remodeling
+ - Improve offline remodeling to use installed revisions of snaps to
+   fulfill the remodel revision requirement
+ - Add rpi configuration option sdtv_mode
+ - When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if
+   present on host
+ - Fix gadget zero-sized disk mapping caused by not ignoring zero
+   sized storage traits
+ - Fix gadget install case where size of existing partition was not
+   correctly taken into account
+ - Fix trying to unmount early kernel mount if it does not exist
+ - Fix restarting mount units on snapd start
+ - Fix call to udev in preseed mode
+ - Fix to ensure always setting up the device cgroup for base bare
+   and core24+
+ - Fix not copying data from newly set homedirs on revision change
+ - Fix leaving behind empty snap home directories after snap is
+   removed (resulting in broken symlink)
+ - Fix to avoid using libzstd from host by adding to snapd snap
+ - Fix autorefresh to correctly handle forever refresh hold
+ - Fix username regex allowed for system-user assertion to not allow
+   '+'
+ - Fix incorrect application icon for notification after autorefresh
+   completion
+ - Fix to restart mount units when changed
+ - Fix to support AppArmor running under incus
+ - Fix case of snap-update-ns dropping synthetic mounts due to
+   failure to match  desired mount dependencies
+ - Fix parsing of base snap version to enable pre-seeding of Ubuntu
+   Core Desktop
+ - Fix packaging and tests for various distributions
+ - Add remoteproc interface to allow developers to interact with
+   Remote Processor Framework which enables snaps to load firmware to
+   ARM Cortex microcontrollers
+ - Add kernel-control interface to enable controlling the kernel
+   firmware search path
+ - Add nfs-mount interface to allow mounting of NFS shares
+ - Add ros-opt-data interface to allow snaps to access the host
+   /opt/ros/ paths
+ - Add snap-refresh-observe interface that provides refresh-app-
+   awareness clients access to relevant snapd API endpoints
+ - steam-support interface: generalize Pressure Vessel root paths and
+   allow access to driver information, features and container
+   versions
+ - steam-support interface: make implicit on Ubuntu Core Desktop
+ - desktop interface: improved support for Ubuntu Core Desktop and
+   limit autoconnection to implicit slots
+ - cups-control interface: make autoconnect depend on presence of
+   cupsd on host to ensure it works on classic systems
+ - opengl interface: allow read access to /usr/share/nvidia
+ - personal-files interface: extend to support automatic creation of
+   missing parent directories in write paths
+ - network-control interface: allow creating /run/resolveconf
+ - network-setup-control and network-setup-observe interfaces: allow
+   busctl bind as required for systemd 254+
+ - libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-
+   ro and read access to /var/lib/libvirt/dnsmasq/**
+ - fwupd interface: allow access to IMPI devices (including locking
+   of device nodes), sysfs attributes needed by amdgpu and the COD
+   capsule update directory
+ - uio interface: allow configuring UIO drivers from userspace
+   libraries
+ - serial-port interface: add support for NXP Layerscape SoC
+ - lxd-support interface: add attribute enable-unconfined-mode to
+   require LXD to opt-in to run unconfined
+ - block-devices interface: add support for ZFS volumes
+ - system-packages-doc interface: add support for reading jquery and
+   sphinx documentation
+ - system-packages-doc interface: workaround to prevent autoconnect
+   failure for snaps using base bare
+ - microceph-support interface: allow more types of block devices to
+   be added as an OSD
+ - mount-observe interface: allow read access to
+   /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
+ - polkit interface: changed to not be implicit on core because
+   installing policy files is not possible
+ - upower-observe interface: allow stats refresh
+ - gpg-public-keys interface: allow creating lock file for certain
+   gpg operations
+ - shutdown interface: allow access to SetRebootParameter method
+ - media-control interface: allow device file locking
+ - u2f-devices interface: support for Trustkey G310H, JaCarta U2F,
+   Kensington VeriMark Guard, RSA DS100, Google Titan v2
+
 * Wed Mar 06 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.61.3
  - Install systemd files in correct location for 24.04

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Mar 21 13:31:15 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.62
+
+-------------------------------------------------------------------
 Wed Mar 06 21:18:11 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.61.3

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.61.3
+Version:        2.62
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,126 @@
+snapd (2.62~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2058277
+    - Aspects based configuration schema support (experimental)
+    - Refresh app awareness support for UI (experimental)
+    - Support for user daemons by introducing new control switches
+      --user/--system/--users for service start/stop/restart
+      (experimental)
+    - Add AppArmor prompting experimental flag (feature currently
+      unsupported)
+    - Expose experimental features supported/enabled in snapd REST API
+      endpoint /v2/system-info
+    - Support creating and removing recovery systems for use by factory
+      reset
+    - Enable API route for creating and removing recovery systems using
+      /v2/systems with action create and /v2/systems/{label} with action
+      remove
+    - Lift requirements for fde-setup hook for single boot install
+    - Enable single reboot gadget update for UC20+
+    - Allow core to be removed on classic systems
+    - Support for remodeling on hybrid systems
+    - Install desktop files on Ubuntu Core and update after snapd
+      upgrade
+    - Upgrade sandbox features to account for cgroup v2 device filtering
+    - Support snaps to manage their own cgroups
+    - Add support for AppArmor 4.0 unconfined profile mode
+    - Add AppArmor based read access to /etc/default/keyboard
+    - Upgrade to squashfuse 0.5.0
+    - Support useradd utility to enable removing Perl dependency for
+      UC24+
+    - Support for recovery-chooser to use console-conf snap
+    - Add support for --uid/--gid using strace-static
+    - Add support for notices (from pebble) and expose via the snapd
+      REST API endpoints /v2/notices and /v2/notice
+    - Add polkit authentication for snapd REST API endpoints
+      /v2/snaps/{snap}/conf and /v2/apps
+    - Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
+    - Take into account validation sets during remodeling
+    - Improve offline remodeling to use installed revisions of snaps to
+      fulfill the remodel revision requirement
+    - Add rpi configuration option sdtv_mode
+    - When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if
+      present on host
+    - Fix gadget zero-sized disk mapping caused by not ignoring zero
+      sized storage traits
+    - Fix gadget install case where size of existing partition was not
+      correctly taken into account
+    - Fix trying to unmount early kernel mount if it does not exist
+    - Fix restarting mount units on snapd start
+    - Fix call to udev in preseed mode
+    - Fix to ensure always setting up the device cgroup for base bare
+      and core24+
+    - Fix not copying data from newly set homedirs on revision change
+    - Fix leaving behind empty snap home directories after snap is
+      removed (resulting in broken symlink)
+    - Fix to avoid using libzstd from host by adding to snapd snap
+    - Fix autorefresh to correctly handle forever refresh hold
+    - Fix username regex allowed for system-user assertion to not allow
+      '+'
+    - Fix incorrect application icon for notification after autorefresh
+      completion
+    - Fix to restart mount units when changed
+    - Fix to support AppArmor running under incus
+    - Fix case of snap-update-ns dropping synthetic mounts due to
+      failure to match  desired mount dependencies
+    - Fix parsing of base snap version to enable pre-seeding of Ubuntu
+      Core Desktop
+    - Fix packaging and tests for various distributions
+    - Add remoteproc interface to allow developers to interact with
+      Remote Processor Framework which enables snaps to load firmware to
+      ARM Cortex microcontrollers
+    - Add kernel-control interface to enable controlling the kernel
+      firmware search path
+    - Add nfs-mount interface to allow mounting of NFS shares
+    - Add ros-opt-data interface to allow snaps to access the host
+      /opt/ros/ paths
+    - Add snap-refresh-observe interface that provides refresh-app-
+      awareness clients access to relevant snapd API endpoints
+    - steam-support interface: generalize Pressure Vessel root paths and
+      allow access to driver information, features and container
+      versions
+    - steam-support interface: make implicit on Ubuntu Core Desktop
+    - desktop interface: improved support for Ubuntu Core Desktop and
+      limit autoconnection to implicit slots
+    - cups-control interface: make autoconnect depend on presence of
+      cupsd on host to ensure it works on classic systems
+    - opengl interface: allow read access to /usr/share/nvidia
+    - personal-files interface: extend to support automatic creation of
+      missing parent directories in write paths
+    - network-control interface: allow creating /run/resolveconf
+    - network-setup-control and network-setup-observe interfaces: allow
+      busctl bind as required for systemd 254+
+    - libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-
+      ro and read access to /var/lib/libvirt/dnsmasq/**
+    - fwupd interface: allow access to IMPI devices (including locking
+      of device nodes), sysfs attributes needed by amdgpu and the COD
+      capsule update directory
+    - uio interface: allow configuring UIO drivers from userspace
+      libraries
+    - serial-port interface: add support for NXP Layerscape SoC
+    - lxd-support interface: add attribute enable-unconfined-mode to
+      require LXD to opt-in to run unconfined
+    - block-devices interface: add support for ZFS volumes
+    - system-packages-doc interface: add support for reading jquery and
+      sphinx documentation
+    - system-packages-doc interface: workaround to prevent autoconnect
+      failure for snaps using base bare
+    - microceph-support interface: allow more types of block devices to
+      be added as an OSD
+    - mount-observe interface: allow read access to
+      /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
+    - polkit interface: changed to not be implicit on core because
+      installing policy files is not possible
+    - upower-observe interface: allow stats refresh
+    - gpg-public-keys interface: allow creating lock file for certain
+      gpg operations
+    - shutdown interface: allow access to SetRebootParameter method
+    - media-control interface: allow device file locking
+    - u2f-devices interface: support for Trustkey G310H, JaCarta U2F,
+      Kensington VeriMark Guard, RSA DS100, Google Titan v2
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 21 Mar 2024 15:31:15 +0200
+
 snapd (2.61.3~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,126 @@
+snapd (2.62) xenial; urgency=medium
+
+  * New upstream release, LP: #2058277
+    - Aspects based configuration schema support (experimental)
+    - Refresh app awareness support for UI (experimental)
+    - Support for user daemons by introducing new control switches
+      --user/--system/--users for service start/stop/restart
+      (experimental)
+    - Add AppArmor prompting experimental flag (feature currently
+      unsupported)
+    - Expose experimental features supported/enabled in snapd REST API
+      endpoint /v2/system-info
+    - Support creating and removing recovery systems for use by factory
+      reset
+    - Enable API route for creating and removing recovery systems using
+      /v2/systems with action create and /v2/systems/{label} with action
+      remove
+    - Lift requirements for fde-setup hook for single boot install
+    - Enable single reboot gadget update for UC20+
+    - Allow core to be removed on classic systems
+    - Support for remodeling on hybrid systems
+    - Install desktop files on Ubuntu Core and update after snapd
+      upgrade
+    - Upgrade sandbox features to account for cgroup v2 device filtering
+    - Support snaps to manage their own cgroups
+    - Add support for AppArmor 4.0 unconfined profile mode
+    - Add AppArmor based read access to /etc/default/keyboard
+    - Upgrade to squashfuse 0.5.0
+    - Support useradd utility to enable removing Perl dependency for
+      UC24+
+    - Support for recovery-chooser to use console-conf snap
+    - Add support for --uid/--gid using strace-static
+    - Add support for notices (from pebble) and expose via the snapd
+      REST API endpoints /v2/notices and /v2/notice
+    - Add polkit authentication for snapd REST API endpoints
+      /v2/snaps/{snap}/conf and /v2/apps
+    - Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
+    - Take into account validation sets during remodeling
+    - Improve offline remodeling to use installed revisions of snaps to
+      fulfill the remodel revision requirement
+    - Add rpi configuration option sdtv_mode
+    - When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if
+      present on host
+    - Fix gadget zero-sized disk mapping caused by not ignoring zero
+      sized storage traits
+    - Fix gadget install case where size of existing partition was not
+      correctly taken into account
+    - Fix trying to unmount early kernel mount if it does not exist
+    - Fix restarting mount units on snapd start
+    - Fix call to udev in preseed mode
+    - Fix to ensure always setting up the device cgroup for base bare
+      and core24+
+    - Fix not copying data from newly set homedirs on revision change
+    - Fix leaving behind empty snap home directories after snap is
+      removed (resulting in broken symlink)
+    - Fix to avoid using libzstd from host by adding to snapd snap
+    - Fix autorefresh to correctly handle forever refresh hold
+    - Fix username regex allowed for system-user assertion to not allow
+      '+'
+    - Fix incorrect application icon for notification after autorefresh
+      completion
+    - Fix to restart mount units when changed
+    - Fix to support AppArmor running under incus
+    - Fix case of snap-update-ns dropping synthetic mounts due to
+      failure to match  desired mount dependencies
+    - Fix parsing of base snap version to enable pre-seeding of Ubuntu
+      Core Desktop
+    - Fix packaging and tests for various distributions
+    - Add remoteproc interface to allow developers to interact with
+      Remote Processor Framework which enables snaps to load firmware to
+      ARM Cortex microcontrollers
+    - Add kernel-control interface to enable controlling the kernel
+      firmware search path
+    - Add nfs-mount interface to allow mounting of NFS shares
+    - Add ros-opt-data interface to allow snaps to access the host
+      /opt/ros/ paths
+    - Add snap-refresh-observe interface that provides refresh-app-
+      awareness clients access to relevant snapd API endpoints
+    - steam-support interface: generalize Pressure Vessel root paths and
+      allow access to driver information, features and container
+      versions
+    - steam-support interface: make implicit on Ubuntu Core Desktop
+    - desktop interface: improved support for Ubuntu Core Desktop and
+      limit autoconnection to implicit slots
+    - cups-control interface: make autoconnect depend on presence of
+      cupsd on host to ensure it works on classic systems
+    - opengl interface: allow read access to /usr/share/nvidia
+    - personal-files interface: extend to support automatic creation of
+      missing parent directories in write paths
+    - network-control interface: allow creating /run/resolveconf
+    - network-setup-control and network-setup-observe interfaces: allow
+      busctl bind as required for systemd 254+
+    - libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-
+      ro and read access to /var/lib/libvirt/dnsmasq/**
+    - fwupd interface: allow access to IMPI devices (including locking
+      of device nodes), sysfs attributes needed by amdgpu and the COD
+      capsule update directory
+    - uio interface: allow configuring UIO drivers from userspace
+      libraries
+    - serial-port interface: add support for NXP Layerscape SoC
+    - lxd-support interface: add attribute enable-unconfined-mode to
+      require LXD to opt-in to run unconfined
+    - block-devices interface: add support for ZFS volumes
+    - system-packages-doc interface: add support for reading jquery and
+      sphinx documentation
+    - system-packages-doc interface: workaround to prevent autoconnect
+      failure for snaps using base bare
+    - microceph-support interface: allow more types of block devices to
+      be added as an OSD
+    - mount-observe interface: allow read access to
+      /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
+    - polkit interface: changed to not be implicit on core because
+      installing policy files is not possible
+    - upower-observe interface: allow stats refresh
+    - gpg-public-keys interface: allow creating lock file for certain
+      gpg operations
+    - shutdown interface: allow access to SetRebootParameter method
+    - media-control interface: allow device file locking
+    - u2f-devices interface: support for Trustkey G310H, JaCarta U2F,
+      Kensington VeriMark Guard, RSA DS100, Google Titan v2
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 21 Mar 2024 15:31:15 +0200
+
 snapd (2.61.3) xenial; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -496,9 +496,15 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
-			// Pin 4.0 abi if host supports it.
+			// Detect but ignore apparmor 4.0 ABI support.
+			//
+			// At present this causes some bugs with mqueue mediation that can
+			// be avoided by pinning to 3.0 (which is also supported on
+			// apparmor 4). Once the mqueue issue is analyzed and fixed, this
+			// can be replaced with a --policy-features=hostAbi40File pin like
+			// we do below.
 			if fi, err := os.Lstat(hostAbi40File); err == nil && !fi.IsDir() {
-				return exec.Command(path, "--policy-features", hostAbi40File), false, nil
+				logger.Debugf("apparmor 4.0 ABI detected but ignored")
 			}
 
 			// Perhaps 3.0?

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -80,8 +80,7 @@ execute: |
   # wait for the system to finish being seeded
   remote.exec "sudo snap wait system seed.loaded"
 
-  # hold everything so that we can check their revisions before they get auto-refreshed
-  remote.exec "snap list | awk 'NR != 1 { print \$1 }' | xargs sudo snap refresh --hold"
+  boot_id="$(tests.nested boot-id)"
 
   if [ "${MODE}" = 'recover' ]; then
     remote.exec 'cat /proc/cmdline' | MATCH 'snapd_recovery_mode=recover'
@@ -100,10 +99,20 @@ execute: |
     # since out new system is now the default and the current recovery system,
     # we should be able to remove the old one
 
-    # sometimes, this will conflict with an auto-refresh change. retry just in
-    # case.
-    export -f post_json_data
-    retry -n 10 --wait 2 bash -c "post_json_data '/v2/systems/${prev_system}' '{\"action\": \"remove\"}'"
+    # removing a recovery system conflicts with auto-refresh, wait for the
+    # auto-refresh to start and finish before attempting the removal.
+    if retry -n 60 --wait 1 remote.exec 'snap watch --last=auto-refresh'; then
+      # if an auto-refresh happened, we know we need to wait for the system to
+      # finish rebooting, since the kernel, gadget, and base snaps will be
+      # updated
+      remote.wait-for reboot "${boot_id}"
+
+      # one more watch to wait for the change to finish once the reboot is
+      # completed
+      remote.exec 'snap watch --last=auto-refresh'
+    fi
+
+    post_json_data "/v2/systems/${prev_system}" '{"action": "remove"}'
 
     remote.exec "snap watch --last=remove-recovery-system"
     remote.exec "sudo snap recovery" | NOMATCH "${prev_system}"
@@ -113,6 +122,13 @@ execute: |
   # should be here in all tested modes.
   remote.exec 'snap list hello-world'
 
-  remote.exec 'snap list core22' | awk 'NR != 1 { print $3 }' | MATCH '1033'
-  remote.exec 'snap list pc' | awk 'NR != 1 { print $3 }' | MATCH '145'
-  remote.exec 'snap list pc-kernel' | awk 'NR != 1 { print $3 }' | MATCH '1606'
+  # make sure that all our other snaps are there too. we can't check their
+  # revisions here, since auto-refresh might have updated them.
+  remote.exec 'snap list core22'
+  remote.exec 'snap list pc'
+  remote.exec 'snap list pc-kernel'
+
+  # however, we can check that the seed contains the correct revisions
+  remote.exec "test -f /var/lib/snapd/seed/snaps/core22_1033.snap"
+  remote.exec "test -f /var/lib/snapd/seed/snaps/pc-kernel_1606.snap"
+  remote.exec "test -f /var/lib/snapd/seed/snaps/pc_145.snap"


### PR DESCRIPTION
This release targets Ubuntu 24.04 BETA freeze.

Cherry picked single last minute additions:
- [Fix gadget zero-sized disk mapping caused by not ignoring zero sized storage traits](https://github.com/snapcore/snapd/pull/13719)
- [Fix recovery-system-reboot install test that was being interrupted by a system reboot](https://github.com/snapcore/snapd/pull/13736)
- [sandbox/apparmor: detect but ignore apparmor 4](https://github.com/snapcore/snapd/pull/13740)

Generated changelogs with:
DEBEMAIL="Ernest Lotter ernest.lotter@canonical.com" release-tools/changelog.py 2.62 2058277 NEWS.md

NEWS.md and changelogs was updated in the final commit: [release: 2.62](https://github.com/snapcore/snapd/pull/13731/commits/3fa0c816c422138af01c662b7d7a6e6a5f782298)