### PR TITLE
spread.yaml: use ubuntu-image from latest/edge

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     # a global setting for LXD channel to use in the tests
     # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
     LXD_SNAP_CHANNEL: "latest/edge"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
     UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'


### PR DESCRIPTION
Other versions are broken
