### PR TITLE
interfaces/builtin, snap: remove sanitized plugs from component hook plugs

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -118,6 +118,11 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 		for _, hook := range snapInfo.Hooks {
 			delete(hook.Plugs, plugName)
 		}
+		for _, component := range snapInfo.Components {
+			for _, hook := range component.ExplicitHooks {
+				delete(hook.Plugs, plugName)
+			}
+		}
 	}
 	for _, slotName := range badSlots {
 		delete(snapInfo.Slots, slotName)
@@ -135,6 +140,8 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 		for _, hook := range snapInfo.Hooks {
 			delete(hook.Slots, slotName)
 		}
+		// TODO: if component ever get slots, then we'll need to sanitize them
+		// here
 	}
 }
 

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -317,6 +317,11 @@ apps:
 hooks:
     install:
         plugs: [iface]
+components:
+    comp:
+        hooks:
+            install:
+                plugs: [iface]
 `
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
@@ -363,10 +368,12 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugInterface(c *C) {
 	snapInfo := snaptest.MockInfo(c, testInvalidPlugInterfaceYaml, nil)
 	c.Check(snapInfo.Apps["app"].Plugs, HasLen, 1)
 	c.Check(snapInfo.Hooks["install"].Plugs, HasLen, 1)
+	c.Check(snapInfo.Components["comp"].ExplicitHooks["install"].Plugs, HasLen, 1)
 	c.Assert(snapInfo.Plugs, HasLen, 1)
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.Apps["app"].Plugs, HasLen, 0)
 	c.Check(snapInfo.Hooks["install"].Plugs, HasLen, 0)
+	c.Check(snapInfo.Components["comp"].ExplicitHooks["install"].Plugs, HasLen, 0)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
 	c.Assert(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: iface \(unknown interface "iface"\)`)
 	c.Assert(snapInfo.Plugs, HasLen, 0)


### PR DESCRIPTION
Make sure to remove sanitized plugs from component hook plugs.