### PR TITLE
tests/lib/prepare.sh: disable cloud-init on GCE

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1172,6 +1172,10 @@ EOF
             for cmd in "console=ttyS0" "dangerous" "systemd.journald.forward_to_console=1" "rd.systemd.journald.forward_to_console=1" "panic=-1"; do
                 echo "$cmd" >> pc-gadget/cmdline.full
             done
+            # On GCE, cloud-init enables itself even though is not
+            # expected in the tests. So we need to disable it
+            # manually.
+            echo "cloud-init=disabled" >>pc-gadget/cmdline.full
         else
             # but for other backends, just add the additional debugging things
             # on top of whatever the gadget currently is configured to use


### PR DESCRIPTION
On GCE, cloud-init enables itself even though is not expected in the tests. So we need to disable it manually.
