### PR TITLE
aspects: limit Set value's nestedness

### DIFF
--- a/aspects/export_test.go
+++ b/aspects/export_test.go
@@ -20,3 +20,11 @@
 package aspects
 
 var GetValuesThroughPaths = getValuesThroughPaths
+
+func MockMaxValueDepth(newDepth int) (restore func()) {
+	oldDepth := maxValueDepth
+	maxValueDepth = newDepth
+	return func() {
+		maxValueDepth = oldDepth
+	}
+}


### PR DESCRIPTION
Limit how many nested levels a value set to an aspect can have. This is necessary because we recurse to traverse objects and it takes much less memory to create an object than it takes to traverse it. Here are my back-of-the-envelope calculations, please let me know if anything is off: the default limit on the http request body is 10Mb, since a nested level in the JSON object takes just 6 bytes {"a": ...} the API would accept JSON with more than 1.7 million levels and recursing into them would (at a 2Kb min stack size) take 3.5Gb. Limiting the recursion levels to 4096 keeps the stack size in the low MBs.