### PR TITLE
data/systemd: allow notifications for all snapd subprocesses

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -20,6 +20,7 @@ EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Restart=always
 WatchdogSec=5m
 Type=notify
+NotifyAccess=all
 SuccessExitStatus=42
 RestartPreventExitStatus=42
 KillMode=process


### PR DESCRIPTION
Allow all service's control group processes to send notifications via sd_notify. This is necesssary to prevent log flooding with systemd warnings like:

Apr 05 14:36:55 qemuname systemd[1]: snapd.service: Got notification message from PID 1002, but reception only permitted for main PID 917

These warnings are happening due to a change in systemd 254 that makes all systemd programs (systemctl, udevadm, systemd-detect-virt, etc.) send EXIT_STATUS notifications when exiting.

Fixes LP#2060310.