### PR TITLE
o/state, o/snapstate: use warnings as fallback for RAA desktop notifications

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017-2023 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,12 +20,15 @@
 package snapstate
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -739,8 +742,19 @@ var asyncPendingRefreshNotification = func(ctx context.Context, refreshInfo *use
 // maybeAsyncPendingRefreshNotification broadcasts desktop notification in a goroutine.
 //
 // The notification is sent only if no snap has the marker "snap-refresh-observe"
-// interface connected.
+// interface connected and the "refresh-app-awareness-ux" experimental flag is disabled.
 func maybeAsyncPendingRefreshNotification(ctx context.Context, st *state.State, refreshInfo *userclient.PendingSnapRefreshInfo) {
+	tr := config.NewTransaction(st)
+	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
+	if err != nil && !config.IsNoOption(err) {
+		logger.Noticef("Cannot send notification about pending refresh: %v", err)
+		return
+	}
+	if experimentalRefreshAppAwarenessUX {
+		// use notices + warnings fallback flow instead
+		return
+	}
+
 	markerExists, err := HasActiveConnection(st, "snap-refresh-observe")
 	if err != nil {
 		logger.Noticef("Cannot send notification about pending refresh: %v", err)
@@ -880,6 +894,86 @@ func maybeAddRefreshInhibitNotice(st *state.State) error {
 		st.Set("last-recorded-inhibited-snaps", curInhibitedSnaps)
 	}
 
+	if err := maybeAddRefreshInhibitWarningFallback(st, curInhibitedSnaps); err != nil {
+		logger.Noticef("Cannot add refresh inhibition warning: %v", err)
+	}
+
+	return nil
+}
+
+// maybeAddRefreshInhibitWarningFallback records a warning if the set of
+// inhibited snaps was changed since the last notice.
+//
+// The warning is recorded only if:
+// 	1. There is at least 1 inhibited snap.
+// 	2. The "refresh-app-awareness-ux" experimental flag is enabled.
+// 	3. No snap exists with the marker "snap-refresh-observe" interface connected.
+//
+// Note: If no snaps are inhibited then existing inhibition warning
+// will be removed.
+func maybeAddRefreshInhibitWarningFallback(st *state.State, inhibitedSnaps map[string]bool) error {
+	if len(inhibitedSnaps) == 0 {
+		// no more inhibited snaps, remove inhibition warning if it exists.
+		return removeRefreshInhibitWarning(st)
+	}
+
+	tr := config.NewTransaction(st)
+	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if !experimentalRefreshAppAwarenessUX {
+		// snapd will send notifications directly, check maybeAsyncPendingRefreshNotification
+		return nil
+	}
+
+	markerExists, err := HasActiveConnection(st, "snap-refresh-observe")
+	if err != nil {
+		return err
+	}
+	if markerExists {
+		// do nothing
+		return nil
+	}
+
+	// let's fallback to issuing warnings if no snap exists with the
+	// marker snap-refresh-observe interface connected.
+
+	// remove inhibition warning if it exists.
+	if err := removeRefreshInhibitWarning(st); err != nil {
+		return err
+	}
+
+	// building warning message
+	var snapsBuf bytes.Buffer
+	i := 0
+	for snap := range inhibitedSnaps {
+		if i > 0 {
+			snapsBuf.WriteString(", ")
+		}
+		snapsBuf.WriteString(snap)
+		i++
+	}
+	message := fmt.Sprintf("cannot refresh (%s) due running apps; close running apps to continue refresh.", snapsBuf.String())
+
+	// wait some time before showing the same warning to the user again after okaying.
+	st.AddWarning(message, &state.AddWarningOptions{RepeatAfter: 24 * time.Hour})
+
+	return nil
+}
+
+// removeRefreshInhibitWarning removes inhibition warning if it exists.
+func removeRefreshInhibitWarning(st *state.State) error {
+	// XXX: is it worth it to check for unexpected multiple matches?
+	for _, warning := range st.AllWarnings() {
+		if !strings.HasSuffix(warning.String(), "close running apps to continue refresh.") {
+			continue
+		}
+		if err := st.RemoveWarning(warning.String()); err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+		return nil
+	}
 	return nil
 }
 

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017-2022 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -1262,19 +1263,37 @@ func (s *autoRefreshTestSuite) TestSnapStoreOffline(c *C) {
 	s.state.Unlock()
 }
 
-func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNotice(c *C) {
+func (s *autoRefreshTestSuite) testMaybeAddRefreshInhibitNotice(c *C, markerInterfaceConnected bool, warningFallback bool) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
 
+	var connCheckCalled int
+	restore := snapstate.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
+		connCheckCalled++
+		c.Check(iface, Equals, "snap-refresh-observe")
+		return markerInterfaceConnected, nil
+	})
+	defer restore()
+
+	// let's add some random warnings
+	st.Warnf("this is a random warning 1")
+	st.Warnf("this is a random warning 2")
+
 	err := snapstate.MaybeAddRefreshInhibitNotice(st)
 	c.Assert(err, IsNil)
-	// empty set of inhibited snaps unchanged -> [], no notice recorded
+	// empty set of inhibited snaps unchanged -> []
+	// no notice recorded
 	c.Assert(st.Notices(nil), HasLen, 0)
+	// no "refresh inhibition" warnings recorded
+	checkNoRefreshInhibitWarning(c, st)
 	// Verify list is empty
 	checkLastRecordedInhibitedSnaps(c, st, nil)
 
 	now := time.Now()
+	warningTime := now
+	// mock time to determine if recorded warning is recent
+	defer state.MockTime(warningTime)()
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
@@ -1286,14 +1305,33 @@ func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNotice(c *C) {
 	})
 	err = snapstate.MaybeAddRefreshInhibitNotice(st)
 	c.Assert(err, IsNil)
