### PR TITLE
 interfaces/builtin/system_observe: allow listing systemd units and their properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 * Installation of local snap components
 * Started support for snap services to show real status of user daemons
 
+# New in snapd 2.63:
+* system-observe now allows listing systemd units and querying their properties over DBus
+
 # New in snapd 2.62:
 * Aspects based configuration schema support (experimental)
 * Refresh app awareness support for UI (experimental)

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -156,6 +156,25 @@ dbus (send)
     member=GetMachineId
     peer=(label=unconfined),
 
+# Allow clients to get properties of systemd (the manager) and
+# units
+dbus (send)
+    bus=system
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/systemd1{,/**}
+    member=Get{,All}
+    peer=(label=unconfined),
+
+# Allow clients to explicitly list units with some of their details (path,
+# status) and get unit path, see
+# https://www.freedesktop.org/wiki/Software/systemd/dbus/ for details
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member={GetUnit,ListUnits}
+    peer=(label=unconfined),
+
 # Allow reading if protected hardlinks are enabled, but don't allow enabling or
 # disabling them
 @{PROC}/sys/fs/protected_hardlinks r,

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -20,7 +20,10 @@ prepare: |
         systemctl start systemd-hostnamed
     fi
 
+    # TODO: we should use only one snap for testing
     "$TESTSTOOLS"/snaps-state install-local testsnap
+    snap connect testsnap:system-observe
+    snap connect testsnap:network-setup-observe
 
 restore: |
     if not os.query is-trusty; then
@@ -36,7 +39,6 @@ execute: |
         && ! os.query is-arch-linux \
         && ! os.query is-opensuse tumbleweed; then
         echo "Check that we can read /boot"
-        snap connect testsnap:system-observe
         KERNEL_VERSION="$(uname -r)"
         testsnap.cmd cat "/boot/config-$KERNEL_VERSION" | MATCH "CONFIG_"
 
@@ -63,6 +65,21 @@ execute: |
         su -l -c "test-snapd-system-observe-consumer.dbus-introspect" test | MATCH "$expected"
     fi
 
+    echo "Snap is able is able to query systemd properties"
+    testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Properties \
+        GetAll s org.freedesktop.systemd1.Manager
+
+    # systemd in 14.04 does not implement org.freedesktop.systemd1.Unit for units
+    if not os.query is-trusty; then
+        echo "Snap is able to list units"
+        testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ListUnits
+
+        echo "Snap is able to query unit properties"
+        testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/snapd_2eservice \
+            org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit
+    fi
+
+
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
@@ -72,6 +89,7 @@ execute: |
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-system-observe-consumer:system-observe
+    snap disconnect testsnap:system-observe
 
     echo "Then the snap is not able to get system information"
     if su -l -c "test-snapd-system-observe-consumer.consumer" test 2> consumer.error; then
@@ -87,5 +105,22 @@ execute: |
             exit 1
         fi
         MATCH "Permission denied" < introspect.error
+    fi
+
+    echo "Snap is not permitted to query systemd properties"
+    not testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Properties \
+        GetAll s org.freedesktop.systemd1.Manager 2> log.error
+    MATCH 'Access denied' < log.error
+
+    if not os.query is-trusty; then
+        echo "Snap is not able to list units"
+        not testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager \
+            ListUnits 2> log.error
+        MATCH 'Access denied' < log.error
+
+        echo "Snap is not permitted to query unit properties"
+        not testsnap.cmd busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/snapd_2eservice \
+            org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit 2> log.error
+        MATCH 'Access denied' < log.error
     fi
 

--- a/tests/main/interfaces-system-observe/testsnap/meta/snap.yaml
+++ b/tests/main/interfaces-system-observe/testsnap/meta/snap.yaml
@@ -4,4 +4,8 @@ base: core18
 apps:
   cmd:
     command: bin/cmd
-    plugs: [ system-observe ]
+    plugs:
+      # for the test
+      - system-observe
+      # so that we can run busctl
+      - network-setup-observe


### PR DESCRIPTION
Allow listing systemd units and querying their properties. This enables service
plugging system-observe to obtain more information about the state of the
system. Specifically, this enables Prometheus' systemd_exporter to work.