### PR TITLE
many: add support for user daemons in "snapctl services"

### DIFF
--- a/client/clientutil/service_scope.go
+++ b/client/clientutil/service_scope.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -73,4 +75,25 @@ func (us *ServiceScopeOptions) Users() client.UserSelector {
 		Selector: client.UserSelectionList,
 		Names:    strutil.CommaSeparatedList(us.Usernames),
 	}
+}
+
+// FmtServiceStatus formats a given service application into the following string
+// <snap.app>             <enabled> <active> <notes>
+// To keep output persistent between snapctl and snap cmd.
+func FmtServiceStatus(svc *client.AppInfo, isGlobal bool) string {
+	startup := i18n.G("disabled")
+	if svc.Enabled {
+		startup = i18n.G("enabled")
+	}
+
+	// When requesting global service status, we don't have any active
+	// information available for user daemons.
+	current := i18n.G("inactive")
+	if svc.DaemonScope == snap.UserDaemon && isGlobal {
+		current = "-"
+	} else if svc.Active {
+		current = i18n.G("active")
+	}
+
+	return fmt.Sprintf("%s.%s\t%s\t%s\t%s", svc.Snap, svc.Name, startup, current, ClientAppInfoNotes(svc))
 }

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -95,9 +95,9 @@ func init() {
 	}}
 	addCommand("services", shortServicesHelp, longServicesHelp, func() flags.Commander { return &svcStatus{} }, map[string]string{
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"global": i18n.G("Show the global enable status for user-services instead of the status for the current user."),
+		"global": i18n.G("Show the global enable status for user services instead of the status for the current user."),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"user": i18n.G("Show the current status of the user-services instead of the global enable status."),
+		"user": i18n.G("Show the current status of the user services instead of the global enable status."),
 	}, argdescs)
 	addCommand("logs", shortLogsHelp, longLogsHelp, func() flags.Commander { return &svcLogs{} },
 		timeDescs.also(map[string]string{

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/snap"
 )
 
 type svcStatus struct {
@@ -133,24 +132,6 @@ func svcNames(s []serviceName) []string {
 	return svcNames
 }
 
-func fmtServiceStatus(svc *client.AppInfo, isGlobal bool) string {
-	startup := i18n.G("disabled")
-	if svc.Enabled {
-		startup = i18n.G("enabled")
-	}
-
-	// When requesting global service status, we don't have any active
-	// information available for user daemons.
-	current := i18n.G("inactive")
-	if svc.DaemonScope == snap.UserDaemon && isGlobal {
-		current = "-"
-	} else if svc.Active {
-		current = i18n.G("active")
-	}
-
-	return fmt.Sprintf("%s.%s\t%s\t%s\t%s", svc.Snap, svc.Name, startup, current, clientutil.ClientAppInfoNotes(svc))
-}
-
 func (s *svcStatus) showGlobalEnablement(u *user.User) bool {
 	if u.Uid == "0" && !s.User {
 		return true
@@ -201,7 +182,7 @@ func (s *svcStatus) Execute(args []string) error {
 
 	fmt.Fprintln(w, i18n.G("Service\tStartup\tCurrent\tNotes"))
 	for _, svc := range services {
-		fmt.Fprintln(w, fmtServiceStatus(svc, isGlobal))
+		fmt.Fprintln(w, clientutil.FmtServiceStatus(svc, isGlobal))
 	}
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/jessevdk/go-flags"
 
@@ -45,10 +46,15 @@ type baseCommand struct {
 	stderr io.Writer
 	c      *hookstate.Context
 	name   string
+	uid    string
 }
 
 func (c *baseCommand) setName(name string) {
 	c.name = name
+}
+
+func (c *baseCommand) setUid(uid uint32) {
+	c.uid = strconv.FormatUint(uint64(uid), 10)
 }
 
 func (c *baseCommand) setStdout(w io.Writer) {
@@ -88,6 +94,7 @@ func (c *baseCommand) ensureContext() (context *hookstate.Context, err error) {
 
 type command interface {
 	setName(name string)
+	setUid(uid uint32)
 
 	setStdout(w io.Writer)
 	setStderr(w io.Writer)
@@ -157,6 +164,7 @@ func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr 
 	for name, cmdInfo := range commands {
 		cmd := cmdInfo.generator()
 		cmd.setName(name)
+		cmd.setUid(uid)
 		cmd.setStdout(&stdoutBuffer)
 		cmd.setStderr(&stderrBuffer)
 		cmd.setContext(context)

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -20,10 +20,12 @@
 package ctlcmd
 
 import (
+	"context"
 	"fmt"
 	"os/user"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -155,4 +157,10 @@ func MockAutoRefreshForGatingSnap(f func(st *state.State, gatingSnap string) err
 	return func() {
 		autoRefreshForGatingSnap = old
 	}
+}
+
+func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid string) clientutil.StatusDecorator) (restore func()) {
+	restore = testutil.Backup(&newStatusDecorator)
+	newStatusDecorator = f
+	return restore
 }

--- a/overlord/hookstate/ctlcmd/services.go
+++ b/overlord/hookstate/ctlcmd/services.go
@@ -48,8 +48,8 @@ type servicesCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
-	Global bool `long:"global" short:"g" description:"Show the global enable status for user-services instead of the status for the current user"`
-	User   bool `long:"user" short:"u" description:"Show the current user's user-services instead of the global enable status"`
+	Global bool `long:"global" short:"g" description:"Show the global enable status for user services instead of the status for the current user"`
+	User   bool `long:"user" short:"u" description:"Show the current status of the user services instead of the global enable status"`
 }
 
 type byApp []*snap.AppInfo

--- a/overlord/hookstate/ctlcmd/services.go
+++ b/overlord/hookstate/ctlcmd/services.go
@@ -82,16 +82,6 @@ func (c *servicesCommand) validateArguments() error {
 	if c.Global && c.User {
 		return fmt.Errorf(i18n.G("cannot combine --global and --user switches."))
 	}
-
-	// --user is supported for root
-	if c.User && c.uid != "0" {
-		return fmt.Errorf(i18n.G("unsupported argument --user when not root."))
-	}
-
-	// --global is supported for non-root
-	if c.Global && c.uid == "0" {
-		return fmt.Errorf(i18n.G("unsupported argument --global when root."))
-	}
 	return nil
 }
 

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -844,16 +844,6 @@ func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitches(c *C) {
 	c.Assert(err, ErrorMatches, "cannot combine --global and --user switches.")
 }
 
-func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitchesRoot(c *C) {
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"services", "--global"}, 0)
-	c.Assert(err, ErrorMatches, "unsupported argument --global when root.")
-}
-
-func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitchesNonRoot(c *C) {
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"services", "--user"}, 1337)
-	c.Assert(err, ErrorMatches, "unsupported argument --user when not root.")
-}
-
 func (s *servicectlSuite) TestServicesWithoutContext(c *C) {
 	actions := []string{
 		"start",

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -98,12 +99,19 @@ func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentS
 	return snaps, nil, nil
 }
 
+type appsSuiteDecoratorResult struct {
+	daemonType string
+	active     bool
+	enabled    bool
+}
+
 type servicectlSuite struct {
 	testutil.BaseTest
-	st          *state.State
-	fakeStore   fakeStore
-	mockContext *hookstate.Context
-	mockHandler *hooktest.MockHandler
+	st               *state.State
+	fakeStore        fakeStore
+	mockContext      *hookstate.Context
+	mockHandler      *hooktest.MockHandler
+	decoratorResults map[string]appsSuiteDecoratorResult
 }
 
 var _ = Suite(&servicectlSuite{})
@@ -744,6 +752,106 @@ Service                 Startup  Current  Notes
 test-snap.test-service  enabled  active   -
 `[1:])
 	c.Check(string(stderr), Equals, "")
+}
+
+func (s *servicectlSuite) TestServicesAsUserWithGlobal(c *C) {
+	restore := systemd.MockSystemctl(func(args ...string) (buf []byte, err error) {
+		c.Assert(args[0], Equals, "show")
+		c.Check(args[2], Equals, "snap.test-snap.test-service.service")
+		return []byte(`Id=snap.test-snap.test-service.service
+Names=snap.test-snap.test-service.service
+Type=simple
+ActiveState=active
+UnitFileState=enabled
+NeedDaemonReload=no
+`), nil
+	})
+	defer restore()
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"services", "--global", "test-snap.test-service"}, 1337)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, `
+Service                 Startup  Current  Notes
+test-snap.test-service  enabled  active   -
+`[1:])
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *servicectlSuite) DecorateWithStatus(appInfo *client.AppInfo, snapApp *snap.AppInfo) error {
+	name := snapApp.Snap.RealName + "." + appInfo.Name
+	dec, ok := s.decoratorResults[name]
+	if !ok {
+		return fmt.Errorf("%s not found in expected test decorator results", name)
+	}
+	appInfo.Daemon = dec.daemonType
+	appInfo.Enabled = dec.enabled
+	appInfo.Active = dec.active
+	return nil
+}
+
+func (s *servicectlSuite) TestServicesUserSwitch(c *C) {
+	restore := ctlcmd.MockNewStatusDecorator(func(ctx context.Context, isGlobal bool, uid string) clientutil.StatusDecorator {
+		c.Check(isGlobal, Equals, false)
+		c.Check(uid, Equals, "0")
+		return s
+	})
+	defer restore()
+
+	s.decoratorResults = map[string]appsSuiteDecoratorResult{
+		"test-snap.user-service": {
+			daemonType: "simple",
+			active:     true,
+			enabled:    true,
+		},
+	}
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"services", "--user", "test-snap.user-service"}, 0)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, `
+Service                 Startup  Current  Notes
+test-snap.user-service  enabled  active   user
+`[1:])
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *servicectlSuite) TestServicesAsUser(c *C) {
+	restore := ctlcmd.MockNewStatusDecorator(func(ctx context.Context, isGlobal bool, uid string) clientutil.StatusDecorator {
+		c.Check(isGlobal, Equals, false)
+		c.Check(uid, Equals, "1337")
+		return s
+	})
+	defer restore()
+
+	s.decoratorResults = map[string]appsSuiteDecoratorResult{
+		"test-snap.user-service": {
+			daemonType: "simple",
+			active:     true,
+			enabled:    true,
+		},
+	}
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"services", "test-snap.user-service"}, 1337)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, `
+Service                 Startup  Current  Notes
+test-snap.user-service  enabled  active   user
+`[1:])
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitches(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"services", "--global", "--user"}, 0)
+	c.Assert(err, ErrorMatches, "cannot combine --global and --user switches.")
+}
+
+func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitchesRoot(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"services", "--global"}, 0)
+	c.Assert(err, ErrorMatches, "unsupported argument --global when root.")
+}
+
+func (s *servicectlSuite) TestAppStatusInvalidUserGlobalSwitchesNonRoot(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"services", "--user"}, 1337)
+	c.Assert(err, ErrorMatches, "unsupported argument --user when not root.")
 }
 
 func (s *servicectlSuite) TestServicesWithoutContext(c *C) {


### PR DESCRIPTION
Introduce matching functionality for "snapctl services" as in "snap services" by this PR https://github.com/snapcore/snapd/pull/13381.

"Snapctl services" is one of the few commands that can run without being root user, which means we cannot make any assumptions around the user running the command, introducing the same decision logic around how to deal with the caller.