### PR TITLE
cmd/libsnap-confine-private: account for 'kill' apparmor profile mode

### DIFF
--- a/cmd/libsnap-confine-private/apparmor-support.c
+++ b/cmd/libsnap-confine-private/apparmor-support.c
@@ -37,6 +37,7 @@
 #define SC_AA_ENFORCE_STR "enforce"
 #define SC_AA_COMPLAIN_STR "complain"
 #define SC_AA_MIXED_STR "mixed"
+#define SC_AA_KILL_STR "kill"
 #define SC_AA_UNCONFINED_STR "unconfined"
 
 void sc_init_apparmor_support(struct sc_apparmor *apparmor)
@@ -92,8 +93,9 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 	// expect to be confined by a profile with the name of a valid
 	// snap-confine binary since if not we may be executed under a
 	// profile with more permissions than expected
-	if (label != NULL && sc_streq(mode, SC_AA_ENFORCE_STR)
-	    && sc_is_expected_path(label)) {
+	bool confined_mode = sc_streq(mode, SC_AA_ENFORCE_STR)
+	    || sc_streq(mode, SC_AA_KILL_STR);
+	if (label != NULL && confined_mode && sc_is_expected_path(label)) {
 		apparmor->is_confined = true;
 	} else {
 		apparmor->is_confined = false;
@@ -106,6 +108,8 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 		apparmor->mode = SC_AA_ENFORCE;
 	} else if (mode != NULL && strcmp(mode, SC_AA_MIXED_STR) == 0) {
 		apparmor->mode = SC_AA_MIXED;
+	} else if (mode != NULL && strcmp(mode, SC_AA_KILL_STR) == 0) {
+		apparmor->mode = SC_AA_KILL;
 	} else {
 		apparmor->mode = SC_AA_INVALID;
 	}

--- a/cmd/libsnap-confine-private/apparmor-support.h
+++ b/cmd/libsnap-confine-private/apparmor-support.h
@@ -34,6 +34,8 @@ enum sc_apparmor_mode {
 	SC_AA_COMPLAIN,
 	// The enforcement mode is "mixed"
 	SC_AA_MIXED,
+	// The enforcement mode is "kill"
+	SC_AA_KILL,
 };
 
 /**


### PR DESCRIPTION
The apparmor profile can use 'kill' enforcement mode, in which case the process execution an action it has no permissions for will be sent SIGKILL. We need to account for this mode explicitly, otherwise s-c will complain about running with elevated permissions and exit with an error, which makes not sense since the process is still properly confined.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