-	// set of inhibited snaps changed -> ["some-snap"], notice recorded
-	checkRefreshInhibitNotice(c, st, 1)
+	// set of inhibited snaps changed -> ["some-snap"]
+	// notice recorded
+	expectedOccurrances := 1
+	checkRefreshInhibitNotice(c, st, expectedOccurrances)
+	// check warnings fallback
+	if warningFallback {
+		checkRefreshInhibitWarning(c, st, []string{"some-snap"}, warningTime)
+	} else {
+		checkNoRefreshInhibitWarning(c, st)
+	}
+	// check that the set of last recorded inhibited snaps is persisted
 	checkLastRecordedInhibitedSnaps(c, st, []string{"some-snap"})
 
+	// mock time to determine if recorded warning is recent
+	warningTime = warningTime.Add(1 * time.Hour)
+	defer state.MockTime(warningTime)()
 	err = snapstate.MaybeAddRefreshInhibitNotice(st)
 	c.Assert(err, IsNil)
-	// set of inhibited snaps unchanged -> ["some-snap"], no notice recorded
-	checkRefreshInhibitNotice(c, st, 1)
+	// set of inhibited snaps unchanged -> ["some-snap"]
+	// no new notice recorded
+	checkRefreshInhibitNotice(c, st, expectedOccurrances)
+	// check warnings fallback
+	if warningFallback {
+		checkRefreshInhibitWarning(c, st, []string{"some-snap"}, warningTime)
+	} else {
+		checkNoRefreshInhibitWarning(c, st)
+	}
 	checkLastRecordedInhibitedSnaps(c, st, []string{"some-snap"})
 
 	// mark "some-snap" as not inhibited
@@ -1316,14 +1354,219 @@ func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNotice(c *C) {
 		SnapType:             string(snap.TypeApp),
 		RefreshInhibitedTime: &now,
 	})
+	// mock time to determine if recorded warning is recent
+	warningTime = warningTime.Add(1 * time.Hour)
+	defer state.MockTime(warningTime)()
 	err = snapstate.MaybeAddRefreshInhibitNotice(st)
 	c.Assert(err, IsNil)
