### PR TITLE
desktop/notification/notificationtest: fix data race

### DIFF
--- a/desktop/notification/notificationtest/fdo.go
+++ b/desktop/notification/notificationtest/fdo.go
@@ -92,6 +92,9 @@ func (server *FdoServer) Stop() error {
 // If not nil, all the fdoApi methods will return the provided error
 // in place of performing their usual task.
 func (server *FdoServer) SetError(err *dbus.Error) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
 	server.err = err
 }
 
@@ -136,6 +139,9 @@ type fdoApi struct {
 }
 
 func (a fdoApi) GetCapabilities() ([]string, *dbus.Error) {
+	a.server.mu.Lock()
+	defer a.server.mu.Unlock()
+
 	if a.server.err != nil {
 		return nil, a.server.err
 	}
@@ -144,12 +150,12 @@ func (a fdoApi) GetCapabilities() ([]string, *dbus.Error) {
 }
 
 func (a fdoApi) Notify(appName string, replacesID uint32, icon, summary, body string, actions []string, hints map[string]dbus.Variant, expires int32) (uint32, *dbus.Error) {
+	a.server.mu.Lock()
+	defer a.server.mu.Unlock()
+
 	if a.server.err != nil {
 		return 0, a.server.err
 	}
-
-	a.server.mu.Lock()
-	defer a.server.mu.Unlock()
 
 	a.server.lastID += 1
 	notification := &FdoNotification{
@@ -171,6 +177,9 @@ func (a fdoApi) Notify(appName string, replacesID uint32, icon, summary, body st
 }
 
 func (a fdoApi) CloseNotification(id uint32) *dbus.Error {
+	a.server.mu.Lock()
+	defer a.server.mu.Unlock()
+
 	if a.server.err != nil {
 		return a.server.err
 	}
@@ -187,6 +196,9 @@ func (a fdoApi) CloseNotification(id uint32) *dbus.Error {
 }
 
 func (a fdoApi) GetServerInformation() (name, vendor, version, specVersion string, err *dbus.Error) {
+	a.server.mu.Lock()
+	defer a.server.mu.Unlock()
+
 	if a.server.err != nil {
 		return "", "", "", "", a.server.err
 	}


### PR DESCRIPTION
Use sever mutex to protect access to err field. Running `go test -race` fails with the following error:

```
==================
WARNING: DATA RACE
Read at 0x00c0003b72f8 by goroutine 468:
  github.com/snapcore/snapd/desktop/notification/notificationtest.fdoApi.Notify()
      /home/maciek/work/canonical/snapd/desktop/notification/notificationtest/fdo.go:149 +0x9c
  runtime.call128()
      /usr/lib/go/src/runtime/asm_amd64.s:773 +0x57
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:380 +0xb5
  github.com/godbus/dbus.exportedMethod.Call()
      /home/maciek/work/canonical/snapd/vendor/github.com/godbus/dbus/default_handler.go:128 +0x219
  github.com/godbus/dbus.(*exportedMethod).Call()
      <autogenerated>:1 +0x84
  github.com/godbus/dbus.(*Conn).handleCall()
      /home/maciek/work/canonical/snapd/vendor/github.com/godbus/dbus/export.go:153 +0x591
  github.com/godbus/dbus.(*Conn).inWorker.gowrap1()
      /home/maciek/work/canonical/snapd/vendor/github.com/godbus/dbus/conn.go:334 +0x44

Previous write at 0x00c0003b72f8 by goroutine 453:
  github.com/snapcore/snapd/desktop/notification/notificationtest.(*FdoServer).SetError()
      /home/maciek/work/canonical/snapd/desktop/notification/notificationtest/fdo.go:97 +0x99
  github.com/snapcore/snapd/usersession/agent_test.(*restSuite).TestPostPendingRefreshNotificationNotificationServerFailure()
      /home/maciek/work/canonical/snapd/usersession/agent/rest_api_test.go:855 +0xed
  runtime.call16()
      /usr/lib/go/src/runtime/asm_amd64.s:770 +0x42
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:775 +0x9c5
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xe9

Goroutine 468 (running) created at:
  github.com/godbus/dbus.(*Conn).inWorker()
      /home/maciek/work/canonical/snapd/vendor/github.com/godbus/dbus/conn.go:334 +0x346
  github.com/godbus/dbus.(*Conn).Auth.gowrap1()
      /home/maciek/work/canonical/snapd/vendor/github.com/godbus/dbus/auth.go:118 +0x33

Goroutine 453 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x5ba
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x155
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x419
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x3c6
  gopkg.in/check%2ev1.Run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x44
  gopkg.in/check%2ev1.RunAll()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x124
  gopkg.in/check%2ev1.TestingT()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x5d3
  github.com/snapcore/snapd/usersession/agent_test.Test()
      /home/maciek/work/canonical/snapd/usersession/agent/session_agent_test.go:44 +0x26
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/lib/go/src/testing/testing.go:1742 +0x44
==================
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
