### PR TITLE
interfaces/bultin/kubernetes_support: allow SOCK_SEQPACKET

### DIFF
--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -73,6 +73,11 @@ capability dac_override,
 /etc/ssl/certs/java/{,*} r,
 #include <abstractions/ssl_certs>
 
+
+# some workloads like cilium may attempt to use tc to set up complex
+# network traffic control, which in turn uses seqpacket
+network alg seqpacket,
+
 /{,usr/}bin/systemd-run Cxr -> systemd_run,
 /run/systemd/private r,
 profile systemd_run (attach_disconnected,mediate_deleted) {


### PR DESCRIPTION
When running cilium under microk8s, the following denial is observed:

  apparmor="DENIED" operation="create" class="net"
  profile="snap.microk8s.daemon-containerd" pid=20550 comm="tc" family="alg"
  sock_type="seqpacket" protocol=0 requested_mask="create" denied_mask="create"

which is triggered when cilium attempts to set up network package classifier through tc.
