### PR TITLE
o/state: adjust format of task failed log message

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -296,7 +296,7 @@ func (r *TaskRunner) run(t *Task) {
 			t.SetStatus(ErrorStatus)
 			t.Errorf("%s", err)
 			// ensure the error is available in the global log too
-			logger.Noticef("[change %s %q task] failed: %v", t.Change().ID(), t.Summary(), err)
+			logger.Noticef("Change %s task (%s) failed: %v", t.Change().ID(), t.Summary(), err)
 			if r.taskErrorCallback != nil {
 				r.taskErrorCallback(err)
 			}

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1295,7 +1295,7 @@ func (ts *taskRunnerSuite) TestErrorCallbackCalledOnError(c *C) {
 	c.Check(strings.Join(t1.Log(), ""), Matches, `.*handler error for "foo"`)
 	c.Check(called, Equals, true)
 
-	c.Check(logbuf.String(), Matches, `(?m).*: \[change 1 "task summary" task\] failed: handler error for "foo".*`)
+	c.Check(logbuf.String(), Matches, `(?m).*: Change 1 task \(task summary\) failed: handler error for "foo".*`)
 }
 
 func (ts *taskRunnerSuite) TestErrorCallbackNotCalled(c *C) {


### PR DESCRIPTION
This is a backport of the following PR from pebble: https://github.com/canonical/pebble/pull/391

In short, this changes the format of task failed log messages from this:
```
2024-03-21T06:37:37.224Z [pebble] [change 32 "Start service \"svc1\"" task] failed: cannot start service: exited quickly with code 1
```
to this
```
2024-03-21T06:43:09.559Z [pebble] Change 33 task (Start service "svc1") failed: cannot start service: exited quickly with code 1
```

This increases readability and consistency with pebble.

CC @benhoyt 