### PR TITLE
aspects: make unset and set behaviour consistent with options

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -1383,12 +1383,7 @@ func set(subKeys []string, index int, node map[string]json.RawMessage, value int
 		}
 
 		node[key] = data
-		newData, err := json.Marshal(node)
-		if err != nil {
-			return nil, err
-		}
-
-		return newData, nil
+		return json.Marshal(node)
 	}
 
 	rawLevel, ok := node[key]
@@ -1430,15 +1425,12 @@ func unset(subKeys []string, index int, node map[string]json.RawMessage) (json.R
 	matchAll := isPlaceholder(key)
 
 	if index == len(subKeys)-1 {
-		if !matchAll {
-			delete(node, key)
-		}
-
-		if matchAll || len(node) == 0 {
+		if matchAll {
 			// remove entire level
 			return nil, nil
 		}
 
+		delete(node, key)
 		return json.Marshal(node)
 	}
 
@@ -1478,10 +1470,6 @@ func unset(subKeys []string, index int, node map[string]json.RawMessage) (json.R
 		if err := unsetKey(node, key); err != nil {
 			return nil, err
 		}
-	}
-
-	if len(node) == 0 {
-		return nil, nil
 	}
 
 	return json.Marshal(node)

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -1363,7 +1363,14 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 // If the value is nil, the entry is deleted.
 func (s JSONDataBag) Set(path string, value interface{}) error {
 	subKeys := strings.Split(path, ".")
-	_, err := set(subKeys, 0, s, value)
+
+	var err error
+	if value != nil {
+		_, err = set(subKeys, 0, s, value)
+	} else {
+		_, err = unset(subKeys, 0, s)
+	}
+
 	return err
 }
 

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -1374,9 +1374,30 @@ func (s JSONDataBag) Set(path string, value interface{}) error {
 	return err
 }
 
+func removeNilValues(value interface{}) interface{} {
+	level, ok := value.(map[string]interface{})
+	if !ok {
+		return value
+	}
+
+	for k, v := range level {
+		if v == nil {
+			delete(level, k)
+			continue
+		}
+
+		level[k] = removeNilValues(v)
+	}
+
+	return level
+}
+
 func set(subKeys []string, index int, node map[string]json.RawMessage, value interface{}) (json.RawMessage, error) {
 	key := subKeys[index]
 	if index == len(subKeys)-1 {
+		// remove nil values that may be nested in the value
+		value = removeNilValues(value)
+
 		data, err := json.Marshal(value)
 		if err != nil {
 			return nil, err

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -666,7 +666,7 @@ func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 }
 
-func (s *aspectSuite) TestAspectUnsetLeafUnsetsParent(c *C) {
+func (s *aspectSuite) TestAspectUnsetLeafLeavesEmptyParent(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": map[string]interface{}{
@@ -689,8 +689,9 @@ func (s *aspectSuite) TestAspectUnsetLeafUnsetsParent(c *C) {
 	err = aspect.Unset(databag, "bar")
 	c.Assert(err, IsNil)
 
-	_, err = aspect.Get(databag, "foo")
-	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+	value, err = aspect.Get(databag, "foo")
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{})
 }
 
 func (s *aspectSuite) TestAspectUnsetAlreadyUnsetEntry(c *C) {
@@ -1864,7 +1865,7 @@ func (s *aspectSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 			"one": "value",
 			"two": "other",
 		},
-		// should be completely removed (only has a "one" path)
+		// the nested value should be removed, leaving an empty map
 		"b": map[string]interface{}{
 			"one": "value",
 		},
@@ -1884,6 +1885,7 @@ func (s *aspectSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 		"a": map[string]interface{}{
 			"two": "other",
 		},
+		"b": map[string]interface{}{},
 		"c": map[string]interface{}{
 			"two": "value",
 		},


### PR DESCRIPTION
This makes the behaviour of aspects when unsetting or setting maps with nil leaves more consistent with options. It also changes the behaviour of removing to not remove empty maps and removes nulls from values, which is also consistent with options.