### PR TITLE
o/state,daemon: add snap-run-inhibit notice

### DIFF
--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -378,3 +378,11 @@ func MockSystemUserFromRequest(f func(r *http.Request) (*user.User, error)) (res
 	systemUserFromRequest = f
 	return restore
 }
+
+func MockOsReadlink(f func(string) (string, error)) func() {
+	old := osReadlink
+	osReadlink = f
+	return func() {
+		osReadlink = old
+	}
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -26,6 +26,8 @@ import (
 const (
 	// defaultNoticeExpireAfter is the default expiry time for notices.
 	defaultNoticeExpireAfter = 7 * 24 * time.Hour
+	// maxNoticeKeyLength is the max size in bytes for a notice key.
+	maxNoticeKeyLength = 256
 )
 
 // Notice represents an aggregated notice. The combination of type and key is unique.
@@ -199,11 +201,15 @@ const (
 
 	// Recorded whenever an auto-refresh is inhibited for one or more snaps.
 	RefreshInhibitNotice NoticeType = "refresh-inhibit"
+
+	// Recorded by "snap run" command when it is inhibited from running a
+	// a snap due an ongoing refresh.
+	SnapRunInhibitNotice NoticeType = "snap-run-inhibit"
 )
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice:
+	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice:
 		return true
 	}
 	return false
@@ -228,9 +234,9 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if options == nil {
 		options = &AddNoticeOptions{}
 	}
-	err := validateNotice(noticeType, key, options)
+	err := ValidateNotice(noticeType, key, options)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("internal error: %w", err)
 	}
 
 	s.writing()
@@ -279,15 +285,19 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	return notice.id, nil
 }
 
-func validateNotice(noticeType NoticeType, key string, options *AddNoticeOptions) error {
+// ValidateNotice validates notice type and key before adding.
+func ValidateNotice(noticeType NoticeType, key string, options *AddNoticeOptions) error {
 	if !noticeType.Valid() {
-		return fmt.Errorf("internal error: attempted to add notice with invalid type %q", noticeType)
+		return fmt.Errorf("cannot add notice with invalid type %q", noticeType)
 	}
 	if key == "" {
-		return fmt.Errorf("internal error: attempted to add %s notice with invalid key %q", noticeType, key)
+		return fmt.Errorf("cannot add %s notice with invalid key %q", noticeType, key)
+	}
+	if len(key) > maxNoticeKeyLength {
+		return fmt.Errorf("cannot add %s notice with invalid key: key must be %d bytes or less", noticeType, maxNoticeKeyLength)
 	}
 	if noticeType == RefreshInhibitNotice && key != "-" {
-		return fmt.Errorf(`internal error: attempted to add %s notice with invalid key %q, only "-" key is supported`, noticeType, key)
+		return fmt.Errorf(`cannot add %s notice with invalid key %q: only "-" key is supported`, noticeType, key)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds the `snap-run-inhibit` notice which is need for the "snap-run during refresh UX" flow described in [SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.v228s8hnqd53).

This is mostly a port of `custom` notices implementation from pebble https://github.com/canonical/pebble/pull/296 adapted for the `snap-run-inhibit` notice.

This PR is a building block for https://github.com/snapcore/snapd/pull/13770.