### PR TITLE
cmd/snap: record snap-run-inhibit notice

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -516,7 +516,7 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 			return fmt.Errorf("race condition detected, snap-run can only retry once")
 		}
 
-		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), snapName, appName)
+		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), x.client, snapName, appName)
 		if errors.Is(err, errSnapRefreshConflict) {
 			// Possible race condition detected, let's retry.
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/tooling"
 	"github.com/snapcore/snapd/testutil"
-	usersessionclient "github.com/snapcore/snapd/usersession/client"
 )
 
 var RunMain = run
@@ -133,28 +132,27 @@ func SetVerbose(iw *infoWriter, verbose bool) {
 }
 
 var (
-	ClientSnapFromPath                            = clientSnapFromPath
-	SetupDiskSnap                                 = (*infoWriter).setupDiskSnap
-	SetupSnap                                     = (*infoWriter).setupSnap
-	MaybePrintServices                            = (*infoWriter).maybePrintServices
-	MaybePrintCommands                            = (*infoWriter).maybePrintCommands
-	MaybePrintType                                = (*infoWriter).maybePrintType
-	PrintSummary                                  = (*infoWriter).printSummary
-	MaybePrintPublisher                           = (*infoWriter).maybePrintPublisher
-	MaybePrintNotes                               = (*infoWriter).maybePrintNotes
-	MaybePrintStandaloneVersion                   = (*infoWriter).maybePrintStandaloneVersion
-	MaybePrintBuildDate                           = (*infoWriter).maybePrintBuildDate
-	MaybePrintLinks                               = (*infoWriter).maybePrintLinks
-	MaybePrintBase                                = (*infoWriter).maybePrintBase
-	MaybePrintPath                                = (*infoWriter).maybePrintPath
-	MaybePrintSum                                 = (*infoWriter).maybePrintSum
-	MaybePrintCohortKey                           = (*infoWriter).maybePrintCohortKey
-	MaybePrintHealth                              = (*infoWriter).maybePrintHealth
-	MaybePrintRefreshInfo                         = (*infoWriter).maybePrintRefreshInfo
-	WaitWhileInhibited                            = waitWhileInhibited
-	TryNotifyRefreshViaSnapDesktopIntegrationFlow = tryNotifyRefreshViaSnapDesktopIntegrationFlow
-	NewInhibitionFlow                             = newInhibitionFlow
-	ErrSnapRefreshConflict                        = errSnapRefreshConflict
+	ClientSnapFromPath          = clientSnapFromPath
+	SetupDiskSnap               = (*infoWriter).setupDiskSnap
+	SetupSnap                   = (*infoWriter).setupSnap
+	MaybePrintServices          = (*infoWriter).maybePrintServices
+	MaybePrintCommands          = (*infoWriter).maybePrintCommands
+	MaybePrintType              = (*infoWriter).maybePrintType
+	PrintSummary                = (*infoWriter).printSummary
+	MaybePrintPublisher         = (*infoWriter).maybePrintPublisher
+	MaybePrintNotes             = (*infoWriter).maybePrintNotes
+	MaybePrintStandaloneVersion = (*infoWriter).maybePrintStandaloneVersion
+	MaybePrintBuildDate         = (*infoWriter).maybePrintBuildDate
+	MaybePrintLinks             = (*infoWriter).maybePrintLinks
+	MaybePrintBase              = (*infoWriter).maybePrintBase
+	MaybePrintPath              = (*infoWriter).maybePrintPath
+	MaybePrintSum               = (*infoWriter).maybePrintSum
+	MaybePrintCohortKey         = (*infoWriter).maybePrintCohortKey
+	MaybePrintHealth            = (*infoWriter).maybePrintHealth
+	MaybePrintRefreshInfo       = (*infoWriter).maybePrintRefreshInfo
+	WaitWhileInhibited          = waitWhileInhibited
+	NewInhibitionFlow           = newInhibitionFlow
+	ErrSnapRefreshConflict      = errSnapRefreshConflict
 )
 
 func MockPollTime(d time.Duration) (restore func()) {
@@ -436,43 +434,9 @@ func MockWaitWhileInhibited(f func(ctx context.Context, snapName string, notInhi
 	return restore
 }
 
-func MockIsGraphicalSession(graphical bool) (restore func()) {
-	old := isGraphicalSession
-	isGraphicalSession = func() bool {
-		return graphical
-	}
-	return func() {
-		isGraphicalSession = old
-	}
-}
-
-func MockPendingRefreshNotification(f func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error) (restore func()) {
-	old := pendingRefreshNotification
-	pendingRefreshNotification = f
-	return func() {
-		pendingRefreshNotification = old
-	}
-}
-
-func MockFinishRefreshNotification(f func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error) (restore func()) {
-	old := finishRefreshNotification
-	finishRefreshNotification = f
-	return func() {
-		finishRefreshNotification = old
-	}
-}
-
-func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(ctx context.Context, snapName string) bool) (restore func()) {
-	old := tryNotifyRefreshViaSnapDesktopIntegrationFlow
-	tryNotifyRefreshViaSnapDesktopIntegrationFlow = f
-	return func() {
-		tryNotifyRefreshViaSnapDesktopIntegrationFlow = old
-	}
-}
-
 func MockInhibitionFlow(flow inhibitionFlow) (restore func()) {
 	old := newInhibitionFlow
-	newInhibitionFlow = func(name string) inhibitionFlow {
+	newInhibitionFlow = func(cli *client.Client, name string) inhibitionFlow {
 		return flow
 	}
 	return func() {

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -23,18 +23,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
-	"github.com/snapcore/snapd/dbusutil"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/usersession/client"
 )
 
 var runinhibitWaitWhileInhibited = runinhibit.WaitWhileInhibited
@@ -46,10 +43,10 @@ var errSnapRefreshConflict = fmt.Errorf("snap refresh conflict detected")
 
 // maybeWaitWhileInhibited is a wrapper for waitWhileInhibited that skips waiting
 // if refresh-app-awareness flag is disabled.
-func maybeWaitWhileInhibited(ctx context.Context, snapName string, appName string) (info *snap.Info, app *snap.AppInfo, hintFlock *osutil.FileLock, err error) {
+func maybeWaitWhileInhibited(ctx context.Context, cli *client.Client, snapName string, appName string) (info *snap.Info, app *snap.AppInfo, hintFlock *osutil.FileLock, err error) {
 	// wait only if refresh-app-awareness flag is enabled
 	if features.RefreshAppAwareness.IsEnabled() {
-		return waitWhileInhibited(ctx, snapName, appName)
+		return waitWhileInhibited(ctx, cli, snapName, appName)
 	}
 
 	info, app, err = getInfoAndApp(snapName, appName, snap.R(0))
@@ -67,8 +64,8 @@ func maybeWaitWhileInhibited(ctx context.Context, snapName string, appName strin
 // NOTE: A snap without a hint file is considered not inhibited and a nil FileLock is returned.
 //
 // NOTE: It is the caller's responsibility to release the returned file lock.
-func waitWhileInhibited(ctx context.Context, snapName string, appName string) (info *snap.Info, app *snap.AppInfo, hintFlock *osutil.FileLock, err error) {
-	flow := newInhibitionFlow(snapName)
+func waitWhileInhibited(ctx context.Context, cli *client.Client, snapName string, appName string) (info *snap.Info, app *snap.AppInfo, hintFlock *osutil.FileLock, err error) {
+	var flow inhibitionFlow
 	notified := false
 	notInhibited := func(ctx context.Context) (err error) {
 		// Get updated "current" snap info.
@@ -84,6 +81,7 @@ func waitWhileInhibited(ctx context.Context, snapName string, appName string) (i
 	}
 	inhibited := func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error) {
 		if !notified {
+			flow = newInhibitionFlow(cli, snapName)
 			info, app, err = getInfoAndApp(snapName, appName, inhibitInfo.Previous)
 			if err != nil {
 				return false, err
@@ -145,95 +143,57 @@ type inhibitionFlow interface {
 	FinishInhibitionNotification(ctx context.Context) error
 }
 
-var newInhibitionFlow = func(instanceName string) inhibitionFlow {
-	if isGraphicalSession() {
-		return &graphicalFlow{instanceName: instanceName}
-	}
-	return &textFlow{instanceName: instanceName}
+var newInhibitionFlow = func(cli *client.Client, instanceName string) inhibitionFlow {
+	return &noticesFlow{instanceName: instanceName, cli: cli}
 }
 
-type textFlow struct {
+type noticesFlow struct {
 	instanceName string
+
+	cli *client.Client
 }
 
-func (tf *textFlow) StartInhibitionNotification(ctx context.Context) error {
-	_, err := fmt.Fprintf(Stdout, i18n.G("snap package %q is being refreshed, please wait\n"), tf.instanceName)
-	// TODO: add proper progress spinner
-	return err
-}
+func (gf *noticesFlow) StartInhibitionNotification(ctx context.Context) error {
+	opts := client.NotifyOptions{
+		Type: client.SnapRunInhibitNotice,
+		Key:  gf.instanceName,
+	}
+	_, err := gf.cli.Notify(&opts)
+	if err != nil {
+		return err
+	}
 
-func (tf *textFlow) FinishInhibitionNotification(ctx context.Context) error {
+	// Fallback to text notification if marker "snap-refresh-observe"
+	// interface is not connected and a terminal is detected.
+	if isStdoutTTY && !markerInterfaceConnected(gf.cli) {
+		fmt.Fprintf(Stderr, i18n.G("snap package %q is being refreshed, please wait\n"), gf.instanceName)
+	}
+
 	return nil
 }
 
-type graphicalFlow struct {
-	instanceName string
-
-	notifiedDesktopIntegration bool
+func (gf *noticesFlow) FinishInhibitionNotification(ctx context.Context) error {
+	// snapd-desktop-integration (or any other client) should detect that the
+	// snap is no longer inhibited by itself, do nothing.
+	return nil
 }
 
-func (gf *graphicalFlow) StartInhibitionNotification(ctx context.Context) error {
-	gf.notifiedDesktopIntegration = tryNotifyRefreshViaSnapDesktopIntegrationFlow(ctx, gf.instanceName)
-	if gf.notifiedDesktopIntegration {
-		return nil
+func markerInterfaceConnected(cli *client.Client) bool {
+	// Check if marker interface "snap-refresh-observe" is connected.
+	connOpts := client.ConnectionOptions{
+		Interface: "snap-refresh-observe",
 	}
-
-	// unable to use snapd-desktop-integration, let's fall back to graphical session flow
-	refreshInfo := client.PendingSnapRefreshInfo{
-		InstanceName: gf.instanceName,
-		// remaining time = 0 results in "Snap .. is refreshing now" message from
-		// usersession agent.
-		TimeRemaining: 0,
-	}
-	return pendingRefreshNotification(ctx, &refreshInfo)
-}
-
-func (gf *graphicalFlow) FinishInhibitionNotification(ctx context.Context) error {
-	if gf.notifiedDesktopIntegration {
-		// snapd-desktop-integration detects inhibit unlock itself, do nothing
-		return nil
-	}
-
-	// finish graphical session flow
-	finishRefreshInfo := client.FinishedSnapRefreshInfo{InstanceName: gf.instanceName}
-	return finishRefreshNotification(ctx, &finishRefreshInfo)
-}
-
-var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(ctx context.Context, snapName string) (notified bool) {
-	// Check if Snapd-Desktop-Integration is available
-	conn, err := dbusutil.SessionBus()
+	connections, err := cli.Connections(&connOpts)
 	if err != nil {
-		logger.Noticef("unable to connect dbus session: %v", err)
+		// Ignore error (maybe snapd is being updated) and fallback to
+		// text flow instead.
 		return false
 	}
-	obj := conn.Object("io.snapcraft.SnapDesktopIntegration", "/io/snapcraft/SnapDesktopIntegration")
-	extraParams := make(map[string]dbus.Variant)
-	err = obj.CallWithContext(ctx, "io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, runinhibit.HintFile(snapName), extraParams).Store()
-	if err != nil {
-		logger.Noticef("unable to successfully call io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed: %v", err)
+	if len(connections.Established) == 0 {
+		// Marker interface is not connected.
+		// No snap (i.e. snapd-desktop-integration) is listening, let's fallback
+		// to text flow.
 		return false
 	}
 	return true
-}
-
-var isGraphicalSession = func() bool {
-	// TODO: uncomment once there is a proper UX review
-	//return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
-	return false
-}
-
-var pendingRefreshNotification = func(ctx context.Context, refreshInfo *client.PendingSnapRefreshInfo) error {
-	userclient := client.NewForUids(os.Getuid())
-	if err := userclient.PendingRefreshNotification(ctx, refreshInfo); err != nil {
-		return err
-	}
-	return nil
-}
-
-var finishRefreshNotification = func(ctx context.Context, refreshInfo *client.FinishedSnapRefreshInfo) error {
-	userclient := client.NewForUids(os.Getuid())
-	if err := userclient.FinishRefreshNotification(ctx, refreshInfo); err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/snap/inhibit_test.go
+++ b/cmd/snap/inhibit_test.go
@@ -21,22 +21,22 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+	"io"
+	"net/http"
+	"net/url"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/client"
 	snaprun "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
-	"github.com/snapcore/snapd/dbusutil"
-	"github.com/snapcore/snapd/dbusutil/dbustest"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
-	usersessionclient "github.com/snapcore/snapd/usersession/client"
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 )
 
@@ -103,7 +103,7 @@ func (s *RunSuite) TestWaitWhileInhibitedRunThrough(c *C) {
 	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	defer hintLock.Unlock()
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "snapname")
@@ -136,7 +136,7 @@ func (s *RunSuite) TestWaitWhileInhibitedErrorOnStartNotification(c *C) {
 	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	c.Assert(err, ErrorMatches, "boom")
 	c.Check(info, IsNil)
 	c.Check(app, IsNil)
@@ -192,7 +192,7 @@ func (s *RunSuite) TestWaitWhileInhibitedErrorOnFinishNotification(c *C) {
 	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	c.Assert(err, ErrorMatches, "boom")
 	c.Check(info, IsNil)
 	c.Check(app, IsNil)
@@ -229,7 +229,7 @@ func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *C) {
 	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	_, _, _, err := snaprun.WaitWhileInhibited(originalCtx, "snapname", "app")
+	_, _, _, err := snaprun.WaitWhileInhibited(originalCtx, snaprun.Client(), "snapname", "app")
 	c.Assert(err, ErrorMatches, "context canceled")
 	c.Assert(errors.Is(err, context.Canceled), Equals, true)
 	c.Assert(errors.Is(originalCtx.Err(), context.Canceled), Equals, true)
@@ -276,7 +276,7 @@ func (s *RunSuite) TestWaitWhileInhibitedGateRefreshNoNotification(c *C) {
 	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	defer hintLock.Unlock()
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "snapname")
@@ -301,7 +301,7 @@ func (s *RunSuite) TestWaitWhileInhibitedNotInhibitedNoNotification(c *C) {
 	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	info, app, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	c.Assert(err, IsNil)
 	c.Assert(hintLock, IsNil)
 	c.Check(info.InstanceName(), Equals, "snapname")
@@ -322,156 +322,143 @@ func (s *RunSuite) TestWaitWhileInhibitedNotInhibitHintFileOngoingRefresh(c *C) 
 	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
-	_, _, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), "snapname", "app")
+	_, _, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	c.Assert(err, testutil.ErrorIs, snaprun.ErrSnapRefreshConflict)
 	c.Assert(hintLock, IsNil)
 }
 
-func makeDBusMethodNotAvailableMessage(c *C, msg *dbus.Message) *dbus.Message {
-	return &dbus.Message{
-		Type: dbus.TypeError,
-		Headers: map[dbus.HeaderField]dbus.Variant{
-			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
-			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
-			// dbus.FieldDestination is provided automatically by DBus test helper.
-			dbus.FieldErrorName: dbus.MakeVariant("org.freedesktop.DBus.Error.UnknownMethod"),
-		},
-	}
-}
-
-func makeDBusMethodAvailableMessage(c *C, msg *dbus.Message) *dbus.Message {
-	c.Assert(msg.Type, Equals, dbus.TypeMethodCall)
-	c.Check(msg.Flags, Equals, dbus.Flags(0))
-
-	c.Check(msg.Headers, DeepEquals, map[dbus.HeaderField]dbus.Variant{
-		dbus.FieldDestination: dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
-		dbus.FieldPath:        dbus.MakeVariant(dbus.ObjectPath("/io/snapcraft/SnapDesktopIntegration")),
-		dbus.FieldInterface:   dbus.MakeVariant("io.snapcraft.SnapDesktopIntegration"),
-		dbus.FieldMember:      dbus.MakeVariant("ApplicationIsBeingRefreshed"),
-		dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("", "", make(map[string]dbus.Variant))),
-	})
-	c.Check(msg.Body[0], Equals, "some-snap")
-	param2 := fmt.Sprintf("%s", msg.Body[1])
-	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/some-snap.lock"), Equals, true)
-	return &dbus.Message{
-		Type: dbus.TypeMethodReply,
-		Headers: map[dbus.HeaderField]dbus.Variant{
-			dbus.FieldReplySerial: dbus.MakeVariant(msg.Serial()),
-			dbus.FieldSender:      dbus.MakeVariant(":1"), // This does not matter.
-		},
-	}
-}
-
-func (s *RunSuite) TestTextInhibitionFlow(c *C) {
-	textFlow := snaprun.NewInhibitionFlow("snapname")
-
-	c.Assert(textFlow.StartInhibitionNotification(context.TODO()), IsNil)
-	c.Check(s.Stdout(), Equals, "snap package \"snapname\" is being refreshed, please wait\n")
-
-	// Finish is a no-op
-	c.Assert(textFlow.FinishInhibitionNotification(context.TODO()), IsNil)
-	c.Check(s.Stdout(), Equals, "snap package \"snapname\" is being refreshed, please wait\n")
-
-}
-
-func (s *RunSuite) TestDesktopIntegrationInhibitionFlow(c *C) {
-	// mock snapd-desktop-integration dbus available
-	var dbusCalled int
-	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
-		dbusCalled++
-		return []*dbus.Message{makeDBusMethodAvailableMessage(c, msg)}, nil
-	})
-	c.Assert(err, IsNil)
-
-	restore := dbusutil.MockOnlySessionBusAvailable(conn)
+func (s *RunSuite) TestInhibitionFlow(c *C) {
+	restore := snaprun.MockIsStdoutTTY(true)
 	defer restore()
 
-	// check that the normal graphical notification flow is not called
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		return fmt.Errorf("this should never be reached")
+	var noticeCreated int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/connections":
+			c.Assert(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Query(), check.DeepEquals, url.Values{"interface": []string{"snap-refresh-observe"}})
+			body, err := io.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]any{
+				"type": "sync",
+				"result": client.Connections{
+					// mock snap exists with connected marker interface
+					Established: []client.Connection{{Interface: "snap-refresh-observe"}},
+				},
+			})
+		case "/v2/notices":
+			noticeCreated++
+			c.Assert(r.Method, check.Equals, "POST")
+			body, err := io.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			var noticeRequest map[string]string
+			c.Assert(json.Unmarshal(body, &noticeRequest), check.IsNil)
+			c.Check(noticeRequest["action"], check.Equals, "add")
+			c.Check(noticeRequest["type"], check.Equals, "snap-run-inhibit")
+			c.Check(noticeRequest["key"], check.Equals, "some-snap")
+			EncodeResponseBody(c, w, map[string]any{
+				"type":   "sync",
+				"result": map[string]string{"id": "1"},
+			})
+		default:
+			c.Error("this should never be reached")
+		}
 	})
-	defer restorePendingRefreshNotification()
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		return fmt.Errorf("this should never be reached")
-	})
-	defer restoreFinishRefreshNotification()
 
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
-
-	graphicalFlow := snaprun.NewInhibitionFlow("some-snap")
+	graphicalFlow := snaprun.NewInhibitionFlow(snaprun.Client(), "some-snap")
 
 	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), IsNil)
-	c.Check(dbusCalled, Equals, 1)
-	// check that text flow is not called
-	c.Check(s.Stdout(), Equals, "")
+	// A snap-run-inhibit notice is always created
+	c.Check(noticeCreated, check.Equals, 1)
+	c.Check(s.Stderr(), Equals, "")
 
 	c.Assert(graphicalFlow.FinishInhibitionNotification(context.TODO()), IsNil)
-	// Finish is a no-op, so dbus is only called once
-	c.Check(dbusCalled, Equals, 1)
-	// check that text flow is not called
-	c.Check(s.Stdout(), Equals, "")
+	// Finish is no-op, no new notices
+	c.Check(noticeCreated, check.Equals, 1)
+	c.Check(s.Stderr(), Equals, "")
 }
 
-func (s *RunSuite) TestGraphicalSessionInhibitionFlow(c *C) {
-	_, r := logger.MockLogger()
-	defer r()
-
-	// mock snapd-desktop-integration dbus available
-	var dbusCalled int
-	conn, _, err := dbustest.InjectableConnection(func(msg *dbus.Message, n int) ([]*dbus.Message, error) {
-		dbusCalled++
-		return []*dbus.Message{makeDBusMethodNotAvailableMessage(c, msg)}, nil
-	})
-	c.Assert(err, IsNil)
-
-	restore := dbusutil.MockOnlySessionBusAvailable(conn)
+func (s *RunSuite) testInhibitionFlowTextFallback(c *C, connectionsAPIErr bool) {
+	restore := snaprun.MockIsStdoutTTY(true)
 	defer restore()
 
-	// check that the normal graphical notification flow is called
-	var pendingRefreshNotificationCalled int
-	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
-		pendingRefreshNotificationCalled++
-		return nil
-	})
-	defer restorePendingRefreshNotification()
-	var finishRefreshNotificationCalled int
-	restoreFinishRefreshNotification := snaprun.MockFinishRefreshNotification(func(ctx context.Context, refreshInfo *usersessionclient.FinishedSnapRefreshInfo) error {
-		finishRefreshNotificationCalled++
-		return nil
-	})
-	defer restoreFinishRefreshNotification()
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/connections":
+			if connectionsAPIErr {
+				w.WriteHeader(500)
+				EncodeResponseBody(c, w, map[string]any{"type": "error"})
+			} else {
+				EncodeResponseBody(c, w, map[string]any{"type": "sync", "result": nil})
 
-	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
-	defer restoreIsGraphicalSession()
+			}
+		case "/v2/notices":
+			EncodeResponseBody(c, w, map[string]any{"type": "sync", "result": map[string]string{"id": "1"}})
+		default:
+			c.Error("this should never be reached")
+		}
+	})
 
-	graphicalFlow := snaprun.NewInhibitionFlow("some-snap")
+	graphicalFlow := snaprun.NewInhibitionFlow(snaprun.Client(), "some-snap")
 
 	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), IsNil)
-	c.Check(pendingRefreshNotificationCalled, Equals, 1)
-	c.Check(finishRefreshNotificationCalled, Equals, 0)
-	// snapd-desktop-integration dbus is checked for availability
-	c.Check(dbusCalled, Equals, 1)
-	// check that text flow is not called
-	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "snap package \"some-snap\" is being refreshed, please wait\n")
 
 	c.Assert(graphicalFlow.FinishInhibitionNotification(context.TODO()), IsNil)
-	c.Check(pendingRefreshNotificationCalled, Equals, 1)
-	c.Check(finishRefreshNotificationCalled, Equals, 1)
-	// snapd-desktop-integration dbus is not checked on finish
-	c.Check(dbusCalled, Equals, 1)
-	// check that text flow is not called
-	c.Check(s.Stdout(), Equals, "")
+	// Finish is a noop
+	c.Check(s.Stderr(), Equals, "snap package \"some-snap\" is being refreshed, please wait\n")
 }
 
-func (s *RunSuite) TestDesktopIntegrationNoDBus(c *C) {
-	_, r := logger.MockLogger()
-	defer r()
+func (s *RunSuite) TestInhibitionFlowTextFallbackNoMarkerInterface(c *C) {
+	const connectionsAPIErr = false
+	s.testInhibitionFlowTextFallback(c, connectionsAPIErr)
+}
 
-	noDBus := func() (*dbus.Conn, error) { return nil, fmt.Errorf("dbus not available") }
-	restore := dbusutil.MockConnections(noDBus, noDBus)
+func (s *RunSuite) TestInhibitionFlowTextFallbackConnectionsAPIError(c *C) {
+	const connectionsAPIErr = true
+	s.testInhibitionFlowTextFallback(c, connectionsAPIErr)
+}
+
+func (s *RunSuite) TestInhibitionFlowNoTTY(c *C) {
+	restore := snaprun.MockIsStdoutTTY(false)
 	defer restore()
 
-	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow(context.TODO(), "Test")
-	c.Assert(sent, Equals, false)
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/connections":
+			// No marker interface connected
+			EncodeResponseBody(c, w, map[string]any{"type": "sync", "result": nil})
+		case "/v2/notices":
+			EncodeResponseBody(c, w, map[string]any{"type": "sync", "result": map[string]string{"id": "1"}})
+		default:
+			c.Error("this should never be reached")
+		}
+	})
+
+	graphicalFlow := snaprun.NewInhibitionFlow(snaprun.Client(), "some-snap")
+
+	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), IsNil)
+	// No TTY, no text notification
+	c.Check(s.Stderr(), Equals, "")
+
+	c.Assert(graphicalFlow.FinishInhibitionNotification(context.TODO()), IsNil)
+	// No TTY, no text notification
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *RunSuite) TestInhibitionFlowError(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/notices":
+			c.Assert(r.Method, check.Equals, "POST")
+			w.WriteHeader(500)
+			EncodeResponseBody(c, w, map[string]any{"type": "error"})
+		default:
+			c.Error("this should never be reached")
+		}
+	})
+
+	graphicalFlow := snaprun.NewInhibitionFlow(snaprun.Client(), "some-snap")
+	c.Assert(graphicalFlow.StartInhibitionNotification(context.TODO()), ErrorMatches, `server error: "Internal Server Error"`)
 }