-	// set of inhibited snaps changed -> ["some-other-snap"], notice recorded
-	checkRefreshInhibitNotice(c, st, 2)
+	// set of inhibited snaps changed -> ["some-other-snap"]
+	// notice recorded
+	expectedOccurrances++
+	checkRefreshInhibitNotice(c, st, expectedOccurrances)
+	// check warnings fallback
+	if warningFallback {
+		checkRefreshInhibitWarning(c, st, []string{"some-other-snap"}, warningTime)
+	} else {
+		checkNoRefreshInhibitWarning(c, st)
+	}
 	checkLastRecordedInhibitedSnaps(c, st, []string{"some-other-snap"})
+
+	// mark "some-other-snap" as not inhibited
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:              snap.R(1),
+		SnapType:             string(snap.TypeApp),
+		RefreshInhibitedTime: nil,
+	})
+	// mock time to determine if recorded warning is recent
+	warningTime = warningTime.Add(1 * time.Hour)
+	defer state.MockTime(warningTime)()
+	err = snapstate.MaybeAddRefreshInhibitNotice(st)
+	c.Assert(err, IsNil)
+	// set of inhibited snaps changed -> []
+	// notice recorded
+	expectedOccurrances++
+	checkRefreshInhibitNotice(c, st, expectedOccurrances)
+	// no warning should be recorded and existing warning should be
+	// removed if inhibited snaps set is empty
+	checkNoRefreshInhibitWarning(c, st)
+	checkLastRecordedInhibitedSnaps(c, st, []string{})
+
+	// exercise multiple snaps inhibited
+	// mark "some-snap" as inhibited
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:              snap.R(1),
+		SnapType:             string(snap.TypeApp),
+		RefreshInhibitedTime: &now,
+	})
+	// mark "some-other-snap" as inhibited
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:              snap.R(1),
+		SnapType:             string(snap.TypeApp),
+		RefreshInhibitedTime: &now,
+	})
+	// mock time to determine if recorded warning is recent
+	warningTime = warningTime.Add(1 * time.Hour)
+	defer state.MockTime(warningTime)()
+	err = snapstate.MaybeAddRefreshInhibitNotice(st)
+	c.Assert(err, IsNil)
+	// set of inhibited snaps changed -> ["some-snap", "some-other-snap"]
+	// notice recorded
+	expectedOccurrances++
+	checkRefreshInhibitNotice(c, st, expectedOccurrances)
+	// check warnings fallback
+	if warningFallback {
+		checkRefreshInhibitWarning(c, st, []string{"some-snap", "some-other-snap"}, warningTime)
+	} else {
+		checkNoRefreshInhibitWarning(c, st)
+	}
+	// check that the set of last recorded inhibited snaps is persisted
+	checkLastRecordedInhibitedSnaps(c, st, []string{"some-snap", "some-other-snap"})
+}
+
+func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNotice(c *C) {
+	s.enableRefreshAppAwarenessUX()
+	const markerInterfaceConnected = true
+	const warningFallback = false
+	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
+}
+
+func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallbackError(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	// mark "some-snap" as inhibited
+	now := time.Now()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:              snap.R(1),
+		SnapType:             string(snap.TypeApp),
+		RefreshInhibitedTime: &now,
+	})
+
+	// Highly unlikely but just in case
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", "trigger-error")
+	tr.Commit()
+
+	err := snapstate.MaybeAddRefreshInhibitNotice(st)
+	// warning fallback error is not propagated, only logged
+	c.Assert(err, IsNil)
+	// check error is logged
+	c.Check(logbuf.String(), testutil.Contains, `Cannot add refresh inhibition warning: refresh-app-awareness-ux can only be set to 'true' or 'false', got "trigger-error"`)
+	// notice recorded
+	checkRefreshInhibitNotice(c, st, 1)
+	// no warnings recorded due to error
+	checkNoRefreshInhibitWarning(c, st)
+
+	restore = snapstate.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
+		return false, fmt.Errorf("boom")
+	})
+	defer restore()
+
+	st.Unlock()
+	s.enableRefreshAppAwarenessUX()
+	st.Lock()
+	err = snapstate.MaybeAddRefreshInhibitNotice(st)
+	// warning fallback error is not propagated, only logged
+	c.Assert(err, IsNil)
+	// check error is logged
+	c.Check(logbuf.String(), testutil.Contains, "Cannot add refresh inhibition warning: boom")
+	// set of inhibited snaps unchanged -> ["some-snap"]
+	// no new notice recorded
+	checkRefreshInhibitNotice(c, st, 1)
+	// no warnings recorded due to error
+	checkNoRefreshInhibitWarning(c, st)
+}
+
+func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallback(c *C) {
+	s.enableRefreshAppAwarenessUX()
+	const markerInterfaceConnected = false
+	const warningFallback = true
+	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
+}
+
+func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallbackNoRAAUX(c *C) {
+	const markerInterfaceConnected = false
+	const warningFallback = false // because refresh-app-awareness-ux is disabled
+	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
+}
+
+func (s *autoRefreshTestSuite) enableRefreshAppAwarenessUX() {
+	s.state.Lock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+	s.state.Unlock()
+}
+
+func checkNoRefreshInhibitWarning(c *C, st *state.State) {
+	for _, warning := range st.AllWarnings() {
+		if strings.HasSuffix(warning.String(), "close running apps to continue refresh.") {
+			c.Error("inhibition warning found")
+			return
+		}
+	}
+}
+
+func checkRefreshInhibitWarning(c *C, st *state.State, snaps []string, warningTime time.Time) {
+	var inhibitionWarning *state.Warning
+	for _, warning := range st.AllWarnings() {
+		if !strings.HasSuffix(warning.String(), "close running apps to continue refresh.") {
+			continue
+		}
+		if inhibitionWarning != nil {
+			c.Errorf("found multiple inhibition warnings")
+			return
+		}
+		inhibitionWarning = warning
+	}
+
+	// There is always one warning
+	c.Assert(inhibitionWarning, NotNil)
+	w := warningToMap(c, inhibitionWarning)
+	c.Check(w["message"], Matches, "cannot refresh (.*) due running apps; close running apps to continue refresh.")
+	for _, snap := range snaps {
+		c.Check(w["message"], testutil.Contains, snap)
+	}
+	c.Check(w["repeat-after"], Equals, "24h0m0s")
+	if !warningTime.IsZero() {
+		c.Check(w["last-added"], Equals, warningTime.UTC().Format(time.RFC3339Nano))
+	}
+}
+
+// warningToMap converts a Warning to a map using a JSON marshal-unmarshal round trip.
+func warningToMap(c *C, warning *state.Warning) map[string]any {
+	buf, err := json.Marshal(warning)
+	c.Assert(err, IsNil)
+	var n map[string]any
+	err = json.Unmarshal(buf, &n)
+	c.Assert(err, IsNil)
+	return n
 }
 
 func (s *autoRefreshTestSuite) TestMaybeAsyncPendingRefreshNotification(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	var connCheckCalled int
 	restore := snapstate.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
 		connCheckCalled++
@@ -1344,12 +1587,29 @@ func (s *autoRefreshTestSuite) TestMaybeAsyncPendingRefreshNotification(c *C) {
 	})
 	defer restore()
 
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+
 	snapstate.MaybeAsyncPendingRefreshNotification(context.TODO(), s.state, expectedInfo)
