### PR TITLE
tests/main/preseed-lxd: restore apparmor profiles on the host

### DIFF
--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -60,7 +60,7 @@ restore: |
     apt autoremove --purge -y
   fi
 
-    umount "$IMAGE_MOUNTPOINT"
+  umount "$IMAGE_MOUNTPOINT"
   rmdir "$IMAGE_MOUNTPOINT"
 
   # qemu-nbd -d may sporadically fail when removing the device,
@@ -68,6 +68,11 @@ restore: |
   retry -n 30 --wait 1 qemu-nbd -d /dev/nbd0
 
   "$TESTSTOOLS"/lxd-state undo-mount-changes
+
+  # the test started a privileged LXD container which most likely replaced the
+  # AppArmor profile for /usr/lib/snapd/snap-confine with its own version,
+  # restart apparmor.service so we get back the right profiles
+  systemctl restart apparmor.service
 
 execute: |
   echo "Create a trivial container using the lxd snap"


### PR DESCRIPTION
The test stars a privileged LXD container which most likely replaced the AppArmor profiles on the host. Attempt to reload the host profiles in restore.