--- a/tests/main/snap-run-inhibition-flow/api-client/bin/api-client.py
+++ b/tests/main/snap-run-inhibition-flow/api-client/bin/api-client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import argparse
+import http.client
+import sys
+import socket
+
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path):
+        super().__init__('localhost')
+        self._socket_path = socket_path
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(self._socket_path)
+        self.sock = s
+
+
+def main(argv):
+    parser = argparse.ArgumentParser('Call the snapd REST API')
+    parser.add_argument('--socket', default='/run/snapd.socket',
+                        help='The socket path to connect to')
+    parser.add_argument('--method', default='GET',
+                        help='The HTTP method to use')
+    parser.add_argument('path', metavar='PATH',
+                        help='The HTTP path to request')
+    parser.add_argument('body', metavar='BODY', default=None, nargs='?',
+                        help='The HTTP request body')
+    args = parser.parse_args(argv[1:])
+
+    conn = UnixSocketHTTPConnection(args.socket)
+    conn.request(args.method, args.path, args.body)
+
+    response = conn.getresponse()
+    body = response.read()
+    print(body.decode('UTF-8'))
+    return response.status >= 300
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/snap-run-inhibition-flow/api-client/meta/snap.yaml
+++ b/tests/main/snap-run-inhibition-flow/api-client/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: api-client
+version: 1
+base: core18
+apps:
+  api-client:
+    command: bin/api-client.py
+    plugs:
+      - snap-refresh-observe

