### PR TITLE
snap: format container.go

### DIFF
--- a/snap/container.go
+++ b/snap/container.go
@@ -104,39 +104,38 @@ type symlinkInfo struct {
 // continue further either due to absolute symlinks or symlinks
 // that escape the container.
 //
-//       max depth reached?<------
-//               /\               \
-//            yes  no              \
-//            /      \              \
-//           V        V              \
-//        error      path             \
-//                    │                \
-//                    V                 \
-//                read target            \
-//                    │                   \
-//                    V                    \
-//               is absolute?               \
-//                   /\                      \
-//                yes  no                     \
-//                /      \                     \
-//               V        V                     \
-//       isExternal     eval relative target     \
-//           +               \                    \
-//     return target          V                    \
-//                     escapes container?           \
-//                           /\                      \
-//                        yes  no                     \
-//                       /      \                      |
-//                      V        V                     |
-//              isExternal      is symlink?            |
-//                   +                /\               |
-//             return target       yes  no             │
-//                                /      \             │
-//                               V        V            │
-//                       !isExternal    path = target  │
-//                            +             \----------│
-//                      return target
-//
+//	  max depth reached?<------
+//	          /\               \
+//	       yes  no              \
+//	       /      \              \
+//	      V        V              \
+//	   error      path             \
+//	               │                \
+//	               V                 \
+//	           read target            \
+//	               │                   \
+//	               V                    \
+//	          is absolute?               \
+//	              /\                      \
+//	           yes  no                     \
+//	           /      \                     \
+//	          V        V                     \
+//	  isExternal     eval relative target     \
+//	      +               \                    \
+//	return target          V                    \
+//	                escapes container?           \
+//	                      /\                      \
+//	                   yes  no                     \
+//	                  /      \                      |
+//	                 V        V                     |
+//	         isExternal      is symlink?            |
+//	              +                /\               |
+//	        return target       yes  no             │
+//	                           /      \             │
+//	                          V        V            │
+//	                  !isExternal    path = target  │
+//	                       +             \----------│
+//	                 return target
 func evalSymlink(c Container, path string) (symlinkInfo, error) {
 	var naiveTarget string
 


### PR DESCRIPTION
This was introduced by b66fee81606a1c05f965a876ccbaf44174194063 (many: container validation improvements) but somehow flew under our radar in CI?
