### PR TITLE
store: conditionally skip download monitoring unit tests

### DIFF
--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -883,6 +883,10 @@ func (s *storeDownloadSuite) TestDownloadTimeout(c *C) {
 }
 
 func (s *storeDownloadSuite) TestTransferSpeedMonitoringWriterHappy(c *C) {
+	if os.Getenv("SNAPD_SKIP_SLOW_TESTS") != "" {
+		c.Skip("skipping slow test")
+	}
+
 	origCtx := context.TODO()
 	w, ctx := store.NewTransferSpeedMonitoringWriterAndContext(origCtx, 50*time.Millisecond, 1)
 
@@ -907,6 +911,10 @@ func (s *storeDownloadSuite) TestTransferSpeedMonitoringWriterHappy(c *C) {
 }
 
 func (s *storeDownloadSuite) TestTransferSpeedMonitoringWriterUnhappy(c *C) {
+	if os.Getenv("SNAPD_SKIP_SLOW_TESTS") != "" {
+		c.Skip("skipping slow test")
+	}
+
 	origCtx := context.TODO()
 	w, ctx := store.NewTransferSpeedMonitoringWriterAndContext(origCtx, 50*time.Millisecond, 1000)
 


### PR DESCRIPTION
Skip download speed monitoring unit tests if SNAPD_SKIP_SLOW_TESTS is set. The test is based on getting the timings right and so it becomes generally unreliable when running in super slow environment, such as a build VM in OBS, thus failing like so:

```
[ 2317s] ----------------------------------------------------------------------
[ 2317s] FAIL: store_download_test.go:886: storeDownloadSuite.TestTransferSpeedMonitoringWriterHappy
[ 2317s]
[ 2317s] store_download_test.go:903:
[ 2317s]     c.Check(store.Cancelled(ctx), Equals, false)
[ 2317s] ... obtained bool = true
[ 2317s] ... expected bool = false
[ 2317s]
[ 2317s] store_download_test.go:904:
[ 2317s]     c.Check(w.Err(), IsNil)
[ 2317s] ... value *store.transferSpeedError = &store.transferSpeedError{Speed:0} ("download too slow: 0.00 bytes/sec")
[ 2317s]
[ 2317s] store_download_test.go:907:
[ 2317s]     // we should hit at least 100*5/50 = 10 measurement windows
[ 2317s]     c.Assert(w.MeasuredWindowsCount() >= 10, Equals, true, Commentf("%d", w.MeasuredWindowsCount()))
[ 2317s] ... obtained bool = false
[ 2317s] ... expected bool = true
[ 2317s] ... 9
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
