### PR TITLE
tests: fix recovery-system-reboot install test that was being interrupted by a system reboot

### DIFF
--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -106,6 +106,10 @@ execute: |
       # finish rebooting, since the kernel, gadget, and base snaps will be
       # updated
       remote.wait-for reboot "${boot_id}"
+
+      # one more watch to wait for the change to finish once the reboot is
+      # completed
+      remote.exec 'snap watch --last=auto-refresh'
     fi
 
     post_json_data "/v2/systems/${prev_system}" '{"action": "remove"}'

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -80,8 +80,7 @@ execute: |
   # wait for the system to finish being seeded
   remote.exec "sudo snap wait system seed.loaded"
 
-  # hold everything so that we can check their revisions before they get auto-refreshed
-  remote.exec "snap list | awk 'NR != 1 { print \$1 }' | xargs sudo snap refresh --hold"
+  boot_id="$(tests.nested boot-id)"
 
   if [ "${MODE}" = 'recover' ]; then
     remote.exec 'cat /proc/cmdline' | MATCH 'snapd_recovery_mode=recover'
@@ -100,10 +99,16 @@ execute: |
     # since out new system is now the default and the current recovery system,
     # we should be able to remove the old one
 
-    # sometimes, this will conflict with an auto-refresh change. retry just in
-    # case.
-    export -f post_json_data
-    retry -n 10 --wait 2 bash -c "post_json_data '/v2/systems/${prev_system}' '{\"action\": \"remove\"}'"
+    # removing a recovery system conflicts with auto-refresh, wait for the
+    # auto-refresh to start and finish before attempting the removal.
+    if retry -n 60 --wait 1 remote.exec 'snap watch --last=auto-refresh'; then
+      # if an auto-refresh happened, we know we need to wait for the system to
+      # finish rebooting, since the kernel, gadget, and base snaps will be
+      # updated
+      remote.wait-for reboot "${boot_id}"
+    fi
+
+    post_json_data "/v2/systems/${prev_system}" '{"action": "remove"}'
 
     remote.exec "snap watch --last=remove-recovery-system"
     remote.exec "sudo snap recovery" | NOMATCH "${prev_system}"
@@ -113,6 +118,13 @@ execute: |
   # should be here in all tested modes.
   remote.exec 'snap list hello-world'
 
-  remote.exec 'snap list core22' | awk 'NR != 1 { print $3 }' | MATCH '1033'
-  remote.exec 'snap list pc' | awk 'NR != 1 { print $3 }' | MATCH '145'
-  remote.exec 'snap list pc-kernel' | awk 'NR != 1 { print $3 }' | MATCH '1606'
+  # make sure that all our other snaps are there too. we can't check their
+  # revisions here, since auto-refresh might have updated them.
+  remote.exec 'snap list core22'
+  remote.exec 'snap list pc'
+  remote.exec 'snap list pc-kernel'
+
+  # however, we can check that the seed contains the correct revisions
+  remote.exec "test -f /var/lib/snapd/seed/snaps/core22_1033.snap"
+  remote.exec "test -f /var/lib/snapd/seed/snaps/pc-kernel_1606.snap"
+  remote.exec "test -f /var/lib/snapd/seed/snaps/pc_145.snap"


### PR DESCRIPTION
In the case of an auto-refresh, the system would reboot. This resulted in some cryptic failures. Make sure to wait for an auto-refresh to happen before removing the recovery system, and make sure to wait for the system to reboot once the auto-refresh has finished.
