### PR TITLE
tests: add static checks for snapd branches 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -242,6 +242,12 @@ jobs:
     #if: github.ref != 'refs/heads/master'
     steps:
 
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+
     - name: check-branch-ubuntu-daily-spread
       run: |
         # Compare the daily system in master and in the current branch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -241,7 +241,8 @@ jobs:
     needs: [cache-build-deps]
     #if: github.ref != 'refs/heads/master'
     steps:
-      name: check-branch-ubuntu-daily-spread
+
+    - name: check-branch-ubuntu-daily-spread
       run: |
         # Compare the daily system in master and in the current branch
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -236,6 +236,20 @@ jobs:
               exit 1
           fi
 
+  branch-static-checks:
+    runs-on: ubuntu-latest
+    needs: [cache-build-deps]
+    #if: github.ref != 'refs/heads/master'
+    steps:
+      name: check-branch-ubuntu-daily-spread
+      run: |
+        # Compare the daily system in master and in the current branch
+        wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
+        system_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
+        current_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
+        test "$system_daily" == "$current_daily"
+      shell: bash
+
   unit-tests:
     needs: [static-checks]
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -254,7 +254,7 @@ jobs:
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
         system_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
         current_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
-        test "$system_daily" == "$current_daily"
+        test "$system_daily" != "$current_daily"
       shell: bash
 
   unit-tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -239,7 +239,7 @@ jobs:
   branch-static-checks:
     runs-on: ubuntu-latest
     needs: [cache-build-deps]
-    #if: github.ref != 'refs/heads/master'
+    if: github.ref != 'refs/heads/master'
     steps:
 
     - name: Checkout code
@@ -254,7 +254,7 @@ jobs:
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
         system_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
         current_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
-        test "$system_daily" != "$current_daily"
+        test "$system_daily" == "$current_daily"
       shell: bash
 
   unit-tests:


### PR DESCRIPTION
The idea is to have in this new job the checks needed to validate specific aspects when the branch is not master (just for release/**).

The first check requested is to validate the daily ubuntu system is the same than in master, this is needed to make sure that we can compile snapd and run tests on the latest ubuntu when we branch a new version