### PR TITLE
interfaces/desktop: allow DBus access to plasmashell

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -181,14 +181,14 @@ dbus (send)
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
     member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
     member={ActionInvoked,NotificationClosed,NotificationReplied}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # KDE Plasma's Inhibited property indicating "do not disturb" mode
 # https://invent.kde.org/plasma/plasma-workspace/-/blob/master/libnotificationmanager/dbus/org.freedesktop.Notifications.xml#L42
@@ -197,14 +197,14 @@ dbus (send)
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.DBus.Properties
     member="Get{,All}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # DesktopAppInfo Launched
 dbus (send)

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -302,35 +302,35 @@ dbus (send)
     path=/{StatusNotifierWatcher,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierWatcher
     member=RegisterStatusNotifierItem
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (send)
     bus=session
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(name=org.freedesktop.DBus, label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member={Activate,ContextMenu,Scroll,SecondaryActivate,ProvideXdgActivationToken,XAyatanaSecondaryActivate}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (send)
     bus=session
     path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(name=org.freedesktop.DBus, label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{StatusNotifierItem,StatusNotifierItem/menu,org/ayatana/NotificationItem/**}
     interface={org.freedesktop.DBus.Properties,com.canonical.dbusmenu}
     member={Get*,AboutTo*,Event*}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # notifications
 dbus (send)
@@ -368,7 +368,7 @@ dbus (send)
     path=/org/ayatana/NotificationItem/*
     interface=org.kde.StatusNotifierItem
     member=XAyatanaNew*
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(name=org.freedesktop.DBus, label="{plasmashell,unconfined}"),
 `
 
 const desktopLegacyConnectedPlugSecComp = `

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -362,35 +362,35 @@ dbus (send)
     path=/{MenuBar{,/[0-9A-F]*},com/canonical/{menu/[0-9A-F]*,dbusmenu}}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{MenuBar{,/[0-9A-F]*},com/canonical/{menu/[0-9A-F]*,dbusmenu}}
     interface="{com.canonical.dbusmenu,org.freedesktop.DBus.Properties}"
     member=Get*
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{MenuBar{,/[0-9A-F]*},com/canonical/{menu/[0-9A-F]*,dbusmenu}}
     interface=com.canonical.dbusmenu
     member="{AboutTo*,Event*}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{MenuBar{,/[0-9A-F]*},com/canonical/{menu/[0-9A-F]*,dbusmenu}}
     interface=org.freedesktop.DBus.Introspectable
     member=Introspect
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/com/canonical/dbusmenu
     interface=org.freedesktop.DBus.Properties
     member=Get*
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # app-indicators
 dbus (send)
@@ -423,35 +423,35 @@ dbus (send)
     path=/{StatusNotifierWatcher,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierWatcher
     member=RegisterStatusNotifierItem
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (send)
     bus=session
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member={Activate,ContextMenu,Scroll,SecondaryActivate,ProvideXdgActivationToken,XAyatanaSecondaryActivate}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (send)
     bus=session
     path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/{StatusNotifierItem,StatusNotifierItem/menu,org/ayatana/NotificationItem/**}
     interface={org.freedesktop.DBus.Properties,com.canonical.dbusmenu}
     member={Get*,AboutTo*,Event*}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # notifications
 dbus (send)
@@ -459,14 +459,14 @@ dbus (send)
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
     member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
     member={ActionInvoked,NotificationClosed,NotificationReplied}
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # KDE Plasma's Inhibited property indicating "do not disturb" mode
 # https://invent.kde.org/plasma/plasma-workspace/-/blob/master/libnotificationmanager/dbus/org.freedesktop.Notifications.xml#L42
@@ -475,21 +475,21 @@ dbus (send)
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.DBus.Properties
     member="Get{,All}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 dbus (send)
     bus=session
     path=/org/ayatana/NotificationItem/*
     interface=org.kde.StatusNotifierItem
     member=XAyatanaNew*
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # unity launcher
 dbus (send)
@@ -591,7 +591,7 @@ dbus (receive)
     path=/com/canonical/menu/[0-9]*
     interface="{org.freedesktop.DBus.Properties,com.canonical.dbusmenu}"
     member="{GetAll,GetLayout}"
-    peer=(label=unconfined),
+    peer=(label="{plasmashell,unconfined}"),
 
 # Allow requesting interest in receiving media key events. This tells Gnome
 # settings that our application should be notified when key events we are


### PR DESCRIPTION
apparmor in Ubuntu 24.04 LTS introduces an AppArmor profile for KDEs plasmashell
called "plasmashell". As such, the various DBus objects are now implemented
by a process that has the apparmor label "plasmashell" instead of
"unconfined" (since previously it did not have an AppArmor profile).

Extend the DBus rules for these objects to include this new
peer label to allow snaps to send notifications as before.

Fixes LP: #2056696

Signed-off-by: Alex Murray <alex.murray@canonical.com>