### PR TITLE
c/snap-confine, i/udev, i/ifacetest: update snap-confine and snap-device-helper to understand component hook security tags

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -4,3 +4,8 @@ ignore_files:
   - packaging/debian-sid/changelog
   - packaging/fedora/snapd.spec
   - cmd/snap-confine/snap-confine.apparmor.in
+  - cmd/snap-confine/snap-confine.c
+  - cmd/libsnap-confine-private/string-utils.c
+  - cmd/libsnap-confine-private/string-utils-test.c
+  - cmd/libsnap-confine-private/string-utils-test.c
+  - cmd/libsnap-confine-private/snap.c

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -580,9 +580,30 @@ static void test_sc_snap_component_validate(void)
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_snap_component_validate("snapname+compname", "othername_instance",
+				   &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+
+	// component name should never have an instance key in it, so this should
+	// fail
+	sc_snap_component_validate("snapname_instance+compname",
+				   "snapname_instance", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_snap_component_validate("snapname_instance+compname", "snapname",
+				   &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
 
 	// check that we can validate the snap name in the snap component
 	sc_snap_component_validate("snapname+compname", "snapname", &err);
+	g_assert_null(err);
+	sc_snap_component_validate("snapname+compname", "snapname_instance",
+				   &err);
 	g_assert_null(err);
 
 	const char *cases[] = {

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -580,11 +580,14 @@ static void test_sc_snap_component_validate(void)
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_error_free(err);
+
 	sc_snap_component_validate("snapname+compname", "othername_instance",
 				   &err);
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_error_free(err);
 
 	// component name should never have an instance key in it, so this should
 	// fail
@@ -593,11 +596,14 @@ static void test_sc_snap_component_validate(void)
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_error_free(err);
+
 	sc_snap_component_validate("snapname_instance+compname", "snapname",
 				   &err);
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	sc_error_free(err);
 
 	// check that we can validate the snap name in the snap component
 	sc_snap_component_validate("snapname+compname", "snapname", &err);
@@ -619,6 +625,7 @@ static void test_sc_snap_component_validate(void)
 		g_assert_nonnull(err);
 		g_assert_true(sc_error_match
 			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+		sc_error_free(err);
 	}
 }
 

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -612,7 +612,7 @@ static void test_sc_snap_component_validate_respects_error_protocol(void)
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
 	g_test_trap_assert_stderr
-	    ("snap name must use lower case letters, digits or dashes\n");
+	    ("snap name in component must use lower case letters, digits or dashes\n");
 }
 
 static void __attribute__((constructor)) init(void)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -23,84 +23,142 @@
 static void test_sc_security_tag_validate(void)
 {
 	// First, test the names we know are good
-	g_assert_true(sc_security_tag_validate("snap.name.app", "name"));
+	g_assert_true(sc_security_tag_validate("snap.name.app", "name", NULL));
 	g_assert_true(sc_security_tag_validate
 		      ("snap.network-manager.NetworkManager",
-		       "network-manager"));
-	g_assert_true(sc_security_tag_validate("snap.f00.bar-baz1", "f00"));
-	g_assert_true(sc_security_tag_validate("snap.foo.hook.bar", "foo"));
-	g_assert_true(sc_security_tag_validate("snap.foo.hook.bar-baz", "foo"));
+		       "network-manager", NULL));
 	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_instance.bar-baz", "foo_instance"));
+		      ("snap.f00.bar-baz1", "f00", NULL));
 	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_instance.hook.bar-baz", "foo_instance"));
+		      ("snap.foo.hook.bar", "foo", NULL));
 	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_bar.hook.bar-baz", "foo_bar"));
+		      ("snap.foo.hook.bar-baz", "foo", NULL));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.foo_instance.bar-baz", "foo_instance", NULL));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.foo_instance.hook.bar-baz", "foo_instance", NULL));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.foo_bar.hook.bar-baz", "foo_bar", NULL));
 
 	// Now, test the names we know are bad
 	g_assert_false(sc_security_tag_validate
-		       ("pkg-foo.bar.0binary-bar+baz", "bar"));
-	g_assert_false(sc_security_tag_validate("pkg-foo_bar_1.1", ""));
-	g_assert_false(sc_security_tag_validate("appname/..", ""));
-	g_assert_false(sc_security_tag_validate("snap", ""));
-	g_assert_false(sc_security_tag_validate("snap.", ""));
-	g_assert_false(sc_security_tag_validate("snap.name", "name"));
-	g_assert_false(sc_security_tag_validate("snap.name.", "name"));
-	g_assert_false(sc_security_tag_validate("snap.name.app.", "name"));
-	g_assert_false(sc_security_tag_validate("snap.name.hook.", "name"));
-	g_assert_false(sc_security_tag_validate("snap!name.app", "!name"));
-	g_assert_false(sc_security_tag_validate("snap.-name.app", "-name"));
-	g_assert_false(sc_security_tag_validate("snap.name!app", "name!"));
-	g_assert_false(sc_security_tag_validate("snap.name.-app", "name"));
+		       ("pkg-foo.bar.0binary-bar+baz", "bar", NULL));
+	g_assert_false(sc_security_tag_validate("pkg-foo_bar_1.1", NULL, NULL));
+	g_assert_false(sc_security_tag_validate("appname/..", NULL, NULL));
+	g_assert_false(sc_security_tag_validate("snap", NULL, NULL));
+	g_assert_false(sc_security_tag_validate("snap.", NULL, NULL));
+	g_assert_false(sc_security_tag_validate("snap.name", "name", NULL));
+	g_assert_false(sc_security_tag_validate("snap.name.", "name", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app!hook.foo", "name"));
+		       ("snap.name.app.", "name", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook!foo", "name"));
+		       ("snap.name.hook.", "name", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook.-foo", "name"));
+		       ("snap!name.app", "!name", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook.f00", "name"));
-	g_assert_false(sc_security_tag_validate("sna.pname.app", "pname"));
-	g_assert_false(sc_security_tag_validate("snap.n@me.app", "n@me"));
-	g_assert_false(sc_security_tag_validate("SNAP.name.app", "name"));
-	g_assert_false(sc_security_tag_validate("snap.Name.app", "Name"));
+		       ("snap.-name.app", "-name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name!app", "name!", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.-app", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.app!hook.foo", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.app.hook!foo", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.app.hook.-foo", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.app.hook.f00", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("sna.pname.app", "pname", NULL));
+	g_assert_false(sc_security_tag_validate("snap.n@me.app", "n@me", NULL));
+	g_assert_false(sc_security_tag_validate("SNAP.name.app", "name", NULL));
+	g_assert_false(sc_security_tag_validate("snap.Name.app", "Name", NULL));
 	// This used to be false but it's now allowed.
-	g_assert_true(sc_security_tag_validate("snap.0name.app", "0name"));
-	g_assert_false(sc_security_tag_validate("snap.-name.app", "-name"));
-	g_assert_false(sc_security_tag_validate("snap.name.@app", "name"));
-	g_assert_false(sc_security_tag_validate(".name.app", "name"));
-	g_assert_false(sc_security_tag_validate("snap..name.app", ".name"));
-	g_assert_false(sc_security_tag_validate("snap.name..app", "name."));
-	g_assert_false(sc_security_tag_validate("snap.name.app..", "name"));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.0name.app", "0name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.-name.app", "-name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.@app", "name", NULL));
+	g_assert_false(sc_security_tag_validate(".name.app", "name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap..name.app", ".name", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name..app", "name.", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.name.app..", "name", NULL));
 	// These contain invalid instance key
-	g_assert_false(sc_security_tag_validate("snap.foo_.bar-baz", "foo"));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_toolonginstance.bar-baz", "foo"));
+		       ("snap.foo_.bar-baz", "foo", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_inst@nace.bar-baz", "foo"));
+		       ("snap.foo_toolonginstance.bar-baz", "foo", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_in-stan-ce.bar-baz", "foo"));
+		       ("snap.foo_inst@nace.bar-baz", "foo", NULL));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_in stan.bar-baz", "foo"));
+		       ("snap.foo_in-stan-ce.bar-baz", "foo", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo_in stan.bar-baz", "foo", NULL));
 
 	// Test names that are both good, but snap name doesn't match security tag
-	g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "fo"));
-	g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "fooo"));
-	g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "snap"));
-	g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "bar"));
 	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_instance.bar", "foo_bar"));
