### PR TITLE
cmd/snap: use updated "current" revision after snap refresh run inhibition

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -513,7 +513,7 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 		if retryCnt > 1 {
 			// This should never happen, but it is better to fail instead
 			// of retrying forever.
-			return fmt.Errorf("internal error: race condition detected, snap-run can only retry once")
+			return fmt.Errorf("race condition detected, snap-run can only retry once")
 		}
 
 		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), snapName, appName)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 /*
- * Copyright (C) 2014-2022 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,6 +40,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/desktop/portal"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
@@ -257,16 +258,6 @@ func (x *cmdRun) Execute(args []string) error {
 	}
 
 	return x.snapRunApp(snapApp, args)
-}
-
-func maybeWaitWhileInhibited(ctx context.Context, snapName string) error {
-	// If the snap is inhibited from being used then postpone running it until
-	// that condition passes. Inhibition UI can be dismissed by the user, in
-	// which case we don't run the application at all.
-	if features.RefreshAppAwareness.IsEnabled() {
-		return waitWhileInhibited(ctx, snapName)
-	}
-	return nil
 }
 
 // antialias changes snapApp and args if snapApp is actually an alias
@@ -492,30 +483,97 @@ func (x *cmdRun) straceOpts() (opts []string, raw bool, err error) {
 	return opts, raw, nil
 }
 
+// isSnapRefreshConflictDetected detects if snap refreshed was started while not
+// holding the inhibition hint file lock.
+//
+// For context, on snap first install, the inhibition hint lock file is not created
+// so we cannot hold it. It is created after the first refresh. This allows for a
+// window where we don't hold the lock before the tracking cgroup is created where
+// a snap refresh could start.
+func isSnapRefreshConflictDetected(app *snap.AppInfo, hintFlock *osutil.FileLock) bool {
+	if !features.RefreshAppAwareness.IsEnabled() || app.IsService() || hintFlock != nil {
+		// Skip check
+		return false
+	}
+
+	// We started without a hint lock file, if it exists now this means that a
+	// refresh was started.
+	return osutil.FileExists(runinhibit.HintFile(app.Snap.InstanceName()))
+}
+
 func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 	if x.DebugLog {
 		os.Setenv("SNAPD_DEBUG", "1")
 		logger.Debugf("enabled debug logging of early snap startup")
 	}
 	snapName, appName := snap.SplitSnapApp(snapApp)
-	info, err := getSnapInfo(snapName, snap.R(0))
-	if err != nil {
-		return err
-	}
 
-	app := info.Apps[appName]
-	if app == nil {
-		return fmt.Errorf(i18n.G("cannot find app %q in %q"), appName, snapName)
-	}
+	var retryCnt int
+	for {
+		if retryCnt > 1 {
+			// This should never happen, but it is better to fail instead
+			// of retrying forever.
+			return fmt.Errorf("internal error: race condition detected, snap-run can only retry once")
+		}
 
-	if !app.IsService() {
-		// TODO: use signal.NotifyContext as context when snap-run flow is finalized
-		if err := maybeWaitWhileInhibited(context.Background(), snapName); err != nil {
+		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), snapName, appName)
+		if errors.Is(err, errSnapRefreshConflict) {
+			// Possible race condition detected, let's retry.
+
+			// This will not retry infinitely because this can only be caused by
+			// a missing inhibition hint initially which is now created due to a
+			// refresh.
+			retryCnt++
+			logger.Debugf("retry due to possible snap refresh conflict detected")
+			continue
+		}
+		if err != nil {
 			return err
 		}
-	}
 
-	return x.runSnapConfine(info, app.SecurityTag(), snapApp, "", args)
+		closeFlockOrRetry := func() error {
+			// This needs to run inside the transient cgroup created for a snap
+			// such that any pending refresh of the snap will get blocked after
+			// we release the lock.
+			if hintFlock != nil {
+				// It is okay to release the lock here (beforeExec) because snapd unless forced
+				// will not inhibit the snap and do a refresh anymore because it detects app
+				// processes are running for via the established transient cgroup cgroup.
+
+				// Note: We cannot rely on O_CLOEXEC to unlock because might run in
+				// fork + exec mode like when running under gdb or strace.
+				hintFlock.Close()
+				return nil
+			}
+			// hintFlock might be nil if the hint file did not exist
+			if isSnapRefreshConflictDetected(app, hintFlock) {
+				return errSnapRefreshConflict
+			}
+			return nil
+		}
+
+		err = x.runSnapConfine(info, app.SecurityTag(), snapApp, "", closeFlockOrRetry, args)
+		if errors.Is(err, errSnapRefreshConflict) {
+			// Possible race condition detected, let's retry.
+			//
+			// This will not retry infinitely because this can only be caused by
+			// a missing inhibition hint initially which is now created due to a
+			// refresh.
+			retryCnt++
+			logger.Debugf("retry due to possible snap refresh conflict detected")
+			continue
+		}
+		if err != nil {
+			// Make sure we release the lock in case runSnapConfine fails before
+			// closing hint lock file, it is fine if we double close.
+			if hintFlock != nil {
+				hintFlock.Close()
+			}
+			return err
+		}
+
+		return nil
+	}
 }
 
 func (x *cmdRun) snapRunHook(snapName string) error {
@@ -534,7 +592,7 @@ func (x *cmdRun) snapRunHook(snapName string) error {
 		return fmt.Errorf(i18n.G("cannot find hook %q in %q"), x.HookName, snapName)
 	}
 
-	return x.runSnapConfine(info, hook.SecurityTag(), snapName, hook.Name, nil)
+	return x.runSnapConfine(info, hook.SecurityTag(), snapName, hook.Name, nil, nil)
 }
 
 func (x *cmdRun) snapRunTimer(snapApp, timer string, args []string) error {
@@ -1046,7 +1104,7 @@ func (x *cmdRun) runCmdUnderStrace(origCmd []string, envForExec envForExecFunc) 
 	return err
 }
 
-func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook string, args []string) error {
+func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook string, beforeExec func() error, args []string) error {
 	snapConfine, err := snapdHelperPath("snap-confine")
 	if err != nil {
 		return err
@@ -1061,7 +1119,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 
 	logger.Debugf("executing snap-confine from %s", snapConfine)
 
-	snapName, _ := snap.SplitSnapApp(snapApp)
+	snapName, appName := snap.SplitSnapApp(snapApp)
 	opts, err := getSnapDirOptions(snapName)
 	if err != nil {
 		return fmt.Errorf("cannot get snap dir options: %w", err)
@@ -1209,7 +1267,6 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	//
 	// For more information about systemd cgroups, including unit types, see:
 	// https://www.freedesktop.org/wiki/Software/systemd/ControlGroupInterface/
-	_, appName := snap.SplitSnapApp(snapApp)
 	needsTracking := true
 	if app := info.Apps[appName]; hook == "" && app != nil && app.IsService() {
 		// If we are running a service app then we do not need to use
@@ -1237,6 +1294,17 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	// Allow using the session bus for all apps but not for hooks.
 	allowSessionBus := hook == ""
 	// Track, or confirm existing tracking from systemd.
+	if err := cgroupConfirmSystemdAppTracking(securityTag); err != nil {
+		if err != cgroup.ErrCannotTrackProcess {
+			return err
+		}
+	} else {
+		// A transient scope was already created in a previous attempt. Skip creating
+		// another transient scope to avoid leaking cgroups.
+		//
+		// Note: This could happen if beforeExec fails and triggers a retry.
+		needsTracking = false
+	}
 	if needsTracking {
 		opts := &cgroup.TrackingOptions{AllowSessionBus: allowSessionBus}
 		if err = cgroupCreateTransientScopeForTracking(securityTag, opts); err != nil {
@@ -1250,6 +1318,13 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 			logger.Debugf("snap refreshes will not be postponed by this process")
 		}
 	}
+
+	if beforeExec != nil {
+		if err := beforeExec(); err != nil {
+			return err
+		}
+	}
+
 	logger.StartupStageTimestamp("snap to snap-confine")
 	if x.TraceExec {
 		return x.runCmdWithTraceExec(cmd, envForExec)
@@ -1300,3 +1375,4 @@ func getSnapDirOptions(snap string) (*dirs.SnapDirOptions, error) {
 
 var cgroupCreateTransientScopeForTracking = cgroup.CreateTransientScopeForTracking
 var cgroupConfirmSystemdServiceTracking = cgroup.ConfirmSystemdServiceTracking
+var cgroupConfirmSystemdAppTracking = cgroup.ConfirmSystemdAppTracking

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -922,7 +922,7 @@ func (s *RunSuite) TestSnapRunAppMaxRetry(c *check.C) {
 	defer restore()
 
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
-	c.Assert(err, check.ErrorMatches, "internal error: race condition detected, snap-run can only retry once")
+	c.Assert(err, check.ErrorMatches, "race condition detected, snap-run can only retry once")
 	// check we only retried once
 	c.Check(called, check.Equals, 2)
 }

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -33,24 +33,18 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/godbus/dbus"
 	snaprun "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
-	"github.com/snapcore/snapd/dbusutil"
-	"github.com/snapcore/snapd/dbusutil/dbustest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/strace"
-	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/progress/progresstest"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/selinux"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-	usersessionclient "github.com/snapcore/snapd/usersession/client"
 	"github.com/snapcore/snapd/x11"
 )
 
@@ -99,6 +93,10 @@ func (s *RunSuite) SetUpTest(c *check.C) {
 	}))
 	s.AddCleanup(snaprun.MockCreateTransientScopeForTracking(func(string, *cgroup.TrackingOptions) error {
 		return nil
+	}))
+	s.AddCleanup(snaprun.MockConfirmSystemdAppTracking(func(securityTag string) error {
+		// default to showing no existing tracking
+		return cgroup.ErrCannotTrackProcess
 	}))
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(false)
 	s.AddCleanup(restoreIsGraphicalSession)
@@ -218,6 +216,20 @@ func (s *RunSuite) TestSnapRunAppIntegration(c *check.C) {
 	c.Check(execEnv, testutil.Contains, fmt.Sprintf("TMPDIR=%s", tmpdir))
 }
 
+func checkHintFileNotLocked(c *check.C, snapName string) {
+	flock, err := openHintFileLock(snapName)
+	c.Assert(err, check.IsNil)
+	c.Check(flock.TryLock(), check.IsNil)
+	flock.Close()
+}
+
+func checkHintFileLocked(c *check.C, snapName string) {
+	flock, err := openHintFileLock(snapName)
+	c.Assert(err, check.IsNil)
+	c.Check(flock.TryLock(), check.Equals, osutil.ErrAlreadyLocked)
+	flock.Close()
+}
+
 func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
@@ -227,6 +239,9 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 	var execArg0 string
 	var execArgs []string
 	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		// lock should be released before calling snap-confine using beforeExec() callback
+		checkHintFileNotLocked(c, "snapname")
+
 		execArg0 = arg0
 		execArgs = args
 		return nil
@@ -244,16 +259,15 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 		c.Check(snapName, check.Equals, "snapname")
 		c.Check(ctx, check.NotNil)
 
-		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-		c.Assert(err, check.IsNil)
-		// non-service apps should keep waiting
-		c.Check(cont, check.Equals, false)
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
+		var err error
 		flock, err = openHintFileLock(snapName)
 		c.Assert(err, check.IsNil)
+		// mock held lock and check that it is released after snap run finishes
+		c.Assert(flock.ReadLock(), check.IsNil)
+
+		err = notInhibited(ctx)
+		c.Assert(err, check.IsNil)
+
 		return flock, nil
 	})
 	defer restore()
@@ -268,6 +282,144 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 		"snap.snapname.app",
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1"})
+
+	// lock should be released now
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppRefreshAppAwarenessUnsetSkipsInhibitionLockCheck(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		return nil
+	})
+	defer restorer()
+
+	// mark snap as inhibited
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R("x2")}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	// unset refresh-app-awareness flag
+	c.Assert(os.RemoveAll(features.RefreshAppAwareness.ControlFile()), check.IsNil)
+
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		return nil, fmt.Errorf("runinhibit.WaitWhileInhibited should not have been called")
+	})
+	defer restore()
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *RunSuite) TestSnapRunAppNewRevisionAfterInhibition(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	// mock installed snap
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	var execEnv []string
+	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execEnv = envv
+		return nil
+	})
+	defer restorer()
+
+	// mark snap as inhibited
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R("x2")}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
+	// unset refresh-app-awareness flag
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	var called bool
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		called = true
+		c.Check(snapName, check.Equals, "snapname")
+
+		var err error
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		c.Assert(flock.ReadLock(), check.IsNil)
+
+		// snap is inhibited for sometime
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &runinhibit.InhibitInfo{Previous: snap.R("x2")})
+			c.Assert(err, check.IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, check.Equals, false)
+		}
+
+		// mock installed snap's new revision with current symlink
+		snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x3")})
+
+		// snap is not inhibited anymore
+		err = notInhibited(ctx)
+		c.Assert(err, check.IsNil)
+
+		return flock, nil
+	})
+	defer restore()
+
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
+	c.Assert(err, check.IsNil)
+	c.Check(called, check.Equals, true)
+	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
+	// Check snap-confine points to latest revision
+	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x3")
+
+	// lock should be released now
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppMissingAppAfterInhibition(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	const mockYaml1 = `name: snapname
+version: 1.0
+apps:
+ app-1:
+  command: run-app
+`
+	const mockYaml2 = `name: snapname
+version: 1.1
+apps:
+ app-2:
+  command: run-app
+`
+
+	// mock installed snap
+	snaptest.MockSnap(c, string(mockYaml1), &snap.SideInfo{Revision: snap.R("x2")})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	var called bool
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		called = true
+		c.Check(snapName, check.Equals, "snapname")
+
+		// snap is inhibited
+		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &runinhibit.InhibitInfo{Previous: snap.R("x2")})
+		c.Assert(err, check.IsNil)
+		// non-service apps should keep waiting
+		c.Check(cont, check.Equals, false)
+
+		// mock installed snap's new revision with current symlink
+		snaptest.MockSnapCurrent(c, string(mockYaml2), &snap.SideInfo{Revision: snap.R("x3")})
+
+		// snap is not inhibited anymore
+		err = notInhibited(ctx)
+		c.Assert(err, check.ErrorMatches, `cannot find app "app-1" in "snapname"`)
+		return nil, err
+	})
+	defer restore()
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app-1", "--arg1"})
+	c.Assert(err, check.ErrorMatches, `cannot find app "app-1" in "snapname"`)
+	c.Check(called, check.Equals, true)
 }
 
 func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
@@ -290,11 +442,8 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 	})
 	defer restorer()
 
-	var called bool
 	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called = true
-		c.Errorf("runinhibit.WaitWhileInhibited should not have been called")
-		return nil, nil
+		return nil, fmt.Errorf("runinhibit.WaitWhileInhibited should not have been called")
 	})
 	defer restore()
 
@@ -313,7 +462,6 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
-	c.Check(called, check.Equals, false)
 }
 
 func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
@@ -324,9 +472,11 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 
 	var execArg0 string
 	var execArgs []string
+	var execEnv []string
 	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
 		execArg0 = arg0
 		execArgs = args
+		execEnv = envv
 		return nil
 	})
 	defer restorer()
@@ -336,11 +486,23 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
-	var called bool
+	var called int
 	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called = true
-		c.Errorf("runinhibit.WaitWhileInhibited should not have been called")
-		return nil, nil
+		called++
+		c.Check(snapName, check.Equals, "snapname")
+
+		var err error
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, check.IsNil)
+		c.Assert(flock.ReadLock(), check.IsNil)
+
+		// snap is inhibited
+		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &inhibitInfo)
+		c.Assert(err, check.IsNil)
+		// services should not be blocked waiting
+		c.Check(cont, check.Equals, true)
+
+		return flock, nil
 	})
 	defer restore()
 
@@ -352,12 +514,417 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 
 	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.svc"})
 	c.Assert(err, check.IsNil)
-	c.Check(called, check.Equals, false)
+	c.Check(called, check.Equals, 1)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.svc"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
 		filepath.Join(dirs.DistroLibExecDir, "snap-confine"), "snap.snapname.svc",
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"), "snapname.svc"})
+	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+
+	// lock should be released now
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppHintUnlockedOnSnapConfineFailure(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	// mock not-inhibited empty hint
+	c.Assert(os.MkdirAll(runinhibit.InhibitDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(runinhibit.HintFile("snapname"), []byte(""), 0644), check.IsNil)
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	var confirmCgroupCalled int
+	restore = snaprun.MockConfirmSystemdAppTracking(func(securityTag string) error {
+		confirmCgroupCalled++
+		// force error before beforeExec is called
+		return fmt.Errorf("boom")
+	})
+	defer restore()
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
+	c.Assert(err, check.ErrorMatches, "boom")
+	c.Check(confirmCgroupCalled, check.Equals, 1)
+
+	// lock should be released on failure
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppHintLockedUntilTrackingCgroupIsCreated(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	var execArg0 string
+	var execArgs []string
+	restore := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execArg0 = arg0
+		execArgs = args
+		return nil
+	})
+	defer restore()
+
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	// mock not-inhibited empty hint
+	c.Assert(os.MkdirAll(runinhibit.InhibitDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(runinhibit.HintFile("snapname"), []byte(""), 0644), check.IsNil)
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	var confirmCgroupCalled int
+	restore = snaprun.MockConfirmSystemdAppTracking(func(securityTag string) error {
+		confirmCgroupCalled++
+		// hint file must be locked until transient cgroup is created
+		checkHintFileLocked(c, "snapname")
+		return nil
+	})
+	defer restore()
+
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
+	c.Check(execArgs, check.DeepEquals, []string{
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
+		"snap.snapname.app",
+		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
+		"snapname.app", "--arg1"})
+	c.Check(confirmCgroupCalled, check.Equals, 1)
+
+	// lock should be released on failure
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) testSnapRunAppRetryNoInhibitHintFileThenOngoingRefresh(c *check.C, svc bool) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	var execEnv []string
+	restore = snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execEnv = envv
+		return nil
+	})
+	defer restore()
+
+	// mock installed snap
+	si := snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	var startCalled, finishCalled int
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			startCalled++
+			return nil
+		},
+		finish: func(ctx context.Context) error {
+			finishCalled++
+			return nil
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	var waitWhileInhibitedCalled int
+	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		waitWhileInhibitedCalled++
+
+		c.Check(snapName, check.Equals, "snapname")
+		if waitWhileInhibitedCalled == 1 {
+			err := notInhibited(ctx)
+			c.Assert(err, check.IsNil)
+
+			// mock snap inhibited to trigger race condition detection
+			// i.e. we started without a hint lock file (snap on first install)
+			// then a refresh started which created the hint lock file.
+			c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{Previous: snap.R("x2")}), check.IsNil)
+
+			// nil FileLock means no inhibit file exists
+			return nil, nil
+		} else {
+			var err error
+
+			flock, err = openHintFileLock(snapName)
+			c.Assert(err, check.IsNil)
+			c.Assert(flock.ReadLock(), check.IsNil)
+
+			// snap is inhibited
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &runinhibit.InhibitInfo{Previous: snap.R("x2")})
+			c.Check(err, check.IsNil)
+			c.Check(cont, check.Equals, false)
+
+			// remove current symlink to add another "current" revision
+			c.Assert(os.RemoveAll(filepath.Join(si.MountDir(), "../current")), check.IsNil)
+			// update current snap revision
+			snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x3")})
+
+			// snap is not inhibited anymore
+			err = notInhibited(ctx)
+			c.Assert(err, check.IsNil)
+
+			return flock, nil
+		}
+	})
+	defer restore()
+
+	var createCgroupCalled int
+	restore = snaprun.MockCreateTransientScopeForTracking(func(securityTag string, opts *cgroup.TrackingOptions) error {
+		createCgroupCalled++
+		return nil
+	})
+	defer restore()
+
+	var confirmCgroupCalled int
+	confirmCgroup := func(securityTag string) error {
+		confirmCgroupCalled++
+		if createCgroupCalled >= 1 || svc {
+			// tracking cgroup was already created
+			return nil
+		}
+		// no tracking cgroup exists for current process
+		return cgroup.ErrCannotTrackProcess
+	}
+
+	if svc {
+		restore = snaprun.MockConfirmSystemdServiceTracking(confirmCgroup)
+	} else {
+		restore = snaprun.MockConfirmSystemdAppTracking(confirmCgroup)
+	}
+	defer restore()
+
+	cmd := "snapname.app"
+	if svc {
+		cmd = "snapname.svc"
+	}
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--debug-log", "--", cmd})
+	c.Assert(err, check.IsNil)
+
+	if svc {
+		// no retry, sinlge call
+		c.Check(waitWhileInhibitedCalled, check.Equals, 1)
+		c.Check(confirmCgroupCalled, check.Equals, 1)
+		// service cgroup already created
+		c.Check(createCgroupCalled, check.Equals, 0)
+		// Check service continued with initial revision
+		c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+		// notification flow is not started for services
+		c.Check(startCalled, check.Equals, 0)
+		c.Check(finishCalled, check.Equals, 0)
+		// check no retry logs
+		c.Check(strings.Contains(logbuf.String(), "retry due to possible snap refresh conflict detected"), check.Equals, false)
+	} else {
+		// two calls due to retry
+		c.Check(waitWhileInhibitedCalled, check.Equals, 2)
+		c.Check(confirmCgroupCalled, check.Equals, 2)
+		// cgroup must only be created once and reused for further retries
+		// to avoid leaking cgroups
+		c.Check(createCgroupCalled, check.Equals, 1)
+		// Check snap-confine points to latest revision
+		c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x3")
+		// notification flow started and finished
+		c.Check(startCalled, check.Equals, 1)
+		c.Check(finishCalled, check.Equals, 1)
+		// check retry behavior is logged
+		c.Check(logbuf.String(), testutil.Contains, "retry due to possible snap refresh conflict detected")
+	}
+
+	// lock should be released now
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppRetryNoInhibitHintFileThenOngoingRefresh(c *check.C) {
+	const svc = false
+	s.testSnapRunAppRetryNoInhibitHintFileThenOngoingRefresh(c, svc)
+}
+
+func (s *RunSuite) TestSnapRunAppRetryNoInhibitHintFileThenOngoingRefreshService(c *check.C) {
+	const svc = true
+	s.testSnapRunAppRetryNoInhibitHintFileThenOngoingRefresh(c, svc)
+}
+
+func (s *RunSuite) TestSnapRunAppRetryNoInhibitHintFileThenOngoingRefreshMissingCurrent(c *check.C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	var execEnv []string
+	restore = snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execEnv = envv
+		return nil
+	})
+	defer restore()
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	var startCalled, finishCalled int
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			startCalled++
+			return nil
+		},
+		finish: func(ctx context.Context) error {
+			finishCalled++
+			return nil
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	var waitWhileInhibitedCalled int
+	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		waitWhileInhibitedCalled++
+
+		c.Check(snapName, check.Equals, "snapname")
+		if waitWhileInhibitedCalled == 1 {
+			err := notInhibited(ctx)
+			// mock edge case where we started without a hint lock file
+			// and we have an ongoing refresh which removed current symlink.
+			c.Assert(err, testutil.ErrorIs, snaprun.ErrSnapRefreshConflict)
+			// and created the inhibition hint lock file.
+			c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{Previous: snap.R("x2")}), check.IsNil)
+			return nil, err
+		} else {
+			var err error
+
+			flock, err = openHintFileLock(snapName)
+			c.Assert(err, check.IsNil)
+			c.Assert(flock.ReadLock(), check.IsNil)
+
+			// snap is inhibited
+			inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R("x3")}
+			// update current snap revision
+			snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x3")})
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &inhibitInfo)
+			c.Check(err, check.IsNil)
+			c.Check(cont, check.Equals, false)
+
+			// snap is not inhibited anymore
+			err = notInhibited(ctx)
+			c.Assert(err, check.IsNil)
+
+			return flock, nil
+		}
+	})
+	defer restore()
+
+	var createCgroupCalled int
+	restore = snaprun.MockCreateTransientScopeForTracking(func(securityTag string, opts *cgroup.TrackingOptions) error {
+		createCgroupCalled++
+		return nil
+	})
+	defer restore()
+
+	var confirmCgroupCalled int
+	confirmCgroup := func(securityTag string) error {
+		confirmCgroupCalled++
+		if createCgroupCalled >= 1 {
+			// tracking cgroup was already created
+			return nil
+		}
+		// no tracking cgroup exists for current process
+		return cgroup.ErrCannotTrackProcess
+	}
+
+	restore = snaprun.MockConfirmSystemdAppTracking(confirmCgroup)
+	defer restore()
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--debug-log", "--", "snapname.app"})
+	c.Assert(err, check.IsNil)
+
+	// two calls due to retry
+	c.Check(waitWhileInhibitedCalled, check.Equals, 2)
+	// We entered snap-confine only once
+	c.Check(confirmCgroupCalled, check.Equals, 1)
+	c.Check(createCgroupCalled, check.Equals, 1)
+	// Check snap-confine points to latest revision
+	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x3")
+	// notification flow started and finished
+	c.Check(startCalled, check.Equals, 1)
+	c.Check(finishCalled, check.Equals, 1)
+	// check retry behavior is logged
+	c.Check(logbuf.String(), testutil.Contains, "cannot find current revision for snap snapname")
+	c.Check(logbuf.String(), testutil.Contains, "retry due to possible snap refresh conflict detected")
+
+	// lock should be released now
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestSnapRunAppMaxRetry(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	var called int
+	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		called++
+		c.Check(snapName, check.Equals, "snapname")
+
+		err := notInhibited(ctx)
+		c.Assert(err, check.IsNil)
+
+		// mock snap inhibited to trigger race condition detection
+		// i.e. we started without a hint lock file (snap on first install)
+		// then a refresh started which created the hint lock file.
+		c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{Previous: snap.R("x2")}), check.IsNil)
+
+		// nil FileLock means no inhibit file exists
+		return nil, nil
+	})
+	defer restore()
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
+	c.Assert(err, check.ErrorMatches, "internal error: race condition detected, snap-run can only retry once")
+	// check we only retried once
+	c.Check(called, check.Equals, 2)
 }
 
 func (s *RunSuite) TestSnapRunClassicAppIntegration(c *check.C) {
@@ -1867,378 +2434,6 @@ func openHintFileLock(snapName string) (*osutil.FileLock, error) {
 	return osutil.NewFileLockWithMode(runinhibit.HintFile(snapName), 0644)
 }
 
-func checkHintFileNotLocked(c *check.C, snapName string) {
-	flock, err := openHintFileLock(snapName)
-	c.Assert(err, check.IsNil)
-	c.Check(flock.TryLock(), check.IsNil)
-	flock.Close()
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-
-	var called int
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called++
-
-		c.Check(snapName, check.Equals, "some-snap")
-		c.Check(ctx, check.NotNil)
-		for i := 0; i < 3; i++ {
-			cont, err := inhibited(ctx, runinhibit.HintInhibitedGateRefresh, nil)
-			c.Assert(err, check.IsNil)
-			// non-service apps should keep waiting
-			c.Check(cont, check.Equals, false)
-		}
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
-		flock, err := openHintFileLock(snapName)
-		c.Assert(err, check.IsNil)
-		return flock, nil
-	})
-	defer restore()
-
-	meter := &progresstest.Meter{}
-	defer progress.MockMeter(meter)()
-
-	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 1)
-
-	c.Check(meter.Values, check.HasLen, 0)
-	c.Check(meter.Written, check.HasLen, 0)
-	c.Check(meter.Finishes, check.Equals, 0)
-	c.Check(meter.Labels, check.HasLen, 0)
-	c.Check(meter.Labels, check.HasLen, 0)
-
-	// lock must be released
-	checkHintFileNotLocked(c, "some-snap")
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-
-	var called int
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called++
-
-		c.Check(snapName, check.Equals, "some-snap")
-		cont, err := inhibited(ctx, runinhibit.HintInhibitedGateRefresh, nil)
-		c.Assert(err, check.IsNil)
-		// non-service apps should keep waiting
-		c.Check(cont, check.Equals, false)
-		cont, err = inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-		c.Assert(err, check.IsNil)
-		// non-service apps should keep waiting
-		c.Check(cont, check.Equals, false)
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
-		flock, err = openHintFileLock(snapName)
-		c.Assert(err, check.IsNil)
-		return flock, nil
-	})
-	defer restore()
-
-	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 1)
-
-	c.Check(s.Stdout(), check.Equals, "snap package \"some-snap\" is being refreshed, please wait\n")
-
-	// lock must be released
-	checkHintFileNotLocked(c, "some-snap")
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedDesktopIntegrationFlow(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	var dbusCalled int
-	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
-		dbusCalled++
-		return []*dbus.Message{makeDBusMethodAvailableMessage(c, msg)}, nil
-	})
-	c.Assert(err, check.IsNil)
-
-	restore := dbusutil.MockOnlySessionBusAvailable(conn)
-	defer restore()
-
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	var pendingRefreshNotificationCalled int
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		pendingRefreshNotificationCalled++
-		c.Error("this should never be reached")
-		return nil
-	})
-	defer restorePendingRefreshNotification()
-
-	var finishRefreshNotificationCalled int
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		finishRefreshNotificationCalled++
-		c.Error("this should never be reached")
-		return nil
-	})
-	defer restoreFinishRefreshNotification()
-
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-
-	var called int
-	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called++
-
-		c.Check(snapName, check.Equals, "some-snap")
-		for i := 0; i < 3; i++ {
-			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-			c.Assert(err, check.IsNil)
-			// non-service apps should keep waiting
-			c.Check(cont, check.Equals, false)
-		}
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
-		flock, err := openHintFileLock(snapName)
-		c.Assert(err, check.IsNil)
-		return flock, nil
-	})
-	defer restore()
-
-	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 1)
-	c.Check(s.Stdout(), check.Equals, "")
-
-	// snapd-desktop-integration snap monitors inhibit file
-	// flow.Finish is a no-op, so it's only called once
-	c.Check(dbusCalled, check.Equals, 1)
-	// session flow was not called
-	c.Check(pendingRefreshNotificationCalled, check.Equals, 0)
-	c.Check(finishRefreshNotificationCalled, check.Equals, 0)
-
-	// lock must be released
-	checkHintFileNotLocked(c, "some-snap")
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	originalCtx := context.Background()
-
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
-		c.Check(snapName, check.Equals, "some-snap")
-		// check context is propagated properly
-		c.Assert(ctx, check.Equals, originalCtx)
-		c.Check(ctx.Err(), check.IsNil)
-		return false
-	})
-	defer restoreTryNotifyRefresh()
-
-	var pendingRefreshNotificationCalled int
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		pendingRefreshNotificationCalled++
-		// check context is propagated properly
-		c.Assert(ctx, check.Equals, originalCtx)
-		c.Check(ctx.Err(), check.IsNil)
-		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
-			InstanceName:  "some-snap",
-			TimeRemaining: 0,
-		})
-		return nil
-	})
-	defer restorePendingRefreshNotification()
-
-	var finishRefreshNotificationCalled int
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		finishRefreshNotificationCalled++
-		// check context is propagated properly
-		c.Assert(ctx, check.Equals, originalCtx)
-		c.Check(ctx.Err(), check.IsNil)
-		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.FinishedSnapRefreshInfo{
-			InstanceName: "some-snap",
-		})
-		return nil
-	})
-	defer restoreFinishRefreshNotification()
-
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-
-	var called int
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		called++
-
-		c.Check(snapName, check.Equals, "some-snap")
-		for i := 0; i < 3; i++ {
-			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-			c.Assert(err, check.IsNil)
-			// non-service apps should keep waiting
-			c.Check(cont, check.Equals, false)
-		}
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
-		flock, err := openHintFileLock(snapName)
-		c.Assert(err, check.IsNil)
-		return flock, nil
-	})
-	defer restore()
-
-	c.Assert(snaprun.WaitWhileInhibited(originalCtx, "some-snap"), check.IsNil)
-	c.Check(called, check.Equals, 1)
-	c.Check(s.Stdout(), check.Equals, "")
-
-	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
-	c.Check(finishRefreshNotificationCalled, check.Equals, 1)
-
-	// lock must be released
-	checkHintFileNotLocked(c, "some-snap")
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
-		c.Check(snapName, check.Equals, "some-snap")
-		return false
-	})
-	defer restoreTryNotifyRefresh()
-
-	var pendingRefreshNotificationCalled int
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		pendingRefreshNotificationCalled++
-		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
-			InstanceName:  "some-snap",
-			TimeRemaining: 0,
-		})
-		return fmt.Errorf("boom")
-	})
-	defer restorePendingRefreshNotification()
-
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		c.Errorf("this should never be reached")
-		return nil
-	})
-	defer restoreFinishRefreshNotification()
-
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		c.Check(snapName, check.Equals, "some-snap")
-
-		_, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-		c.Assert(err, check.ErrorMatches, "boom")
-		return nil, err
-	})
-	defer restore()
-
-	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.ErrorMatches, "boom")
-
-	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
-		c.Check(snapName, check.Equals, "some-snap")
-		return false
-	})
-	defer restoreTryNotifyRefresh()
-
-	var pendingRefreshNotificationCalled int
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		pendingRefreshNotificationCalled++
-		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.PendingSnapRefreshInfo{
-			InstanceName:  "some-snap",
-			TimeRemaining: 0,
-		})
-		return nil
-	})
-	defer restorePendingRefreshNotification()
-
-	var finishRefreshNotificationCalled int
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		finishRefreshNotificationCalled++
-		c.Check(refreshInfo, check.DeepEquals, &usersessionclient.FinishedSnapRefreshInfo{
-			InstanceName: "some-snap",
-		})
-		return fmt.Errorf("boom")
-	})
-	defer restoreFinishRefreshNotification()
-
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		c.Check(snapName, check.Equals, "some-snap")
-
-		cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, nil)
-		c.Assert(err, check.IsNil)
-		// non-service apps should keep waiting
-		c.Check(cont, check.Equals, false)
-		if notInhibited != nil {
-			c.Errorf("this should never be reached")
-		}
-
-		flock, err = openHintFileLock(snapName)
-		c.Assert(err, check.IsNil)
-		return flock, nil
-	})
-	defer restore()
-
-	c.Assert(snaprun.WaitWhileInhibited(context.TODO(), "some-snap"), check.ErrorMatches, "boom")
-
-	c.Check(pendingRefreshNotificationCalled, check.Equals, 1)
-	c.Check(finishRefreshNotificationCalled, check.Equals, 1)
-
-	// lock must be released
-	checkHintFileNotLocked(c, "some-snap")
-}
-
-func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *check.C) {
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	originalCtx, cancel := context.WithCancel(context.Background())
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(ctx context.Context, snapName string) bool {
-		c.Check(snapName, check.Equals, "some-snap")
-		// check context is propagated properly
-		c.Assert(ctx, check.Equals, originalCtx)
-		c.Check(ctx.Err(), check.IsNil)
-		// cancel context to trigger cancellation error
-		cancel()
-		return true
-	})
-	defer restoreTryNotifyRefresh()
-
-	err := snaprun.WaitWhileInhibited(originalCtx, "some-snap")
-	c.Assert(err, check.ErrorMatches, "context canceled")
-	c.Assert(errors.Is(err, context.Canceled), check.Equals, true)
-	c.Assert(errors.Is(originalCtx.Err(), context.Canceled), check.Equals, true)
-}
-
 func (s *RunSuite) TestCreateSnapDirPermissions(c *check.C) {
 	usr, err := user.Current()
 	c.Assert(err, check.IsNil)
@@ -2325,83 +2520,4 @@ func (s *RunSuite) TestRunDebugLog(c *check.C) {
 	c.Check(os.Getenv("SNAPD_DEBUG"), check.Equals, "1")
 	// and we've let the user know that logging was enabled
 	c.Check(logBuf.String(), testutil.Contains, "DEBUG: enabled debug logging of early snap startup")
-}
-
-func (s *RunSuite) TestDesktopIntegrationNoDBus(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	noDBus := func() (*dbus.Conn, error) { return nil, fmt.Errorf("dbus not available") }
-	restore := dbusutil.MockConnections(noDBus, noDBus)
-	defer restore()
-
-	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "Test")
-	c.Assert(sent, check.Equals, false)
-}
-
-func makeDBusMethodNotAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
-	return &dbus.Message{
-		Type: dbus.TypeError,
-		Headers: map[dbus.HeaderField]dbus.Variant{
-			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
-			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
-			// dbus.FieldDestination is provided automatically by DBus test helper.
-			dbus.FieldErrorName: dbus.MakeVariant("org.freedesktop.DBus.Error.UnknownMethod"),
-		},
-	}
-}
-
-func (s *RunSuite) TestDesktopIntegrationDBusAvailableNoMethod(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
-		return []*dbus.Message{makeDBusMethodNotAvailableMessage(c, msg)}, nil
-	})
-	c.Assert(err, check.IsNil)
-
-	restore := dbusutil.MockOnlySessionBusAvailable(conn)
-	defer restore()
-
-	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "some-snap")
-	c.Assert(sent, check.Equals, false)
-}
-
-func makeDBusMethodAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
-	c.Assert(msg.Type, check.Equals, dbus.TypeMethodCall)
-	c.Check(msg.Flags, check.Equals, dbus.Flags(0))
-
-	c.Check(msg.Headers, check.DeepEquals, map[dbus.HeaderField]dbus.Variant{
-		dbus.FieldDestination: dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
-		dbus.FieldPath:        dbus.MakeVariant(dbus.ObjectPath("/io/snapcraft/SnapDesktopIntegration")),
-		dbus.FieldInterface:   dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
-		dbus.FieldMember:      dbus.MakeVariant("ApplicationIsBeingRefreshed"),
-		dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("", "", make(map[string]dbus.Variant))),
-	})
-	c.Check(msg.Body[0], check.Equals, "some-snap")
-	param2 := fmt.Sprintf("%s", msg.Body[1])
-	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/some-snap.lock"), check.Equals, true)
-	return &dbus.Message{
-		Type: dbus.TypeMethodReply,
-		Headers: map[dbus.HeaderField]dbus.Variant{
-			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
-			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
-		},
-	}
-}
-
-func (s *RunSuite) TestDesktopIntegrationDBusAvailableMethodWorks(c *check.C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
-		return []*dbus.Message{makeDBusMethodAvailableMessage(c, msg)}, nil
-	})
-	c.Assert(err, check.IsNil)
-
-	restore := dbusutil.MockOnlySessionBusAvailable(conn)
-	defer restore()
-
-	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "some-snap")
-	c.Assert(sent, check.Equals, true)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -154,6 +154,7 @@ var (
 	WaitWhileInhibited                            = waitWhileInhibited
 	TryNotifyRefreshViaSnapDesktopIntegrationFlow = tryNotifyRefreshViaSnapDesktopIntegrationFlow
 	NewInhibitionFlow                             = newInhibitionFlow
+	ErrSnapRefreshConflict                        = errSnapRefreshConflict
 )
 
 func MockPollTime(d time.Duration) (restore func()) {
@@ -357,6 +358,14 @@ func MockConfirmSystemdServiceTracking(fn func(securityTag string) error) (resto
 	}
 }
 
+func MockConfirmSystemdAppTracking(fn func(securityTag string) error) (restore func()) {
+	old := cgroupConfirmSystemdAppTracking
+	cgroupConfirmSystemdAppTracking = fn
+	return func() {
+		cgroupConfirmSystemdAppTracking = old
+	}
+}
+
 func MockApparmorSnapAppFromPid(f func(pid int) (string, string, string, error)) (restore func()) {
 	old := apparmorSnapAppFromPid
 	apparmorSnapAppFromPid = f
@@ -458,6 +467,16 @@ func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(ctx context.Contex
 	tryNotifyRefreshViaSnapDesktopIntegrationFlow = f
 	return func() {
 		tryNotifyRefreshViaSnapDesktopIntegrationFlow = old
+	}
+}
+
+func MockInhibitionFlow(flow inhibitionFlow) (restore func()) {
+	old := newInhibitionFlow
+	newInhibitionFlow = func(name string) inhibitionFlow {
+		return flow
+	}
+	return func() {
+		newInhibitionFlow = old
 	}
 }
 

--- a/cmd/snap/inhibit_test.go
+++ b/cmd/snap/inhibit_test.go
@@ -1,0 +1,477 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/godbus/dbus"
+	snaprun "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
+	"github.com/snapcore/snapd/dbusutil"
+	"github.com/snapcore/snapd/dbusutil/dbustest"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	usersessionclient "github.com/snapcore/snapd/usersession/client"
+	. "gopkg.in/check.v1"
+)
+
+type fakeInhibitionFlow struct {
+	start  func(ctx context.Context) error
+	finish func(ctx context.Context) error
+}
+
+func (flow *fakeInhibitionFlow) StartInhibitionNotification(ctx context.Context) error {
+	if flow.start == nil {
+		return fmt.Errorf("StartInhibitionNotification is not implemented")
+	}
+	return flow.start(ctx)
+}
+
+func (flow *fakeInhibitionFlow) FinishInhibitionNotification(ctx context.Context) error {
+	if flow.finish == nil {
+		return fmt.Errorf("FinishInhibitionNotification is not implemented")
+	}
+	return flow.finish(ctx)
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedRunThrough(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
+
+	var waitWhileInhibitedCalled int
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		waitWhileInhibitedCalled++
+
+		c.Check(snapName, Equals, "snapname")
+		c.Check(ctx, NotNil)
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &inhibitInfo)
+			c.Assert(err, IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, Equals, false)
+		}
+		err := notInhibited(ctx)
+		c.Assert(err, IsNil)
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, IsNil)
+		err = flock.ReadLock()
+		c.Assert(err, IsNil)
+		return flock, nil
+	})
+	defer restore()
+
+	var startCalled, finishCalled int
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			startCalled++
+			return nil
+		},
+		finish: func(ctx context.Context) error {
+			finishCalled++
+			return nil
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	defer hintLock.Unlock()
+	c.Assert(err, IsNil)
+	c.Check(info.InstanceName(), Equals, "snapname")
+	c.Check(app.Name, Equals, "app")
+
+	c.Check(startCalled, Equals, 1)
+	c.Check(finishCalled, Equals, 1)
+	c.Check(waitWhileInhibitedCalled, Equals, 1)
+	checkHintFileLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedErrorOnStartNotification(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
+
+	var startCalled, finishCalled int
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			startCalled++
+			return fmt.Errorf("boom")
+		},
+		finish: func(ctx context.Context) error {
+			finishCalled++
+			return nil
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	c.Assert(err, ErrorMatches, "boom")
+	c.Check(info, IsNil)
+	c.Check(app, IsNil)
+	c.Check(hintLock, IsNil)
+
+	c.Check(startCalled, Equals, 1)
+	c.Check(finishCalled, Equals, 0)
+	// lock must be released
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedErrorOnFinishNotification(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
+
+	var waitWhileInhibitedCalled int
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		waitWhileInhibitedCalled++
+
+		c.Check(snapName, Equals, "snapname")
+		c.Check(ctx, NotNil)
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedForRefresh, &inhibitInfo)
+			c.Assert(err, IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, Equals, false)
+		}
+		err := notInhibited(ctx)
+		c.Assert(err, IsNil)
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, IsNil)
+		err = flock.ReadLock()
+		c.Assert(err, IsNil)
+		return flock, nil
+	})
+	defer restore()
+
+	var startCalled, finishCalled int
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			startCalled++
+			return nil
+		},
+		finish: func(ctx context.Context) error {
+			finishCalled++
+			return fmt.Errorf("boom")
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	c.Assert(err, ErrorMatches, "boom")
+	c.Check(info, IsNil)
+	c.Check(app, IsNil)
+	c.Check(hintLock, IsNil)
+
+	c.Check(startCalled, Equals, 1)
+	c.Check(finishCalled, Equals, 1)
+	c.Check(waitWhileInhibitedCalled, Equals, 1)
+	// lock must be released
+	checkHintFileNotLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
+
+	originalCtx, cancel := context.WithCancel(context.Background())
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			// check context is propagated properly
+			c.Assert(ctx, Equals, originalCtx)
+			c.Check(ctx.Err(), IsNil)
+			// cancel context to trigger cancellation error
+			cancel()
+			return nil
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	_, _, _, err := snaprun.WaitWhileInhibited(originalCtx, "snapname", "app")
+	c.Assert(err, ErrorMatches, "context canceled")
+	c.Assert(errors.Is(err, context.Canceled), Equals, true)
+	c.Assert(errors.Is(originalCtx.Err(), context.Canceled), Equals, true)
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedGateRefreshNoNotification(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedGateRefresh, inhibitInfo), IsNil)
+
+	var called int
+	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
+		called++
+
+		c.Check(snapName, Equals, "snapname")
+		c.Check(ctx, NotNil)
+		for i := 0; i < 3; i++ {
+			cont, err := inhibited(ctx, runinhibit.HintInhibitedGateRefresh, &inhibitInfo)
+			c.Assert(err, IsNil)
+			// non-service apps should keep waiting
+			c.Check(cont, Equals, false)
+		}
+		err := notInhibited(ctx)
+		c.Assert(err, IsNil)
+
+		flock, err = openHintFileLock(snapName)
+		c.Assert(err, IsNil)
+		err = flock.ReadLock()
+		c.Assert(err, IsNil)
+		return flock, nil
+	})
+	defer restore()
+
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	defer hintLock.Unlock()
+	c.Assert(err, IsNil)
+	c.Check(info.InstanceName(), Equals, "snapname")
+	c.Check(app.Name, Equals, "app")
+
+	c.Check(called, Equals, 1)
+	checkHintFileLocked(c, "snapname")
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedNotInhibitedNoNotification(c *C) {
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	c.Assert(err, IsNil)
+	c.Assert(hintLock, IsNil)
+	c.Check(info.InstanceName(), Equals, "snapname")
+	c.Check(app.Name, Equals, "app")
+
+	c.Check(runinhibit.HintFile("snapname"), testutil.FileAbsent)
+}
+
+func (s *RunSuite) TestWaitWhileInhibitedNotInhibitHintFileOngoingRefresh(c *C) {
+	inhibitionFlow := fakeInhibitionFlow{
+		start: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+		finish: func(ctx context.Context) error {
+			return fmt.Errorf("this should never be reached")
+		},
+	}
+	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
+	defer restore()
+
+	_, _, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	c.Assert(err, testutil.ErrorIs, snaprun.ErrSnapRefreshConflict)
+	c.Assert(hintLock, IsNil)
+}
+
+func makeDBusMethodNotAvailableMessage(c *C, msg *dbus.Message) *dbus.Message {
+	return &dbus.Message{
+		Type: dbus.TypeError,
+		Headers: map[dbus.HeaderField]dbus.Variant{
+			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
+			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
+			// dbus.FieldDestination is provided automatically by DBus test helper.
+			dbus.FieldErrorName: dbus.MakeVariant("org.freedesktop.DBus.Error.UnknownMethod"),
+		},
+	}
+}
+
+func makeDBusMethodAvailableMessage(c *C, msg *dbus.Message) *dbus.Message {
+	c.Assert(msg.Type, Equals, dbus.TypeMethodCall)
+	c.Check(msg.Flags, Equals, dbus.Flags(0))
+
+	c.Check(msg.Headers, DeepEquals, map[dbus.HeaderField]dbus.Variant{
+		dbus.FieldDestination: dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
+		dbus.FieldPath:        dbus.MakeVariant(dbus.ObjectPath("/io/snapcraft/SnapDesktopIntegration")),
+		dbus.FieldInterface:   dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
+		dbus.FieldMember:      dbus.MakeVariant("ApplicationIsBeingRefreshed"),
+		dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("", "", make(map[string]dbus.Variant))),
+	})
+	c.Check(msg.Body[0], Equals, "some-snap")
+	param2 := fmt.Sprintf("%s", msg.Body[1])
+	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/some-snap.lock"), Equals, true)
+	return &dbus.Message{
+		Type: dbus.TypeMethodReply,
+		Headers: map[dbus.HeaderField]dbus.Variant{
+			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
+			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
+		},
+	}
+}
+
+func (s *RunSuite) TestTextInhibitionFlow(c *C) {
+	textFlow := snaprun.NewInhibitionFlow("snapname")
+
+	c.Assert(textFlow.StartInhibitionNotification(context.TODO()), IsNil)
+	c.Check(s.Stdout(), Equals, "snap package \"snapname\" is being refreshed, please wait\n")
+
+	// Finish is a no-op
+	c.Assert(textFlow.FinishInhibitionNotification(context.TODO()), IsNil)
+	c.Check(s.Stdout(), Equals, "snap package \"snapname\" is being refreshed, please wait\n")
+
+}
+
+func (s *RunSuite) TestDesktopIntegrationInhibitionFlow(c *C) {
+	// mock snapd-desktop-integration dbus available
+	var dbusCalled int
+	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
+		dbusCalled++
+		return []*dbus.Message{makeDBusMethodAvailableMessage(c, msg)}, nil
+	})
+	c.Assert(err, IsNil)
+
+	restore := dbusutil.MockOnlySessionBusAvailable(conn)
+	defer restore()
+
+	// check that the normal graphical notification flow is not called
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		return fmt.Errorf("this should never be reached")
+	})
+	defer restorePendingRefreshNotification()
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		return fmt.Errorf("this should never be reached")
+	})
+	defer restoreFinishRefreshNotification()
+
+	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
+	defer restoreIsGraphicalSession()
+
+	graphicalFlow := snaprun.NewInhibitionFlow("some-snap")
+
+	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), IsNil)
+	c.Check(dbusCalled, Equals, 1)
+	// check that text flow is not called
+	c.Check(s.Stdout(), Equals, "")
+
+	c.Assert(graphicalFlow.FinishInhibitionNotification(context.TODO()), IsNil)
+	// Finish is a no-op, so dbus is only called once
+	c.Check(dbusCalled, Equals, 1)
+	// check that text flow is not called
+	c.Check(s.Stdout(), Equals, "")
+}
+
+func (s *RunSuite) TestGraphicalSessionInhibitionFlow(c *C) {
+	_, r := logger.MockLogger()
+	defer r()
+
+	// mock snapd-desktop-integration dbus available
+	var dbusCalled int
+	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
+		dbusCalled++
+		return []*dbus.Message{makeDBusMethodNotAvailableMessage(c, msg)}, nil
+	})
+	c.Assert(err, IsNil)
+
+	restore := dbusutil.MockOnlySessionBusAvailable(conn)
+	defer restore()
+
+	// check that the normal graphical notification flow is called
+	var pendingRefreshNotificationCalled int
+	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
+		pendingRefreshNotificationCalled++
+		return nil
+	})
+	defer restorePendingRefreshNotification()
+	var finishRefreshNotificationCalled int
+	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
+		finishRefreshNotificationCalled++
+		return nil
+	})
+	defer restoreFinishRefreshNotification()
+
+	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
+	defer restoreIsGraphicalSession()
+
+	graphicalFlow := snaprun.NewInhibitionFlow("some-snap")
+
+	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), IsNil)
+	c.Check(pendingRefreshNotificationCalled, Equals, 1)
+	c.Check(finishRefreshNotificationCalled, Equals, 0)
+	// snapd-desktop-integration dbus is checked for availability
+	c.Check(dbusCalled, Equals, 1)
+	// check that text flow is not called
+	c.Check(s.Stdout(), Equals, "")
+
+	c.Assert(graphicalFlow.FinishInhibitionNotification(context.TODO()), IsNil)
+	c.Check(pendingRefreshNotificationCalled, Equals, 1)
+	c.Check(finishRefreshNotificationCalled, Equals, 1)
+	// snapd-desktop-integration dbus is not checked on finish
+	c.Check(dbusCalled, Equals, 1)
+	// check that text flow is not called
+	c.Check(s.Stdout(), Equals, "")
+}
+
+func (s *RunSuite) TestDesktopIntegrationNoDBus(c *C) {
+	_, r := logger.MockLogger()
+	defer r()
+
+	noDBus := func() (*dbus.Conn, error) { return nil, fmt.Errorf("dbus not available") }
+	restore := dbusutil.MockConnections(noDBus, noDBus)
+	defer restore()
+
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "Test")
+	c.Assert(sent, Equals, false)
+}

--- a/snap/info.go
+++ b/snap/info.go
@@ -1402,6 +1402,12 @@ type NotFoundError struct {
 }
 
 func (e NotFoundError) Error() string {
+	if e.Revision.Unset() {
+		if e.Path != "" {
+			return fmt.Sprintf("cannot find current revision for snap %s: missing file %s", e.Snap, e.Path)
+		}
+		return fmt.Sprintf("cannot find current revision for snap %s", e.Snap)
+	}
 	if e.Path != "" {
 		return fmt.Sprintf("cannot find installed snap %q at revision %s: missing file %s", e.Snap, e.Revision, e.Path)
 	}
@@ -1503,7 +1509,7 @@ func ReadCurrentInfo(snapName string) (*Info, error) {
 	curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
 	realFn, err := os.Readlink(curFn)
 	if err != nil {
-		return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
+		return nil, fmt.Errorf("%w: %s", NotFoundError{Snap: snapName, Revision: R(0)}, err)
 	}
 	rev := filepath.Base(realFn)
 	revision, err := ParseRevision(rev)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -377,6 +377,7 @@ func (s *infoSuite) TestReadCurrentInfo(c *C) {
 	snapInfo3, err := snap.ReadCurrentInfo("not-sample")
 	c.Check(snapInfo3, IsNil)
 	c.Assert(err, ErrorMatches, `cannot find current revision for snap not-sample:.*`)
+	c.Assert(errors.As(err, &snap.NotFoundError{}), Equals, true)
 }
 
 func (s *infoSuite) TestReadCurrentInfoWithInstance(c *C) {
@@ -395,6 +396,7 @@ func (s *infoSuite) TestReadCurrentInfoWithInstance(c *C) {
 	snapInfo3, err := snap.ReadCurrentInfo("sample_other")
 	c.Check(snapInfo3, IsNil)
 	c.Assert(err, ErrorMatches, `cannot find current revision for snap sample_other:.*`)
+	c.Assert(errors.As(err, &snap.NotFoundError{}), Equals, true)
 }
 
 func (s *infoSuite) TestInstallDate(c *C) {

--- a/tests/main/snap-run-symlink-error/task.yaml
+++ b/tests/main/snap-run-symlink-error/task.yaml
@@ -1,4 +1,11 @@
-summary: Check error handling in symlinks to /usr/bin/snap
+summary: Check error handling in symlinks to /usr/bin/snap"
+
+details: |
+ Check that missing current symlinks are detected by snap run and
+ does not cause an infinite retry loop.
+
+environment:
+    SNAPD_DEBUG: "1"
 
 restore: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
@@ -11,14 +18,14 @@ execute: |
     ln -s /usr/bin/snap "$SNAP_MOUNT_DIR/bin/xxx"
 
     echo Running unknown command
-    output="$("$SNAP_MOUNT_DIR/bin/xxx" 2>&1 )" && exit 1
+    "$SNAP_MOUNT_DIR/bin/xxx" > output.txt 2>&1 && exit 1
     err=$?
-    echo "$output"
+    cat output.txt
 
     echo Verifying error message
     if [[ $err -ne 46 ]]; then
       echo "expected error code 46 but got $err"
       exit 1
     fi
-    expected="internal error, please report: running \"xxx\" failed: cannot find current revision for snap xxx: readlink $SNAP_MOUNT_DIR/xxx/current: no such file or directory"
-    test "$output" = "$expected"
+    MATCH "internal error, please report: running \"xxx\" failed: race condition detected, snap-run can only retry once" < output.txt
+    MATCH "cannot find current revision for snap xxx: readlink $SNAP_MOUNT_DIR/xxx/current: no such file or directory" < output.txt


### PR DESCRIPTION
This PR is a rebase of https://github.com/snapcore/snapd/pull/13411 on top of master + minor test refactoring. A lot changed on master and a direct rebase would have been very messy, I thought it would be better to keep the discussions there intact with the changes history and created a new PR.

`snap run` was failing due to missing `current` revision symlink when `snap run` is inhibited because due to refresh.

This PR fixes that by directly checking the old revision stored in the inhibition hint file and properly waits until the snap is no longer inhibited from running.

A retry might be needed if the snap was never inhibited before (inhibition hint file doesn't exist) and the refresh was started/completed in the tiny window between starting `snap run` and the transient cgroup being created.