+	// no notification as refresh-appawareness-ux is enabled
+	// i.e. notices + warnings fallback is used instead
+	c.Check(connCheckCalled, Equals, 0)
+	c.Check(notificationCalled, Equals, 0)
+
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+
+	snapstate.MaybeAsyncPendingRefreshNotification(context.TODO(), s.state, expectedInfo)
+	// notification sent as refresh-appawareness-ux is now disabled
 	c.Check(connCheckCalled, Equals, 1)
 	c.Check(notificationCalled, Equals, 1)
 }
 
 func (s *autoRefreshTestSuite) TestMaybeAsyncPendingRefreshNotificationSkips(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	var connCheckCalled int
 	restore := snapstate.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
 		connCheckCalled++

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -45,15 +45,6 @@ func MockTaskTimes(t *Task, spawnTime, readyTime time.Time) {
 	t.readyTime = readyTime
 }
 
-func (s *State) AddWarning(message string, lastAdded, lastShown time.Time, expireAfter, repeatAfter time.Duration) {
-	s.addWarning(Warning{
-		message:     message,
-		lastShown:   lastShown,
-		expireAfter: expireAfter,
-		repeatAfter: repeatAfter,
-	}, lastAdded)
-}
-
 func (w Warning) LastAdded() time.Time {
 	return w.lastAdded
 }
@@ -67,11 +58,13 @@ func (t *Task) AccumulateUndoingTime(duration time.Duration) {
 }
 
 var (
+	DefaultWarningExpireAfter = defaultWarningExpireAfter
+	DefaultWarningRepeatAfter = defaultWarningRepeatAfter
+
 	ErrNoWarningMessage     = errNoWarningMessage
 	ErrBadWarningMessage    = errBadWarningMessage
 	ErrNoWarningFirstAdded  = errNoWarningFirstAdded
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
-	ErrNoWarningRepeatAfter = errNoWarningRepeatAfter
 )
 
 // NumNotices returns the total bumber of notices, including expired ones that

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -833,7 +833,10 @@ func (ss *stateSuite) TestPrune(c *C) {
 	state.MockTaskTimes(t5, now.Add(-pruneWait), now.Add(-pruneWait))
 
 	// two warnings, one expired
-	st.AddWarning("hello", now, never, time.Nanosecond, state.DefaultRepeatAfter)
+	st.AddWarning("hello", &state.AddWarningOptions{
+		Time:        now.Add(-state.DefaultWarningExpireAfter),
+		RepeatAfter: state.DefaultWarningRepeatAfter,
+	})
 	st.Warnf("hello again")
 
 	past := time.Now().AddDate(-1, 0, 0)

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -229,6 +229,20 @@ func (s *State) AddWarning(message string, options *AddWarningOptions) {
 	warning.repeatAfter = options.RepeatAfter
 }
 
+// RemoveWarning removes a warning given its message.
+//
+// Returns state.ErrNoState if no warning exists with given message.
+func (s *State) RemoveWarning(message string) error {
+	s.writing()
+	_, ok := s.warnings[message]
+	if !ok {
+		return ErrNoState
+	}
+
+	delete(s.warnings, message)
+	return nil
+}
+
 type byLastAdded []*Warning
 
 func (a byLastAdded) Len() int           { return len(a) }

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -206,7 +206,7 @@ func (s *State) AddWarning(message string, options *AddWarningOptions) {
 
 	now := options.Time
 	if now.IsZero() {
-		now = time.Now()
+		now = timeNow()
 	}
 	now = now.UTC()
 


### PR DESCRIPTION
This PR allows using warnings as a fallback instead of the [current desktop notifications fallback](https://github.com/snapcore/snapd/blob/199386c78cd88be1a74a942fc7bd59437f736a18/overlord/snapstate/autorefresh.go#L743-L754) when no snap exists with the marker `snap-refresh-observe` interface (i.e. `snapd-desktop-integration` snap).

[SD167 - Refresh App Awareness Desktop UX Flow](https://docs.google.com/document/d/1HJQWKzgaB3yPKwRUqlxYhgyaKG5IcJe8eZOT4YY1CI8/edit)

This alternative fallback flow is hidden behind the experimental `refresh-app-awareness-ux` flag to avoid disrupting the current user experience until `snapd-desktop-integration` is compatible with the new flow.

This PR is split into two main parts:
1. Extending the warnings API
    - [o/state: allow specifying options when creating warnings](https://github.com/snapcore/snapd/commit/8675f75144ed2ee6c9eb8c36b86fc874bfa3d4d8)
        - This allows specifying `RepeatAfter` field on warnings to avoid spamming users on every new auto-refresh
    - [o/state: allow replacing warning message in-place](https://github.com/snapcore/snapd/commit/bfd5105ef5a4fcc1b7115aa12074da5eb527eb1f)
        - This allows replacing the warning message in-place through the added `State.ReplaceWarningMessage`
2. Implementing the warnings fallback for inhibited snaps
    - [o/snapstate: use warnings as fallback for RAA notifications](https://github.com/snapcore/snapd/commit/3f6dc10f8c15751242c2f44e1bad1ae59a49295f)

Please let me know if it would be better to split them into two separate PRs, I kept them together because they provide context to each other.