### PR TITLE
sandbox/apparmor: detect but ignore apparmor 4

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -496,9 +496,15 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
-			// Pin 4.0 abi if host supports it.
+			// Detect but ignore apparmor 4.0 ABI support.
+			//
+			// At present this causes some bugs with mqueue mediation that can
+			// be avoided by pinning to 3.0 (which is also supported on
+			// apparmor 4). Once the mqueue issue is analyzed and fixed, this
+			// can be replaced with a --policy-features=hostAbi40File pin like
+			// we do below.
 			if fi, err := os.Lstat(hostAbi40File); err == nil && !fi.IsDir() {
-				return exec.Command(path, "--policy-features", hostAbi40File), false, nil
+				logger.Debugf("apparmor 4.0 ABI detected but ignored")
 			}
 
 			// Perhaps 3.0?


### PR DESCRIPTION
Due to issues with incorrect behavior to mediate:

    stat /dev/mqueue

For applications governed by the profile that allows it via

    mqueue,

We cannot yet use apparmor 4, even if one is supported on the host. This does
impact userns mediation but it is better to have the old mediation and not
break snaps, than to have some new mediation in some cases and some unexpected
mediation in other cases.

Once the mqueue, issue is identified and we have updated bundled apparmor to a
stable release of apparmor 4, this patch can be reverted.
