### PR TITLE
aspects: validate map keys in Set value

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -509,7 +509,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 func validMapKeys(v map[string]json.RawMessage) error {
 	for k := range v {
 		if !validSubkey.Match([]byte(k)) {
-			return fmt.Errorf(`key %q doesn't conform to required format`, k)
+			return fmt.Errorf(`key %q doesn't conform to required format: %s`, k, validSubkey.String())
 		}
 	}
 

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -466,7 +466,7 @@ func (*schemaSuite) TestMapSchemaWithInvalidKeyFormat(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse map: key "-foo" doesn't conform to required format`)
+	c.Assert(err, ErrorMatches, `cannot parse map: key "-foo" doesn't conform to required format: .*`)
 }
 
 func (*schemaSuite) TestMapRejectsInputMapWithInvalidKeyFormat(c *C) {
@@ -483,7 +483,7 @@ func (*schemaSuite) TestMapRejectsInputMapWithInvalidKeyFormat(c *C) {
 	"-foo": 1
 }`)
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept top level element: key "-foo" doesn't conform to required format`)
+	c.Assert(err, ErrorMatches, `cannot accept top level element: key "-foo" doesn't conform to required format: .*`)
 }
 
 func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {


### PR DESCRIPTION
Ensure that that value we are setting has keys that match the required format (similar to snap names). The map schema check enforces this constraint but we should always ensure it and not just when there's a schema for it.