### PR TITLE
tests: move ubuntu core os.query logic to prepare.sh

### DIFF
--- a/tests/lib/external/snapd-testing-tools/tools/os.query
+++ b/tests/lib/external/snapd-testing-tools/tools/os.query
@@ -13,63 +13,67 @@ show_help() {
 }
 
 is_core() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release
-    fi
+    grep -qFx 'ID=ubuntu-core' /etc/os-release
 }
 
 is_core16() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="16"' /etc/os-release
-    fi
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="16"' /etc/os-release
 }
 
 is_core18() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="18"' /etc/os-release
-    fi
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="18"' /etc/os-release
 }
 
 is_core20() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="20"' /etc/os-release
-    fi
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="20"' /etc/os-release
 }
 
 is_core22() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="22"' /etc/os-release
-    fi
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="22"' /etc/os-release
 }
 
 is_core24() {
-    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
-    # not contain the ubuntu-core info while the system is being prepared
-    if [ -n "$SPREAD_SYSTEM" ]; then
-        [[ "$SPREAD_SYSTEM" == ubuntu-core-24-* ]]
-    else
-        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
+}
+
+is_core_gt() {
+    local VERSION=$1
+    if [ -z "$VERSION" ]; then
+        echo "os.query: version id is expected"
+        exit 1
     fi
+
+    compare_ubuntu "$VERSION" "-gt"
+}
+
+is_core_ge() {
+    local VERSION=$1
+    if [ -z "$VERSION" ]; then
+        echo "os.query: version id is expected"
+        exit 1
+    fi
+
+    compare_ubuntu "$VERSION" "-ge"
+}
+
+is_core_lt() {
+    local VERSION=$1
+    if [ -z "$VERSION" ]; then
+        echo "os.query: version id is expected"
+        exit 1
+    fi
+
+    compare_ubuntu "$VERSION" "-lt"
+}
+
+is_core_le() {
+    local VERSION=$1
+    if [ -z "$VERSION" ]; then
+        echo "os.query: version id is expected"
+        exit 1
+    fi
+
+    compare_ubuntu "$VERSION" "-le"
 }
 
 is_core_gt() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -629,7 +629,9 @@ prepare_project_each() {
 prepare_suite() {
     # shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
-    if os.query is-core; then
+    # os.query cannot be used because first time the suite is prepared, the current system
+    # is classic ubuntu, so it is needed to check the system set in $SPREAD_SYSTEM
+    if is_core; then
         prepare_ubuntu_core
     else
         prepare_classic

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -44,6 +44,34 @@ EOF
     systemctl daemon-reload
 }
 
+# It is supposed the name of the system follows 
+# ubuntu-core-<VERSION>[-ARCH]-<BITS>
+# with arch is "" for amd64, arm for armhf and arm64, etc
+is_core() {
+    local VERSION=${1:-}
+    [[ "$SPREAD_SYSTEM" = ubuntu-core-${VERSION}* ]]
+}
+
+is_core_ge() {
+    local VERSION=${1:-}
+    if [ -z "$VERSION" ]; then
+        echo "version id is expected"
+        exit 1
+    fi
+    CURR_VERSION="$(cut -d- -f3 <<< "$SPREAD_SYSTEM")"
+    [ "$CURR_VERSION" -ge "${VERSION}" ]
+}
+
+is_core_le() {
+    local VERSION=${1:-}
+    if [ -z "$VERSION" ]; then
+        echo "version id is expected"
+        exit 1
+    fi
+    CURR_VERSION="$(cut -d- -f3 <<< "$SPREAD_SYSTEM")"
+    [ "$CURR_VERSION" -le "${VERSION}" ]
+}
+
 ensure_jq() {
     if command -v jq; then
         return
@@ -978,19 +1006,19 @@ setup_reflash_magic() {
     snap wait system seed.loaded
 
     # download the snapd snap for all uc systems except uc16
-    if ! os.query is-core16; then
+    if ! is_core 16; then
         snap download "--channel=${SNAPD_CHANNEL}" snapd
     fi
 
     # we cannot use "snaps.names tool" here because no snaps are installed yet
     core_name="core"
-    if os.query is-core18; then
+    if is_core 18; then
         core_name="core18"
-    elif os.query is-core20; then
+    elif is_core 20; then
         core_name="core20"
-    elif os.query is-core22; then
+    elif is_core 22; then
         core_name="core22"
-    elif os.query is-core24; then
+    elif is_core 24; then
         core_name="core24"
         # TODO: revert this once snaps are ready in target channel
         KERNEL_CHANNEL=beta
@@ -1010,7 +1038,7 @@ setup_reflash_magic() {
 
     if os.query is-arm; then
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-    elif os.query is-core16; then
+    elif is_core 16; then
         # the new ubuntu-image expects mkfs to support -d option, which was not
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
@@ -1033,21 +1061,21 @@ setup_reflash_magic() {
     cp /usr/bin/snap "$IMAGE_HOME"
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
-    if os.query is-core18; then
+    if is_core 18; then
         repack_snapd_snap_with_deb_content "$IMAGE_HOME"
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
-    elif os.query is-core20; then
+    elif is_core 20; then
         repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
-    elif os.query is-core22; then
+    elif is_core 22; then
         repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         if os.query is-arm; then
             cp "$TESTSLIB/assertions/ubuntu-core-22-arm64.model" "$IMAGE_HOME/pc.model"
         else
             cp "$TESTSLIB/assertions/ubuntu-core-22-amd64.model" "$IMAGE_HOME/pc.model"
         fi
-    elif os.query is-core24; then
+    elif is_core 24; then
         repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-24-amd64.model" "$IMAGE_HOME/pc.model"
     else
@@ -1093,10 +1121,10 @@ EOF
         IMAGE_CHANNEL="$KERNEL_CHANNEL"
     else
         IMAGE_CHANNEL="$GADGET_CHANNEL"
-        if os.query is-core16 || os.query is-core18; then
-            if os.query is-core16; then
+        if is_core_le 18; then
+            if is_core 16; then
                 BRANCH=latest
-            elif os.query is-core18; then
+            elif is_core 18; then
                 BRANCH=18
             fi
             # download pc-kernel snap for the specified channel and set
@@ -1115,19 +1143,19 @@ EOF
         fi
     fi
 
-    if os.query is-core-ge 20; then
-        if os.query is-core20; then
+    if is_core_ge 20; then
+        if is_core 20; then
             BRANCH=20
-        elif os.query is-core22; then
+        elif is_core 22; then
             BRANCH=22
-        elif os.query is-core24; then
+        elif is_core 24; then
             BRANCH=24
         fi
         snap download --basename=pc-kernel --channel="${BRANCH}/${KERNEL_CHANNEL}" pc-kernel
         # make sure we have the snap
         test -e pc-kernel.snap
         # build the initramfs with our snapd assets into the kernel snap
-        if os.query is-core-ge 24; then
+        if is_core_ge 24; then
             uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$IMAGE_HOME"
         else    
             uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$IMAGE_HOME"
@@ -1136,24 +1164,14 @@ EOF
 
         # also add debug command line parameters to the kernel command line via
         # the gadget in case things go side ways and we need to debug
-        if os.query is-core24; then
+        if is_core 24; then
             # TODO: remove this once pc snap is available in beta channel
             snap download --basename=pc --channel="${BRANCH}/edge" pc
-            # TODO: remove this once 24/edge channel is fixed
-            snap download --basename=pc-23 --channel="classic-23.10/edge" pc
         else
             snap download --basename=pc --channel="${BRANCH}/${KERNEL_CHANNEL}" pc
         fi
         test -e pc.snap
         unsquashfs -d pc-gadget pc.snap
-
-        # TODO: remove this once 24/edge channel is fixed
-        if os.query is-core24; then
-            unsquashfs -d pc-gadget-23 pc-23.snap
-            cp pc-gadget-23/shim.efi.signed pc-gadget/shim.efi.signed
-            cp pc-gadget-23/grubx64.efi pc-gadget/grubx64.efi
-            rm -r pc-gadget-23 pc-23.{snap,assert}
-        fi
 
         # TODO: it would be desirable when we need to do in-depth debugging of
         # UC20 runs in google to have snapd.debug=1 always on the kernel command
@@ -1202,7 +1220,7 @@ EOF
 
     # on core18 we need to use the modified snapd snap and on core16
     # it is the modified core that contains our freshly build snapd
-    if os.query is-core-ge 18; then
+    if is_core_ge 18; then
         extra_snap=("$IMAGE_HOME"/snapd_*.snap)
     else
         extra_snap=("$IMAGE_HOME"/core_*.snap)
@@ -1215,11 +1233,13 @@ EOF
     fi
 
     # download the core20 snap manually from the specified channel for UC20
-    if os.query os.query is-core-ge 20; then
-        if os.query is-core20; then
+    if is_core_ge 20; then
+        if is_core 20; then
             BASE=core20
-        elif os.query is-core22; then
+        elif is_core 22; then
             BASE=core22
+        elif is_core 24; then
+            BASE=core24
         fi
         snap download "${BASE}" --channel="$BASE_CHANNEL" --basename="${BASE}"
         
@@ -1249,7 +1269,7 @@ EOF
         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap ${IMAGE_HOME}/${BASE}.snap"
     fi
     local UBUNTU_IMAGE="$GOHOME"/bin/ubuntu-image
-    if os.query is-core16 || os.query is-arm; then
+    if is_core 16 || os.query is-arm; then
         # ubuntu-image on 16.04 needs to be installed from a snap
         UBUNTU_IMAGE=/snap/bin/ubuntu-image
     fi
@@ -1265,7 +1285,7 @@ EOF
 
     if os.query is-arm; then
         LOOP_PARTITION=1
-    elif os.query is-core-ge 20; then
+    elif is_core_ge 20; then
         # (ab)use ubuntu-seed
         LOOP_PARTITION=2
     else
@@ -1275,7 +1295,7 @@ EOF
     # expand the uc16 and uc18 images a little bit (400M) as it currently will
     # run out of space easily from local spread runs if there are extra files in
     # the project not included in the git ignore and spread ignore, etc.
-    if os.query is-core-le 18; then
+    if is_core_le 18; then
         # grow the image by 400M
         truncate --size=+400M "$IMAGE_HOME/$IMAGE"
         # fix the GPT table because old versions of parted complain about this 
@@ -1311,7 +1331,7 @@ EOF
     # - built debs
     # - golang archive files and built packages dir
     # - govendor .cache directory and the binary,
-    if os.query is-core-le 18; then
+    if is_core_le 18; then
         mkdir -p /mnt/user-data/
         # we need to include "core" here because -C option says to ignore 
         # files the way CVS(?!) does, so it ignores files named "core" which
@@ -1364,7 +1384,7 @@ EOF
     fi
 
     # now modify the image writable partition - only possible on uc16 / uc18
-    if os.query is-core-le 18; then
+    if is_core_le 18; then
         # modify the writable partition of "core" so that we have the
         # test user
         setup_core_for_testing_by_modify_writable "$UNPACK_DIR"
@@ -1375,7 +1395,7 @@ EOF
     kpartx -d "$IMAGE_HOME/$IMAGE"
 
     gzip "${IMAGE_HOME}/${IMAGE}"
-    if os.query is-core16; then
+    if is_core 16; then
         "${TESTSLIB}/uc16-reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"
     else
         "${TESTSLIB}/reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -32,12 +32,12 @@ execute: |
     NOTES=core
 
     #shellcheck disable=SC2166
-    if [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
+    if [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && os.query is-core16; then
         echo "With customized images the core snap is sideloaded"
         REV=$SIDELOAD_REV
         PUBLISHER=-
 
-    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" = "google-arm" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" -o "$SPREAD_SYSTEM" = "ubuntu-core-20-64" -o "$SPREAD_SYSTEM" = "ubuntu-core-22-64" -o "$SPREAD_SYSTEM" = "ubuntu-core-22-arm-64" ]; then
+    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" = "google-arm" -o "$SPREAD_BACKEND" == "qemu" ] && os.query is-core-ge 18; then
         echo "With customized images the snapd snap is sideloaded"
         NAME=snapd
         VERSION=$SNAPD_GIT_VERSION
@@ -54,7 +54,7 @@ execute: |
         echo "On the external device the core snap tested could be in any track"
         TRACKING="(latest/)?(edge|beta|candidate|stable)"
 
-    elif [ "$SPREAD_BACKEND" = "external" ] && { os.query is-core18 || os.query is-core20 || os.query is-core22; }; then
+    elif [ "$SPREAD_BACKEND" = "external" ] && os.query is-core-ge 18; then
         echo "On the external device the snapd snap tested could be in any track"
         NAME=snapd
         VERSION=$SNAPD_GIT_VERSION


### PR DESCRIPTION
In snapd, to prepare ubuntu core, first it is booted an ubuntu classic image.
The logic needed to manage that has been moved from os.query to prepare.sh

This change is needed because os.query is a generic tool which is used in
other projects and shouln't have logic specific to snapd project.