### PR TITLE
interfaces/builtin: allow kwalletd version 6

### DIFF
--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -70,13 +70,13 @@ dbus (receive, send)
 #
 dbus (receive, send)
     bus=session
-    path=/modules/kwalletd{,5}
+    path=/modules/kwalletd{,[56]}
     interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
 
 dbus (receive, send)
     bus=session
-    path=/modules/kwalletd{,5}
+    path=/modules/kwalletd{,[56]}
     interface=org.kde.KWallet
     peer=(label=unconfined),
 `


### PR DESCRIPTION
https://launchpad.net/bugs/2058840: KDE 6 comes with Kwalletd6, so the profile needs updating.