### PR TITLE
many: use symlinks for active component

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -78,6 +78,7 @@ type managerBackend interface {
 	CopySnapData(newSnap, oldSnap *snap.Info, opts *dirs.SnapDirOptions, meter progress.Meter) error
 	SetupSnapSaveData(info *snap.Info, dev snap.Device, meter progress.Meter) error
 	LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootInfo boot.RebootInfo, err error)
+	LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error
 	StartServices(svcs []*snap.AppInfo, disabledSvcs []string, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error)
@@ -92,6 +93,7 @@ type managerBackend interface {
 
 	// remove related
 	UnlinkSnap(info *snap.Info, linkCtx backend.LinkContext, meter progress.Meter) error
+	UnlinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error
 	RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error
 	RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error
 	RemoveSnapData(info *snap.Info, opts *dirs.SnapDirOptions) error

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -971,3 +971,82 @@ type: snapd
 	c.Check(readMountTarget, Equals, "oldactivevalue")
 	c.Check(readDataTarget, Equals, "olddatavalue")
 }
+
+func (s *linkSuite) TestLinkComponentIdempotent(c *C) {
+	compName := "mycomp"
+	compRev := snap.R(-2)
+	snapName := "mysnap"
+	snapRev := snap.R(2)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
+	c.Assert(os.MkdirAll(cpi.MountDir(), 0755), IsNil)
+
+	err := s.be.LinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+	err = s.be.LinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+
+	linkPath := filepath.Join(dirs.SnapMountDir, snapName,
+		"components", snapRev.String(), compName)
+	relTarget, err := os.Readlink(linkPath)
+	c.Assert(relTarget, Equals, filepath.Join("../mnt", compName, compRev.String()))
+	c.Assert(err, IsNil)
+	linkTarget, err := filepath.EvalSymlinks(linkPath)
+	c.Assert(err, IsNil)
+	c.Assert(linkTarget, Equals,
+		filepath.Join(snap.ComponentsBaseDir(snapName), "mnt", compName, compRev.String()))
+}
+
+func (s *linkSuite) TestLinkComponentError(c *C) {
+	compName := "mycomp"
+	compRev := snap.R(-2)
+	snapName := "mysnap"
+	snapRev := snap.R(2)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
+	c.Assert(os.MkdirAll(cpi.MountDir(), 0755), IsNil)
+	// Put a regular directory in the link path
+	linkPath := filepath.Join(dirs.SnapMountDir, snapName,
+		"components", snapRev.String(), compName)
+	c.Assert(os.MkdirAll(linkPath, 0755), IsNil)
+
+	err := s.be.LinkComponent(cpi, snapRev)
+	c.Assert(err, ErrorMatches, `rename .*: file exists`)
+}
+
+func (s *linkSuite) TestUnlinkComponentIdempotent(c *C) {
+	compName := "mycomp"
+	compRev := snap.R(-2)
+	snapName := "mysnap"
+	snapRev := snap.R(2)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
+	linkPath := filepath.Join(dirs.SnapMountDir, snapName,
+		"components", snapRev.String(), compName)
+	target := filepath.Join("../mnt", compName, compRev.String())
+
+	c.Assert(os.MkdirAll(cpi.MountDir(), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(linkPath), 0755), IsNil)
+	c.Assert(osutil.AtomicSymlink(target, linkPath), IsNil)
+
+	err := s.be.UnlinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+	c.Assert(linkPath, testutil.FileAbsent)
+	c.Assert(cpi.MountDir(), testutil.FilePresent)
+
+	err = s.be.UnlinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+}
+
+func (s *linkSuite) TestUnlinkComponentError(c *C) {
+	compName := "mycomp"
+	compRev := snap.R(-2)
+	snapName := "mysnap"
+	snapRev := snap.R(2)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
+	c.Assert(os.MkdirAll(cpi.MountDir(), 0755), IsNil)
+	// Put a regular directory inside the link path
+	insideLinkPath := filepath.Join(dirs.SnapMountDir, snapName,
+		"components", snapRev.String(), compName, "xx")
+	c.Assert(os.MkdirAll(insideLinkPath, 0755), IsNil)
+
+	err := s.be.UnlinkComponent(cpi, snapRev)
+	c.Assert(err, ErrorMatches, `remove .*: directory not empty`)
+}

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -476,7 +476,7 @@ version: 1.0
 
 	// ensure the right unit is created
 	where := filepath.Join(dirs.StripRootDir(dirs.SnapMountDir),
-		instanceName+"/components/"+snapRev.String()+"/"+compName)
+		instanceName+"/components/"+snapRev.String()+"/"+compName+"_"+compRev.String())
 	mup := systemd.MountUnitPath(where)
 	c.Assert(mup, testutil.FileMatches, fmt.Sprintf("(?ms).*^Where=%s", where))
 	compBlobPath := "/var/lib/snapd/snaps/" + compFileName

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -463,7 +463,7 @@ version: 1.0
 `, snapName, compName)
 
 	compPath := snaptest.MakeTestComponent(c, componentYaml)
-	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, instanceName, snapRev)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, instanceName)
 
 	installRecord, err := s.be.SetupComponent(compPath, cpi, mockDev, progress.Null)
 	c.Assert(err, IsNil)
@@ -476,7 +476,7 @@ version: 1.0
 
 	// ensure the right unit is created
 	where := filepath.Join(dirs.StripRootDir(dirs.SnapMountDir),
-		instanceName+"/components/"+snapRev.String()+"/"+compName+"_"+compRev.String())
+		instanceName+"/components/mnt/"+compName+"/"+compRev.String())
 	mup := systemd.MountUnitPath(where)
 	c.Assert(mup, testutil.FileMatches, fmt.Sprintf("(?ms).*^Where=%s", where))
 	compBlobPath := "/var/lib/snapd/snaps/" + compFileName
@@ -490,7 +490,7 @@ version: 1.0
 
 func (s *setupSuite) testSetupComponentUndo(c *C, compName, snapName, instanceName string, compRev, snapRev snap.Revision, installRecord *backend.InstallRecord) {
 	// undo undoes the mount unit and the instdir creation
-	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, instanceName, snapRev)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, instanceName)
 
 	err := s.be.UndoSetupComponent(cpi, installRecord, mockDev, progress.Null)
 	c.Assert(err, IsNil)
@@ -514,7 +514,6 @@ func (s *setupSuite) testSetupComponentDoUndo(c *C, compName, snapName, instance
 func (s *setupSuite) TestSetupComponentCleanupAfterFail(c *C) {
 	snapName := "mysnap"
 	compName := "mycomp"
-	snapRev := snap.R(11)
 	compRev := snap.R(33)
 
 	componentYaml := fmt.Sprintf(`component: %s+%s
