### PR TITLE
tests: filter the debug output of the spread tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -738,6 +738,7 @@ jobs:
           (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output -f debug.log)
 
     - name: Uploading debug logs
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: spread-logs-${{ matrix.system }}
@@ -912,6 +913,7 @@ jobs:
           (set -o pipefail; spread $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output -f debug.log)
 
     - name: Uploading spread logs
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: spread-logs-${{ matrix.system }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -735,7 +735,13 @@ jobs:
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
           echo "Running command: $SPREAD $RUN_TESTS"
-          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log)
+          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output)
+
+    - name: Uploading debug logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: debug-logs
+        path: "debug.log"
 
     - name: Discard spread workers
       if: always()
@@ -903,7 +909,13 @@ jobs:
           # "pipefail" ensures that a non-zero status from the spread is
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
-          (set -o pipefail; spread $RUN_TESTS | tee spread.log)
+          (set -o pipefail; spread $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output)
+
+    - name: Uploading debug logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: debug-logs
+        path: "debug.log"
 
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -735,13 +735,13 @@ jobs:
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
           echo "Running command: $SPREAD $RUN_TESTS"
-          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output)
+          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output -f debug.log)
 
     - name: Uploading debug logs
       uses: actions/upload-artifact@v3
       with:
-        name: debug-logs
-        path: "debug.log"
+        name: spread-logs-${{ matrix.system }}
+        path: "*.log"
 
     - name: Discard spread workers
       if: always()
@@ -909,13 +909,13 @@ jobs:
           # "pipefail" ensures that a non-zero status from the spread is
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
-          (set -o pipefail; spread $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output)
+          (set -o pipefail; spread $RUN_TESTS | tee spread.log | tests/lib/tools/filter-debug-output -f debug.log)
 
-    - name: Uploading debug logs
+    - name: Uploading spread logs
       uses: actions/upload-artifact@v3
       with:
-        name: debug-logs
-        path: "debug.log"
+        name: spread-logs-${{ matrix.system }}
+        path: "*.log"
 
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -742,7 +742,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spread-logs-${{ matrix.systems }}
-        path: "*.log"
+        path: "debug.log"
 
     - name: Discard spread workers
       if: always()
@@ -917,7 +917,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spread-logs-${{ matrix.systems }}
-        path: "*.log"
+        path: "debug.log"
 
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -741,7 +741,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: spread-logs-${{ matrix.system }}
+        name: spread-logs-${{ matrix.systems }}
         path: "*.log"
 
     - name: Discard spread workers
@@ -916,7 +916,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: spread-logs-${{ matrix.system }}
+        name: spread-logs-${{ matrix.systems }}
         path: "*.log"
 
     - name: Discard spread workers

