### PR TITLE
tests/main/high-user-handling: force kill test user's session

### DIFF
--- a/tests/main/high-user-handling/task.yaml
+++ b/tests/main/high-user-handling/task.yaml
@@ -11,6 +11,7 @@ prepare: |
 
 restore: |
     tests.session -u hightest restore
+    loginctl kill-user hightest || true
     userdel -r hightest
 
 execute: |

--- a/tests/main/high-user-handling/task.yaml
+++ b/tests/main/high-user-handling/task.yaml
@@ -1,4 +1,6 @@
-summary: Check that the refresh data copy works.
+summary: Check handling of exceptionally high user IDs
+details: |
+  Check that osutil handling of exceptionally high user IDs is correct.
 
 systems:
     - -ubuntu-14.04-*  # no support for tests.session


### PR DESCRIPTION
Apparently some test user processes may still be running when we try to remove it.

```
2024-04-09 12:47:47 Restoring google-central:fedora-38-64:tests/main/high-user-handling (apr091230-325924)... Error: 2024-04-09 12:47:47 Error restoring google-central:fedora-38-64:tests/main/high-user-handling (apr091230-325924) : -----
+ tests.session -u hightest restore umount: /run/user/4294967294/gvfs: no mount point specified. umount: /run/user/4294967294/doc: no mount point specified.
+ userdel -r hightest userdel: user hightest is currently used by process 39295 -----
.
```

