### PR TITLE
daemon, o/snapstate, snap: add hooks to snap.ComponentInfo

### DIFF
--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -392,7 +392,10 @@ func readComponentInfoFromContImpl(tempPath string) (*snap.ComponentInfo, error)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open container: %w", err)
 	}
-	return snap.ReadComponentInfoFromContainer(compf)
+
+	// hook information isn't loaded here, but it shouldn't be needed in this
+	// context
+	return snap.ReadComponentInfoFromContainer(compf, nil)
 }
 
 // readComponentInfo reads ComponentInfo from a snap component file and the

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -53,16 +53,17 @@ func OpenSnapFile(snapPath string, sideInfo *snap.SideInfo) (*snap.Info, snap.Co
 	return info, snapf, nil
 }
 
-// OpenComponentFile opens a component blob returning a snap.ComponentInfo and
-// a corresponding snap.Container. Assumes the file was verified beforehand or
-// the user asked for --dangerous.
-func OpenComponentFile(compPath string) (*snap.ComponentInfo, snap.Container, error) {
+// OpenComponentFile opens a component blob returning a snap.ComponentInfo and a
+// corresponding snap.Container. Assumes the file was verified beforehand or the
+// user asked for --dangerous. The returned snap.ComponentInfo is completed by
+// the provided snap.Info, if it is not nil.
+func OpenComponentFile(compPath string, snapInfo *snap.Info) (*snap.ComponentInfo, snap.Container, error) {
 	snapf, err := snapfile.Open(compPath)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	info, err := snap.ReadComponentInfoFromContainer(snapf)
+	info, err := snap.ReadComponentInfoFromContainer(snapf, snapInfo)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/backend/backend_test.go
+++ b/overlord/snapstate/backend/backend_test.go
@@ -113,7 +113,7 @@ version: 33
 `
 
 	compPath := snaptest.MakeTestComponent(c, componentYaml)
-	compInfo, cont, err := backend.OpenComponentFile(compPath)
+	compInfo, cont, err := backend.OpenComponentFile(compPath, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(cont, FitsTypeOf, &squashfs.Snap{})

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -136,7 +136,7 @@ func (b Backend) RemoveKernelSnapSetup(instanceName string, rev snap.Revision, m
 func (b Backend) SetupComponent(compFilePath string, compPi snap.ContainerPlaceInfo, dev snap.Device, meter progress.Meter) (installRecord *InstallRecord, err error) {
 	// This assumes that the component was already verified or --dangerous was used.
 
-	compInfo, snapf, oErr := OpenComponentFile(compFilePath)
+	compInfo, snapf, oErr := OpenComponentFile(compFilePath, nil)
 	if oErr != nil {
 		return nil, oErr
 	}

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -50,7 +50,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	}
 
 	// Read ComponentInfo
-	compInfo, _, err := backend.OpenComponentFile(path)
+	compInfo, _, err := backend.OpenComponentFile(path, info)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -49,30 +49,11 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 		return nil, err
 	}
 
-	// Read ComponentInfo
+	// Read ComponentInfo and verify that the component is consistent with the
+	// data in the snap info
 	compInfo, _, err := backend.OpenComponentFile(path, info)
 	if err != nil {
 		return nil, err
-	}
-
-	// Check snap name matches
-	if compInfo.Component.SnapName != info.SnapName() {
-		return nil, fmt.Errorf(
-			"component snap name %q does not match snap name %q",
-			compInfo.Component.SnapName, info.RealName)
-	}
-
-	// Check that the component is specified in snap metadata
-	comp, ok := info.Components[csi.Component.ComponentName]
-	if !ok {
-		return nil, fmt.Errorf("%q is not a component for snap %q",
-			csi.Component.ComponentName, info.RealName)
-	}
-	// and that types in snap and component match
-	if comp.Type != compInfo.Type {
-		return nil,
-			fmt.Errorf("inconsistent component type (%q in snap, %q in component)",
-				comp.Type, compInfo.Type)
 	}
 
 	snapsup := &SnapSetup{

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -108,11 +108,11 @@ func verifyComponentInstallTasks(c *C, opts int, ts *state.TaskSet) {
 	}
 }
 
-func createTestComponent(c *C, snapName, compName string) (*snap.ComponentInfo, string) {
-	return createTestComponentWithType(c, snapName, compName, "test")
+func createTestComponent(c *C, snapName, compName string, snapInfo *snap.Info) (*snap.ComponentInfo, string) {
+	return createTestComponentWithType(c, snapName, compName, "test", snapInfo)
 }
 
-func createTestComponentWithType(c *C, snapName, compName string, typ string) (*snap.ComponentInfo, string) {
+func createTestComponentWithType(c *C, snapName, compName string, typ string, snapInfo *snap.Info) (*snap.ComponentInfo, string) {
 	componentYaml := fmt.Sprintf(`component: %s+%s
 type: %s
 version: 1.0
@@ -121,7 +121,7 @@ version: 1.0
 	compf, err := snapfile.Open(compPath)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, snapInfo)
 	c.Assert(err, IsNil)
 
 	return ci, compPath
@@ -195,8 +195,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPath(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -219,9 +219,9 @@ func (s *snapmgrTestSuite) TestInstallComponentPathWrongComponent(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	// The snap does not declare "mycomp"
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, "other-comp")
+	_, compPath := createTestComponent(c, snapName, compName, nil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -233,20 +233,21 @@ func (s *snapmgrTestSuite) TestInstallComponentPathWrongComponent(c *C) {
 	ts, err := snapstate.InstallComponentPath(s.state, csi, info, compPath,
 		snapstate.Flags{})
 	c.Assert(ts, IsNil)
-	c.Assert(err.Error(), Equals, `"mycomp" is not a component for snap "mysnap"`)
+	c.Assert(err, ErrorMatches, `.*"mycomp" is not a component for snap "mysnap"`)
 }
 
 func (s *snapmgrTestSuite) TestInstallComponentPathWrongType(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, "other-comp")
 	// The component in snap.yaml has type different to the one in component.yaml
 	// (we have to set it in this way as parsers check for allowed types).
 	info.Components[compName] = &snap.Component{
 		Type: "random-comp-type",
 	}
+
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -267,9 +268,9 @@ func (s *snapmgrTestSuite) TestInstallComponentPathForParallelInstall(c *C) {
 	const compName = "mycomp"
 	const snapKey = "key"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snap.R(1), compName)
 	info.InstanceKey = snapKey
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -306,8 +307,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathWrongSnap(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, "other-snap", snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -328,8 +329,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresent(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -355,8 +356,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresentDiffSnapRe
 	snapRev1 := snap.R(1)
 	snapRev2 := snap.R(2)
 	compRev := snap.R(7)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev1, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -396,8 +397,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompAlreadyInstalled(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(33)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -421,8 +422,8 @@ func (s *snapmgrTestSuite) TestInstallComponentPathSnapNotActive(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -449,8 +450,8 @@ func (s *snapmgrTestSuite) TestInstallComponentRemodelConflict(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -474,8 +475,8 @@ func (s *snapmgrTestSuite) TestInstallComponentUpdateConflict(c *C) {
 	const snapName = "some-snap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponent(c, snapName, compName)
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -502,8 +503,8 @@ func (s *snapmgrTestSuite) TestInstallKernelModulesComponentPath(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
-	_, compPath := createTestComponentWithType(c, snapName, compName, "kernel-modules")
 	info := createTestSnapInfoForComponentWithType(c, snapName, snapRev, compName, "kernel-modules")
+	_, compPath := createTestComponentWithType(c, snapName, compName, "kernel-modules", info)
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -44,7 +44,8 @@ version: 1.0
 	}
 
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info,
+	) (*snap.ComponentInfo, error) {
 		for i, ci := range cis {
 			if strings.HasSuffix(compMntDir, "/"+ci.Component.ComponentName+"/"+compRevs[i].String()) {
 				return ci, nil

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -68,7 +68,7 @@ func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, err
 	return func() { snapReadInfo = old }
 }
 
-func MockReadComponentInfo(mock func(compMntDir string) (*snap.ComponentInfo, error)) (restore func()) {
+func MockReadComponentInfo(mock func(compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error)) (restore func()) {
 	old := readComponentInfo
 	readComponentInfo = mock
 	return func() { readComponentInfo = old }

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -165,7 +165,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	var readInfoErr error
 	for i := 0; i < 10; i++ {
 		compMntDir := cpi.MountDir()
-		_, readInfoErr = readComponentInfo(compMntDir)
+		_, readInfoErr = readComponentInfo(compMntDir, nil)
 		if readInfoErr == nil {
 			logger.Debugf("component %q (%v) available at %q",
 				csi.Component, compSetup.Revision(), compMntDir)
@@ -203,9 +203,9 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 }
 
 // Maybe we will need flags as in readInfo
-var readComponentInfo = func(compMntDir string) (*snap.ComponentInfo, error) {
+var readComponentInfo = func(compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 	cont := snapdir.New(compMntDir)
-	return snap.ReadComponentInfoFromContainer(cont)
+	return snap.ReadComponentInfoFromContainer(cont, snapInfo)
 }
 
 func (m *SnapManager) undoMountComponent(t *state.Task, _ *tomb.Tomb) error {

--- a/overlord/snapstate/handlers_components_mount_test.go
+++ b/overlord/snapstate/handlers_components_mount_test.go
@@ -46,11 +46,11 @@ func (s *mountCompSnapSuite) TestDoMountComponent(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	ci, compPath := createTestComponent(c, snapName, compName)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ci, compPath := createTestComponent(c, snapName, compName, si)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 		return ci, nil
 	}))
 
@@ -88,11 +88,11 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponent(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	ci, compPath := createTestComponent(c, snapName, compName)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ci, compPath := createTestComponent(c, snapName, compName, si)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 		return ci, nil
 	}))
 
@@ -144,11 +144,11 @@ func (s *mountCompSnapSuite) TestDoMountComponentSetupFails(c *C) {
 	const compName = "broken"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	ci, compPath := createTestComponent(c, snapName, compName)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ci, compPath := createTestComponent(c, snapName, compName, si)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 		return ci, nil
 	}))
 
@@ -191,11 +191,11 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponentFails(c *C) {
 	const compName = "brokenundo"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	ci, compPath := createTestComponent(c, snapName, compName)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ci, compPath := createTestComponent(c, snapName, compName, si)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 		return ci, nil
 	}))
 
@@ -244,11 +244,11 @@ func (s *mountCompSnapSuite) TestDoMountComponentMountFails(c *C) {
 	const compName = "mycomp"
 	snapRev := snap.R(1)
 	compRev := snap.R(7)
-	ci, compPath := createTestComponent(c, snapName, compName)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ci, compPath := createTestComponent(c, snapName, compName, si)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
-		compMntDir string) (*snap.ComponentInfo, error) {
+		compMntDir string, snapInfo *snap.Info) (*snap.ComponentInfo, error) {
 		return ci, fmt.Errorf("cannot read component")
 	}))
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -522,7 +522,7 @@ func (snapst *SnapState) CurrentComponentInfo(cref naming.ComponentRef) (*snap.C
 
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
 		csi.Revision, si.InstanceName())
-	return readComponentInfo(cpi.MountDir())
+	return readComponentInfo(cpi.MountDir(), si)
 }
 
 func (snapst *SnapState) InstanceName() string {

--- a/snap/component.go
+++ b/snap/component.go
@@ -39,7 +39,7 @@ type ComponentInfo struct {
 	// component itself and the snap.Info that represents the snap this
 	// component is associated with. This field may be empty if the
 	// ComponentInfo was not created with the help of a snap.Info.
-	Hooks map[string]*HookInfo `json:"hooks,omitempty"`
+	Hooks map[string]*HookInfo `yaml:"-"`
 }
 
 // NewComponentInfo creates a new ComponentInfo.

--- a/snap/component.go
+++ b/snap/component.go
@@ -181,12 +181,12 @@ func ReadComponentInfoFromContainer(compf Container, snapInfo *Info) (*Component
 
 	// attach the implicit hooks, these are not defined in the snap.yaml.
 	// unscoped plugs are bound to the implicit hooks here.
-	addAndBindImplicitComponentHooksFromContainer(compf, componentInfo, snapInfo, component)
+	addAndBindImplicitComponentHooksFromContainer(compf, componentInfo, component, snapInfo)
 
 	return componentInfo, nil
 }
 
-func addAndBindImplicitComponentHooksFromContainer(compf Container, componentInfo *ComponentInfo, info *Info, component *Component) {
+func addAndBindImplicitComponentHooksFromContainer(compf Container, componentInfo *ComponentInfo, component *Component, info *Info) {
 	hooks, err := compf.ListDir("meta/hooks")
 	if err != nil {
 		return

--- a/snap/component.go
+++ b/snap/component.go
@@ -205,7 +205,7 @@ func addAndBindImplicitComponentHook(componentInfo *ComponentInfo, snapInfo *Inf
 
 	// TODO: ignore unsupported implicit component hooks, or return an error?
 	if !IsComponentHookSupported(hook) {
-		logger.Debugf("ignoring unsupported implicit hook %q for component %q", componentInfo.Component, hook)
+		logger.Noticef("ignoring unsupported implicit hook %q for component %q", componentInfo.Component, hook)
 		return
 	}
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -161,7 +161,7 @@ func ReadComponentInfoFromContainer(compf Container, snapInfo *Info) (*Component
 
 	component, ok := snapInfo.Components[componentName]
 	if !ok {
-		return nil, fmt.Errorf("internal error: %q is not a component for snap %q", componentName, snapInfo.RealName)
+		return nil, fmt.Errorf("cannot find component %q in snap %q", componentName, snapInfo.SnapName())
 	}
 
 	// attach the explicit hooks, these are defined in the snap.yaml. plugs are

--- a/snap/component.go
+++ b/snap/component.go
@@ -118,8 +118,7 @@ func (c *componentPlaceInfo) Filename() string {
 // will be of the form:
 // /snaps/<snap_instance>/components/mnt/<component_name>/<component_revision>
 func (c *componentPlaceInfo) MountDir() string {
-	return filepath.Join(ComponentsBaseDir(c.snapInstance), "mnt",
-		c.compName, c.compRevision.String())
+	return ComponentMountDir(c.compName, c.compRevision, c.snapInstance)
 }
 
 // MountFile returns the path of the file to be mounted for a component,

--- a/snap/component.go
+++ b/snap/component.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap/naming"
 	"gopkg.in/yaml.v2"
 )
@@ -197,13 +198,14 @@ func addAndBindImplicitComponentHooksFromContainer(compf Container, componentInf
 }
 
 func addAndBindImplicitComponentHook(componentInfo *ComponentInfo, snapInfo *Info, component *Component, hook string) {
-	// TODO: ignore unsupported implicit component hooks, or return an error?
-	if !IsComponentHookSupported(hook) {
+	// don't overwrite a hook that has already been loaded from the snap.yaml
+	if _, ok := componentInfo.Hooks[hook]; ok {
 		return
 	}
 
-	// don't overwrite a hook that has already been loaded from the snap.yaml
-	if _, ok := componentInfo.Hooks[hook]; ok {
+	// TODO: ignore unsupported implicit component hooks, or return an error?
+	if !IsComponentHookSupported(hook) {
+		logger.Debugf("ignoring unsupported implicit hook %q for component %q", componentInfo.Component, hook)
 		return
 	}
 

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -333,6 +333,7 @@ components:
     hooks:
       install:
         plugs: [network]
+      remove:
 plugs:
   network-client:
 `
@@ -367,6 +368,13 @@ plugs:
 	c.Check(preRefreshHook.Explicit, Equals, false)
 	c.Check(preRefreshHook.Plugs, HasLen, 1)
 	c.Check(preRefreshHook.Plugs["network-client"], NotNil)
+
+	removeHook := ci.Hooks["remove"]
+	c.Assert(removeHook, NotNil)
+	c.Check(removeHook.Name, Equals, "remove")
+	c.Check(removeHook.Explicit, Equals, true)
+	c.Check(removeHook.Plugs, HasLen, 1)
+	c.Check(removeHook.Plugs["network-client"], NotNil)
 }
 
 func (s *componentSuite) TestReadComponentInfoFinishedWithSnapInfoMissingComponentError(c *C) {

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -369,7 +369,7 @@ plugs:
 	c.Check(preRefreshHook.Plugs["network-client"], NotNil)
 }
 
-func (s *componentSuite) TestReadComponentInfoFinishedWithDifferentSnapInfoError(c *C) {
+func (s *componentSuite) TestReadComponentInfoFinishedWithSnapInfoMissingComponentError(c *C) {
 	const componentYaml = `component: snap+component
 type: test
 version: 1.0
@@ -377,10 +377,7 @@ summary: short description
 description: long description
 `
 	const compName = "snap+component"
-	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, [][]string{
-		{"meta/hooks/install", "echo 'explicit hook'"},
-		{"meta/hooks/pre-refresh", "echo 'implicit hook'"},
-	})
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
 
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
@@ -396,5 +393,59 @@ components:
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadComponentInfoFromContainer(compf, snapInfo)
-	c.Assert(err, ErrorMatches, `cannot find component "component" in snap "snap"`)
+	c.Assert(err, ErrorMatches, `"component" is not a component for snap "snap"`)
+}
+
+func (s *componentSuite) TestReadComponentInfoFinishedWithDifferentSnapInfoError(c *C) {
+	const componentYaml = `component: snap+component
+type: test
+version: 1.0
+summary: short description
+description: long description
+`
+	const compName = "snap+component"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	const snapYaml = `
+name: other-snap
+components:
+  component:
+    type: test
+`
+
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadComponentInfoFromContainer(compf, snapInfo)
+	c.Assert(err, ErrorMatches, `component "snap\+component" is not a component for snap "other-snap"`)
+}
+
+func (s *componentSuite) TestReadComponentInfoInconsistentTypes(c *C) {
+	const componentYaml = `component: snap+component
+type: test
+version: 1.0
+summary: short description
+description: long description
+`
+	const compName = "snap+component"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	const snapYaml = `
+name: snap
+components:
+  component:
+    type: kernel-modules
+`
+
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadComponentInfoFromContainer(compf, snapInfo)
+	c.Assert(err, ErrorMatches, `inconsistent component type \("kernel-modules" in snap, "test" in component\)`)
 }

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -352,7 +352,7 @@ plugs:
 	c.Check(ci.Description, Equals, "long description")
 	c.Check(ci.FullName(), Equals, compName)
 
-	c.Check(ci.Hooks, HasLen, 2)
+	c.Check(ci.Hooks, HasLen, 3)
 
 	installHook := ci.Hooks["install"]
 	c.Assert(installHook, NotNil)

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -40,6 +40,7 @@ var _ = Suite(&componentSuite{})
 
 func (s *componentSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	dirs.SetRootDir(c.MkDir())
 }
 
@@ -61,7 +62,7 @@ description: long description
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err, IsNil)
 	c.Assert(ci, DeepEquals, snap.NewComponentInfo(
 		naming.NewComponentRef("mysnap", "test-info"),
@@ -84,7 +85,7 @@ version: 1.0.2
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err, IsNil)
 	c.Assert(ci, DeepEquals, snap.NewComponentInfo(
 		naming.NewComponentRef("mysnap", "test-info"),
@@ -105,7 +106,7 @@ description: long description
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err.Error(), Equals, `cannot parse component.yaml: incorrect component name "mysnap-test-info"`)
 	c.Assert(ci, IsNil)
 }
@@ -121,7 +122,7 @@ foo: bar
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err, ErrorMatches, `.*\n.*: field foo not found in type snap.ComponentInfo`)
 	c.Assert(ci, IsNil)
 }
@@ -146,7 +147,7 @@ version: 1.0
 		compf, err := snapfile.Open(testComp)
 		c.Assert(err, IsNil)
 
-		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 		c.Assert(err, ErrorMatches, tc.error)
 		c.Assert(ci, IsNil)
 	}
@@ -161,7 +162,7 @@ version: 1.0
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err.Error(), Equals, `component type cannot be empty`)
 	c.Assert(ci, IsNil)
 }
@@ -176,7 +177,7 @@ version: 1.0
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err.Error(), Equals, `cannot parse component.yaml: unknown component type "unknowntype"`)
 	c.Assert(ci, IsNil)
 }
@@ -204,7 +205,7 @@ version: %s
 		compf, err := snapfile.Open(testComp)
 		c.Assert(err, IsNil)
 
-		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 		if tc.error != "" {
 			c.Check(err, ErrorMatches, tc.error)
 			c.Check(ci, IsNil)
@@ -233,7 +234,7 @@ version: 1.0
 		compf, err := snapfile.Open(testComp)
 		c.Assert(err, IsNil)
 
-		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 		c.Check(err, ErrorMatches, tc.error)
 		c.Assert(ci, IsNil)
 	}
@@ -253,7 +254,7 @@ description: 👹👺👻👽👾🤖
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err, ErrorMatches, "summary can have up to 128 codepoints, got 130")
 	c.Assert(ci, IsNil)
 }
@@ -271,7 +272,7 @@ description: %s
 	compf, err := snapfile.Open(testComp)
 	c.Assert(err, IsNil)
 
-	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil)
 	c.Assert(err, ErrorMatches, "description can have up to 4096 codepoints, got 4098")
 	c.Assert(ci, IsNil)
 }
@@ -306,4 +307,64 @@ func (s *componentSuite) TestComponentSideInfoEqual(c *C) {
 	} {
 		c.Check(csi.Equal(tc.csi), Equals, tc.equal)
 	}
+}
+
+func (s *componentSuite) TestReadComponentInfoFinishedWithSnapInfo(c *C) {
+	const componentYaml = `component: snap+component
+type: test
+version: 1.0
+summary: short description
+description: long description
+`
+	const compName = "snap+component"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, [][]string{
+		{"meta/hooks/install", "echo 'explicit hook'"},
+		{"meta/hooks/pre-refresh", "echo 'implicit hook'"},
+	})
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	const snapYaml = `
+name: snap
+components:
+  component:
+    type: test
+    hooks:
+      install:
+        plugs: [network]
+plugs:
+  network-client:
+`
+
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf, snapInfo)
+	c.Assert(err, IsNil)
+
+	c.Check(ci.Component.ComponentName, Equals, "component")
+	c.Check(ci.Component.SnapName, Equals, "snap")
+	c.Check(ci.Type, Equals, snap.TestComponent)
+	c.Check(ci.Version, Equals, "1.0")
+	c.Check(ci.Summary, Equals, "short description")
+	c.Check(ci.Description, Equals, "long description")
+	c.Check(ci.FullName(), Equals, compName)
+
+	c.Check(ci.Hooks, HasLen, 2)
+
+	installHook := ci.Hooks["install"]
+	c.Assert(installHook, NotNil)
+	c.Check(installHook.Name, Equals, "install")
+	c.Check(installHook.Explicit, Equals, true)
+	c.Check(installHook.Plugs, HasLen, 2)
+	c.Check(installHook.Plugs["network-client"], NotNil)
+	c.Check(installHook.Plugs["network"], NotNil)
+
+	preRefreshHook := ci.Hooks["pre-refresh"]
+	c.Assert(preRefreshHook, NotNil)
+	c.Check(preRefreshHook.Name, Equals, "pre-refresh")
+	c.Check(preRefreshHook.Explicit, Equals, false)
+	c.Check(preRefreshHook.Plugs, HasLen, 1)
+	c.Check(preRefreshHook.Plugs["network-client"], NotNil)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -262,8 +262,8 @@ func HooksDir(name string, revision Revision) string {
 // ComponentHooksDir returns the directory containing the component's hooks for
 // the given component hook name. The provided snap name can be either a snap
 // name or snap instance name.
-func ComponentHooksDir(snapName, componentName string, revision Revision) string {
-	return filepath.Join(BaseDir(snapName), "components", revision.String(), componentName, "meta", "hooks")
+func ComponentHooksDir(componentName string, compRevision Revision, snapInstance string) string {
+	return filepath.Join(ComponentMountDir(componentName, compRevision, snapInstance), "meta", "hooks")
 }
 
 func snapDataDir(opts *dirs.SnapDirOptions) string {
@@ -1233,18 +1233,6 @@ type HookInfo struct {
 	CommandChain []string
 
 	Explicit bool
-}
-
-// Path returns the path to the this hook. This handles both the component and
-// regular hook cases.
-func (hook *HookInfo) Path() string {
-	var dir string
-	if hook.Component != nil {
-		dir = ComponentHooksDir(hook.Snap.InstanceName(), hook.Component.Name, hook.Snap.Revision)
-	} else {
-		dir = HooksDir(hook.Snap.InstanceName(), hook.Snap.Revision)
-	}
-	return filepath.Join(dir, hook.Name)
 }
 
 // SystemUsernameInfo provides information about a system username (ie, a

--- a/snap/info.go
+++ b/snap/info.go
@@ -1361,6 +1361,12 @@ func (app *AppInfo) EnvChain() []osutil.ExpandableEnv {
 // Security tags are used by various security subsystems as "profile names" and
 // sometimes also as a part of the file name.
 func (hook *HookInfo) SecurityTag() string {
+	if hook.Component != nil {
+		return HookSecurityTag(SnapComponentName(
+			hook.Snap.InstanceName(),
+			hook.Component.Name,
+		), hook.Name)
+	}
 	return HookSecurityTag(hook.Snap.InstanceName(), hook.Name)
 }
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -1635,9 +1635,8 @@ func SplitSnapComponentInstanceName(name string) (snapInstance, componentName st
 	return snapInstance, componentName
 }
 
-// SnapComponentName takes the snap name, the component name, and the
-// instance key and returns an instance name of the snap component. The instance
-// key will only be included if it is not empty.
+// SnapComponentName takes a snap instance name and a component name and returns
+// a snap component name.
 func SnapComponentName(snapInstance, componentName string) string {
 	return fmt.Sprintf("%s+%s", snapInstance, componentName)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -1607,6 +1607,21 @@ func SplitInstanceName(instanceName string) (snapName, instanceKey string) {
 	return snapName, instanceKey
 }
 
+// SplitSnapComponentInstanceName extracts the snap component name from
+// a snap component instance name. Example:
+//   - SplitSnapComponentInstanceName("snap+component_1") -> "snap_1", "component"
+func SplitSnapComponentInstanceName(name string) (snapInstance, componentName string) {
+	snapInstance, componentName, _ = strings.Cut(name, "+")
+	return snapInstance, componentName
+}
+
+// SnapComponentName takes the snap name, the component name, and the
+// instance key and returns an instance name of the snap component. The instance
+// key will only be included if it is not empty.
+func SnapComponentName(snapInstance, componentName string) string {
+	return fmt.Sprintf("%s+%s", snapInstance, componentName)
+}
+
 // InstanceName takes the snap name and the instance key and returns an instance
 // name of the snap.
 func InstanceName(snapName, instanceKey string) string {

--- a/snap/info.go
+++ b/snap/info.go
@@ -184,6 +184,13 @@ func MountDir(name string, revision Revision) string {
 	return filepath.Join(BaseDir(name), revision.String())
 }
 
+// ComponentMountDir returns the directory where a component gets mounted, which
+// will be of the form:
+// /snaps/<snap_instance>/components/mnt/<component_name>/<component_revision>
+func ComponentMountDir(componentName string, compRevision Revision, snapInstance string) string {
+	return filepath.Join(ComponentsBaseDir(snapInstance), "mnt", componentName, compRevision.String())
+}
+
 // MountFile returns the path where the snap file that is mounted is installed,
 // using the default blob directory (dirs.SnapBlobDir).
 func MountFile(name string, revision Revision) string {
@@ -250,6 +257,13 @@ func CommonDataDir(name string) string {
 // name. The name can be either a snap name or snap instance name.
 func HooksDir(name string, revision Revision) string {
 	return filepath.Join(MountDir(name, revision), "meta", "hooks")
+}
+
+// ComponentHooksDir returns the directory containing the component's hooks for
+// the given component hook name. The provided snap name can be either a snap
+// name or snap instance name.
+func ComponentHooksDir(snapName, componentName string, revision Revision) string {
+	return filepath.Join(BaseDir(snapName), "components", revision.String(), componentName, "meta", "hooks")
 }
 
 func snapDataDir(opts *dirs.SnapDirOptions) string {
@@ -1219,6 +1233,18 @@ type HookInfo struct {
 	CommandChain []string
 
 	Explicit bool
+}
+
+// Path returns the path to the this hook. This handles both the component and
+// regular hook cases.
+func (hook *HookInfo) Path() string {
+	var dir string
+	if hook.Component != nil {
+		dir = ComponentHooksDir(hook.Snap.InstanceName(), hook.Component.Name, hook.Snap.Revision)
+	} else {
+		dir = HooksDir(hook.Snap.InstanceName(), hook.Snap.Revision)
+	}
+	return filepath.Join(dir, hook.Name)
 }
 
 // SystemUsernameInfo provides information about a system username (ie, a

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -662,11 +662,11 @@ func (s *infoSuite) TestAppEnvSimple(c *C) {
 version: 1.0
 type: app
 environment:
- global-k: global-v
+  global-k: global-v
 apps:
- foo:
-  environment:
-   app-k: app-v
+  foo:
+    environment:
+      app-k: app-v
 `
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
@@ -682,13 +682,13 @@ func (s *infoSuite) TestAppEnvOverrideGlobal(c *C) {
 version: 1.0
 type: app
 environment:
- global-k: global-v
- global-and-local: global-v
+  global-k: global-v
+  global-and-local: global-v
 apps:
- foo:
-  environment:
-   app-k: app-v
-   global-and-local: local-v
+  foo:
+    environment:
+      app-k: app-v
+      global-and-local: local-v
 `
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
@@ -704,11 +704,11 @@ func (s *infoSuite) TestHookEnvSimple(c *C) {
 version: 1.0
 type: app
 environment:
- global-k: global-v
+  global-k: global-v
 hooks:
- foo:
-  environment:
-   app-k: app-v
+  foo:
+    environment:
+      app-k: app-v
 `
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
@@ -724,13 +724,13 @@ func (s *infoSuite) TestHookEnvOverrideGlobal(c *C) {
 version: 1.0
 type: app
 environment:
- global-k: global-v
- global-and-local: global-v
+  global-k: global-v
+  global-and-local: global-v
 hooks:
- foo:
-  environment:
-   app-k: app-v
-   global-and-local: local-v
+  foo:
+    environment:
+      app-k: app-v
+      global-and-local: local-v
 `
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -764,6 +764,7 @@ version: 1.0
 type: app
 components:
  comp:
+  type: test
   hooks:
    install:
 `

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1757,6 +1757,32 @@ func (s *infoSuite) TestInstanceNameInSnapInfo(c *C) {
 	c.Check(info.SnapName(), Equals, "snap-name")
 }
 
+func (s *infoSuite) TestComponentFromSnapComponentInstance(c *C) {
+	type testcase struct {
+		input        string
+		snapInstance string
+		component    string
+	}
+
+	tests := []testcase{
+		{"snap", "snap", ""},
+		{"snap_instance", "snap_instance", ""},
+		{"snap+component", "snap", "component"},
+		{"snap_instance+component", "snap_instance", "component"},
+	}
+
+	for _, t := range tests {
+		snapInstance, component := snap.SplitSnapComponentInstanceName(t.input)
+		c.Check(snapInstance, Equals, t.snapInstance)
+		c.Check(component, Equals, t.component)
+	}
+}
+
+func (s *infoSuite) TestSnapComponentInstanceName(c *C) {
+	c.Check(snap.SnapComponentName("snap", "component"), Equals, "snap+component")
+	c.Check(snap.SnapComponentName("snap_instance", "component"), Equals, "snap_instance+component")
+}
+
 func (s *infoSuite) TestIsActive(c *C) {
 	info1 := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(1)})
 	info2 := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(2)})

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2283,3 +2283,53 @@ slots:
 	unscopedHooks := info.HooksForSlot(unscoped)
 	c.Assert(unscopedHooks, testutil.DeepUnsortedMatches, []*snap.HookInfo{info.Hooks["install"], info.Hooks["pre-refresh"]})
 }
+
+func (s *infoSuite) TestHookSecurityTags(c *C) {
+	const snapYaml = `
+name: test-snap
+version: 1
+components:
+  test-component:
+    hooks:
+      install:
+hooks:
+  install:
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+
+	component := info.Components["test-component"]
+	c.Assert(component, NotNil)
+
+	componentHook := component.ExplicitHooks["install"]
+	c.Assert(componentHook, NotNil)
+	c.Check(componentHook.SecurityTag(), Equals, "snap.test-snap+test-component.hook.install")
+
+	hook := info.Hooks["install"]
+	c.Assert(hook, NotNil)
+	c.Check(hook.SecurityTag(), Equals, "snap.test-snap.hook.install")
+}
+
+func (s *infoSuite) TestHookSecurityTagsInstance(c *C) {
+	const snapYaml = `
+name: test-snap
+version: 1
+components:
+  test-component:
+    hooks:
+      install:
+hooks:
+  install:
+`
+	info := snaptest.MockSnapInstance(c, "test-snap_instance", snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+
+	component := info.Components["test-component"]
+	c.Assert(component, NotNil)
+
+	componentHook := component.ExplicitHooks["install"]
+	c.Assert(componentHook, NotNil)
+	c.Check(componentHook.SecurityTag(), Equals, "snap.test-snap_instance+test-component.hook.install")
+
+	hook := info.Hooks["install"]
+	c.Assert(hook, NotNil)
+	c.Check(hook.SecurityTag(), Equals, "snap.test-snap_instance.hook.install")
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -741,48 +741,6 @@ hooks:
 	})
 }
 
-func (s *infoSuite) TestHookPath(c *C) {
-	yaml := `name: foo
-version: 1.0
-type: app
-environment:
- global-k: global-v
-hooks:
- foo:
-  environment:
-   app-k: app-v
-`
-	info, err := snap.InfoFromSnapYaml([]byte(yaml))
-	c.Assert(err, IsNil)
-
-	c.Check(info.Hooks["foo"].Path(), Equals, filepath.Join(dirs.SnapMountDir, "foo", info.Revision.String(), "meta", "hooks", "foo"))
-}
-
-func (s *infoSuite) TestComponentHookPath(c *C) {
-	yaml := `name: foo
-version: 1.0
-type: app
-components:
- comp:
-  type: test
-  hooks:
-   install:
-`
-	info, err := snap.InfoFromSnapYaml([]byte(yaml))
-	c.Assert(err, IsNil)
-
-	componentYaml := `component: foo+comp
-type: test
-version: 1.0
-    `
-
-	componentInfo := snaptest.MockComponent(c, componentYaml, info)
-
-	c.Check(componentInfo.Hooks["install"].Path(), Equals, filepath.Join(
-		dirs.SnapMountDir, "foo", "components", info.Revision.String(), "comp", "meta", "hooks", "install"),
-	)
-}
-
 func (s *infoSuite) TestSplitSnapApp(c *C) {
 	for _, t := range []struct {
 		in  string
@@ -1860,7 +1818,7 @@ func (s *infoSuite) TestDirAndFileHelpers(c *C) {
 	c.Check(snap.MountFile("name", snap.R(1)), Equals, "/var/lib/snapd/snaps/name_1.snap")
 	c.Check(snap.HooksDir("name", snap.R(1)), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapMountDir))
 	c.Check(snap.BaseDataDir("name"), Equals, "/var/snap/name")
-	c.Check(snap.ComponentHooksDir("name", "comp", snap.R(1)), Equals, fmt.Sprintf("%s/name/components/1/comp/meta/hooks", dirs.SnapMountDir))
+	c.Check(snap.ComponentHooksDir("comp", snap.R(1), "name"), Equals, fmt.Sprintf("%s/name/components/mnt/comp/1/meta/hooks", dirs.SnapMountDir))
 	c.Check(snap.DataDir("name", snap.R(1)), Equals, "/var/snap/name/1")
 	c.Check(snap.CommonDataDir("name"), Equals, "/var/snap/name/common")
 	c.Check(snap.CommonDataSaveDir("name"), Equals, "/var/lib/snapd/save/snap/name")

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -251,7 +251,7 @@ func packSnap(sourceDir string, yaml []byte, opts *Options) (string, error) {
 
 func packComponent(sourceDir string, yaml []byte, opts *Options) (string, error) {
 	cont := snapdir.New(sourceDir)
-	ci, err := snap.ReadComponentInfoFromContainer(cont)
+	ci, err := snap.InfoFromComponentYaml(yaml)
 	if err != nil {
 		return "", err
 	}

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -85,6 +85,39 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return mockSnap(c, "", yamlText, sideInfo)
 }
 
+// MockComponent puts a component.yaml file on disk so to mock an installed
+// component, based on the provided arguments.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockComponent(c *check.C, yamlText string, info *snap.Info) *snap.ComponentInfo {
+	infoForName, err := snap.InfoFromComponentYaml([]byte(yamlText))
+	c.Assert(err, check.IsNil)
+
+	componentName := infoForName.Component.ComponentName
+
+	// Put the YAML on disk, in the right spot.
+	metaDir := filepath.Join(snap.BaseDir(info.InstanceName()), "components", info.Revision.String(), componentName, "meta")
+	err = os.MkdirAll(metaDir, 0755)
+	c.Assert(err, check.IsNil)
+
+	err = os.WriteFile(filepath.Join(metaDir, "component.yaml"), []byte(yamlText), 0644)
+	c.Assert(err, check.IsNil)
+
+	// Write the .snap to disk
+	err = os.MkdirAll(filepath.Dir(info.MountFile()), 0755)
+	c.Assert(err, check.IsNil)
+
+	// TODO: write something to disk for the component snap file, like in
+	// MockSnap
+
+	container := snapdir.New(filepath.Dir(metaDir))
+	component, err := snap.ReadComponentInfoFromContainer(container, info)
+	c.Assert(err, check.IsNil)
+
+	return component
+}
+
 // MockSnapInstance puts a snap.yaml file on disk so to mock an installed snap
 // instance, based on the provided arguments.
 //


### PR DESCRIPTION
This PR expands the component hook information to snap.ComponentInfo. The hook data structures are derived from both the component directory itself (getting implicit hooks) and a `snap.Info`, which allows us to access explicit hooks and plugs that might be applied to the hooks.

Based on https://github.com/snapcore/snapd/pull/13763, first relevant commit is da5afbce327b0f65f3672c50b854f6bc86e98794.