--- a/spread.yaml
+++ b/spread.yaml
@@ -900,6 +900,7 @@ prepare: |
     # The idea is to have a single directory with all the testing tools
     cp -f "$TESTSLIB"/external/snapd-testing-tools/tools/* "$TESTSTOOLS"
     cp -f "$TESTSLIB"/external/snapd-testing-tools/remote/* "$TESTSTOOLS"
+    cp -f "$TESTSLIB"/external/snapd-testing-tools/utils/* "$TESTSTOOLS"
 
     # ensure there are no broken snaps or the invariant test will fail later
     if command -v snap; then

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -85,8 +85,15 @@ jobs:
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           fi
+          CHANGE_ID="${{ github.event.number }}"
+          if [ -z "$PR_ID" ]; then
+            CHANGE_ID="main"
+          fi
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}"
+          # The log-filter tool is used to filter the spread logs to be stored
+          FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"
 
-          (set -o pipefail; spread $RUN_TESTS | tee spread.log)
+          (set -o pipefail; spread $RUN_TESTS | ./utils/log-filter $FILTER_PARAMS | tee spread.log)
 
     - name: Discard spread workers
       if: always()

--- a/tests/lib/external/snapd-testing-tools/CODE_OF_CONDUCT.md
+++ b/tests/lib/external/snapd-testing-tools/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
@@ -1,0 +1,51 @@
+summary: test for the log filter tool
+
+details: |
+    This test checks the log-filter tool is able to read the spread output
+    and filter the log following a set of rules. It is also checked that the
+    output of the log-filter tool is the same than spread.
+
+backends: [google]
+
+# Github actions agents are just running ubuntu jammy
+systems: [ubuntu-22.04-64]
+
+prepare: |
+    wget https://storage.googleapis.com/snapd-spread-tests/dependencies/spread-log-filter.tar.xz
+    tar -xf spread-log-filter.tar.xz
+
+restore: |
+    rm -rf spread-log-filter.tar.xz ./*.log
+
+execute: |
+    log-filter --help | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+    log-filter -h | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+
+    # Run the tool for a real log    
+    # The output should:
+    # 1. the output should go to test.filtered.log file
+    # 2. exclude: Preparing, Restoring, Error, Warning
+    # 3. show: debug lines with ###DEBUG
+    # 4. show: failed tests for google-nested
+    log-filter -o test.filtered.log -e Error -e Restoring -e Preparing -f "Debug=###DEBUG" -f "Failed=google-nested:" < spread-log-filter.log > output.log
+
+    # Check the stdout is the same than the stdin
+    diff -Z spread-log-filter.log output.log
+
+    # Check exclude
+    test "$(grep -c Restoring test.filtered.log)" -eq 0
+    test "$(grep -c Preparing test.filtered.log)" -eq 0
+    test "$(grep -c Error test.filtered.log)" -eq 0
+
+    # Check the non excluded
+    test "$(grep -c 'Debug output' test.filtered.log)" -eq "$(grep -c 'Debug output' spread-log-filter.log)"
+
+    # Check the filters
+    test "$(grep -c '###DEBUG' test.filtered.log)" -eq "$(grep -c '###DEBUG' spread-log-filter.log)"
+    grep -A 1 'Failed suite prepare: 4' test.filtered.log | MATCH 'Failed suite restore: 1'
+
+    # Check no repeated
+    test "$(grep -c 'Failed suite prepare: 4' test.filtered.log)" -eq 1
+    test "$(grep -c 'Executing' test.filtered.log)" -eq "$(grep -c 'Executing' spread-log-filter.log)"
+    test "$(grep -c 'Aborted tasks' test.filtered.log)" -eq 1
+

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
@@ -93,7 +93,7 @@ created 0 fifos
 2022-05-18 18:07:57 Restoring google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-never-used-not-vuln:firstboot (may181749-433163)...
 2022-05-18 18:08:00 Preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163)...
 2022-05-18 18:08:40 Executing google-nested:ubuntu-16.04-64:tests/nested/core/image-build (may181749-432987) (2/13)...
-Error: 2022-05-18 18:09:34 Error preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163) : 
+2022-05-18 18:09:34 Error preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163) : 
 -----
 + /home/gopath/src/github.com/snapcore/snapd/tests/lib/prepare-restore.sh --prepare-project-each
 + set -e
@@ -160,4 +160,3 @@ google-nested:ubuntu-16.04-64:tests/nested/classic/hotplug google-nested:ubuntu-
 2022-05-18 16:45:15 Failed project restore: 2
     - google:ubuntu-core-22-64:project
     - google:ubuntu-core-22-64:project
-error: unsuccessful run

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+import argparse
+import io
+import re
+import sys
+
+import log_helper as helper
+
+# Rules are applied to filter content in the following operation details:
+# ERROR: The error shoes the bash output when a task fails
+# DEBUG: The debug includes the output of the debug script for task/suite errors
+# WARNING: The last lines from the task execution output
+# FAILED: Include a list of failed tests in the results section
+SUPPORTED_RULES = [ helper.ERROR, helper.DEBUG, helper.WARNING, helper.FAILED]
+
+def print_line(line: str):
+    if not line:
+        print()
+    else:
+        print(line.strip())
+
+def write_line(line: str, to_stream: io.TextIOWrapper):
+    if not line:
+        to_stream.write('\n')
+    else:
+        to_stream.write(line.strip() + '\n')
+
+def compile_rules(rules, operation):
+    patterns = []
+    regex_list = []
+
+    for rule in rules:
+        parts = rule.split('=',1)
+        if len(parts) != 2:
+            raise ValueError("Error: Rule '{}' does not follow the OPERATION=PATTERN format".format(rule))
+
+        rule_operation = parts[0]
+        rule_pattern = parts[1]
+
+        if rule_operation not in SUPPORTED_RULES:
+            raise ValueError("Error: Rule operation '{}' not in supported list: {}".format(rule_operation, SUPPORTED_RULES))
+
+        if operation == rule_operation:
+            patterns.append(rule_pattern)
+
+    for pattern in patterns:
+        regex_list.append(re.compile(pattern))
+    return regex_list
+
+
+def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
+        if not regex_list:
+            write_line(line, to_stream)
+        else:
+            for regex in regex_list:
+                matches = regex.findall(line)
+                for match in matches:
+                    write_line(match, to_stream)
+
+def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: list, to_stream: io.TextIOWrapper) -> str:
+    """Process lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    write_line(start_line, to_stream)
+    for line in sys.stdin:
+        print_line(line)
+
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if helper.is_detail_finished(line):
+            return line
+
+        # Print all the lines
+        process_detail_line(line, regex_list,  to_stream)
+
+            
+def skip_detail(from_stream: io.TextIOWrapper) -> str:
+    """Skip lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    for line in sys.stdin:
+        print_line(line)
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if helper.is_detail_finished(line):
+            return line
+
+def process_spread_output(output_file, exclude_lines, filter_rules):
+    error_regex = compile_rules(filter_rules, helper.ERROR)
+    debug_regex = compile_rules(filter_rules, helper.DEBUG)
+    failed_regex = compile_rules(filter_rules, helper.FAILED)
+    warning_regex = compile_rules(filter_rules, helper.WARNING)
+
+    with open(output_file, "w") as myfile:
+        for line in sys.stdin:
+            print_line(line)
+
+            while helper.is_detail_start(line):
+                regex_list = []
+                if helper.is_line(line, helper.DEBUG):
+                    if helper.DEBUG in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = debug_regex
+                
+                if helper.is_line(line, helper.ERROR):
+                    if helper.ERROR in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = error_regex
+
+                if helper.is_line(line, helper.WARNING):
+                    if helper.WARNING in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = warning_regex
+
+                if helper.is_line(line, helper.FAILED):
+                    if helper.FAILED in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = failed_regex
+                    
+                line = process_detail(sys.stdin, line, regex_list, myfile)
+
+            if not exclude_lines or \
+                not helper.is_operation(line) or \
+                not helper.get_operation(line) in exclude_lines:
+                write_line(line, myfile)
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+This tool is used to save a filtered version of the spread output. It parses the spread output and filters
+sections and debug/error details to the file passed as parameter (all the lines are printed).
+When a output file is not provided the debug output is sent to spread_filtered.log
+""")
+    parser.add_argument(
+        "-o",
+        "--output-file", 
+        metavar="PATH",
+        default="spread.filtered.log",
+        help="path to the filtered output file"
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude", 
+        action="append",
+        default=[],
+        choices=helper.OPERATIONS,
+        help="A line section to exclude from the output"
+    )
+    parser.add_argument(
+        "-f",
+        "--filter", 
+        action="append",
+        metavar="OPERATION=PATTERN",
+        default=[],
+        help="It is used to extract specific data from errors. Allowed operations are Error, Debug, Failed and WARNING:"
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = _make_parser()
+    args = parser.parse_args()
+    process_spread_output(args.output_file, args.exclude, args.filter)
+    

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -12,7 +12,8 @@ import log_helper as helper
 # DEBUG: The debug includes the output of the debug script for task/suite errors
 # WARNING: The last lines from the task execution output
 # FAILED: Include a list of failed tests in the results section
-SUPPORTED_RULES = [ helper.ERROR, helper.DEBUG, helper.WARNING, helper.FAILED]
+SUPPORTED_RULES = [helper.ERROR, helper.DEBUG, helper.WARNING, helper.FAILED]
+
 
 def print_line(line: str):
     if not line:
@@ -20,26 +21,36 @@ def print_line(line: str):
     else:
         print(line.strip())
 
+
 def write_line(line: str, to_stream: io.TextIOWrapper):
     if not line:
-        to_stream.write('\n')
+        to_stream.write("\n")
     else:
-        to_stream.write(line.strip() + '\n')
+        to_stream.write(line.strip() + "\n")
+
 
 def compile_rules(rules, operation):
     patterns = []
     regex_list = []
 
     for rule in rules:
-        parts = rule.split('=',1)
+        parts = rule.split("=", 1)
         if len(parts) != 2:
-            raise ValueError("Error: Rule '{}' does not follow the OPERATION=PATTERN format".format(rule))
+            raise ValueError(
+                "Error: Rule '{}' does not follow the OPERATION=PATTERN format".format(
+                    rule
+                )
+            )
 
         rule_operation = parts[0]
         rule_pattern = parts[1]
 
         if rule_operation not in SUPPORTED_RULES:
-            raise ValueError("Error: Rule operation '{}' not in supported list: {}".format(rule_operation, SUPPORTED_RULES))
+            raise ValueError(
+                "Error: Rule operation '{}' not in supported list: {}".format(
+                    rule_operation, SUPPORTED_RULES
+                )
+            )
 
         if operation == rule_operation:
             patterns.append(rule_pattern)
@@ -50,15 +61,21 @@ def compile_rules(rules, operation):
 
 
 def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
-        if not regex_list:
-            write_line(line, to_stream)
-        else:
-            for regex in regex_list:
-                matches = regex.findall(line)
-                for match in matches:
-                    write_line(match, to_stream)
+    if not regex_list:
+        write_line(line, to_stream)
+    else:
+        for regex in regex_list:
+            matches = regex.findall(line)
+            for match in matches:
+                write_line(match, to_stream)
 
-def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: list, to_stream: io.TextIOWrapper) -> str:
+
+def process_detail(
+    from_stream: io.TextIOWrapper,
+    start_line: str,
+    regex_list: list,
+    to_stream: io.TextIOWrapper,
+) -> str:
     """Process lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -74,9 +91,9 @@ def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: l
             return line
 
         # Print all the lines
-        process_detail_line(line, regex_list,  to_stream)
+        process_detail_line(line, regex_list, to_stream)
 
-            
+
 def skip_detail(from_stream: io.TextIOWrapper) -> str:
     """Skip lines from the start of the details section until the last line,
     returns the first line right after the details section
@@ -90,6 +107,7 @@ def skip_detail(from_stream: io.TextIOWrapper) -> str:
         if helper.is_detail_finished(line):
             return line
 
+
 def process_spread_output(output_file, exclude_lines, filter_rules):
     error_regex = compile_rules(filter_rules, helper.ERROR)
     debug_regex = compile_rules(filter_rules, helper.DEBUG)
@@ -102,40 +120,43 @@ def process_spread_output(output_file, exclude_lines, filter_rules):
 
             while helper.is_detail_start(line):
                 regex_list = []
-                if helper.is_line(line, helper.DEBUG):
+                if helper.is_operation(line, helper.DEBUG):
                     if helper.DEBUG in exclude_lines:
                         line = skip_detail(sys.stdin)
                         continue
                     else:
                         regex_list = debug_regex
-                
-                if helper.is_line(line, helper.ERROR):
+
+                if helper.is_operation(line, helper.ERROR):
                     if helper.ERROR in exclude_lines:
                         line = skip_detail(sys.stdin)
                         continue
                     else:
                         regex_list = error_regex
 
-                if helper.is_line(line, helper.WARNING):
+                if helper.is_operation(line, helper.WARNING):
                     if helper.WARNING in exclude_lines:
                         line = skip_detail(sys.stdin)
                         continue
                     else:
                         regex_list = warning_regex
 
-                if helper.is_line(line, helper.FAILED):
+                if helper.is_operation(line, helper.FAILED):
                     if helper.FAILED in exclude_lines:
                         line = skip_detail(sys.stdin)
                         continue
                     else:
                         regex_list = failed_regex
-                    
+
                 line = process_detail(sys.stdin, line, regex_list, myfile)
 
-            if not exclude_lines or \
-                not helper.is_operation(line) or \
-                not helper.get_operation(line) in exclude_lines:
+            if (
+                not exclude_lines
+                or not helper.is_any_operation(line)
+                or not helper.get_operation(line) in exclude_lines
+            ):
                 write_line(line, myfile)
+
 
 def _make_parser():
     # type: () -> argparse.ArgumentParser
@@ -144,29 +165,30 @@ def _make_parser():
 This tool is used to save a filtered version of the spread output. It parses the spread output and filters
 sections and debug/error details to the file passed as parameter (all the lines are printed).
 When a output file is not provided the debug output is sent to spread_filtered.log
-""")
+"""
+    )
     parser.add_argument(
         "-o",
-        "--output-file", 
+        "--output-file",
         metavar="PATH",
         default="spread.filtered.log",
-        help="path to the filtered output file"
+        help="path to the filtered output file",
     )
     parser.add_argument(
         "-e",
-        "--exclude", 
+        "--exclude",
         action="append",
         default=[],
         choices=helper.OPERATIONS,
-        help="A line section to exclude from the output"
+        help="A line section to exclude from the output",
     )
     parser.add_argument(
         "-f",
-        "--filter", 
+        "--filter",
         action="append",
         metavar="OPERATION=PATTERN",
         default=[],
-        help="It is used to extract specific data from errors. Allowed operations are Error, Debug, Failed and WARNING:"
+        help="It is used to extract specific data from errors. Allowed operations are Error, Debug, Failed and WARNING:",
     )
 
     return parser
@@ -176,4 +198,3 @@ if __name__ == "__main__":
     parser = _make_parser()
     args = parser.parse_args()
     process_spread_output(args.output_file, args.exclude, args.filter)
-    

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -15,24 +15,30 @@ import sys
 import log_helper as helper
 
 # Printable names
-ALL = 'all'
-NONE = 'none'
-ACTION = 'action'
-OPERATION = 'operation'
-INFO = 'info'
-ERROR = 'error'
-ERROR_DEBUG = 'error-debug'
+ALL = "all"
+NONE = "none"
+ACTION = "action"
+OPERATION = "operation"
+INFO = "info"
+ERROR = "error"
+ERROR_DEBUG = "error-debug"
 
-RESULT = 'result'
-START = 'Found'
-SPREAD_FILE = 'spread.yaml'
+RESULT = "result"
+START = "Found"
+SPREAD_FILE = "spread.yaml"
 
 EXEC_VERBS = [helper.PREPARING, helper.EXECUTING, helper.RESTORING]
 INFO_TYPES = [helper.ERROR, helper.DEBUG, helper.WARNING]
 LIFECYCLE_VERBS = [
-    helper.ALLOCATING, helper.CONNECTING, helper.WAITING, helper.REBOOTING,
-    helper.DISCARDING, helper.SENDING, helper.ALLOCATED, helper.CONNECTED
-    ]
+    helper.ALLOCATING,
+    helper.CONNECTING,
+    helper.WAITING,
+    helper.REBOOTING,
+    helper.DISCARDING,
+    helper.SENDING,
+    helper.ALLOCATED,
+    helper.CONNECTED,
+]
 RESULTS = [helper.SUCCESSFUL, helper.ABORTED, helper.FAILED]
 FAILED_LEVELS = [helper.TASK, helper.SUITE, helper.PROJECT]
 
@@ -56,12 +62,12 @@ class Action:
 
     def __dict__(self):
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'verb': self.verb,
-            'task': self.task
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "verb": self.verb,
+            "task": self.task,
+        }
 
 
 class Result:
@@ -70,8 +76,9 @@ class Result:
     The results can be: Successful, failed and aborted
     """
 
-    def __init__(self, result_type, level, stage, number, date, time,
-                 detail, source_line):
+    def __init__(
+        self, result_type, level, stage, number, date, time, detail, source_line
+    ):
         self.type = RESULT
         self.result_type = result_type
         self.level = level
@@ -84,7 +91,7 @@ class Result:
 
     def __repr__(self):
         if self.detail:
-            return '{}{}'.format(self.source_line, str(self.detail))
+            return "{}{}".format(self.source_line, str(self.detail))
         return self.source_line
 
     def __dict__(self):
@@ -92,15 +99,15 @@ class Result:
         if self.detail:
             prepared_detail = self.detail.__dict__()
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'result_type': self.result_type,
-            'level': self.level,
-            'stage': self.stage,
-            'number': self.number,
-            'detail': prepared_detail
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "result_type": self.result_type,
+            "level": self.level,
+            "stage": self.stage,
+            "number": self.number,
+            "detail": prepared_detail,
+        }
 
 
 class Info:
@@ -109,8 +116,7 @@ class Info:
     spread log. The info can be: Error, Debug and Warning
     """
 
-    def __init__(self, info_type, verb, task, extra, date, time,
-                 detail, source_line):
+    def __init__(self, info_type, verb, task, extra, date, time, detail, source_line):
         self.type = INFO
         self.info_type = info_type
         self.verb = verb
@@ -123,7 +129,7 @@ class Info:
 
     def __repr__(self):
         if self.detail:
-            return '{}{}'.format(self.source_line, self.detail)
+            return "{}{}".format(self.source_line, self.detail)
         return self.source_line
 
     def __dict__(self):
@@ -131,15 +137,15 @@ class Info:
         if self.detail:
             prepared_detail = self.detail.__dict__()
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'info_type': self.info_type,
-            'verb': self.verb,
-            'task': self.task,
-            'extra': self.extra,
-            'detail': prepared_detail
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "info_type": self.info_type,
+            "verb": self.verb,
+            "task": self.task,
+            "extra": self.extra,
+            "detail": prepared_detail,
+        }
 
 
 class Rule:
@@ -148,9 +154,11 @@ class Rule:
     """
 
     def __init__(self, rule):
-        parts = rule.split('=',1)
+        parts = rule.split("=", 1)
         if len(parts) != 2:
-            raise ValueError("Error: Rule '{}' does not follow the KEY=PATTERN format".format(rule))
+            raise ValueError(
+                "Error: Rule '{}' does not follow the KEY=PATTERN format".format(rule)
+            )
 
         self.key = parts[0]
         self.pattern = parts[1]
@@ -158,7 +166,9 @@ class Rule:
         try:
             re.compile(self.pattern)
         except re.error as err:
-            raise ValueError("Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err))
+            raise ValueError(
+                "Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err)
+            )
 
     def filter(self, lines):
         regex = re.compile(self.pattern)
@@ -170,6 +180,7 @@ class Rule:
                     all_matches.append(match)
 
         return all_matches
+
 
 class Detail:
     """
@@ -188,19 +199,19 @@ class Detail:
 
         # Use self.lines_limit-1 because the last line is a '.' and we don't
         # want to count it as a line in the log details
-        return self.lines[-self.lines_limit-1:]
+        return self.lines[-self.lines_limit - 1 :]
 
     def _process_rules(self, rules):
         for rule in rules:
             key = rule.key
             matches = rule.filter(self.lines)
-            self.data[key] = '\n'.join(matches)
+            self.data[key] = "\n".join(matches)
 
     def __repr__(self):
-        return ''.join(self._get_lines())
+        return "".join(self._get_lines())
 
     def __dict__(self):
-        details_dict = {'lines': self.lines[-self.lines_limit-1:]}
+        details_dict = {"lines": self.lines[-self.lines_limit - 1 :]}
         for key in self.data.keys():
             details_dict[key] = self.data[key]
 
@@ -228,20 +239,23 @@ class Operation:
 
     def __dict__(self):
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'verb': self.verb,
-            'task': self.task,
-            'extra': self.extra
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "verb": self.verb,
+            "task": self.task,
+            "extra": self.extra,
+        }
 
 
 class LogReader:
     """
     LogReader manages the spread log, it allows to read, export and print
     """
-    def __init__(self, filepath, output_type, lines_limit, store_setup, error_rules, debug_rules):
+
+    def __init__(
+        self, filepath, output_type, lines_limit, store_setup, error_rules, debug_rules
+    ):
         self.filepath = filepath
         self.output_type = output_type
         self.lines_limit = lines_limit
@@ -256,7 +270,7 @@ class LogReader:
         return str(self.__dict__())
 
     def __dict__(self):
-        return {'full_log': self.full_log}
+        return {"full_log": self.full_log}
 
     def print_log(self, details, results):
         if not self.full_log:
@@ -264,32 +278,58 @@ class LogReader:
 
         # Print the details
         if details == ALL:
-            print(''.join(str(x) for x in self.full_log))
+            print("".join(str(x) for x in self.full_log))
         elif details == NONE:
             pass
         elif details == ERROR:
-            print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  x.info_type == helper.ERROR))
+            print(
+                "".join(
+                    str(x)
+                    for x in self.full_log
+                    if x.type == INFO and x.info_type == helper.ERROR
+                )
+            )
         elif details == ERROR_DEBUG:
-            print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  (x.info_type == helper.ERROR or x.info_type == helper.DEBUG)))
+            print(
+                "".join(
+                    str(x)
+                    for x in self.full_log
+                    if x.type == INFO
+                    and (x.info_type == helper.ERROR or x.info_type == helper.DEBUG)
+                )
+            )
         else:
-            print(''.join(str(x) for x in self.full_log if x.type == details))
+            print("".join(str(x) for x in self.full_log if x.type == details))
 
         # Print the results
         if results == ALL:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT))
+            print("".join(str(x) for x in self.full_log if x.type == RESULT))
         elif results == NONE:
             pass
         elif results == helper.FAILED.lower():
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == helper.FAILED))
+            print(
+                "".join(
+                    str(x)
+                    for x in self.full_log
+                    if x.type == RESULT and x.result_type == helper.FAILED
+                )
+            )
         elif results == helper.ABORTED.lower():
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == helper.ABORTED))
+            print(
+                "".join(
+                    str(x)
+                    for x in self.full_log
+                    if x.type == RESULT and x.result_type == helper.ABORTED
+                )
+            )
         else:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == helper.SUCCESSFUL))
+            print(
+                "".join(
+                    str(x)
+                    for x in self.full_log
+                    if x.type == RESULT and x.result_type == helper.SUCCESSFUL
+                )
+            )
 
     def export_log(self, filepath):
         prepared_log = []
@@ -298,22 +338,22 @@ class LogReader:
                 prepared_log.append(item)
             else:
                 prepared_log.append(item.__dict__())
-        with open(filepath, 'w') as json_file:
+        with open(filepath, "w") as json_file:
             json.dump(prepared_log, json_file, indent=4)
 
     def _next_line(self):
         self.iter = self.iter + 1
-        return self.lines[self.iter-1]
+        return self.lines[self.iter - 1]
 
     def check_log_exists(self):
         return os.path.exists(self.filepath)
 
     def read_spread_log(self):
         try:
-            with open(self.filepath, 'r', encoding='utf-8') as filepath:
+            with open(self.filepath, "r", encoding="utf-8") as filepath:
                 self.lines = filepath.readlines()
         except UnicodeDecodeError:
-            with open(self.filepath, 'r', encoding='latin-1') as filepath:
+            with open(self.filepath, "r", encoding="latin-1") as filepath:
                 self.lines = filepath.readlines()
 
         # Find the start of the log, the log file could include
@@ -322,7 +362,7 @@ class LogReader:
         if self.store_setup:
             while self.iter < len(self.lines):
                 line = self._next_line()
-                if helper.is_start_line(line):
+                if helper.is_initial_line(line):
                     break
                 self.full_log.append(line)
 
@@ -364,16 +404,23 @@ class LogReader:
                 continue
 
     def _match_info(self, line):
-        return helper.is_operation(line) and helper.get_operation(line) in INFO_TYPES
+        return (
+            helper.is_any_operation(line) and helper.get_operation(line) in INFO_TYPES
+        )
 
     def _match_task(self, line):
-        return helper.is_operation(line) and helper.get_operation(line) in EXEC_VERBS
+        return (
+            helper.is_any_operation(line) and helper.get_operation(line) in EXEC_VERBS
+        )
 
     def _match_operation(self, line):
-        return helper.is_operation(line) and helper.get_operation(line) in LIFECYCLE_VERBS
+        return (
+            helper.is_any_operation(line)
+            and helper.get_operation(line) in LIFECYCLE_VERBS
+        )
 
     def _match_result(self, line):
-        return helper.is_operation(line) and helper.get_operation(line) in RESULTS
+        return helper.is_any_operation(line) and helper.get_operation(line) in RESULTS
 
     def _get_detail(self, rules, results=False, other_limit=None):
         """
@@ -382,18 +429,18 @@ class LogReader:
         a limit of lines to tail the log and show the last lines.
         It returns a Detail object included all the lines.
         """
-        detail=[]
-        while self.iter < len(self.lines):            
-            previous_line = self.lines[self.iter-1]
+        detail = []
+        while self.iter < len(self.lines):
+            previous_line = self.lines[self.iter - 1]
             line = self._next_line()
             if helper.is_detail_finished(line):
                 # This is needed because it could happen that in the details there is a spread log
                 # because sometimes we run nested spread
                 # The is not valid when the details are for failed tests in results section
-                if results or previous_line.strip() == '.':
+                if results or previous_line.strip() == ".":
                     break
-            
-            detail.append(line)            
+
+            detail.append(line)
 
         # We leave the iter in the last line in case the log has finished
         if not self.iter == len(self.lines):
@@ -417,20 +464,20 @@ class LogReader:
         task = None
         if info_type == helper.WARNING:
             # Removing the : from WARNING:
-            info_type = info_type.split(':')[0]
+            info_type = info_type.split(":")[0]
             verb = None
             task = None
             extra = info_extra
         elif info_type == helper.ERROR:
-            verb = info_extra.split(' ')[0]
-            task = info_extra.split(' ')[1]
+            verb = info_extra.split(" ")[0]
+            task = info_extra.split(" ")[1]
             extra = None
         elif info_type == helper.DEBUG:
             verb = None
-            task = info_extra.split(' ')[2]
+            task = info_extra.split(" ")[2]
             extra = None
         else:
-            print('log-processor: detail type not recognized: {}'.format(info_type))
+            print("log-processor: detail type not recognized: {}".format(info_type))
 
         # Pass the rules according to the info type
         rules = self.debug_rules
@@ -444,19 +491,19 @@ class LogReader:
         return Info(info_type, verb, task, extra, date, time, detail, line)
 
     def _get_result(self, line):
-        """ Get the Result object including the details for the result """
+        """Get the Result object including the details for the result"""
         date = helper.get_date(line)
         time = helper.get_time(line)
         result_type = helper.get_operation(line)
         result_extra = helper.get_operation_info(line)
-        level = result_extra.split(' ')[0].split(':')[0]
-        number = result_extra.split(' ')[-1]
+        level = result_extra.split(" ")[0].split(":")[0]
+        number = result_extra.split(" ")[-1]
 
         stage = None
         detail = None
         if result_type == helper.FAILED:
             if level in FAILED_LEVELS:
-                stage = result_extra.split(' ')[1].split(':')[0]
+                stage = result_extra.split(" ")[1].split(":")[0]
             detail = self._get_detail([], results=True, other_limit=-1)
 
         return Result(result_type, level, stage, number, date, time, detail, line)
@@ -469,11 +516,11 @@ class LogReader:
         date = helper.get_date(line)
         time = helper.get_time(line)
         verb = helper.get_operation(line)
-        task = helper.get_operation_info(line).split(' ')[0]
-        return Action(verb, task.split('...')[0], date, time, line)
+        task = helper.get_operation_info(line).split(" ")[0]
+        return Action(verb, task.split("...")[0], date, time, line)
 
     def _get_operation(self, line):
-        """ Get the Operation object for lines rebooting, allocating, etc """
+        """Get the Operation object for lines rebooting, allocating, etc"""
 
         date = helper.get_date(line)
         time = helper.get_time(line)
@@ -504,7 +551,7 @@ for the error/debug/warning output.
         "--format",
         type=str,
         default="json",
-        choices=['json'],
+        choices=["json"],
         help="format for the output",
     )
     parser.add_argument(
@@ -520,7 +567,13 @@ for the error/debug/warning output.
         "--print-results",
         type=str,
         default=NONE,
-        choices=[ALL, helper.FAILED.lower(), helper.ABORTED.lower(), helper.SUCCESSFUL.lower(), NONE],
+        choices=[
+            ALL,
+            helper.FAILED.lower(),
+            helper.ABORTED.lower(),
+            helper.SUCCESSFUL.lower(),
+            NONE,
+        ],
         help="Filter which results to print",
     )
     parser.add_argument(
@@ -537,17 +590,17 @@ for the error/debug/warning output.
     )
     parser.add_argument(
         "-er",
-        "--error-rule", 
+        "--error-rule",
         action="append",
         default=[],
-        help="A KEY=PATTERN used to extract and store specific data from errors"
+        help="A KEY=PATTERN used to extract and store specific data from errors",
     )
     parser.add_argument(
         "-dr",
-        "--debug-rule", 
+        "--debug-rule",
         action="append",
         default=[],
-        help="A KEY=PATTERN used to extract and store specific data from debug output"
+        help="A KEY=PATTERN used to extract and store specific data from debug output",
     )
     parser.add_argument(
         "log_path", metavar="PATH", help="path to the log to be analyzed"
@@ -564,7 +617,14 @@ def main():
         parser.print_usage()
         parser.exit(0)
 
-    reader = LogReader(args.log_path, args.format, args.cut, args.store_setup, args.error_rule, args.debug_rule)
+    reader = LogReader(
+        args.log_path,
+        args.format,
+        args.cut,
+        args.store_setup,
+        args.error_rule,
+        args.debug_rule,
+    )
     if not reader.check_log_exists():
         print("log-processor: log not found")
         sys.exit(1)

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -12,15 +12,7 @@ import os
 import re
 import sys
 
-# Info types
-ERROR_TYPE = 'Error'
-DEBUG_TYPE = 'Debug'
-WARN_TYPE = 'WARNING:'
-
-# Results
-FAILED_TYPE = 'Failed'
-ABORTED_TYPE = 'Aborted'
-SUCCESSFUL_TYPE = 'Successful'
+import log_helper as helper
 
 # Printable names
 ALL = 'all'
@@ -30,23 +22,19 @@ OPERATION = 'operation'
 INFO = 'info'
 ERROR = 'error'
 ERROR_DEBUG = 'error-debug'
-FAILED = 'failed'
-ABORTED = 'aborted'
-SUCCESSFUL = 'successful'
 
 RESULT = 'result'
 START = 'Found'
 SPREAD_FILE = 'spread.yaml'
 
-EXEC_VERBS = ['Preparing', 'Executing', 'Restoring']
-INFO_TYPES = [ERROR_TYPE, DEBUG_TYPE, WARN_TYPE]
-OPERATIONS = [
-    'Rebooting', 'Discarding', 'Allocating', 'Waiting',
-    'Allocated', 'Connecting', 'Connected', 'Sending'
+EXEC_VERBS = [helper.PREPARING, helper.EXECUTING, helper.RESTORING]
+INFO_TYPES = [helper.ERROR, helper.DEBUG, helper.WARNING]
+LIFECYCLE_VERBS = [
+    helper.ALLOCATING, helper.CONNECTING, helper.WAITING, helper.REBOOTING,
+    helper.DISCARDING, helper.SENDING, helper.ALLOCATED, helper.CONNECTED
     ]
-RESULTS = ['Successful', 'Aborted', 'Failed']
-FAILED_LEVELS = ['task', 'suite', 'project']
-FAILED_STAGES = ['prepare', 'restore']
+RESULTS = [helper.SUCCESSFUL, helper.ABORTED, helper.FAILED]
+FAILED_LEVELS = [helper.TASK, helper.SUITE, helper.PROJECT]
 
 
 class Action:
@@ -68,7 +56,7 @@ class Action:
 
     def __dict__(self):
         return {
-            'type': 'action',
+            'type': self.type,
             'date': self.date,
             'time': self.time,
             'verb': self.verb,
@@ -170,7 +158,7 @@ class Rule:
         try:
             re.compile(self.pattern)
         except re.error as err:
-            raise ValueError("Error: pattern '{}' cannot be compiled: {}".format(pattern, err))
+            raise ValueError("Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err))
 
     def filter(self, lines):
         regex = re.compile(self.pattern)
@@ -281,10 +269,10 @@ class LogReader:
             pass
         elif details == ERROR:
             print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  x.info_type == ERROR_TYPE))
+                  x.info_type == helper.ERROR))
         elif details == ERROR_DEBUG:
             print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  (x.info_type == ERROR_TYPE or x.info_type == DEBUG_TYPE)))
+                  (x.info_type == helper.ERROR or x.info_type == helper.DEBUG)))
         else:
             print(''.join(str(x) for x in self.full_log if x.type == details))
 
@@ -293,15 +281,15 @@ class LogReader:
             print(''.join(str(x) for x in self.full_log if x.type == RESULT))
         elif results == NONE:
             pass
-        elif results == FAILED:
+        elif results == helper.FAILED.lower():
             print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == FAILED_TYPE))
-        elif results == ABORTED:
+                  x.result_type == helper.FAILED))
+        elif results == helper.ABORTED.lower():
             print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == ABORTED_TYPE))
+                  x.result_type == helper.ABORTED))
         else:
             print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == SUCCESSFUL_TYPE))
+                  x.result_type == helper.SUCCESSFUL))
 
     def export_log(self, filepath):
         prepared_log = []
@@ -334,7 +322,7 @@ class LogReader:
         if self.store_setup:
             while self.iter < len(self.lines):
                 line = self._next_line()
-                if self._match_start(line):
+                if helper.is_start_line(line):
                     break
                 self.full_log.append(line)
 
@@ -375,47 +363,17 @@ class LogReader:
                     self.full_log.append(result)
                 continue
 
-    def _match_date(self, date):
-        return re.findall(r'\d{4}-\d{2}-\d{2}', date)
-
-    def _match_time(self, time):
-        return re.findall(r'\d{2}:\d{2}:\d{2}', time)
-
     def _match_info(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 3 and \
-            parts[2] in INFO_TYPES and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+        return helper.is_operation(line) and helper.get_operation(line) in INFO_TYPES
 
     def _match_task(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in EXEC_VERBS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
-
-    def _match_start(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] == START and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1]) and \
-            SPREAD_FILE in parts[3]
+        return helper.is_operation(line) and helper.get_operation(line) in EXEC_VERBS
 
     def _match_operation(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in OPERATIONS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+        return helper.is_operation(line) and helper.get_operation(line) in LIFECYCLE_VERBS
 
     def _match_result(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in RESULTS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+        return helper.is_operation(line) and helper.get_operation(line) in RESULTS
 
     def _get_detail(self, rules, results=False, other_limit=None):
         """
@@ -424,44 +382,20 @@ class LogReader:
         a limit of lines to tail the log and show the last lines.
         It returns a Detail object included all the lines.
         """
-
-        # If the first line matches with a regular line, this means the detail
-        # has no output and has to be discarded
-        line = self.lines[self.iter]
-        if self._match_task(line) or self._match_info(line) or \
-            self._match_operation(line) or self._match_result(line):
-            return None
-
         detail=[]
-        initial_iter = self.iter
-        while self.iter < len(self.lines):
+        while self.iter < len(self.lines):            
+            previous_line = self.lines[self.iter-1]
             line = self._next_line()
-            if self._match_task(line) or self._match_info(line) or \
-            self._match_operation(line) or self._match_result(line):
-                # When the details is for results, then any match is ok to break
-                if results:
+            if helper.is_detail_finished(line):
+                # This is needed because it could happen that in the details there is a spread log
+                # because sometimes we run nested spread
+                # The is not valid when the details are for failed tests in results section
+                if results or previous_line.strip() == '.':
                     break
-                # When the details is no for results, then we need to check also
-                # the the last time was just a '.'
-                # The details for info (Error, Debug and Warning) always finish with
-                # ----
-                # .
-                #
-                # As the iter is already pointing to the next line since 'line = self._next_line()'
-                # to access the previous line of the current one it is needed to do 'self.iter-2'
-                elif self.lines[self.iter-2].strip() == '.':
-                    break
+            
+            detail.append(line)            
 
-                detail.append(line)
-
-            # When the details is for results, if the detail line does not start
-            # with "    - ", then it is time to break
-            if results and not line.startswith("    - "):
-                break
-            else:
-                detail.append(line)
-        
-        # We leave the iter in the last time in case the log has finished
+        # We leave the iter in the last line in case the log has finished
         if not self.iter == len(self.lines):
             self.iter = self.iter - 1
         if not other_limit:
@@ -474,83 +408,78 @@ class LogReader:
         Get the Info object for the error, debug and warning lines including
         the details for this
         """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        info_type = parts[2]
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        info_type = helper.get_operation(line)
+        info_extra = helper.get_operation_info(line)
 
         verb = None
         task = None
-        if info_type == WARN_TYPE:
+        if info_type == helper.WARNING:
+            # Removing the : from WARNING:
             info_type = info_type.split(':')[0]
             verb = None
             task = None
-            extra = ' '.join(parts[3:])
-        elif info_type == ERROR_TYPE:
-            verb = parts[3]
-            task = parts[4]
+            extra = info_extra
+        elif info_type == helper.ERROR:
+            verb = info_extra.split(' ')[0]
+            task = info_extra.split(' ')[1]
             extra = None
-        elif info_type == DEBUG_TYPE:
+        elif info_type == helper.DEBUG:
             verb = None
-            task = parts[5]
+            task = info_extra.split(' ')[2]
             extra = None
         else:
-            print('log-parser: detail type not recognized: {}'.format(info_type))
+            print('log-processor: detail type not recognized: {}'.format(info_type))
 
         # Pass the rules according to the info type
         rules = self.debug_rules
-        if info_type == ERROR_TYPE:
+        if info_type == helper.ERROR:
             rules = self.error_rules
 
-        detail = self._get_detail(rules, results=False)
+        detail = None
+        if not helper.is_detail_eof(line):
+            detail = self._get_detail(rules)
+
         return Info(info_type, verb, task, extra, date, time, detail, line)
 
     def _get_result(self, line):
         """ Get the Result object including the details for the result """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        result_type = parts[2]
-        level = parts[3].split(':')[0]
-        number = parts[-1]
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        result_type = helper.get_operation(line)
+        result_extra = helper.get_operation_info(line)
+        level = result_extra.split(' ')[0].split(':')[0]
+        number = result_extra.split(' ')[-1]
 
         stage = None
         detail = None
-        if result_type == FAILED_TYPE:
+        if result_type == helper.FAILED:
             if level in FAILED_LEVELS:
-                stage = parts[4].split(':')[0]
+                stage = result_extra.split(' ')[1].split(':')[0]
             detail = self._get_detail([], results=True, other_limit=-1)
 
-        return Result(result_type, level, stage, number.strip(), date, time, detail,
-                      line)
+        return Result(result_type, level, stage, number, date, time, detail, line)
 
     def _get_action(self, line):
         """
         Get the Action object for lines preparing, executing and restoring
         """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        verb = parts[2]
-        task = parts[3]
+
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
+        task = helper.get_operation_info(line).split(' ')[0]
         return Action(verb, task.split('...')[0], date, time, line)
 
     def _get_operation(self, line):
         """ Get the Operation object for lines rebooting, allocating, etc """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        verb = parts[2]
+
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
         task = None
-        extra = ' '.join(parts[3:])
+        extra = helper.get_operation_info(line)
         return Operation(verb, task, extra, date, time, line)
 
 
@@ -591,7 +520,7 @@ for the error/debug/warning output.
         "--print-results",
         type=str,
         default=NONE,
-        choices=[ALL, FAILED, ABORTED, SUCCESSFUL, NONE],
+        choices=[ALL, helper.FAILED.lower(), helper.ABORTED.lower(), helper.SUCCESSFUL.lower(), NONE],
         help="Filter which results to print",
     )
     parser.add_argument(
@@ -621,7 +550,7 @@ for the error/debug/warning output.
         help="A KEY=PATTERN used to extract and store specific data from debug output"
     )
     parser.add_argument(
-        "logpath", metavar="PATH", help="path to the log to be analyzed"
+        "log_path", metavar="PATH", help="path to the log to be analyzed"
     )
     return parser
 
@@ -631,13 +560,595 @@ def main():
     parser = _make_parser()
     args = parser.parse_args()
 
-    if len(args.logpath) == 0:
+    if len(args.log_path) == 0:
         parser.print_usage()
         parser.exit(0)
 
-    reader = LogReader(args.logpath, args.format, args.cut, args.store_setup, args.error_rule, args.debug_rule)
+    reader = LogReader(args.log_path, args.format, args.cut, args.store_setup, args.error_rule, args.debug_rule)
     if not reader.check_log_exists():
-        print("log-parser: log not found")
+        print("log-processor: log not found")
+        sys.exit(1)
+
+    reader.read_spread_log()
+
+    if args.output:
+        reader.export_log(args.output)
+
+    reader.print_log(args.print_details, args.print_results)
+
+
+if __name__ == "__main__":
+    main()
+
+#!/usr/bin/env python3
+
+"""
+This tool reads a spread log and creates a file with all the data
+The output file includes the more important information extracted
+from the log to be analyzed
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+import log_helper as helper
+
+# Printable names
+ALL = 'all'
+NONE = 'none'
+ACTION = 'action'
+OPERATION = 'operation'
+INFO = 'info'
+ERROR = 'error'
+ERROR_DEBUG = 'error-debug'
+
+RESULT = 'result'
+START = 'Found'
+SPREAD_FILE = 'spread.yaml'
+
+EXEC_VERBS = [helper.PREPARING, helper.EXECUTING, helper.RESTORING]
+INFO_TYPES = [helper.ERROR, helper.DEBUG, helper.WARNING]
+LIFECYCLE_VERBS = [
+    helper.ALLOCATING, helper.CONNECTING, helper.WAITING, helper.REBOOTING,
+    helper.DISCARDING, helper.SENDING, helper.ALLOCATED, helper.CONNECTED
+    ]
+RESULTS = [helper.SUCCESSFUL, helper.ABORTED, helper.FAILED]
+FAILED_LEVELS = [helper.TASK, helper.SUITE, helper.PROJECT]
+
+
+class Action:
+    """
+    Action represents the main spread tasks actions
+    The actions can be: Preparing, Executing and Restoring
+    """
+
+    def __init__(self, verb, task, date, time, source_line):
+        self.type = ACTION
+        self.verb = verb
+        self.time = time
+        self.date = date
+        self.task = task
+        self.source_line = source_line
+
+    def __repr__(self):
+        return self.source_line
+
+    def __dict__(self):
+        return {
+            'type': self.type,
+            'date': self.date,
+            'time': self.time,
+            'verb': self.verb,
+            'task': self.task
+            }
+
+
+class Result:
+    """
+    Result represents the results for a spread run
+    The results can be: Successful, failed and aborted
+    """
+
+    def __init__(self, result_type, level, stage, number, date, time,
+                 detail, source_line):
+        self.type = RESULT
+        self.result_type = result_type
+        self.level = level
+        self.stage = stage
+        self.number = number
+        self.time = time
+        self.date = date
+        self.detail = detail
+        self.source_line = source_line
+
+    def __repr__(self):
+        if self.detail:
+            return '{}{}'.format(self.source_line, str(self.detail))
+        return self.source_line
+
+    def __dict__(self):
+        prepared_detail = None
+        if self.detail:
+            prepared_detail = self.detail.__dict__()
+        return {
+            'type': self.type,
+            'date': self.date,
+            'time': self.time,
+            'result_type': self.result_type,
+            'level': self.level,
+            'stage': self.stage,
+            'number': self.number,
+            'detail': prepared_detail
+            }
+
+
+class Info:
+    """
+    Info represents the extra tasks information which is included in the
+    spread log. The info can be: Error, Debug and Warning
+    """
+
+    def __init__(self, info_type, verb, task, extra, date, time,
+                 detail, source_line):
+        self.type = INFO
+        self.info_type = info_type
+        self.verb = verb
+        self.time = time
+        self.date = date
+        self.task = task
+        self.extra = extra
+        self.detail = detail
+        self.source_line = source_line
+
+    def __repr__(self):
+        if self.detail:
+            return '{}{}'.format(self.source_line, self.detail)
+        return self.source_line
+
+    def __dict__(self):
+        prepared_detail = None
+        if self.detail:
+            prepared_detail = self.detail.__dict__()
+        return {
+            'type': self.type,
+            'date': self.date,
+            'time': self.time,
+            'info_type': self.info_type,
+            'verb': self.verb,
+            'task': self.task,
+            'extra': self.extra,
+            'detail': prepared_detail
+            }
+
+
+class Rule:
+    """
+    Rule represent the KEY=PATTERN used to extract information from a set of lines
+    """
+
+    def __init__(self, rule):
+        parts = rule.split('=',1)
+        if len(parts) != 2:
+            raise ValueError("Error: Rule '{}' does not follow the KEY=PATTERN format".format(rule))
+
+        self.key = parts[0]
+        self.pattern = parts[1]
+
+        try:
+            re.compile(self.pattern)
+        except re.error as err:
+            raise ValueError("Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err))
+
+    def filter(self, lines):
+        regex = re.compile(self.pattern)
+        all_matches = []
+        for line in lines:
+            matches = regex.findall(line)
+            for match in matches:
+                if match:
+                    all_matches.append(match)
+
+        return all_matches
+
+class Detail:
+    """
+    Detail represents the extra lines which are displayed after the info
+    """
+
+    def __init__(self, lines_limit, lines, rules):
+        self.lines_limit = lines_limit
+        self.lines = lines
+        self.data = {}
+        self._process_rules(rules)
+
+    def _get_lines(self):
+        if self.lines_limit < 0 or self.lines_limit > len(self.lines):
+            return self.lines
+
+        # Use self.lines_limit-1 because the last line is a '.' and we don't
+        # want to count it as a line in the log details
+        return self.lines[-self.lines_limit-1:]
+
+    def _process_rules(self, rules):
+        for rule in rules:
+            key = rule.key
+            matches = rule.filter(self.lines)
+            self.data[key] = '\n'.join(matches)
+
+    def __repr__(self):
+        return ''.join(self._get_lines())
+
+    def __dict__(self):
+        details_dict = {'lines': self.lines[-self.lines_limit-1:]}
+        for key in self.data.keys():
+            details_dict[key] = self.data[key]
+
+        return details_dict
+
+
+class Operation:
+    """
+    Operation represents other actions that the spread running can do while
+    executing tests like: Rebooting, Discarding, Allocating, Waiting,
+    Allocated, Connecting, Connected, Sending
+    """
+
+    def __init__(self, verb, task, extra, date, time, source_line):
+        self.type = OPERATION
+        self.verb = verb
+        self.time = time
+        self.extra = extra
+        self.date = date
+        self.task = task
+        self.source_line = source_line
+
+    def __repr__(self):
+        return self.source_line
+
+    def __dict__(self):
+        return {
+            'type': self.type,
+            'date': self.date,
+            'time': self.time,
+            'verb': self.verb,
+            'task': self.task,
+            'extra': self.extra
+            }
+
+
+class LogReader:
+    """
+    LogReader manages the spread log, it allows to read, export and print
+    """
+    def __init__(self, filepath, output_type, lines_limit, store_setup, error_rules, debug_rules):
+        self.filepath = filepath
+        self.output_type = output_type
+        self.lines_limit = lines_limit
+        self.store_setup = store_setup
+        self.lines = []
+        self.iter = 0
+        self.full_log = []
+        self.error_rules = [Rule(rule) for rule in error_rules]
+        self.debug_rules = [Rule(rule) for rule in debug_rules]
+
+    def __repr__(self):
+        return str(self.__dict__())
+
+    def __dict__(self):
+        return {'full_log': self.full_log}
+
+    def print_log(self, details, results):
+        if not self.full_log:
+            return
+
+        # Print the details
+        if details == ALL:
+            print(''.join(str(x) for x in self.full_log))
+        elif details == NONE:
+            pass
+        elif details == ERROR:
+            print(''.join(str(x) for x in self.full_log if x.type == INFO and
+                  x.info_type == helper.ERROR))
+        elif details == ERROR_DEBUG:
+            print(''.join(str(x) for x in self.full_log if x.type == INFO and
+                  (x.info_type == helper.ERROR or x.info_type == helper.DEBUG)))
+        else:
+            print(''.join(str(x) for x in self.full_log if x.type == details))
+
+        # Print the results
+        if results == ALL:
+            print(''.join(str(x) for x in self.full_log if x.type == RESULT))
+        elif results == NONE:
+            pass
+        elif results == helper.FAILED.lower():
+            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
+                  x.result_type == helper.FAILED))
+        elif results == helper.ABORTED.lower():
+            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
+                  x.result_type == helper.ABORTED))
+        else:
+            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
+                  x.result_type == helper.SUCCESSFUL))
+
+    def export_log(self, filepath):
+        prepared_log = []
+        for item in self.full_log:
+            if isinstance(item, str):
+                prepared_log.append(item)
+            else:
+                prepared_log.append(item.__dict__())
+        with open(filepath, 'w') as json_file:
+            json.dump(prepared_log, json_file, indent=4)
+
+    def _next_line(self):
+        self.iter = self.iter + 1
+        return self.lines[self.iter-1]
+
+    def check_log_exists(self):
+        return os.path.exists(self.filepath)
+
+    def read_spread_log(self):
+        try:
+            with open(self.filepath, 'r', encoding='utf-8') as filepath:
+                self.lines = filepath.readlines()
+        except UnicodeDecodeError:
+            with open(self.filepath, 'r', encoding='latin-1') as filepath:
+                self.lines = filepath.readlines()
+
+        # Find the start of the log, the log file could include
+        # initial lines which are not part of the spread log itself
+        self.iter = 0
+        if self.store_setup:
+            while self.iter < len(self.lines):
+                line = self._next_line()
+                if helper.is_start_line(line):
+                    break
+                self.full_log.append(line)
+
+            if self.iter >= len(self.lines):
+                # Start not found, the log is either empty, corrupted or cut
+                self.iter = 0
+
+        # Then iterate line by line analyzing the log
+        while self.iter < len(self.lines):
+            line = self._next_line()
+
+            # The line is a task execution; preparing, executing, restoring
+            if self._match_task(line):
+                action = self._get_action(line)
+                if action:
+                    self.full_log.append(action)
+                continue
+
+            # The line shows info: error, debug, warning
+            if self._match_info(line):
+                info = self._get_info(line)
+                if info:
+                    self.full_log.append(info)
+                continue
+
+            # The line is another operation: Rebooting, Discarding, Allocating
+            # Waiting, Allocated, Connecting, Connected, Sending'
+            if self._match_operation(line):
+                operation = self._get_operation(line)
+                if operation:
+                    self.full_log.append(operation)
+                continue
+
+            # The line is a result: Successful, Aborted, Failed
+            if self._match_result(line):
+                result = self._get_result(line)
+                if result:
+                    self.full_log.append(result)
+                continue
+
+    def _match_info(self, line):
+        return helper.is_operation(line) and helper.get_operation(line) in INFO_TYPES
+
+    def _match_task(self, line):
+        return helper.is_operation(line) and helper.get_operation(line) in EXEC_VERBS
+
+    def _match_operation(self, line):
+        return helper.is_operation(line) and helper.get_operation(line) in LIFECYCLE_VERBS
+
+    def _match_result(self, line):
+        return helper.is_operation(line) and helper.get_operation(line) in RESULTS
+
+    def _get_detail(self, rules, results=False, other_limit=None):
+        """
+        This function is used to get the piece of log which is after the
+        info lines (error, debug, warning). The detail could also include
+        a limit of lines to tail the log and show the last lines.
+        It returns a Detail object included all the lines.
+        """
+        detail=[]
+        while self.iter < len(self.lines):            
+            previous_line = self.lines[self.iter-1]
+            line = self._next_line()
+            if helper.is_detail_finished(line):
+                # This is needed because it could happen that in the details there is a spread log
+                # because sometimes we run nested spread
+                # The is not valid when the details are for failed tests in results section
+                if results or previous_line.strip() == '.':
+                    break
+            
+            detail.append(line)            
+
+        # We leave the iter in the last line in case the log has finished
+        if not self.iter == len(self.lines):
+            self.iter = self.iter - 1
+        if not other_limit:
+            other_limit = self.lines_limit
+
+        return Detail(other_limit, detail, rules)
+
+    def _get_info(self, line):
+        """
+        Get the Info object for the error, debug and warning lines including
+        the details for this
+        """
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        info_type = helper.get_operation(line)
+        info_extra = helper.get_operation_info(line)
+
+        verb = None
+        task = None
+        if info_type == helper.WARNING:
+            # Removing the : from WARNING:
+            info_type = info_type.split(':')[0]
+            verb = None
+            task = None
+            extra = info_extra
+        elif info_type == helper.ERROR:
+            verb = info_extra.split(' ')[0]
+            task = info_extra.split(' ')[1]
+            extra = None
+        elif info_type == helper.DEBUG:
+            verb = None
+            task = info_extra.split(' ')[2]
+            extra = None
+        else:
+            print('log-processor: detail type not recognized: {}'.format(info_type))
+
+        # Pass the rules according to the info type
+        rules = self.debug_rules
+        if info_type == helper.ERROR:
+            rules = self.error_rules
+
+        detail = None
+        if not helper.is_detail_eof(line):
+            detail = self._get_detail(rules)
+
+        return Info(info_type, verb, task, extra, date, time, detail, line)
+
+    def _get_result(self, line):
+        """ Get the Result object including the details for the result """
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        result_type = helper.get_operation(line)
+        result_extra = helper.get_operation_info(line)
+        level = result_extra.split(' ')[0].split(':')[0]
+        number = result_extra.split(' ')[-1]
+
+        stage = None
+        detail = None
+        if result_type == helper.FAILED:
+            if level in FAILED_LEVELS:
+                stage = result_extra.split(' ')[1].split(':')[0]
+            detail = self._get_detail([], results=True, other_limit=-1)
+
+        return Result(result_type, level, stage, number, date, time, detail, line)
+
+    def _get_action(self, line):
+        """
+        Get the Action object for lines preparing, executing and restoring
+        """
+
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
+        task = helper.get_operation_info(line).split(' ')[0]
+        return Action(verb, task.split('...')[0], date, time, line)
+
+    def _get_operation(self, line):
+        """ Get the Operation object for lines rebooting, allocating, etc """
+
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
+        task = None
+        extra = helper.get_operation_info(line)
+        return Operation(verb, task, extra, date, time, line)
+
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+Parse the spread log and generates a file with a standardized output. It also
+allows to filter the output by type and define the number of lines to show
+for the error/debug/warning output.
+"""
+    )
+    parser.add_argument(
+        "-c",
+        "--cut",
+        type=int,
+        default=1000,
+        help="maximum number of lines for logs on errors and debug sections",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        default="json",
+        choices=['json'],
+        help="format for the output",
+    )
+    parser.add_argument(
+        "-pd",
+        "--print-details",
+        type=str,
+        default=NONE,
+        choices=[ALL, ERROR, ERROR_DEBUG, OPERATION, ACTION, INFO, NONE],
+        help="Filter which info to print",
+    )
+    parser.add_argument(
+        "-pr",
+        "--print-results",
+        type=str,
+        default=NONE,
+        choices=[ALL, helper.FAILED.lower(), helper.ABORTED.lower(), helper.SUCCESSFUL.lower(), NONE],
+        help="Filter which results to print",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="spread-results.json",
+        type=str,
+        help="output file to save the result",
+    )
+    parser.add_argument(
+        "--store-setup",
+        action="store_true",
+        help="will save all the text before the spread run is started",
+    )
+    parser.add_argument(
+        "-er",
+        "--error-rule", 
+        action="append",
+        default=[],
+        help="A KEY=PATTERN used to extract and store specific data from errors"
+    )
+    parser.add_argument(
+        "-dr",
+        "--debug-rule", 
+        action="append",
+        default=[],
+        help="A KEY=PATTERN used to extract and store specific data from debug output"
+    )
+    parser.add_argument(
+        "log_path", metavar="PATH", help="path to the log to be analyzed"
+    )
+    return parser
+
+
+def main():
+    # type: () -> None
+    parser = _make_parser()
+    args = parser.parse_args()
+
+    if len(args.log_path) == 0:
+        parser.print_usage()
+        parser.exit(0)
+
+    reader = LogReader(args.log_path, args.format, args.cut, args.store_setup, args.error_rule, args.debug_rule)
+    if not reader.check_log_exists():
+        print("log-processor: log not found")
         sys.exit(1)
 
     reader.read_spread_log()

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -6,160 +6,185 @@ process the spread output.
 import re
 
 # Tasks status
-PREPARING = 'Preparing'
-EXECUTING = 'Executing'
-RESTORING = 'Restoring'
+PREPARING = "Preparing"
+EXECUTING = "Executing"
+RESTORING = "Restoring"
 
 # Tasks info
-DEBUG = 'Debug'
-ERROR = 'Error'
-WARNING = 'WARNING:'
+DEBUG = "Debug"
+ERROR = "Error"
+WARNING = "WARNING:"
 
 # General actions
-REBOOTING = 'Rebooting'
-DISCARDING = 'Discarding'
-ALLOCATING = 'Allocating'
-WAITING = 'Waiting'
-CONNECTING = 'Connecting'
-SENDING = 'Sending'
+REBOOTING = "Rebooting"
+DISCARDING = "Discarding"
+ALLOCATING = "Allocating"
+WAITING = "Waiting"
+CONNECTING = "Connecting"
+SENDING = "Sending"
 
 # Actions status
-ALLOCATED = 'Allocated'
-CONNECTED = 'Connected'
+ALLOCATED = "Allocated"
+CONNECTED = "Connected"
 
 # Results
-FAILED = 'Failed'
-SUCCESSFUL = 'Successful'
-ABORTED = 'Aborted'
+FAILED = "Failed"
+SUCCESSFUL = "Successful"
+ABORTED = "Aborted"
 
 # Tasks levels
-TASK = 'task'
-SUITE = 'suite'
-PROJECT = 'project'
+TASK = "task"
+SUITE = "suite"
+PROJECT = "project"
 
 # Start line
-START_LINE = '.*Project content is packed for delivery.*'
+START_LINE = ".*Project content is packed for delivery.*"
 
 OPERATIONS = [
-    PREPARING, EXECUTING, RESTORING,
-    REBOOTING , DISCARDING, ALLOCATING, WAITING,
-    ALLOCATED, CONNECTING , CONNECTED, SENDING,
-    ERROR, DEBUG, WARNING, FAILED, SUCCESSFUL, ABORTED
-    ]
+    PREPARING,
+    EXECUTING,
+    RESTORING,
+    REBOOTING,
+    DISCARDING,
+    ALLOCATING,
+    WAITING,
+    ALLOCATED,
+    CONNECTING,
+    CONNECTED,
+    SENDING,
+    ERROR,
+    DEBUG,
+    WARNING,
+    FAILED,
+    SUCCESSFUL,
+    ABORTED,
+]
+
 
 def _match_date(date):
-    return re.match(r'\d{4}-\d{2}-\d{2}', date)
+    return re.match(r"\d{4}-\d{2}-\d{2}", date)
+
 
 def _match_time(time):
-    return re.match(r'\d{2}:\d{2}:\d{2}', time)
+    return re.match(r"\d{2}:\d{2}:\d{2}", time)
 
-def is_start_line(line: str) -> bool: 
+
+def is_initial_line(line: str) -> bool:
     if not line:
         return False
 
     pattern = re.compile(START_LINE)
-    parts = line.strip().split(' ')
-    return len(parts) > 2 and \
-        _match_date(parts[0]) and \
-        _match_time(parts[1]) and \
-        re.match(pattern, line)
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and re.match(pattern, line)
+    )
+
 
 # Debug line starts with the operation
-def is_line(line: str, operation: str) -> bool:
+def is_operation(line: str, operation: str) -> bool:
     if not line:
         return False
 
-    parts = line.strip().split(' ')
-    return len(parts) > 2 and \
-        _match_date(parts[0]) and \
-        _match_time(parts[1]) and \
-        parts[2] == operation
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] == operation
+    )
 
-# Debug line starts with the operation
-def is_operation(line: str) -> bool:
+
+# Check if the line contains any operation
+def is_any_operation(line: str) -> bool:
     if not line:
         return False
 
-    parts = line.strip().split(' ')
-    return len(parts) > 2 and \
-        _match_date(parts[0]) and \
-        _match_time(parts[1]) and \
-        parts[2] in OPERATIONS
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] in OPERATIONS
+    )
+
 
 # Return the date in the line
 def get_date(line: str) -> str:
     if not line:
         raise RuntimeError("Empty line provided")
 
-    parts = line.strip().split(' ')
-    if len(parts) <= 2 or \
-        not _match_date(parts[0]):
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]):
         raise ValueError("Incorrect format for line provided: {}".format(line))
-    
+
     return parts[0]
+
 
 # Return the time in the line
 def get_time(line: str) -> str:
     if not line:
         raise RuntimeError("Empty line provided")
 
-    parts = line.strip().split(' ')
-    if len(parts) <= 2 or \
-        not _match_date(parts[0]) or \
-        not _match_time(parts[1]):
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]) or not _match_time(parts[1]):
         raise ValueError("Incorrect format for line provided: {}".format(line))
-    
+
     return parts[1]
+
 
 # Return the operation in the line
 def get_operation(line: str) -> str:
     if not line:
         raise RuntimeError("Empty line provided")
 
-    parts = line.strip().split(' ')
-    if len(parts) <= 2 or \
-        not _match_date(parts[0]) or \
-        not _match_time(parts[1]):
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]) or not _match_time(parts[1]):
         raise ValueError("Incorrect format for line provided: {}".format(line))
-    
+
     return parts[2]
+
 
 # Return the information that comes after the operation
 def get_operation_info(line: str) -> str:
     if not line:
         raise RuntimeError("Empty line provided")
 
-    parts = line.strip().split(' ')
-    if len(parts) <= 3 or \
-        not _match_date(parts[0]) or \
-        not _match_time(parts[1]):
+    parts = line.strip().split(" ")
+    if len(parts) <= 3 or not _match_date(parts[0]) or not _match_time(parts[1]):
         raise ValueError("Incorrect format for line provided: {}".format(line))
-    
-    return ' '.join(parts[3:])
+
+    return " ".join(parts[3:])
+
 
 # Details are displayed after Error/Debug/Failed/Warning operations
 def is_detail_start(line: str) -> bool:
-    return is_line(line, DEBUG) or \
-        is_line(line, ERROR) or \
-        is_line(line, WARNING) or \
-        is_line(line, FAILED)
+    return (
+        is_operation(line, DEBUG)
+        or is_operation(line, ERROR)
+        or is_operation(line, WARNING)
+        or is_operation(line, FAILED)
+    )
+
 
 # Error/Debug/Failed output sometimes finish witr EOF error
 def is_detail_eof(line: str) -> bool:
-    parts = line.strip().split(' ')
-    return ( is_line(line, DEBUG) or \
-        is_line(line, ERROR) or \
-        is_line(line, WARNING) ) and \
-        parts[-1].strip() == 'EOF'
+    parts = line.strip().split(" ")
+    return (
+        is_operation(line, DEBUG)
+        or is_operation(line, ERROR)
+        or is_operation(line, WARNING)
+    ) and parts[-1].strip() == "EOF"
+
 
 # Error/Debug/Failed output finishes when a new other line starts
 def is_detail_finished(line: str) -> bool:
-    parts = line.strip().split(' ')
-    return len(parts) > 3 and \
-        _match_date(parts[0]) and \
-        _match_time(parts[1]) and \
-        parts[2] in OPERATIONS
-
-
-if __name__ == "__main__":
-    main()
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 3
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] in OPERATIONS
+    )

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -1,0 +1,165 @@
+"""
+This library provides a set of functions that can be used to
+process the spread output.
+"""
+
+import re
+
+# Tasks status
+PREPARING = 'Preparing'
+EXECUTING = 'Executing'
+RESTORING = 'Restoring'
+
+# Tasks info
+DEBUG = 'Debug'
+ERROR = 'Error'
+WARNING = 'WARNING:'
+
+# General actions
+REBOOTING = 'Rebooting'
+DISCARDING = 'Discarding'
+ALLOCATING = 'Allocating'
+WAITING = 'Waiting'
+CONNECTING = 'Connecting'
+SENDING = 'Sending'
+
+# Actions status
+ALLOCATED = 'Allocated'
+CONNECTED = 'Connected'
+
+# Results
+FAILED = 'Failed'
+SUCCESSFUL = 'Successful'
+ABORTED = 'Aborted'
+
+# Tasks levels
+TASK = 'task'
+SUITE = 'suite'
+PROJECT = 'project'
+
+# Start line
+START_LINE = '.*Project content is packed for delivery.*'
+
+OPERATIONS = [
+    PREPARING, EXECUTING, RESTORING,
+    REBOOTING , DISCARDING, ALLOCATING, WAITING,
+    ALLOCATED, CONNECTING , CONNECTED, SENDING,
+    ERROR, DEBUG, WARNING, FAILED, SUCCESSFUL, ABORTED
+    ]
+
+def _match_date(date):
+    return re.match(r'\d{4}-\d{2}-\d{2}', date)
+
+def _match_time(time):
+    return re.match(r'\d{2}:\d{2}:\d{2}', time)
+
+def is_start_line(line: str) -> bool: 
+    if not line:
+        return False
+
+    pattern = re.compile(START_LINE)
+    parts = line.strip().split(' ')
+    return len(parts) > 2 and \
+        _match_date(parts[0]) and \
+        _match_time(parts[1]) and \
+        re.match(pattern, line)
+
+# Debug line starts with the operation
+def is_line(line: str, operation: str) -> bool:
+    if not line:
+        return False
+
+    parts = line.strip().split(' ')
+    return len(parts) > 2 and \
+        _match_date(parts[0]) and \
+        _match_time(parts[1]) and \
+        parts[2] == operation
+
+# Debug line starts with the operation
+def is_operation(line: str) -> bool:
+    if not line:
+        return False
+
+    parts = line.strip().split(' ')
+    return len(parts) > 2 and \
+        _match_date(parts[0]) and \
+        _match_time(parts[1]) and \
+        parts[2] in OPERATIONS
+
+# Return the date in the line
+def get_date(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(' ')
+    if len(parts) <= 2 or \
+        not _match_date(parts[0]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+    
+    return parts[0]
+
+# Return the time in the line
+def get_time(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(' ')
+    if len(parts) <= 2 or \
+        not _match_date(parts[0]) or \
+        not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+    
+    return parts[1]
+
+# Return the operation in the line
+def get_operation(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(' ')
+    if len(parts) <= 2 or \
+        not _match_date(parts[0]) or \
+        not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+    
+    return parts[2]
+
+# Return the information that comes after the operation
+def get_operation_info(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(' ')
+    if len(parts) <= 3 or \
+        not _match_date(parts[0]) or \
+        not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+    
+    return ' '.join(parts[3:])
+
+# Details are displayed after Error/Debug/Failed/Warning operations
+def is_detail_start(line: str) -> bool:
+    return is_line(line, DEBUG) or \
+        is_line(line, ERROR) or \
+        is_line(line, WARNING) or \
+        is_line(line, FAILED)
+
+# Error/Debug/Failed output sometimes finish witr EOF error
+def is_detail_eof(line: str) -> bool:
+    parts = line.strip().split(' ')
+    return ( is_line(line, DEBUG) or \
+        is_line(line, ERROR) or \
+        is_line(line, WARNING) ) and \
+        parts[-1].strip() == 'EOF'
+
+# Error/Debug/Failed output finishes when a new other line starts
+def is_detail_finished(line: str) -> bool:
+    parts = line.strip().split(' ')
+    return len(parts) > 3 and \
+        _match_date(parts[0]) and \
+        _match_time(parts[1]) and \
+        parts[2] in OPERATIONS
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -5,36 +5,7 @@ import io
 import re
 import sys
 
-OPERATIONS = [
-    'Preparing', 'Executing', 'Restoring',
-    'Rebooting', 'Discarding', 'Allocating', 'Waiting',
-    'Allocated', 'Connecting', 'Connected', 'Sending',
-    'Error', 'Debug', 'WARNING'
-    ]
-
-def match_date(date):
-    return re.match(r'\d{4}-\d{2}-\d{2}', date)
-
-def match_time(time):
-    return re.match(r'\d{2}:\d{2}:\d{2}', time)
-
-# Debug line starts with 
-def is_debug_start(line):
-    parts = line.strip().split(' ')
-    return len(parts) > 5 and \
-        match_date(parts[0]) and \
-        match_time(parts[1]) and \
-        parts[2] == 'Debug' and \
-        parts[3] == 'output' and \
-        parts[4] == 'for'
-
-# Debug output finishes when a new other line starts
-def is_debug_finished(line: str) -> bool:
-    parts = line.strip().split(' ')
-    return len(parts) > 3 and \
-        match_date(parts[0]) and \
-        match_time(parts[1]) and \
-        parts[2] in OPERATIONS
+import log_helper as helper
 
 def get_debug_tag(debug_num):
     return "###DEBUG-{}###".format(debug_num)
@@ -56,7 +27,7 @@ def process_debug(from_stream: io.TextIOWrapper, start_line: str, debug_count: i
         myfile.write(get_debug_tag(debug_count) + '\n')
         myfile.write(start_line.strip())
         for line in from_stream:
-            if is_debug_finished(line):
+            if helper.is_detail_finished(line):
                 myfile.write('\n')
                 return line
             
@@ -67,7 +38,7 @@ def process_spread_output(debug_file):
     debug_num = 0
     for line in sys.stdin:
         # A Debug section starts
-        if is_debug_start(line):
+        if helper.is_line(line, helper.DEBUG):
             debug_num += 1
             print_debug_line(line.strip(), debug_num)
             line = process_debug(sys.stdin, line, debug_num, debug_file)

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -35,15 +35,31 @@ def is_debug_finished(line):
         match_time(parts[1]) and \
         parts[2] in OPERATIONS
 
+def get_debug_tag(debug_num):
+    return "###DEBUG-{}###".format(debug_num)
+
+# Prints the debug line and the tag that helps for cross-referencing
+def print_debug_line(line, debug_num):
+    print(line)
+    print("-----")
+    print(get_debug_tag(debug_num))
+    print("-----")
+
+# Writes in the file the debug output lines including the tag that
+# helps for cross-referencing
+def write_debug_lines(debug_lines, debug_num, debug_file):
+    with open(debug_file, 'a+') as myfile:
+        myfile.write(get_debug_tag(debug_num) + '\n')
+        myfile.write(debug_lines)
 
 # Process spread output lines
 def process_spread_output(debug_file):
+    debug_num = 0
     debug_lines = ""
     for line in sys.stdin:
         if debug_lines:
             if is_debug_finished(line):
-                with open(debug_file, 'a+') as myfile:
-                   myfile.write(debug_lines)
+                write_debug_lines(debug_lines, debug_num, debug_file)
 
                 # There is a Debug output right after
                 if match_debug(line):
@@ -58,7 +74,10 @@ def process_spread_output(debug_file):
         else:
             # A Debug section starts
             if match_debug(line):
+                debug_num += 1
                 debug_lines = line
+                print_debug_line(line.strip(), debug_num)
+
                 continue
             # No debug line, just print it
             else:

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -7,8 +7,10 @@ import sys
 
 import log_helper as helper
 
+
 def get_debug_tag(debug_num):
     return "###DEBUG-{}###".format(debug_num)
+
 
 # Prints the debug line and the tag that helps for cross-referencing
 def print_debug_line(line: str, debug_num: int):
@@ -17,33 +19,37 @@ def print_debug_line(line: str, debug_num: int):
     print(get_debug_tag(debug_num))
     print("-----")
 
-def process_debug(from_stream: io.TextIOWrapper, start_line: str, debug_count: int, debug_file) -> str:
+
+def process_debug(
+    from_stream: io.TextIOWrapper, start_line: str, debug_count: int, debug_file
+) -> str:
     """Process lines from the start of the debug section until the last line,
     returns the first line right after the debug section
     """
     with open(debug_file, "a+") as myfile:
         # Writes in the file the debug output lines including the tag that
         # helps for cross-referencing
-        myfile.write(get_debug_tag(debug_count) + '\n')
+        myfile.write(get_debug_tag(debug_count) + "\n")
         myfile.write(start_line.strip())
         for line in from_stream:
             if helper.is_detail_finished(line):
-                myfile.write('\n')
+                myfile.write("\n")
                 return line
-            
+
             myfile.write(line.strip())
-        
+
 
 def process_spread_output(debug_file):
     debug_num = 0
     for line in sys.stdin:
         # A Debug section starts
-        if helper.is_line(line, helper.DEBUG):
+        if helper.is_operation(line, helper.DEBUG):
             debug_num += 1
             print_debug_line(line.strip(), debug_num)
             line = process_debug(sys.stdin, line, debug_num, debug_file)
 
         print(line.strip())
+
 
 def _make_parser():
     # type: () -> argparse.ArgumentParser
@@ -52,13 +58,14 @@ def _make_parser():
 This tool is used to reduce the size of the spread output. It parses the spread output and sends 
 the Debug Output to the file passed as parameter. When a file is not provided
 the debug output is sent to debug.log
-""")
+"""
+    )
     parser.add_argument(
         "-f",
-        "--debug-file", 
+        "--debug-file",
         metavar="PATH",
         default="debug.log",
-        help="path to the debug output file"
+        help="path to the debug output file",
     )
     return parser
 

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+DEBUG_FILENAME = 'debug.log'
+OPERATIONS = [
+    'Preparing', 'Executing', 'Restoring',
+    'Rebooting', 'Discarding', 'Allocating', 'Waiting',
+    'Allocated', 'Connecting', 'Connected', 'Sending',
+    'Error', 'Debug', 'WARNING'
+    ]
+
+def match_date(date):
+    return re.findall(r'\d{4}-\d{2}-\d{2}', date)
+
+def match_time(time):
+    return re.findall(r'\d{2}:\d{2}:\d{2}', time)
+
+# Debug line starts with 
+def match_debug(line):
+    parts = line.strip().split(' ')
+    return len(parts) > 5 and \
+        match_date(parts[0]) and \
+        match_time(parts[1]) and \
+        parts[2] == 'Debug' and \
+        parts[3] == 'output' and \
+        parts[4] == 'for'
+
+# Debug output finishes when a new other line starts
+def is_debug_finished(line):
+    parts = line.strip().split(' ')
+    return len(parts) > 3 and \
+        match_date(parts[0]) and \
+        match_time(parts[1]) and \
+        parts[2] in OPERATIONS
+
+
+# Process spread output lines
+def process_spread_output():
+    debug_lines = ""
+    for line in sys.stdin:
+        if debug_lines:
+            if is_debug_finished(line):
+                with open(DEBUG_FILENAME, 'a+') as myfile:
+                   myfile.write(debug_lines)
+
+                # There is a Debug output right after
+                if match_debug(line):
+                    debug_lines = line
+                else:
+                    print(line.strip())
+                    debug_lines = ""
+                continue
+            else:
+                debug_lines = debug_lines + line
+                continue
+        else:
+            # A Debug section starts
+            if match_debug(line):
+                debug_lines = line
+                continue
+            # No debug line, just print it
+            else:
+                print(line.strip())
+
+
+if __name__ == "__main__":
+    process_spread_output()

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import argparse
 import re
 import sys
 
-DEBUG_FILENAME = 'debug.log'
 OPERATIONS = [
     'Preparing', 'Executing', 'Restoring',
     'Rebooting', 'Discarding', 'Allocating', 'Waiting',
@@ -37,12 +37,12 @@ def is_debug_finished(line):
 
 
 # Process spread output lines
-def process_spread_output():
+def process_spread_output(debug_file):
     debug_lines = ""
     for line in sys.stdin:
         if debug_lines:
             if is_debug_finished(line):
-                with open(DEBUG_FILENAME, 'a+') as myfile:
+                with open(debug_file, 'a+') as myfile:
                    myfile.write(debug_lines)
 
                 # There is a Debug output right after
@@ -64,6 +64,25 @@ def process_spread_output():
             else:
                 print(line.strip())
 
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+This tool is used to reduce the size of the spread output. It parses the spread output and sends 
+the Debug Output to the file passed as parameter. When a file is not provided
+the debug output is sent to debug.log
+""")
+    parser.add_argument(
+        "-f",
+        "--debug-file", 
+        metavar="PATH",
+        default="debug.log",
+        help="path to the debug output file"
+    )
+    return parser
+
 
 if __name__ == "__main__":
-    process_spread_output()
+    parser = _make_parser()
+    args = parser.parse_args()
+    process_spread_output(args.debug_file)

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import io
 import re
 import sys
 
@@ -18,7 +19,7 @@ def match_time(time):
     return re.findall(r'\d{2}:\d{2}:\d{2}', time)
 
 # Debug line starts with 
-def match_debug(line):
+def is_debug_start(line):
     parts = line.strip().split(' ')
     return len(parts) > 5 and \
         match_date(parts[0]) and \
@@ -28,7 +29,7 @@ def match_debug(line):
         parts[4] == 'for'
 
 # Debug output finishes when a new other line starts
-def is_debug_finished(line):
+def is_debug_finished(line: str) -> bool:
     parts = line.strip().split(' ')
     return len(parts) > 3 and \
         match_date(parts[0]) and \
@@ -39,49 +40,39 @@ def get_debug_tag(debug_num):
     return "###DEBUG-{}###".format(debug_num)
 
 # Prints the debug line and the tag that helps for cross-referencing
-def print_debug_line(line, debug_num):
+def print_debug_line(line: str, debug_num: int):
     print(line)
     print("-----")
     print(get_debug_tag(debug_num))
     print("-----")
 
-# Writes in the file the debug output lines including the tag that
-# helps for cross-referencing
-def write_debug_lines(debug_lines, debug_num, debug_file):
-    with open(debug_file, 'a+') as myfile:
-        myfile.write(get_debug_tag(debug_num) + '\n')
-        myfile.write(debug_lines)
+def process_debug(from_stream: io.TextIOWrapper, start_line: str, debug_count: int, debug_file) -> str:
+    """Process lines from the start of the debug section until the last line,
+    returns the first line right after the debug section
+    """
+    with open(debug_file, "a+") as myfile:
+        # Writes in the file the debug output lines including the tag that
+        # helps for cross-referencing
+        myfile.write(get_debug_tag(debug_count) + '\n')
+        myfile.write(start_line.strip())
+        for line in from_stream:
+            if is_debug_finished(line):
+                myfile.write('\n')
+                return line
+            
+            myfile.write(line.strip())
+        
 
-# Process spread output lines
 def process_spread_output(debug_file):
     debug_num = 0
-    debug_lines = ""
     for line in sys.stdin:
-        if debug_lines:
-            if is_debug_finished(line):
-                write_debug_lines(debug_lines, debug_num, debug_file)
+        # A Debug section starts
+        if is_debug_start(line):
+            debug_num += 1
+            print_debug_line(line.strip(), debug_num)
+            line = process_debug(sys.stdin, line, debug_num, debug_file)
 
-                # There is a Debug output right after
-                if match_debug(line):
-                    debug_lines = line
-                else:
-                    print(line.strip())
-                    debug_lines = ""
-                continue
-            else:
-                debug_lines = debug_lines + line
-                continue
-        else:
-            # A Debug section starts
-            if match_debug(line):
-                debug_num += 1
-                debug_lines = line
-                print_debug_line(line.strip(), debug_num)
-
-                continue
-            # No debug line, just print it
-            else:
-                print(line.strip())
+        print(line.strip())
 
 def _make_parser():
     # type: () -> argparse.ArgumentParser

--- a/tests/lib/tools/filter-debug-output
+++ b/tests/lib/tools/filter-debug-output
@@ -13,10 +13,10 @@ OPERATIONS = [
     ]
 
 def match_date(date):
-    return re.findall(r'\d{4}-\d{2}-\d{2}', date)
+    return re.match(r'\d{4}-\d{2}-\d{2}', date)
 
 def match_time(time):
-    return re.findall(r'\d{2}:\d{2}:\d{2}', time)
+    return re.match(r'\d{2}:\d{2}:\d{2}', time)
 
 # Debug line starts with 
 def is_debug_start(line):

--- a/tests/lib/tools/suite/filter-debug-output/task.yaml
+++ b/tests/lib/tools/suite/filter-debug-output/task.yaml
@@ -11,7 +11,7 @@ execute: |
     "$TESTSTOOLS"/filter-debug-output -h | MATCH "usage: filter-debug-output"
     "$TESTSTOOLS"/filter-debug-output --help | MATCH "usage: filter-debug-output"
 
-    cat spread.log | "$TESTSTOOLS"/filter-debug-output -f debug.log | tee result.log
+    "$TESTSTOOLS"/filter-debug-output -f debug.log < spread.log | tee result.log
 
     # Check the number of debug logs in both files is the same
     test "$(grep -c "###DEBUG-" debug.log)" -eq 3

--- a/tests/lib/tools/suite/filter-debug-output/task.yaml
+++ b/tests/lib/tools/suite/filter-debug-output/task.yaml
@@ -1,0 +1,43 @@
+summary: smoke test for the filter-debug-output tool
+
+details: |
+    Check the filter-debug-output tool filters the spread log and stores the
+    debug output to the debug.log file.
+
+systems: [ubuntu-22.04-64]
+
+execute: |
+    # Check help
+    "$TESTSTOOLS"/filter-debug-output -h | MATCH "usage: filter-debug-output"
+    "$TESTSTOOLS"/filter-debug-output --help | MATCH "usage: filter-debug-output"
+
+    cat spread.log | "$TESTSTOOLS"/filter-debug-output -f debug.log | tee result.log
+
+    # Check the number of debug logs in both files is the same
+    test "$(grep -c "###DEBUG-" debug.log)" -eq 3
+    test "$(grep -c "###DEBUG-" result.log)" -eq 3
+
+    # Check the DEBUG-3 tag is sent to both files
+    test "$(grep -c "###DEBUG-3###" debug.log)" -eq 1
+    test "$(grep -c "###DEBUG-3###" result.log)" -eq 1
+
+    # Check the main "Debug output for" line is displayed in both files
+    test "$(grep -c "Debug output for" debug.log)" -eq 3
+    test "$(grep -c "Debug output for" result.log)" -eq 3
+
+    # Check the debug output is just displayed in debug.log
+    test "$(grep -c "journalctl -n" debug.log)" -eq 3
+    test "$(grep -c "journalctl -n" result.log)" -eq 0
+
+    # Check the error debugging is not included in debug.log
+    test "$(grep -c "journalctl -u" debug.log)" -eq 0
+    test "$(grep -c "journalctl -u" result.log)" -eq 1
+
+    # Check other lines are not included in debug.log
+    test "$(grep -c "Allocating google" debug.log)" -eq 0
+    test "$(grep -c "Waiting for google" debug.log)" -eq 0
+    test "$(grep -c "Connecting to google" debug.log)" -eq 0
+    test "$(grep -c "Preparing google" debug.log)" -eq 0
+    test "$(grep -c "Executing google" debug.log)" -eq 0
+    test "$(grep -c "Restoring google" debug.log)" -eq 0
+    test "$(grep -c "Discarding google" debug.log)" -eq 0


### PR DESCRIPTION
The new tool filters the debug output of the tests and saves that to the debug.log file.  This is used as part fo the github workflow to reduce the size of the logs and make is easier to read.  Then the debug.log file is uploaded as an artifact of the job.

