### PR TITLE
i/builtin: allow docker-support to use mqueue

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -62,6 +62,11 @@ const dockerSupportConnectedPlugAppArmorUserNS = `
 userns,
 `
 
+const dockerSupportConnectedPlugAppArmorMqueue = `
+# allow unrestricted use of posix message queues
+mqueue,
+`
+
 const dockerSupportConnectedPlugAppArmor = `
 # Description: allow operating as the Docker daemon/containerd. This policy is
 # intentionally not restrictive and is here to help guard against programming
@@ -1036,6 +1041,9 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 		}
 		if strutil.ListContains(features, "userns") {
 			spec.AddSnippet(dockerSupportConnectedPlugAppArmorUserNS)
+		}
+		if strutil.ListContains(features, "mqueue") {
+			spec.AddSnippet(dockerSupportConnectedPlugAppArmorMqueue)
 		}
 	}
 


### PR DESCRIPTION
Allow docker to do anything with posix message queues. This may be refined later on with more fine-grained permission. This is likely coming out of apparmor 4.0 upgrade.