+		       ("snap.foo.hook.bar", "fo", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo.hook.bar", "fooo", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo.hook.bar", "snap", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo.hook.bar", "bar", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo_instance.bar", "foo_bar", NULL));
 
 	// Regression test 12to8
-	g_assert_true(sc_security_tag_validate("snap.12to8.128to8", "12to8"));
 	g_assert_true(sc_security_tag_validate
-		      ("snap.123test.123test", "123test"));
+		      ("snap.12to8.128to8", "12to8", NULL));
 	g_assert_true(sc_security_tag_validate
-		      ("snap.123test.hook.configure", "123test"));
+		      ("snap.123test.123test", "123test", NULL));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.123test.hook.configure", "123test", NULL));
 
 	// regression test snap.eon-edg-shb-pulseaudio.hook.connect-plug-i2c
 	g_assert_true(sc_security_tag_validate
-		      ("snap.foo.hook.connect-plug-i2c", "foo"));
+		      ("snap.foo.hook.connect-plug-i2c", "foo", NULL));
+
+	// make sure that component hooks can be validated
+	g_assert_true(sc_security_tag_validate
+		      ("snap.foo+comp.hook.install", "foo", "comp"));
+	g_assert_true(sc_security_tag_validate
+		      ("snap.foo_instance+comp.hook.install", "foo_instance",
+		       "comp"));
+	// make sure that only hooks from components can be validated, not apps
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+comp.app", "foo", "comp"));
+
+	// unexpected component names should not work
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+comp.hook.install", "foo", NULL));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+comp.hook.install", "foo", NULL));
+
+	// missing component names when we expect one should not work
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo.hook.install", "foo", "comp"));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo.hook.install", "foo", "comp"));
+
+	// mismatch component names should not work
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+comp.hook.install", "foo", "component"));
+
+	// empty component name should not work
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+comp.hook.install", "foo", ""));
+
+	// invalid component names should not work
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+coMp.hook.install", "foo", "coMp"));
+	g_assert_false(sc_security_tag_validate
+		       ("snap.foo+-omp.hook.install", "foo", "-omp"));
 
 	// Security tag that's too long. The extra +2 is for the string
 	// terminator and to allow us to make the tag too long to validate.
@@ -109,11 +167,11 @@ static void test_sc_security_tag_validate(void)
 	memcpy(long_tag, "snap.foo.b", sizeof "snap.foo.b" - 1);
 	long_tag[sizeof long_tag - 1] = '\0';
 	g_assert_true(strlen(long_tag) == SNAP_SECURITY_TAG_MAX_LEN + 1);
-	g_assert_false(sc_security_tag_validate(long_tag, "foo"));
+	g_assert_false(sc_security_tag_validate(long_tag, "foo", NULL));
 
 	// If we make it one byte shorter it will be valid.
 	long_tag[sizeof long_tag - 2] = '\0';
-	g_assert_true(sc_security_tag_validate(long_tag, "foo"));
+	g_assert_true(sc_security_tag_validate(long_tag, "foo", NULL));
 
 }
 
@@ -486,30 +544,6 @@ static void test_sc_snap_drop_instance_key_basic(void)
 	g_assert_cmpstr(name, ==, "0123456789012345678901234567890123456789");
 }
 
