### PR TITLE
tests/main/services-user: remove polkit policy file

### DIFF
--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -37,6 +37,7 @@ restore: |
         userdel --extrausers -rf test2
     fi
     snap unset system experimental.user-daemons
+    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla
 
 debug: |
     tests.session dump


### PR DESCRIPTION
The polkit policy file was being left behind, and thus broke `tests/main/auth-error` test if that later on the same host.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
