### PR TITLE
i/builtin: revert allow docker-support to use mqueue

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -62,11 +62,6 @@ const dockerSupportConnectedPlugAppArmorUserNS = `
 userns,
 `
 
-const dockerSupportConnectedPlugAppArmorMqueue = `
-# allow unrestricted use of posix message queues
-mqueue,
-`
-
 const dockerSupportConnectedPlugAppArmor = `
 # Description: allow operating as the Docker daemon/containerd. This policy is
 # intentionally not restrictive and is here to help guard against programming
@@ -1041,9 +1036,6 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 		}
 		if strutil.ListContains(features, "userns") {
 			spec.AddSnippet(dockerSupportConnectedPlugAppArmorUserNS)
-		}
-		if strutil.ListContains(features, "mqueue") {
-			spec.AddSnippet(dockerSupportConnectedPlugAppArmorMqueue)
 		}
 	}
 


### PR DESCRIPTION
Reverts snapcore/snapd#13738

Adding `mqueue` to docker-support interface results in spread test failure on focal, jammy, mantic and noble. `mqueue` has been available on apparmor_parser v3.0 already, and it seems apparmor 3.0 bug. The apparmor team was notified of this issue.

Proposing to revert allowing mqueue (all permissions) for the docker-support interface until the bug is fixed, to prevent issues as experienced in the docker smoke test.

### Reproducer for focal, jammy, mantic, noble: with snapd 2.62+ version that contains #13738:
`docker run hello-world`

#### Docker daemon
`docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "mqueue" to rootfs at "/dev/mqueue": change mount propagation through procfd: resolving path inside rootfs failed: lstat /var/snap/docker/common/var-lib-docker/overlay2/b2177d92c633708f32ee9f7c38e7ebe0962218b2e403bae8728e281906669c48/merged/dev/mqueue: permission denied: unknown.
`
#### Dmesg
`[11218.023947] apparmor mqueue disconnected TODO
[11218.023978] audit: type=1400 audit(1711621350.498:112): apparmor="DENIED" operation="unlink" profile="snap.docker.dockerd" name="/" pid=5405 comm="runc:[2:INIT]" requested="getattr" denied="getattr"class="posix_mqueue" fsuid=0 ouid=0
[11218.062079] docker0: port 1(vethb9f5b56) entered disabled state
`