-static void test_sc_snap_split_instance_name_trailing_nil(void)
-{
-	if (g_test_subprocess()) {
-		char dest[3] = { 0 };
-		// pretend there is no place for trailing \0
-		sc_snap_split_instance_name("_", NULL, 0, dest, 0);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-}
-
-static void test_sc_snap_split_instance_name_short_instance_dest(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_snap_split_instance_name("foo_barbarbarbar", NULL, 0,
-					    dest, sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-}
-
 static void test_sc_snap_split_instance_name_basic(void)
 {
 	char name[SNAP_NAME_LEN + 1] = { 0xff };
@@ -519,71 +553,66 @@ static void test_sc_snap_split_instance_name_basic(void)
 				    sizeof instance);
 	g_assert_cmpstr(name, ==, "foo");
 	g_assert_cmpstr(instance, ==, "bar");
+}
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("foo-bar_bar", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "foo-bar");
-	g_assert_cmpstr(instance, ==, "bar");
+static void test_sc_snap_split_snap_component_basic(void)
+{
+	char snap_name[SNAP_NAME_LEN + 1] = { 0xff };
+	char component_name[SNAP_NAME_LEN + 1] = { 0xff };
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("foo-bar", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "foo-bar");
-	g_assert_cmpstr(instance, ==, "");
+	sc_snap_split_snap_component("foo+bar", snap_name, sizeof snap_name,
+				     component_name, sizeof component_name);
+	g_assert_cmpstr(snap_name, ==, "foo");
+	g_assert_cmpstr(component_name, ==, "bar");
+}
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("_baz", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "");
-	g_assert_cmpstr(instance, ==, "baz");
+static void test_sc_snap_component_validate(void)
+{
+	sc_error *err = NULL;
+	sc_snap_component_validate("snapname+compname", NULL, &err);
+	g_assert_null(err);
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("foo", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "foo");
-	g_assert_cmpstr(instance, ==, "");
+	sc_snap_component_validate("snap-name+comp-name", NULL, &err);
+	g_assert_null(err);
 
-	memset(name, 0xff, sizeof name);
-	sc_snap_split_instance_name("foo_bar", name, sizeof name, NULL, 0);
-	g_assert_cmpstr(name, ==, "foo");
+	// check that we fail if the snap name isn't in the snap component
+	sc_snap_component_validate("snapname+compname", "othername", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
 
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("foo_bar", NULL, 0, instance,
-				    sizeof instance);
-	g_assert_cmpstr(instance, ==, "bar");
+	// check that we can validate the snap name in the snap component
+	sc_snap_component_validate("snapname+compname", "snapname", &err);
+	g_assert_null(err);
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("hello_world_surprise", name, sizeof name,
-				    instance, sizeof instance);
-	g_assert_cmpstr(name, ==, "hello");
-	g_assert_cmpstr(instance, ==, "world_surprise");
+	const char *cases[] = {
+		NULL, "snap-name+", "+comp-name", "snap-name",
+		"snap-name+comp_name",
+		"loooooooooooooooooooooooooooong-snap-name+comp-name",
+		"snap-name+loooooooooooooooooooooooooooong-comp-name",
+	};
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "");
-	g_assert_cmpstr(instance, ==, "");
+	for (size_t i = 0; i < sizeof cases / sizeof *cases; ++i) {
+		g_test_message("checking invalid snap name: %s", cases[i]);
+		sc_snap_component_validate(cases[i], NULL, &err);
+		g_assert_nonnull(err);
+		g_assert_true(sc_error_match
+			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+	}
+}
 
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("_", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "");
-	g_assert_cmpstr(instance, ==, "");
-
-	memset(name, 0xff, sizeof name);
-	memset(instance, 0xff, sizeof instance);
-	sc_snap_split_instance_name("foo_", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "foo");
-	g_assert_cmpstr(instance, ==, "");
+static void test_sc_snap_component_validate_respects_error_protocol(void)
+{
+	if (g_test_subprocess()) {
+		sc_snap_component_validate("hello world+comp name", NULL, NULL);
+		g_test_message("expected sc_snap_name_validate to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("snap name must use lower case letters, digits or dashes\n");
 }
 
 static void __attribute__((constructor)) init(void)
@@ -620,8 +649,11 @@ static void __attribute__((constructor)) init(void)
 
 	g_test_add_func("/snap/sc_snap_split_instance_name/basic",
 			test_sc_snap_split_instance_name_basic);
-	g_test_add_func("/snap/sc_snap_split_instance_name/trailing_nil",
-			test_sc_snap_split_instance_name_trailing_nil);
-	g_test_add_func("/snap/sc_snap_split_instance_name/short_instance_dest",
-			test_sc_snap_split_instance_name_short_instance_dest);
+	g_test_add_func("/snap/sc_snap_split_snap_component/basic",
+			test_sc_snap_split_snap_component_basic);
+	g_test_add_func("/snap/sc_snap_component_validate",
+			test_sc_snap_component_validate);
+	g_test_add_func
+	    ("/snap/sc_snap_component_validate/respects_error_protocol",
+	     test_sc_snap_component_validate_respects_error_protocol);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -134,7 +134,7 @@ static int skip_one_char(const char **p, char c)
 	return 0;
 }
 
-static void sc_snap_or_component_name_validate(const char *snap_name,
+static void validate_as_snap_or_component_name(const char *snap_name,
 					       bool is_component,
 					       sc_error **errorp)
 {
@@ -353,12 +353,12 @@ void sc_snap_component_validate(const char *snap_component,
 	char component_name[SNAP_NAME_LEN + 1] = { 0 };
 	strncpy(component_name, pos + 1, component_name_len);
 
-	sc_snap_or_component_name_validate(snap_name, true, &err);
+	validate_as_snap_or_component_name(snap_name, true, &err);
 	if (err != NULL) {
 		goto out;
 	}
 
-	sc_snap_or_component_name_validate(component_name, true, &err);
+	validate_as_snap_or_component_name(component_name, true, &err);
 	if (err != NULL) {
 		goto out;
 	}
@@ -383,7 +383,7 @@ void sc_snap_component_validate(const char *snap_component,
 
 void sc_snap_name_validate(const char *snap_name, sc_error **errorp)
 {
-	sc_snap_or_component_name_validate(snap_name, false, errorp);
+	validate_as_snap_or_component_name(snap_name, false, errorp);
 }
 
 void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -44,8 +44,10 @@ bool sc_security_tag_validate(const char *security_tag,
 
 	// first capture is for verifying the full security tag, second capture
 	// for verifying the snap_name is correct for this security tag, eighth capture
-	// for verifying the component_name is correct for this security tag
-	regmatch_t matches[8];
+	// for verifying the component_name is correct for this security tag. the
+	// expression currently contains 9 capture groups, but we only care about
+	// these 3.
+	regmatch_t matches[9];
 	int status =
 	    regexec(&re, security_tag, sizeof matches / sizeof *matches,
 		    matches, 0);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -45,9 +45,14 @@ bool sc_security_tag_validate(const char *security_tag,
 	// first capture is for verifying the full security tag, second capture
 	// for verifying the snap_name is correct for this security tag, eighth capture
 	// for verifying the component_name is correct for this security tag. the
-	// expression currently contains 9 capture groups, but we only care about
-	// these 3.
+	// expression currently contains 9 capture groups, but we only care about these 3,
+	// which unfortunately are not within the first 3 submatches, but rather group 1,
+	// 2, and 7, so for completeness capture all the groups.
 	regmatch_t matches[9];
+	if (sizeof matches / sizeof matches[0] != re.re_nsub) {
+		die("internal error: all regex capture groups not fully accounted for");
+	}
+
 	int status =
 	    regexec(&re, security_tag, sizeof matches / sizeof *matches,
 		    matches, 0);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -48,8 +48,9 @@ bool sc_security_tag_validate(const char *security_tag,
 	// expression currently contains 9 capture groups, but we only care about these 3,
 	// which unfortunately are not within the first 3 submatches, but rather group 1,
 	// 2, and 7, so for completeness capture all the groups.
-	regmatch_t matches[9];
-	if (sizeof matches / sizeof matches[0] != re.re_nsub) {
+	enum { num_matches = 9 };
+	regmatch_t matches[num_matches];
+	if (num_matches != re.re_nsub) {
 		die("internal error: all regex capture groups not fully accounted for");
 	}
 

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -172,7 +172,7 @@ static void validate_as_snap_or_component_name(const char *name,
 	}
 	bool got_letter = false;
 	int n = 0, m;
-	for (; *p != '\0';) {
+	while (*p != '\0') {
 		if ((m = skip_lowercase_letters(&p)) > 0) {
 			n += m;
 			got_letter = true;

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -66,11 +66,6 @@ bool sc_security_tag_validate(const char *security_tag,
 	// if we expect a component name (a non-null string was passed in here),
 	// then we need to make sure that the regex captured a component name
 	if (component_name != NULL) {
-		// don't allow empty component names, only allow NULL as an indication
-		// that we don't expect a component name.
-		if (strlen(component_name) == 0) {
-			return false;
-		}
 		// fail if the security tag doesn't contain a component name and we
 		// expected one
 		if (matches[7].rm_so < 0) {
@@ -78,6 +73,13 @@ bool sc_security_tag_validate(const char *security_tag,
 		}
 
 		size_t component_name_len = strlen(component_name);
+
+		// don't allow empty component names, only allow NULL as an indication
+		// that we don't expect a component name.
+		if (component_name_len == 0) {
+			return false;
+		}
+
 		size_t len = matches[7].rm_eo - matches[7].rm_so;
 		if (len != component_name_len
 		    || strncmp(security_tag + matches[7].rm_so, component_name,

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -37,7 +37,7 @@ enum {
 	SC_SNAP_INVALID_INSTANCE_NAME = 3,
 	/** System configuration is not supported. */
 	SC_SNAP_MOUNT_DIR_UNSUPPORTED = 4,
-	/** The component name of the snap is not valid. */
+	/** The name of the snap component is not valid. */
 	SC_SNAP_INVALID_COMPONENT = 5,
 };
 

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -816,6 +816,110 @@ static void test_sc_strdup(void)
 	free(s);
 }
 
+static void test_sc_string_split_trailing_nil(void)
+{
+	if (g_test_subprocess()) {
+		char dest[3] = { 0 };
+		// pretend there is no place for trailing \0
+		sc_string_split("_", '_', NULL, 0, dest, 0);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void test_sc_string_split_short_instance_dest(void)
+{
+	if (g_test_subprocess()) {
+		char dest[10] = { 0 };
+		sc_string_split("foo_barbarbarbar", '_', NULL, 0,
+				dest, sizeof dest);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void test_sc_string_split_basic(void)
+{
+	char prefix[41] = { 0xff };
+	char suffix[20] = { 0xff };
+
+	sc_string_split("foo_bar", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo");
+	g_assert_cmpstr(suffix, ==, "bar");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo-bar_bar", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo-bar");
+	g_assert_cmpstr(suffix, ==, "bar");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo-bar_bar", '-', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo");
+	g_assert_cmpstr(suffix, ==, "bar_bar");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo-bar", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo-bar");
+	g_assert_cmpstr(suffix, ==, "");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("_baz", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "");
+	g_assert_cmpstr(suffix, ==, "baz");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo");
+	g_assert_cmpstr(suffix, ==, "");
+
+	memset(prefix, 0xff, sizeof prefix);
+	sc_string_split("foo_bar", '_', prefix, sizeof prefix, NULL, 0);
+	g_assert_cmpstr(prefix, ==, "foo");
+
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo_bar", '_', NULL, 0, suffix, sizeof suffix);
+	g_assert_cmpstr(suffix, ==, "bar");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("hello_world_surprise", '_', prefix, sizeof prefix,
+			suffix, sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "hello");
+	g_assert_cmpstr(suffix, ==, "world_surprise");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "");
+	g_assert_cmpstr(suffix, ==, "");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("_", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "");
+	g_assert_cmpstr(suffix, ==, "");
+
+	memset(prefix, 0xff, sizeof prefix);
+	memset(suffix, 0xff, sizeof suffix);
+	sc_string_split("foo_", '_', prefix, sizeof prefix, suffix,
+			sizeof suffix);
+	g_assert_cmpstr(prefix, ==, "foo");
+	g_assert_cmpstr(suffix, ==, "");
+}
+
 static void __attribute__((constructor)) init(void)
 {
 	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
@@ -874,4 +978,10 @@ static void __attribute__((constructor)) init(void)
 	     test_sc_string_append_char_pair__uninitialized_buf);
 	g_test_add_func("/string-utils/sc_string_quote", test_sc_string_quote);
 	g_test_add_func("/string-utils/sc_strdup", test_sc_strdup);
+	g_test_add_func("/string-utils/sc_string_split/basic",
+			test_sc_string_split_basic);
+	g_test_add_func("/string-utils/sc_string_split/trailing_nil",
+			test_sc_string_split_trailing_nil);
+	g_test_add_func("/string-utils/sc_string_split/short_instance_dest",
+			test_sc_string_split_short_instance_dest);
 }

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -840,6 +840,32 @@ static void test_sc_string_split_short_instance_dest(void)
 	g_test_trap_assert_failed();
 }
 
+static void test_sc_string_split_null_string(void)
+{
+	if (g_test_subprocess()) {
+		char dest[10] = { 0 };
+		sc_string_split(NULL, '_', NULL, 0, dest, sizeof dest);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("internal error: cannot split string when it is unset\n");
+}
+
+static void test_sc_string_split_null_prefix_and_suffix(void)
+{
+	if (g_test_subprocess()) {
+		char dest[10] = { 0 };
+		sc_string_split("some_string", '_', NULL, 0, NULL, 0);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("internal error: cannot split string when both prefix and suffix are unset\n");
+}
+
 static void test_sc_string_split_basic(void)
 {
 	char prefix[41] = { 0xff };
@@ -984,4 +1010,8 @@ static void __attribute__((constructor)) init(void)
 			test_sc_string_split_trailing_nil);
 	g_test_add_func("/string-utils/sc_string_split/short_instance_dest",
 			test_sc_string_split_short_instance_dest);
+	g_test_add_func("/string-utils/sc_string_split/null_string",
+			test_sc_string_split_null_string);
+	g_test_add_func("/string-utils/sc_string_split/null_prefix_and_suffix",
+			test_sc_string_split_null_prefix_and_suffix);
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -269,13 +269,13 @@ void sc_string_quote(char *buf, size_t buf_size, const char *str)
 }
 
 void sc_string_split(const char *string, char delimiter,
-		     char *prefix, size_t prefix_size,
-		     char *suffix, size_t suffix_size)
+		     char *prefix_buf, size_t prefix_size,
+		     char *suffix_buf, size_t suffix_size)
 {
 	if (string == NULL) {
 		die("internal error: cannot split string when it is unset");
 	}
-	if (prefix == NULL && suffix == NULL) {
+	if (prefix_buf == NULL && suffix_buf == NULL) {
 		die("internal error: cannot split string when both prefix and suffix are unset");
 	}
 
@@ -291,20 +291,20 @@ void sc_string_split(const char *string, char delimiter,
 		suffix_len = strlen(suffix_start);
 	}
 
-	if (prefix != NULL) {
+	if (prefix_buf != NULL) {
 		if (prefix_len >= prefix_size) {
 			die("prefix buffer too small");
 		}
 
-		memcpy(prefix, string, prefix_len);
-		prefix[prefix_len] = '\0';
+		memcpy(prefix_buf, string, prefix_len);
+		prefix_buf[prefix_len] = '\0';
 	}
 
-	if (suffix != NULL) {
+	if (suffix_buf != NULL) {
 		if (suffix_len >= suffix_size) {
 			die("suffix buffer too small");
 		}
-		memcpy(suffix, suffix_start, suffix_len);
-		suffix[suffix_len] = '\0';
+		memcpy(suffix_buf, suffix_start, suffix_len);
+		suffix_buf[suffix_len] = '\0';
 	}
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -267,3 +267,44 @@ void sc_string_quote(char *buf, size_t buf_size, const char *str)
 	}
 	sc_string_append_char(buf, buf_size, '"');
 }
+
+void sc_string_split(const char *string, char delimiter,
+		     char *prefix, size_t prefix_size,
+		     char *suffix, size_t suffix_size)
+{
+	if (string == NULL) {
+		die("internal error: cannot split string when it is unset");
+	}
+	if (prefix == NULL && suffix == NULL) {
+		die("internal error: cannot split string when both prefix and suffix are unset");
+	}
+
+	const char *pos = strchr(string, delimiter);
+	const char *prefix_start = "";
+	size_t prefix_len = 0;
+	size_t suffix_len = 0;
+	if (pos == NULL) {
+		prefix_len = strlen(string);
+	} else {
+		prefix_len = pos - string;
+		prefix_start = pos + 1;
+		suffix_len = strlen(prefix_start);
+	}
+
+	if (prefix != NULL) {
+		if (prefix_len >= prefix_size) {
+			die("prefix buffer too small");
+		}
+
+		memcpy(prefix, string, prefix_len);
+		prefix[prefix_len] = '\0';
+	}
+
+	if (suffix != NULL) {
+		if (suffix_len >= suffix_size) {
+			die("suffix buffer too small");
+		}
+		memcpy(suffix, prefix_start, suffix_len);
+		suffix[suffix_len] = '\0';
+	}
+}

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -280,15 +280,15 @@ void sc_string_split(const char *string, char delimiter,
 	}
 
 	const char *pos = strchr(string, delimiter);
-	const char *prefix_start = "";
+	const char *suffix_start = "";
 	size_t prefix_len = 0;
 	size_t suffix_len = 0;
 	if (pos == NULL) {
 		prefix_len = strlen(string);
 	} else {
 		prefix_len = pos - string;
-		prefix_start = pos + 1;
-		suffix_len = strlen(prefix_start);
+		suffix_start = pos + 1;
+		suffix_len = strlen(suffix_start);
 	}
 
 	if (prefix != NULL) {
@@ -304,7 +304,7 @@ void sc_string_split(const char *string, char delimiter,
 		if (suffix_len >= suffix_size) {
 			die("suffix buffer too small");
 		}
-		memcpy(suffix, prefix_start, suffix_len);
+		memcpy(suffix, suffix_start, suffix_len);
 		suffix[suffix_len] = '\0';
 	}
 }

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -113,4 +113,15 @@ void sc_string_init(char *buf, size_t buf_size);
  **/
 void sc_string_quote(char *buf, size_t buf_size, const char *str);
 
+/**
+ * Split a string into two parts on the first occurrence of a delimiter.
+ *
+ * The size of prefix must be large enough to hold the prefix part of the
+ * string, and the size of suffix must be large enough to hold the suffix part
+ * of the string.
+ **/
+void sc_string_split(const char *string, char delimiter,
+		     char *prefix, size_t prefix_size,
+		     char *suffix, size_t suffix_size);
+
 #endif

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -121,7 +121,7 @@ void sc_string_quote(char *buf, size_t buf_size, const char *str);
  * of the string.
  **/
 void sc_string_split(const char *string, char delimiter,
-		     char *prefix, size_t prefix_size,
-		     char *suffix, size_t suffix_size);
+		     char *prefix_buf, size_t prefix_size,
+		     char *suffix_buf, size_t suffix_size);
 
 #endif

--- a/cmd/snap-confine/snap-confine-invocation-test.c
+++ b/cmd/snap-confine/snap-confine-invocation-test.c
@@ -45,7 +45,7 @@ static void test_sc_invocation_basic(snap_mount_dir_fixture *fix, gconstpointer 
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core", NULL);
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
-    sc_init_invocation(&inv, args, "foo");
+    sc_init_invocation(&inv, args, "foo", NULL);
 
     char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
     g_test_queue_free(rootfs_dir);
@@ -57,6 +57,7 @@ static void test_sc_invocation_basic(snap_mount_dir_fixture *fix, gconstpointer 
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo");
     g_assert_cmpstr(inv.snap_name, ==, "foo");
+    g_assert_cmpstr(inv.snap_component, ==, NULL);
     g_assert_false(inv.classic_confinement);
     /* derived later */
     g_assert_false(inv.is_normal_mode);
@@ -66,7 +67,7 @@ static void test_sc_invocation_instance_key(snap_mount_dir_fixture *fix, gconstp
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core", "snap.foo_bar.app");
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
-    sc_init_invocation(&inv, args, "foo_bar");
+    sc_init_invocation(&inv, args, "foo_bar", NULL);
 
     char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
     g_test_queue_free(rootfs_dir);
@@ -74,6 +75,7 @@ static void test_sc_invocation_instance_key(snap_mount_dir_fixture *fix, gconstp
     // Check the error that we've got
     g_assert_cmpstr(inv.snap_instance, ==, "foo_bar");
     g_assert_cmpstr(inv.snap_name, ==, "foo");
+    g_assert_cmpstr(inv.snap_component, ==, NULL);
     g_assert_cmpstr(inv.orig_base_snap_name, ==, "core");
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo_bar.app");
     g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
@@ -88,7 +90,7 @@ static void test_sc_invocation_base_name(snap_mount_dir_fixture *fix, gconstpoin
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("base-snap", NULL);
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
-    sc_init_invocation(&inv, args, "foo");
+    sc_init_invocation(&inv, args, "foo", NULL);
 
     char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/base-snap/current", NULL);
     g_test_queue_free(rootfs_dir);
@@ -100,6 +102,7 @@ static void test_sc_invocation_base_name(snap_mount_dir_fixture *fix, gconstpoin
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo");
     g_assert_cmpstr(inv.snap_name, ==, "foo");
+    g_assert_cmpstr(inv.snap_component, ==, NULL);
     g_assert_false(inv.classic_confinement);
     /* derived later */
     g_assert_false(inv.is_normal_mode);
@@ -110,13 +113,60 @@ static void test_sc_invocation_bad_instance_name(snap_mount_dir_fixture *fix, gc
 
     if (g_test_subprocess()) {
         sc_invocation inv SC_CLEANUP(sc_cleanup_invocation) = {0};
-        sc_init_invocation(&inv, args, "foo_bar_bar_bar");
+        sc_init_invocation(&inv, args, "foo_bar_bar_bar", NULL);
         return;
     }
 
     g_test_trap_subprocess(NULL, 0, 0);
     g_test_trap_assert_failed();
     g_test_trap_assert_stderr("snap instance name can contain only one underscore\n");
+}
+
+static void test_sc_invocation_component(snap_mount_dir_fixture *fix, gconstpointer user_data) {
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core22", "snap.foo+comp.hook.install");
+
+    sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
+
+    sc_init_invocation(&inv, args, "foo", "foo+comp");
+
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core22/current", NULL);
+    g_test_queue_free(rootfs_dir);
+
+    g_assert_cmpstr(inv.base_snap_name, ==, "core22");
+    g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
+    g_assert_cmpstr(inv.orig_base_snap_name, ==, "core22");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
+    g_assert_cmpstr(inv.security_tag, ==, "snap.foo+comp.hook.install");
+    g_assert_cmpstr(inv.snap_instance, ==, "foo");
+    g_assert_cmpstr(inv.snap_name, ==, "foo");
+    g_assert_cmpstr(inv.snap_component, ==, "foo+comp");
+    g_assert_false(inv.classic_confinement);
+    /* derived later */
+    g_assert_false(inv.is_normal_mode);
+}
+
+static void test_sc_invocation_component_instance_key(snap_mount_dir_fixture *fix, gconstpointer user_data) {
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) =
+        test_prepare_args("core22", "snap.foo_instance+comp.hook.install");
+
+    sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
+
+    sc_init_invocation(&inv, args, "foo_instance", "foo+comp");
+
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core22/current", NULL);
+    g_test_queue_free(rootfs_dir);
+
+    g_assert_cmpstr(inv.base_snap_name, ==, "core22");
+    g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
+    g_assert_cmpstr(inv.orig_base_snap_name, ==, "core22");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
+    g_assert_cmpstr(inv.security_tag, ==, "snap.foo_instance+comp.hook.install");
+    g_assert_cmpstr(inv.snap_instance, ==, "foo_instance");
+    g_assert_cmpstr(inv.snap_name, ==, "foo");
+    g_assert_cmpstr(inv.snap_component, ==, "foo+comp");
+    g_assert_false(inv.classic_confinement);
+    /* derived later */
+    g_assert_false(inv.is_normal_mode);
 }
 
 static void test_sc_invocation_classic(snap_mount_dir_fixture *fix, gconstpointer user_data) {
@@ -132,7 +182,7 @@ static void test_sc_invocation_classic(snap_mount_dir_fixture *fix, gconstpointe
     g_assert_nonnull(args);
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation) = {0};
-    sc_init_invocation(&inv, args, "foo-classic");
+    sc_init_invocation(&inv, args, "foo-classic", NULL);
 
     char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
     g_test_queue_free(rootfs_dir);
@@ -144,6 +194,7 @@ static void test_sc_invocation_classic(snap_mount_dir_fixture *fix, gconstpointe
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo-classic.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo-classic");
     g_assert_cmpstr(inv.snap_name, ==, "foo-classic");
+    g_assert_cmpstr(inv.snap_component, ==, NULL);
     g_assert_true(inv.classic_confinement);
 }
 
@@ -153,7 +204,7 @@ static void test_sc_invocation_tag_name_mismatch(snap_mount_dir_fixture *fix, gc
     if (g_test_subprocess()) {
         sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
         ;
-        sc_init_invocation(&inv, args, "foo-not-foo");
+        sc_init_invocation(&inv, args, "foo-not-foo", NULL);
         return;
     }
 
@@ -175,4 +226,8 @@ static void __attribute__((constructor)) init(void) {
                test_sc_invocation_instance_key, snap_mount_dir_fixture_teardown);
     g_test_add("/invocation/tag_name_mismatch", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
                test_sc_invocation_tag_name_mismatch, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/component", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_component, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/component_instance_key", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_component_instance_key, snap_mount_dir_fixture_teardown);
 }

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -26,7 +26,8 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const char *snap_instance) {
+void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const char *snap_instance,
+                        const char *snap_component) {
     /* Snap instance name is conveyed via untrusted environment. It may be
      * unset (typically when experimenting with snap-confine by hand). It
      * must also be a valid snap instance name. */
@@ -35,11 +36,22 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
     }
     sc_instance_name_validate(snap_instance, NULL);
 
+    // snap_component may be NULL if what we're confining isn't from a component
+    char *component_name = NULL;
+    char component_name_buffer[SNAP_NAME_LEN + 1] = {0};
+    if (snap_component != NULL) {
+        sc_snap_component_validate(snap_component, snap_instance, NULL);
+
+        sc_snap_split_snap_component(snap_component, NULL, 0, component_name_buffer, sizeof component_name_buffer);
+
+        component_name = component_name_buffer;
+    }
+
     /* The security tag is conveyed via untrusted command line. It must be
      * in agreement with snap instance name and must be a valid security
      * tag. */
     const char *security_tag = sc_args_security_tag(args);
-    if (!sc_security_tag_validate(security_tag, snap_instance)) {
+    if (!sc_security_tag_validate(security_tag, snap_instance, component_name)) {
         die("security tag %s not allowed", security_tag);
     }
 
@@ -73,6 +85,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
     inv->executable = sc_strdup(executable);
     inv->security_tag = sc_strdup(security_tag);
     inv->snap_instance = sc_strdup(snap_instance);
+    inv->snap_component = snap_component != NULL ? sc_strdup(snap_component) : NULL;
     inv->snap_name = sc_strdup(snap_name);
     inv->classic_confinement = sc_args_is_classic_confinement(args);
 

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -109,6 +109,7 @@ void sc_cleanup_invocation(sc_invocation *inv) {
         sc_cleanup_string(&inv->security_tag);
         sc_cleanup_string(&inv->executable);
         sc_cleanup_string(&inv->rootfs_dir);
+        sc_cleanup_string(&inv->snap_component);
         sc_cleanup_deep_strv(&inv->homedirs);
     }
 }

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -31,6 +31,7 @@ typedef struct sc_invocation {
     /* Things declared by the system. */
     char *snap_instance; /* snap instance name (<snap>_<key>) */
     char *snap_name;     /* snap name (without instance key) */
+    char *snap_component;
     char *orig_base_snap_name;
     char *security_tag;
     char *executable;
@@ -50,7 +51,8 @@ typedef struct sc_invocation {
  * environment value (SNAP_INSTANCE_NAME). All input is untrusted and is
  * validated internally.
  **/
-void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const char *snap_instance);
+void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const char *snap_instance,
+                        const char *component_name);
 
 /**
  * sc_cleanup_invocation is a cleanup function for sc_invocation.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -359,7 +359,12 @@ int main(int argc, char **argv)
 	if (snap_instance_name_env == NULL) {
 		die("SNAP_INSTANCE_NAME is not set");
 	}
-	sc_init_invocation(&invocation, args, snap_instance_name_env);
+	// SNAP_COMPONENT_NAME might not be set by the environment, so callers
+	// should be prepared to handle NULL.
+	const char *snap_component_name_env = getenv("SNAP_COMPONENT_NAME");
+
+	sc_init_invocation(&invocation, args, snap_instance_name_env,
+			   snap_component_name_env);
 
 	// Who are we?
 	uid_t real_uid, effective_uid, saved_uid;

--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -382,7 +382,7 @@ static void test_sdh_err_noaction(sdh_test_fixture *fixture, gconstpointer test_
 }
 
 static void test_sdh_err_funtag1(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap___bar", "8", "4", "block", "security tag \"snap._.bar\" for snap \"_\" is not valid\n");
+    run_sdh_die("add", "snap___bar", "8", "4", "block", "missing app name in tag \"snap___bar\"\n");
 }
 
 static void test_sdh_err_funtag2(sdh_test_fixture *fixture, gconstpointer test_data) {
@@ -416,6 +416,32 @@ static void test_sdh_err_funtag8(sdh_test_fixture *fixture, gconstpointer test_d
                 "security tag \"snap.#.barbar\" for snap \"#\" is not valid\n");
 }
 
+static void test_sdh_err_funtag9(sdh_test_fixture *fixture, gconstpointer test_data) {
+    run_sdh_die("add", "snap_foo___hook_install", "8", "4", "block",
+                "missing component name in tag \"snap_foo___hook_install\"\n");
+}
+
+static void test_sdh_err_funtag10(sdh_test_fixture *fixture, gconstpointer test_data) {
+    run_sdh_die("add", "snap___comp_hook_install", "8", "4", "block",
+                "missing snap name in tag \"snap___comp_hook_install\"\n");
+}
+
+static void test_sdh_err_funtag11(sdh_test_fixture *fixture, gconstpointer test_data) {
+    run_sdh_die(
+        "add", "snap_foo__ccccccccccccccccccccccccccccccccccccccccc_hook_install", "8", "4", "block",
+        "component name of tag \"snap_foo__ccccccccccccccccccccccccccccccccccccccccc_hook_install\" is too long\n");
+}
+
+static void test_sdh_err_funtag12(sdh_test_fixture *fixture, gconstpointer test_data) {
+    run_sdh_die("add", "snap_foo_hook_inst__all", "8", "4", "block",
+                "component separator in tag \"snap_foo_hook_inst__all\" is misplaced\n");
+}
+
+static void test_sdh_err_funtag13(sdh_test_fixture *fixture, gconstpointer test_data) {
+    run_sdh_die("add", "snap_foo__comp_hook__install", "8", "4", "block",
+                "malformed tag \"snap_foo__comp_hook__install\"\n");
+}
+
 static struct sdh_test_data add_data = {"add", "snap.foo.bar", "snap_foo_bar"};
 static struct sdh_test_data change_data = {"change", "snap.foo.bar", "snap_foo_bar"};
 
@@ -440,6 +466,12 @@ static struct sdh_test_data instance_add_hook_data = {"add", "snap.foo_bar.hook.
 
 static struct sdh_test_data instance_add_instance_name_is_hook_data = {"add", "snap.foo_hook.hook.configure",
                                                                        "snap_foo_hook_hook_configure"};
+
+static struct sdh_test_data component_instance_add_hook_data = {"add", "snap.foo_bar+comp.hook.install",
+                                                                "snap_foo_bar__comp_hook_install"};
+
+static struct sdh_test_data component_add_hook_data = {"add", "snap.foo+comp.hook.install",
+                                                       "snap_foo__comp_hook_install"};
 
 static void __attribute__((constructor)) init(void) {
 #define _test_add(_name, _data, _func) \
@@ -466,6 +498,11 @@ static void __attribute__((constructor)) init(void) {
     _test_add("/snap-device-helper/err/funtag6", NULL, test_sdh_err_funtag6);
     _test_add("/snap-device-helper/err/funtag7", NULL, test_sdh_err_funtag7);
     _test_add("/snap-device-helper/err/funtag8", NULL, test_sdh_err_funtag8);
+    _test_add("/snap-device-helper/err/funtag9", NULL, test_sdh_err_funtag9);
+    _test_add("/snap-device-helper/err/funtag10", NULL, test_sdh_err_funtag10);
+    _test_add("/snap-device-helper/err/funtag11", NULL, test_sdh_err_funtag11);
+    _test_add("/snap-device-helper/err/funtag12", NULL, test_sdh_err_funtag12);
+    _test_add("/snap-device-helper/err/funtag13", NULL, test_sdh_err_funtag13);
     // parallel instances
     _test_add("/snap-device-helper/parallel/add", &instance_add_data, test_sdh_action);
     _test_add("/snap-device-helper/parallel/change", &instance_change_data, test_sdh_action);
@@ -477,6 +514,9 @@ static void __attribute__((constructor)) init(void) {
     _test_add("/snap-device-helper/hook/parallel/add", &instance_add_hook_data, test_sdh_action);
     _test_add("/snap-device-helper/hook-name-hook/parallel/add", &instance_add_instance_name_is_hook_data,
               test_sdh_action);
+    // components
+    _test_add("/snap-device-helper/component/add", &component_add_hook_data, test_sdh_action);
+    _test_add("/snap-device-helper/component/parallel/add", &component_instance_add_hook_data, test_sdh_action);
 
     _test_add("/snap-device-helper/nvme", NULL, test_sdh_action_nvme);
 }

--- a/cmd/snap-device-helper/snap-device-helper.c
+++ b/cmd/snap-device-helper/snap-device-helper.c
@@ -160,8 +160,8 @@ static char *udev_to_security_tag(const char *udev_tag) {
         die("missing snap name in tag \"%s\"", udev_tag);
     }
 
-    char *snap_component = NULL;
-    char snap_component_buffer[SNAP_NAME_LEN + 1] = {0};
+    char *component_name = NULL;
+    char component_name_buffer[SNAP_NAME_LEN + 1] = {0};
 
     // at this point, snap_name_start points to the start of the snap's name, and
     // snap_name_end either points to the end of the snap name, or the end of a
@@ -192,11 +192,11 @@ static char *udev_to_security_tag(const char *udev_tag) {
         }
 
         size_t comp_name_len = (size_t)(comp_name_end - comp_name_start);
-        if (comp_name_len >= sizeof(snap_component_buffer)) {
+        if (comp_name_len >= sizeof(component_name_buffer)) {
             die("component name of tag \"%s\" is too long", udev_tag);
         }
-        memcpy(snap_component_buffer, comp_name_start, comp_name_len);
-        snap_component = snap_component_buffer;
+        memcpy(component_name_buffer, comp_name_start, comp_name_len);
+        component_name = component_name_buffer;
     }
 
     /* let's validate the tag, but we need to extract the snap name first */
@@ -208,11 +208,11 @@ static char *udev_to_security_tag(const char *udev_tag) {
     memcpy(snap_instance, snap_name_start, snap_instance_len);
 
     debug("snap instance \"%s\"", snap_instance);
-    if (snap_component != NULL) {
-        debug("snap component \"%s\"", snap_component);
+    if (component_name != NULL) {
+        debug("snap component \"%s\"", component_name);
     }
 
-    if (!sc_security_tag_validate(tag, snap_instance, snap_component)) {
+    if (!sc_security_tag_validate(tag, snap_instance, component_name)) {
         die("security tag \"%s\" for snap \"%s\" is not valid", tag, snap_instance);
     }
 

--- a/cmd/snap-device-helper/snap-device-helper.c
+++ b/cmd/snap-device-helper/snap-device-helper.c
@@ -43,6 +43,21 @@ static unsigned long must_strtoul(const char *str) {
     return val;
 }
 
+static void reverse_component_separator_encoding(char *tag, const char *original) {
+    char *separator = strstr(tag, "__");
+    if (separator == NULL) {
+        return;
+    }
+
+    // if there is another double underscore anywhere in the string, something is wrong
+    if (strstr(separator + 2, "__") != NULL) {
+        die("malformed tag \"%s\"", original);
+    }
+
+    *separator = '+';
+    memmove(separator + 1, separator + 2, strlen(separator + 2) + 1);
+}
+
 /* udev_to_security_tag converts a udev tag (snap_foo_bar) to security tag
  * (snap.foo.bar) */
 static char *udev_to_security_tag(const char *udev_tag) {
@@ -55,22 +70,32 @@ static char *udev_to_security_tag(const char *udev_tag) {
      * snap_foo_instance_bar
      * snap_foo_hook_hookname
      * snap_foo_instance_hook_hookname
+     * snap_foo__comp_hook_hookname
+     * snap_foo_instance__comp_hook_hookname
      * convert those to:
      * snap.foo.bar
      * snap.foo_instance.bar
      * snap.foo.hook.hookname
      * snap.foo_instance.hook.hookname
+     * snap.foo__comp.hook.hookname
+     * snap.foo_instance__comp.hook.hookname
      */
     size_t tag_len = strlen(tag);
     if (tag_len < strlen("snap_a_b") || tag_len > SNAP_SECURITY_TAG_MAX_LEN) {
         die("tag \"%s\" length %zu is incorrect", udev_tag, tag_len);
     }
+
     const size_t snap_prefix_len = strlen("snap_");
     /* we know that the tag at least has a snap_ prefix because it was checked
      * before */
     tag[snap_prefix_len - 1] = '.';
     char *snap_name_start = tag + snap_prefix_len;
     char *snap_name_end = NULL;
+
+    // plus signs, used to denote snap component names, are encoded in the udev
+    // tag as double underscores, so we swap out the double underscores for plus
+    // signs. if there is more than one occurrence of a double underscore, we fail
+    reverse_component_separator_encoding(tag, udev_tag);
 
     /* find the last separator */
     char *last_sep = strrchr(tag, '_');
@@ -83,6 +108,8 @@ static char *udev_to_security_tag(const char *udev_tag) {
      * snap.foo_instance.bar
      * snap.foo_instance_hook.hookname
      * snap.foo_hook.hookname
+     * snap.foo+comp_hook.hookname
+     * snap.foo_instance+comp_hook.hookname
      */
     char *more_sep = strchr(tag, '_');
     if (more_sep == NULL) {
@@ -93,6 +120,8 @@ static char *udev_to_security_tag(const char *udev_tag) {
          * snap.foo_instance.bar
          * snap.foo_instance_hook.hookname
          * snap.foo_hook.hookname
+         * snap.foo+comp_hook.hookname
+         * snap.foo_instance+comp_hook.hookname
          */
 
         /* do we have another separator? */
@@ -101,6 +130,7 @@ static char *udev_to_security_tag(const char *udev_tag) {
             /* no, so we are left with the following possibilities:
              * snap.foo_instance.bar
              * snap.foo_hook.hookname
+             * snap.foo+comp_hook.hookname
              *
              * there is ambiguity and we cannot correctly handle an instance named
              * 'hook' as snap.foo_hook.bar could be snap.foo.hook.bar or
@@ -114,10 +144,13 @@ static char *udev_to_security_tag(const char *udev_tag) {
                 snap_name_end = last_sep;
             }
         } else {
-            /* we have found 2 separators, so this is the only possibility:
+            /* we have found 2 separators, so these are the two possibilities:
              * snap.foo_instance_hook.hookname
+             * snap.foo_instance+comp_hook.hookname
+             *
              * which should be converted to:
              * snap.foo_instance.hook.hookname
+             * snap.foo_instance+comp.hook.hookname
              */
             *another_sep = '.';
             snap_name_end = another_sep;
@@ -127,6 +160,45 @@ static char *udev_to_security_tag(const char *udev_tag) {
         die("missing snap name in tag \"%s\"", udev_tag);
     }
 
+    char *snap_component = NULL;
+    char snap_component_buffer[SNAP_NAME_LEN + 1] = {0};
+
+    // at this point, snap_name_start points to the start of the snap's name, and
+    // snap_name_end either points to the end of the snap name, or the end of a
+    // component name, if present, adjust snap_name_end to point to the end of the
+    // snap name and copy the component name to a separate buffer.
+    char *comp_sep = strchr(snap_name_start, '+');
+    if (comp_sep != NULL) {
+        if (comp_sep >= snap_name_end) {
+            die("component separator in tag \"%s\" is misplaced", udev_tag);
+        }
+
+        char *comp_name_start = comp_sep + 1;
+        char *comp_name_end = snap_name_end;
+
+        // we have a component name attached to the snap instance name, so we
+        // must update snap_name_end
+        snap_name_end = comp_sep;
+
+        // check this again, since snap_name_end was updated. this would catch the case:
+        // snap.+comp.hook.hookname
+        if (snap_name_end <= snap_name_start) {
+            die("missing snap name in tag \"%s\"", udev_tag);
+        }
+
+        // this catches the case: snap.foo_instance+.hook.hookname
+        if (comp_name_end <= comp_name_start) {
+            die("missing component name in tag \"%s\"", udev_tag);
+        }
+
+        size_t comp_name_len = (size_t)(comp_name_end - comp_name_start);
+        if (comp_name_len >= sizeof(snap_component_buffer)) {
+            die("component name of tag \"%s\" is too long", udev_tag);
+        }
+        memcpy(snap_component_buffer, comp_name_start, comp_name_len);
+        snap_component = snap_component_buffer;
+    }
+
     /* let's validate the tag, but we need to extract the snap name first */
     char snap_instance[SNAP_INSTANCE_LEN + 1] = {0};
     size_t snap_instance_len = (size_t)(snap_name_end - snap_name_start);
@@ -134,9 +206,13 @@ static char *udev_to_security_tag(const char *udev_tag) {
         die("snap instance of tag \"%s\" is too long", udev_tag);
     }
     memcpy(snap_instance, snap_name_start, snap_instance_len);
-    debug("snap instance \"%s\"", snap_instance);
 
-    if (!sc_security_tag_validate(tag, snap_instance)) {
+    debug("snap instance \"%s\"", snap_instance);
+    if (snap_component != NULL) {
+        debug("snap component \"%s\"", snap_component);
+    }
+
+    if (!sc_security_tag_validate(tag, snap_instance, snap_component)) {
         die("security tag \"%s\" for snap \"%s\" is not valid", tag, snap_instance);
     }
 

--- a/interfaces/ifacetest/app_set.go
+++ b/interfaces/ifacetest/app_set.go
@@ -56,6 +56,30 @@ func MockConnectedSlot(c *check.C, yaml string, si *snap.SideInfo, slotName stri
 	return MockConnectedSlotWithAttrs(c, yaml, si, slotName, nil, nil)
 }
 
+func MockConnectedSlotWithComponents(c *check.C, yaml string, si *snap.SideInfo, compYamls []string, slotName string) (*interfaces.ConnectedSlot, *snap.SlotInfo) {
+	set := MockInfoAndAppSet(c, yaml, compYamls, si)
+	info := set.Info()
+
+	slotInfo, ok := info.Slots[slotName]
+	if !ok {
+		c.Fatalf("cannot find slot %q in snap %q", slotName, info.InstanceName())
+	}
+
+	return interfaces.NewConnectedSlot(slotInfo, set, nil, nil), slotInfo
+}
+
+func MockConnectedPlugWithComponents(c *check.C, yaml string, si *snap.SideInfo, compYamls []string, plugName string) (*interfaces.ConnectedPlug, *snap.PlugInfo) {
+	set := MockInfoAndAppSet(c, yaml, compYamls, si)
+	info := set.Info()
+
+	plugInfo, ok := info.Plugs[plugName]
+	if !ok {
+		c.Fatalf("cannot find plug %q in snap %q", plugName, info.InstanceName())
+	}
+
+	return interfaces.NewConnectedPlug(plugInfo, set, nil, nil), plugInfo
+}
+
 func MockConnectedSlotWithAttrs(c *check.C, yaml string, si *snap.SideInfo, slotName string, staticAttrs, dynamicAttrs map[string]interface{}) (*interfaces.ConnectedSlot, *snap.SlotInfo) {
 	info := snaptest.MockInfo(c, yaml, si)
 

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -96,8 +96,16 @@ func (spec *Specification) AddSnippet(snippet string) {
 	spec.addEntry(snippet, "")
 }
 
+// udevTag converts a security tag into a string that can be used as a udev tag.
+// systemd only allows alphanumeric characters, underscores and hyphens in tags.
+// Our security tags can contain periods and plus signs, so we replace them with
+// underscores. Periods are replaced with single underscores, and plus signs are
+// replaced with two underscores.
+// Examples:
+//   - "snap.foo+bar.hook.install" -> "snap_foo__bar_hook_install"
+//   - "snap.foo.bar" -> "snap_foo_bar"
 func udevTag(securityTag string) string {
-	return strings.Replace(securityTag, ".", "_", -1)
+	return strings.ReplaceAll(strings.ReplaceAll(securityTag, "+", "__"), ".", "_")
 }
 
 // TagDevice adds an app/hook specific udev tag to devices described by the


### PR DESCRIPTION
This PR teaches `snap-confine` and `snap-device-helper` how to parse security tags that represent component hooks.

An example of a security tag from a component hook would be: `snap.name+comp.hook.install`
And one with an instance key: `snap.name_instance+comp.hook.install`
    
Something important to note is how these are encoded as udev tags. Currently, when converting a security tag to a udev tag, we replace all `.` characters in the tag with `_` characters because systemd limits udev tags to having only alphanumeric characters, with the addition of the characters `-` and `_`. Since security tags can now contain `+`
characters, those will be encoded as two consecutive `_` characters.
    
For example:
```
"snap.name+comp.hook.install" -> "snap_name__comp_hook_install"
"snap.name_instance+comp.hook.install" -> "snap_name_instance__comp_hook_install"
```

This allows the conversion to maintain its reversibility.