### PR TITLE
spread.yaml: add ubuntu-24.04-64 to qemu spread backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -374,6 +374,9 @@ backends:
             - ubuntu-23.10-64:
                   username: ubuntu
                   password: ubuntu
+            - ubuntu-24.04-64:
+                  username: ubuntu
+                  password: ubuntu
             - debian-11-64:
                   username: debian
                   password: debian


### PR DESCRIPTION
Add ubuntu-24.04-64 to the qemu spread backend so that spread tests for noble can be run locally with qemu.