@@ -524,7 +523,7 @@ version: 1.0
 
 	compPath := snaptest.MakeTestComponent(c, componentYaml)
 
-	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName, snapRev)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// mount unit start fails
@@ -552,7 +551,7 @@ func (s *setupSuite) TestSetupComponentFilesDir(c *C) {
 	compRev := snap.R(33)
 	compName := "mycomp"
 	snapInstance := "mysnap_inst"
-	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapInstance, snapRev)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapInstance)
 
 	installRecord := s.testSetupComponentDo(c, compName, "mysnap", snapInstance, compRev, snapRev)
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1136,6 +1136,14 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx b
 	return boot.RebootInfo{RebootRequired: reboot}, nil
 }
 
+func (f *fakeSnappyBackend) LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error {
+	f.appendOp(&fakeOp{
+		op:   "link-component",
+		path: cpi.MountDir(),
+	})
+	return f.maybeErrForLastOp()
+}
+
 func svcSnapMountDir(svcs []*snap.AppInfo) string {
 	if len(svcs) == 0 {
 		return "<no services>"
@@ -1244,6 +1252,14 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkCont
 
 		unlinkFirstInstallUndo: linkCtx.FirstInstall,
 		unlinkSkipBinaries:     linkCtx.SkipBinaries,
+	})
+	return f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) UnlinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error {
+	f.appendOp(&fakeOp{
+		op:   "unlink-component",
+		path: cpi.MountDir(),
 	})
 	return f.maybeErrForLastOp()
 }

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -31,7 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *snapmgrTestSuite) mockComponentInfos(c *C, snapName string, compNames []string) {
+func (s *snapmgrTestSuite) mockComponentInfos(c *C, snapName string, compNames []string, compRevs []snap.Revision) {
 	cis := make([]*snap.ComponentInfo, len(compNames))
 	for i, comp := range compNames {
 		componentYaml := fmt.Sprintf(`component: %s+%s
@@ -45,8 +45,8 @@ version: 1.0
 
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
 		compMntDir string) (*snap.ComponentInfo, error) {
-		for _, ci := range cis {
-			if strings.HasSuffix(compMntDir, "/"+ci.Component.ComponentName) {
+		for i, ci := range cis {
+			if strings.HasSuffix(compMntDir, "/"+ci.Component.ComponentName+"_"+compRevs[i].String()) {
 				return ci, nil
 			}
 		}
@@ -73,7 +73,8 @@ func (s *snapmgrTestSuite) TestComponentHelpers(c *C) {
 	csi := snap.NewComponentSideInfo(cref, compRev)
 	cref2 := naming.NewComponentRef(snapName, compName2)
 	csi2 := snap.NewComponentSideInfo(cref2, compRev)
-	s.mockComponentInfos(c, snapName, []string{compName, compName2})
+	s.mockComponentInfos(c, snapName, []string{compName, compName2},
+		[]snap.Revision{compRev, compRev})
 
 	snapSt := &snapstate.SnapState{
 		Active: true,

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -46,7 +46,7 @@ version: 1.0
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
 		compMntDir string) (*snap.ComponentInfo, error) {
 		for i, ci := range cis {
-			if strings.HasSuffix(compMntDir, "/"+ci.Component.ComponentName+"_"+compRevs[i].String()) {
+			if strings.HasSuffix(compMntDir, "/"+ci.Component.ComponentName+"/"+compRevs[i].String()) {
 				return ci, nil
 			}
 		}

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -128,7 +128,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 
 	csi := compSetup.CompSideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(compSetup.ComponentName(),
-		csi.Revision, snapsup.InstanceName(), snapsup.Revision())
+		csi.Revision, snapsup.InstanceName())
 
 	defer func() {
 		st.Lock()
@@ -235,7 +235,7 @@ func (m *SnapManager) undoMountComponent(t *state.Task, _ *tomb.Tomb) error {
 
 	csi := compSetup.CompSideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(compSetup.ComponentName(),
-		csi.Revision, snapsup.InstanceName(), snapsup.Revision())
+		csi.Revision, snapsup.InstanceName())
 
 	pm := NewTaskProgressAdapterUnlocked(t)
 	if err := m.backend.UndoSetupComponent(cpi, &installRecord, deviceCtx, pm); err != nil {
@@ -289,8 +289,8 @@ func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	// Create the symlink
 	csi := cs.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName(), snapInfo.Revision)
-	if err := m.backend.LinkComponent(cpi); err != nil {
+		csi.Revision, snapInfo.InstanceName())
+	if err := m.backend.LinkComponent(cpi, snapInfo.Revision); err != nil {
 		return err
 	}
 
@@ -332,8 +332,8 @@ func (m *SnapManager) undoLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	// Remove the symlink
 	csi := linkedComp.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName(), snapInfo.Revision)
-	if err := m.backend.UnlinkComponent(cpi); err != nil {
+		csi.Revision, snapInfo.InstanceName())
+	if err := m.backend.UnlinkComponent(cpi, snapInfo.Revision); err != nil {
 		return err
 	}
 
@@ -376,8 +376,8 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 	// Remove symlink
 	csi := unlinkedComp.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName(), snapInfo.Revision)
-	if err := m.backend.UnlinkComponent(cpi); err != nil {
+		csi.Revision, snapInfo.InstanceName())
+	if err := m.backend.UnlinkComponent(cpi, snapInfo.Revision); err != nil {
 		return err
 	}
 
@@ -423,8 +423,8 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 	// Re-create the symlink
 	csi := unlinkedComp.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName(), snapInfo.Revision)
-	if err := m.backend.LinkComponent(cpi); err != nil {
+		csi.Revision, snapInfo.InstanceName())
+	if err := m.backend.LinkComponent(cpi, snapInfo.Revision); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -88,7 +88,7 @@ func (s *linkCompSnapSuite) testDoLinkComponent(c *C, snapName string, snapRev s
 			op: "link-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 	})
 	// state is modified as expected
@@ -171,13 +171,13 @@ func (s *linkCompSnapSuite) testDoLinkThenUndoLinkComponent(c *C, snapName strin
 			op: "link-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 		{
 			op: "unlink-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 	})
 	// the component is not in the state
@@ -247,7 +247,7 @@ func (s *linkCompSnapSuite) testDoUnlinkCurrentComponent(c *C, snapName string, 
 			op: "unlink-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 	})
 	// state is modified as expected
@@ -331,13 +331,13 @@ func (s *linkCompSnapSuite) testDoUnlinkThenUndoUnlinkCurrentComponent(c *C, sna
 			op: "unlink-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 		{
 			op: "link-component",
 			path: filepath.Join(
 				dirs.SnapMountDir, snapName, "components",
-				snapRev.String(), compName+"_"+compRev.String()),
+				"mnt", compName, compRev.String()),
 		},
 	})
 	// the component is still in the state

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -148,8 +148,9 @@ func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, cs *
 	}
 	revSt := snapSeq.Revisions[snapIdx]
 
-	if revSt.FindComponent(cs.SideInfo.Component) != nil {
-		// Component already present
+	if currentCompSt := revSt.FindComponent(cs.SideInfo.Component); currentCompSt != nil {
+		// Component already present, replace revision
+		*currentCompSt = *cs
 		return nil
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -521,7 +521,7 @@ func (snapst *SnapState) CurrentComponentInfo(cref naming.ComponentRef) (*snap.C
 	}
 
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, si.InstanceName(), si.SnapRevision())
+		csi.Revision, si.InstanceName())
 	return readComponentInfo(cpi.MountDir())
 }
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -110,8 +110,8 @@ func (c *componentPlaceInfo) Filename() string {
 // will be of the form:
 // /snaps/<snap_instance>/components/<snap_revision>/<component_name>
 func (c *componentPlaceInfo) MountDir() string {
-	return filepath.Join(BaseDir(c.snapInstance), "components",
-		c.snapRevision.String(), c.compName)
+	return filepath.Join(BaseDir(c.snapInstance), "components", c.snapRevision.String(),
+		fmt.Sprintf("%s_%s", c.compName, c.compRevision.String()))
 }
 
 // MountFile returns the path of the file to be mounted for a component,

--- a/snap/component.go
+++ b/snap/component.go
@@ -70,6 +70,12 @@ func (csi *ComponentSideInfo) Equal(other *ComponentSideInfo) bool {
 	return *csi == *other
 }
 
+// ComponentBaseDir returns where components are to be found for the
+// snap with name instanceName.
+func ComponentsBaseDir(instanceName string) string {
+	return filepath.Join(BaseDir(instanceName), "components")
+}
+
 // componentPlaceInfo holds information about where to put a component in the
 // system. It implements ContainerPlaceInfo and should be used only via this
 // interface.
@@ -77,22 +83,20 @@ type componentPlaceInfo struct {
 	// Name and revision for the component
 	compName     string
 	compRevision Revision
-	// snapInstance and snapRevision identify the snap that uses this component.
+	// snapInstance identifies the snap that uses this component.
 	snapInstance string
-	snapRevision Revision
 }
 
 var _ ContainerPlaceInfo = (*componentPlaceInfo)(nil)
 
 // MinimalComponentContainerPlaceInfo returns a ContainerPlaceInfo with just
 // the location information for a component of the given name and revision that
-// is used by a snapInstance with revision snapRev.
-func MinimalComponentContainerPlaceInfo(compName string, compRev Revision, snapInstance string, snapRev Revision) ContainerPlaceInfo {
+// is used by a snapInstance.
+func MinimalComponentContainerPlaceInfo(compName string, compRev Revision, snapInstance string) ContainerPlaceInfo {
 	return &componentPlaceInfo{
 		compName:     compName,
 		compRevision: compRev,
 		snapInstance: snapInstance,
-		snapRevision: snapRev,
 	}
 }
 
@@ -108,10 +112,10 @@ func (c *componentPlaceInfo) Filename() string {
 
 // MountDir returns the directory where a component gets mounted, which
 // will be of the form:
-// /snaps/<snap_instance>/components/<snap_revision>/<component_name>
+// /snaps/<snap_instance>/components/mnt/<component_name>/<component_revision>
 func (c *componentPlaceInfo) MountDir() string {
-	return filepath.Join(BaseDir(c.snapInstance), "components", c.snapRevision.String(),
-		fmt.Sprintf("%s_%s", c.compName, c.compRevision.String()))
+	return filepath.Join(ComponentsBaseDir(c.snapInstance), "mnt",
+		c.compName, c.compRevision.String())
 }
 
 // MountFile returns the path of the file to be mounted for a component,

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -277,14 +277,14 @@ description: %s
 }
 
 func (s *componentSuite) TestComponentContainerPlaceInfoImpl(c *C) {
-	cpi := snap.MinimalComponentContainerPlaceInfo("test-info", snap.R(25), "mysnap_instance", snap.R(11))
+	cpi := snap.MinimalComponentContainerPlaceInfo("test-info", snap.R(25), "mysnap_instance")
 
 	var contPi snap.ContainerPlaceInfo = cpi
 
 	c.Check(contPi.ContainerName(), Equals, "mysnap_instance+test-info")
 	c.Check(contPi.Filename(), Equals, "mysnap_instance+test-info_25.comp")
 	c.Check(contPi.MountDir(), Equals,
-		filepath.Join(dirs.SnapMountDir, "mysnap_instance/components/11/test-info_25"))
+		filepath.Join(dirs.SnapMountDir, "mysnap_instance/components/mnt/test-info/25"))
 	c.Check(contPi.MountFile(), Equals,
 		filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap_instance+test-info_25.comp"))
 	c.Check(contPi.MountDescription(), Equals, "Mount unit for mysnap_instance+test-info, revision 25")

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -284,7 +284,7 @@ func (s *componentSuite) TestComponentContainerPlaceInfoImpl(c *C) {
 	c.Check(contPi.ContainerName(), Equals, "mysnap_instance+test-info")
 	c.Check(contPi.Filename(), Equals, "mysnap_instance+test-info_25.comp")
 	c.Check(contPi.MountDir(), Equals,
-		filepath.Join(dirs.SnapMountDir, "mysnap_instance/components/11/test-info"))
+		filepath.Join(dirs.SnapMountDir, "mysnap_instance/components/11/test-info_25"))
 	c.Check(contPi.MountFile(), Equals,
 		filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/snaps/mysnap_instance+test-info_25.comp"))
 	c.Check(contPi.MountDescription(), Equals, "Mount unit for mysnap_instance+test-info, revision 25")

--- a/tests/main/component/task.yaml
+++ b/tests/main/component/task.yaml
@@ -3,7 +3,7 @@ summary: Test basic component tasks
 details: |
   Verifies that basic snap component operations (install, refresh, remove) work.
 
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
 execute: |
   # Build snap and component
@@ -15,23 +15,50 @@ execute: |
       exit 1
   fi
 
-  # Install snap and component
+  # Install snap
   snap install --dangerous snap-with-comps_1.0_all.snap
-  chg_id=$(snap install --no-wait --dangerous snap-with-comps+comp1_1.0.comp)
-  snap watch "$chg_id"
 
-  # Chech component install change was as expected
-  snap change "$chg_id" | MATCH "^Done .*Prepare component"
-  snap change "$chg_id" | MATCH "^Done .*Mount component"
-  snap change "$chg_id" | MATCH "^Done .*Make component .* available to the system"
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
 
-  # File has been copied around
-  comp_inst_path=/var/lib/snapd/snaps/snap-with-comps+comp1_x1.comp
-  stat "$comp_inst_path"
+  # Install local component function
+  # $1: expected component revision
+  install_comp() {
+      comp_rev=$1
+      chg_id=$(snap install --no-wait --dangerous snap-with-comps+comp1_1.0.comp)
+      snap watch "$chg_id"
 
-  # Component is mounted (note that we need to escape the "+" in the path)
-  mount | MATCH "^${comp_inst_path/+/\\+} on /snap/snap-with-comps/components/x1/comp1.*"
-  # and is seen from snap app
-  snap-with-comps.test
+      # Check component install change was as expected
+      snap change "$chg_id" | MATCH "^Done .*Prepare component"
+      snap change "$chg_id" | MATCH "^Done .*Mount component"
+      snap change "$chg_id" | MATCH "^Done .*Make component .* available to the system"
 
-  # TODO: refresh and remove checks when implemented by snapd
+      # File has been copied around
+      comp_inst_path=/var/lib/snapd/snaps/snap-with-comps+comp1_${comp_rev}.comp
+      stat "$comp_inst_path"
+
+      # Component is mounted (note that we need to escape the "+" in the path)
+      # x1 is the snap revision
+      symlink=$SNAP_MOUNT_DIR/snap-with-comps/components/x1/comp1
+      mnt_point=$SNAP_MOUNT_DIR/snap-with-comps/components/mnt/comp1/${comp_rev}
+      mount | MATCH "^${comp_inst_path/+/\\+} on ${mnt_point} .*"
+      # And symlinked
+      readlink "$symlink" | MATCH "\\.\\./mnt/comp1/$comp_rev"
+      readlink -f "$symlink" | MATCH "$mnt_point"
+      # and is seen from snap app
+      snap-with-comps.test
+  }
+
+  # Install, then reinstall local component
+  install_comp x1
+  install_comp x2
+
+  # TODO: add checks for components removals when implemented by snapd
+  # For the moment, remove the snap and then manually the components
+  snap remove snap-with-comps
+  cd /etc/systemd/system/
+  systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x1.mount'
+  systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
+  cd -
+  rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x1.mount'
+  rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
+  rm -rf "$SNAP_MOUNT_DIR"/snap-with-comps/


### PR DESCRIPTION
Use symlinks to point to the currently active component for a given snap revision, instead of mounting new component revisions always in the same mountpoint. This makes updates of components more atomic and will simplify parts of the code.

The symlinks will take the form

/snap/<snap_name>/components/<snap_revision>/<comp_name>

while the components will be mounted on

/snap/<snap_name>/components/mnt/<comp_name>/<comp_revision>