### PR TITLE
o/i/a/common: test that CheckAccess attaches all interface to remoteAddr

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -201,6 +201,9 @@ func requireInterfaceApiAccessImpl(d *Daemon, r *http.Request, ucred *ucrednet, 
 		}
 		if connRef.PlugRef.Snap == snapName {
 			r.RemoteAddr = ucrednetAttachInterface(r.RemoteAddr, connState.Interface)
+			// Do not return here, but keep processing connections for the side
+			// effect of attaching all connected interfaces we asked for to the
+			// remote address.
 			foundMatchingInterface = true
 		}
 	}


### PR DESCRIPTION
This PR cherry-picks commit 7870fb3ec40009a24fb6cbdfdc02e94e037e0278 which was lost while rebasing PR #13673.

The commit improves tests to ensure that `CheckAccess` correctly attaches all connected interfaces to the `remoteAddr`.