### PR TITLE
cmd/snap-confine, cmd/libsnap-confine-private: address coverity-scan results

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -250,7 +250,10 @@ static void cgroupv2_own_group_set_up(cgroupv2_own_group_fixture *fixture, gcons
 
 static void cgroupv2_own_group_tear_down(cgroupv2_own_group_fixture *fixture, gconstpointer user_data) {
     sc_set_self_cgroup_path("/proc/self/cgroup");
-    g_remove(fixture->self_cgroup);
+    if (g_remove(fixture->self_cgroup) < 0) {
+        /* test may have removed the file */
+        g_assert_cmpint(errno, ==, ENOENT);
+    }
     g_free(fixture->self_cgroup);
 }
 

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -59,7 +59,8 @@ static void mock_meta_snap_yaml(const char *mocked)
 	const char *old = meta_snap_yaml;
 	if (mocked != NULL) {
 		meta_snap_yaml = "snap-yaml.test";
-		g_file_set_contents(meta_snap_yaml, mocked, -1, NULL);
+		g_assert_true(g_file_set_contents
+			      (meta_snap_yaml, mocked, -1, NULL));
 	} else {
 		meta_snap_yaml = "snap-yaml.missing";
 	}

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -350,6 +350,16 @@ static void test_sc_instance_name_validate(void)
 			"snap instance name can contain only one underscore");
 	sc_error_free(err);
 
+	// too long, 52
+	sc_instance_name_validate
+	    ("0123456789012345678901234567890123456789012345678901", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"snap instance name can be at most 51 characters long");
+	sc_error_free(err);
+
 	const char *valid_names[] = {
 		"aa", "aaa", "aaaa",
 		"aa_a", "aa_1", "aa_123", "aa_0123456789",

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -115,6 +115,14 @@ void sc_instance_name_validate(const char *instance_name, sc_error **errorp)
 				  "snap instance name cannot be NULL");
 		goto out;
 	}
+
+	if (strlen(instance_name) > SNAP_INSTANCE_LEN) {
+		err =
+		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
+				  "snap instance name can be at most %d characters long",
+				  SNAP_INSTANCE_LEN);
+		goto out;
+	}
 	// instance name length + 1 extra overflow + 1 NULL
 	char s[SNAP_INSTANCE_LEN + 1 + 1] = { 0 };
 	strncpy(s, instance_name, sizeof(s) - 1);


### PR DESCRIPTION
Address coverity scan results. None of the issues was classified as more than medium and none was particularly interesting.
https://scan7.scan.coverity.com/#/project-view/49681/15001