### PR TITLE
client: add support to send notices

### DIFF
--- a/client/notices.go
+++ b/client/notices.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type NotifyOptions struct {
+	// Type is the notice's type. Currently only notices of type CustomNotice
+	// can be added.
+	Type NoticeType
+
+	// Key is the notice's key. For "custom" notices, this must be in
+	// "domain.com/key" format.
+	Key string
+}
+
+// Notify records an occurrence of a notice with the specified options,
+// returning the notice ID.
+func (client *Client) Notify(opts *NotifyOptions) (string, error) {
+	var payload = struct {
+		Action string `json:"action"`
+		Type   string `json:"type"`
+		Key    string `json:"key"`
+	}{
+		Action: "add",
+		Type:   string(opts.Type),
+		Key:    opts.Key,
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&payload); err != nil {
+		return "", err
+	}
+
+	result := struct {
+		ID string `json:"id"`
+	}{}
+	_, err := client.doSync("POST", "/v2/notices", nil, nil, &body, &result)
+	if err != nil {
+		return "", err
+	}
+	return result.ID, err
+}
+
+type NoticeType string
+
+const (
+	// SnapRunInhibitNotice is recorded when "snap run" is inhibited due refresh.
+	SnapRunInhibitNotice NoticeType = "snap-run-inhibit"
+)

--- a/client/notices_test.go
+++ b/client/notices_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/snapcore/snapd/client"
+	. "gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestNotify(c *C) {
+	cs.rsp = `{"type": "sync", "result": {"id": "7"}}`
+	noticeID, err := cs.cli.Notify(&client.NotifyOptions{
+		Type: client.SnapRunInhibitNotice,
+		Key:  "snap-name",
+	})
+	c.Assert(err, IsNil)
+	c.Check(noticeID, Equals, "7")
+	c.Assert(cs.req.URL.Path, Equals, "/v2/notices")
+
+	body, err := io.ReadAll(cs.req.Body)
+	c.Assert(err, IsNil)
+	var m map[string]any
+	err = json.Unmarshal(body, &m)
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, map[string]any{
+		"action": "add",
+		"type":   "snap-run-inhibit",
+		"key":    "snap-name",
+	})
+}


### PR DESCRIPTION
This is a backport from pebble: https://github.com/canonical/pebble/pull/297 to allow sending notices from snap command.

This is a building block for https://github.com/snapcore/snapd/pull/13770 to allow snap run to record `snap-run-inhibit` commands.