### PR TITLE
c/snap: do not close test server until test is over

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -135,7 +135,7 @@ func (s *SnapOpSuite) TestWait(c *check.C) {
 	// lazy way of getting a URL that won't work nor break stuff
 	server := httptest.NewServer(nil)
 	snap.ClientConfig.BaseURL = server.URL
-	server.Close()
+	defer server.Close()
 
 	cli := snap.Client()
 	chg, err := snap.Wait(cli, "x")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -132,10 +132,9 @@ func (s *SnapOpSuite) TestWait(c *check.C) {
 	restore := snap.MockMaxGoneTime(time.Millisecond)
 	defer restore()
 
-	// lazy way of getting a URL that won't work nor break stuff
-	server := httptest.NewServer(nil)
-	snap.ClientConfig.BaseURL = server.URL
-	defer server.Close()
+	// should always result in a connection refused error, since port zero isn't
+	// valid
+	snap.ClientConfig.BaseURL = "http://localhost:0"
 
 	cli := snap.Client()
 	chg, err := snap.Wait(cli, "x")


### PR DESCRIPTION
Since we closed the server immediately, the port was being re-used by another test. This caused this test to send its HTTP request to another test that wasn't expecting it.