--- a/tests/main/snap-run-inhibition-flow/task.yaml
+++ b/tests/main/snap-run-inhibition-flow/task.yaml
@@ -1,0 +1,56 @@
+summary: Check that snap run notifies the user about run inhibition due to refreshes.
+
+details: |
+    This test exercises the inhibition flow triggered when snap run is
+    inhibited from running due to an onging refresh. When snap run is inhibited
+    it record a snap-run-inhibit notice which should be parsed by another
+    client (e.g. snapd-desktop-integration snap).
+
+    TODO: Add a check for the text fallback
+    If snap run detects that no snap has the marker interface connected and
+    we are running in a terminal then snap run falls back to showing a text
+    notification.
+
+environment:
+    SNAPD_INHIBIT_DIR: "/var/lib/snapd/inhibit"
+
+prepare: |
+    snap install --edge jq
+
+    echo "Install snap with marker snap-refresh-observe interface connected"
+    "$TESTSTOOLS"/snaps-state install-local api-client
+    snap connect api-client:snap-refresh-observe
+
+    # Make sure inhibit dir exists
+    mkdir -p $SNAPD_INHIBIT_DIR
+
+    # Mock test-snapd-tools snap as inhibited due to refresh
+    snap install test-snapd-tools
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    REVNO="$(readlink "$SNAP_MOUNT_DIR"/test-snapd-tools/current)"
+    echo -n "refresh" > $SNAPD_INHIBIT_DIR/test-snapd-tools.lock
+    echo -n '{"previous":"'"${REVNO}"'"}' > $SNAPD_INHIBIT_DIR/test-snapd-tools.refresh
+
+restore: |
+    rm -f $SNAPD_INHIBIT_DIR/test-snapd-tools.lock
+    rm -f $SNAPD_INHIBIT_DIR/test-snapd-tools.refresh
+    snap remove --purge test-snapd-tools
+
+    snap remove --purge api-client
+    snap remove --purge jq
+
+execute: |
+    echo "Try running inhibited snap"
+    touch output
+    test-snapd-tools.echo hi > output 2>&1 &
+    echo "Command is waiting due to inhibition, no output"
+    NOMATCH "hi" < output
+
+    # Notice is recorded for inhibition
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=snap-run-inhibit&keys=test-snapd-tools" | jq '.result[0].occurrences' | MATCH '^1$'
+
+    echo "Mark snap as no longer inhibited"
+    echo -n "" > $SNAPD_INHIBIT_DIR/test-snapd-tools.lock
+    echo "snap is no longer inhibited, command should run now"
+    sleep 1
+    MATCH "hi" < output


### PR DESCRIPTION
This PR builds on https://github.com/snapcore/snapd/pull/13791 (~~and should be rebased after https://github.com/snapcore/snapd/pull/13791 gets merged~~ already rebased) to enable the "snap-run during refresh UX" flow described in [SD167](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit#heading=h.v228s8hnqd53).

This simply allows `snap run` to issue (per-user) `snap-run-inhibit` notices when it is inhibited for refresh. This notice can later be consumed by something like `snapd-desktop-integration` snap replacing the old flow of directly calling `snapd-desktop-integration` on dbus.

As fallback if no snap exists with the marker `snap-refresh-observe`  interface https://github.com/snapcore/snapd/pull/13619, a normal notification is sent using the user agent.

**NOTE:** The graphical flow (using notices or the fallback) is hidden behind the `refresh-app-awareness-ux` experimental flag https://github.com/snapcore/snapd/pull/13479.
~~**NOTE:** depending if https://github.com/snapcore/snapd/pull/13747 lands first or this PR, the tests structure will need to be updated because they touch similar parts of the tests.~~