### PR TITLE
tests: run tiobe tics tool in a nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,111 @@
+name: Nightly static code analysis
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+
+jobs:
+
+  tics:
+    runs-on: ubuntu-22.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
+      GOROOT: ""
+      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+    strategy:
+      matrix:
+        gochannel:
+          - 1.18
+        unit-scenario:
+          - normal
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+
+    - name: Download Debian dependencies
+      uses: actions/download-artifact@v3
+      with:
+        name: debian-dependencies
+        path: ./debian-deps/
+
+    - name: Copy dependencies
+      run: |
+        test -f ./debian-deps/cached-apt.tar
+        sudo tar xvf ./debian-deps/cached-apt.tar -C /
+
+    - name: Install Debian dependencies
+      run: |
+          sudo apt update
+          sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+
+    # golang latest ensures things work on the edge
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=${{ matrix.gochannel }} go
+
+    - name: Get deps
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/ && ./get-deps.sh
+
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j$(nproc)
+
+    - name: Build Go
+      run: |
+          go build github.com/snapcore/snapd/...
+
+    - name: Test C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+
+    - name: Reset code coverage data
+      run: |
+          rm -rf ${{ github.workspace }}/.coverage/
+
+    - name: Test Go
+      if: ${{ matrix.unit-scenario == 'normal' }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        ./run-checks --unit
+
+    - name: Save coverage
+      if: ${{ matrix.unit-scenario == 'normal' }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        ./run-checks --unit
+
+    - name: Upload the coverage results
+      run: |
+        mv ${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage ${{ github.workspace }}
+
+    - name: TICS scan
+      run: |
+        export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+
+        # Install the TICS
+        . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+
+        TICSQServer -project snapd -tmpdir /tmp/tics -branchdir ${{ github.workspace }}/src/github.com/snapcore/snapd
+        tar -cvzf tics-logs.tar.gz /tmp/tics
+        mv tics-logs.tar.gz ../../
+
+    - name: Uploading TICS logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: tics-logs.tar.gz
+        path: tics-logs.tar.gz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,7 @@
 name: Nightly static code analysis
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 0 * * *'
 
@@ -16,7 +17,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     strategy:
       matrix:
         gochannel:
@@ -38,22 +38,6 @@ jobs:
       run: |
           sudo apt clean
           sudo apt update
-          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
-          # for indent
-          sudo apt install -y texinfo autopoint
-
-    - name: Copy dependencies
-      run: |
-        sudo tar cvf cached-apt.tar /var/cache/apt
-
-    - name: Copy dependencies
-      run: |
-        test -f ./debian-deps/cached-apt.tar
-        sudo tar xvf ./debian-deps/cached-apt.tar -C /
-
-    - name: Install Debian dependencies
-      run: |
-          sudo apt update
           sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
 
     # golang latest ensures things work on the edge
@@ -63,7 +47,8 @@ jobs:
 
     - name: Get deps
       run: |
-          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/ && ./get-deps.sh
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/
+          ./get-deps.sh
 
     - name: Build C
       run: |
@@ -83,32 +68,27 @@ jobs:
       run: |
           rm -rf ${{ github.workspace }}/.coverage/
 
-    - name: Test Go
-      if: ${{ matrix.unit-scenario == 'normal' }}
+    - name: Test Go with coverage
       run: |
-        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        ./run-checks --unit
+        go install github.com/boumenot/gocover-cobertura@latest
 
-    - name: Save coverage
-      if: ${{ matrix.unit-scenario == 'normal' }}
-      run: |
-        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        ./run-checks --unit
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd
+        COVERAGE_OUT=.coverage/coverage.txt ./run-checks --unit
+        gocover-cobertura < .coverage/coverage.txt > .coverage/coverage.xml
 
-    - name: Upload the coverage results
-      run: |
-        mv ${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage ${{ github.workspace }}
+        mv .coverage ${{ github.workspace }}
+        test -f "${{ github.workspace }}/.coverage/coverage.xml"
 
     - name: TICS scan
       run: |
+        set -x
         export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
 
         # Install the TICS
-        . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+        curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
+        . ./install_tics.sh
 
         TICSQServer -project snapd -tmpdir /tmp/tics -branchdir ${{ github.workspace }}/src/github.com/snapcore/snapd
-        tar -cvzf tics-logs.tar.gz /tmp/tics
-        mv tics-logs.tar.gz ../../
 
     - name: Uploading TICS logs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,10 +35,16 @@ jobs:
         path: ./src/github.com/snapcore/snapd
 
     - name: Download Debian dependencies
-      uses: actions/download-artifact@v3
-      with:
-        name: debian-dependencies
-        path: ./debian-deps/
+      run: |
+          sudo apt clean
+          sudo apt update
+          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+          # for indent
+          sudo apt install -y texinfo autopoint
+
+    - name: Copy dependencies
+      run: |
+        sudo tar cvf cached-apt.tar /var/cache/apt
 
     - name: Copy dependencies
       run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}
-      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin and
       # to use the go snap automatically. Note that we install go from the
       # snap in a step below. Without this we get the GitHub-controlled latest
       # version of go.
@@ -40,7 +40,6 @@ jobs:
           sudo apt update
           sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
 
-    # golang latest ensures things work on the edge
     - name: Install the go snap
       run: |
           sudo snap install --classic --channel=${{ matrix.gochannel }} go


### PR DESCRIPTION
This change introduces a new github actions workflow to run the analisys tool (Tiobe tics server)

The workflow has been tested in my forked project. The only step that is failing is the last one because the integration with tics server has to be done from snapd main project (not from the fork).

The data produced is going to be displayed in https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=Project(snapd),Sub()&metric=tqi

Next step is to integrate the analysis as part of the pr pipeline, including a quality gate.