### PR TITLE
notices: ensure that two notices don't have the same lastDateTime

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3310,7 +3310,7 @@ grade=signed
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-timestamp":"0001-01-01T00:00:00Z"}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"last-notice-timestamp":"0001-01-01T00:00:00Z"}`)
 
 	// finally check that the recovery system bootenv was updated to be in run
 	// mode

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3310,7 +3310,7 @@ grade=signed
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-date":"0001-01-01T00:00:00Z"}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-timestamp":"0001-01-01T00:00:00Z"}`)
 
 	// finally check that the recovery system bootenv was updated to be in run
 	// mode

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3310,7 +3310,7 @@ grade=signed
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-date":"0001-01-01T00:00:00Z"}`)
 
 	// finally check that the recovery system bootenv was updated to be in run
 	// mode

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -177,7 +177,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 		"last-task-id": 0,
 		"last-lane-id": 0,
 		"last-notice-id": 0,
-		"notice-last-timestamp":"0001-01-01T00:00:00Z"
+		"last-notice-timestamp":"0001-01-01T00:00:00Z"
 	}`, patch.Level, patch.Sublevel, snapdtool.Version))
 	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -177,7 +177,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 		"last-task-id": 0,
 		"last-lane-id": 0,
 		"last-notice-id": 0,
-		"notice-last-date":"0001-01-01T00:00:00Z"
+		"notice-last-timestamp":"0001-01-01T00:00:00Z"
 	}`, patch.Level, patch.Sublevel, snapdtool.Version))
 	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -176,7 +176,8 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 		"last-change-id": 0,
 		"last-task-id": 0,
 		"last-lane-id": 0,
-		"last-notice-id": 0
+		"last-notice-id": 0,
+		"notice-last-date":"0001-01-01T00:00:00Z"
 	}`, patch.Level, patch.Sublevel, snapdtool.Version))
 	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)

--- a/overlord/state/copy_test.go
+++ b/overlord/state/copy_test.go
@@ -79,7 +79,7 @@ var srcStateContent = []byte(`
 }
 `)
 
-const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-date":"0001-01-01T00:00:00Z"}`
+const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-timestamp":"0001-01-01T00:00:00Z"}`
 
 func (ss *stateSuite) TestCopyStateIntegration(c *C) {
 	// create a mock srcState

--- a/overlord/state/copy_test.go
+++ b/overlord/state/copy_test.go
@@ -79,7 +79,7 @@ var srcStateContent = []byte(`
 }
 `)
 
-const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0}`
+const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-date":"0001-01-01T00:00:00Z"}`
 
 func (ss *stateSuite) TestCopyStateIntegration(c *C) {
 	// create a mock srcState

--- a/overlord/state/copy_test.go
+++ b/overlord/state/copy_test.go
@@ -79,7 +79,7 @@ var srcStateContent = []byte(`
 }
 `)
 
-const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"notice-last-timestamp":"0001-01-01T00:00:00Z"}`
+const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0,"last-notice-timestamp":"0001-01-01T00:00:00Z"}`
 
 func (ss *stateSuite) TestCopyStateIntegration(c *C) {
 	// create a mock srcState

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -73,14 +73,6 @@ func (s *State) NumNotices() int {
 	return len(s.notices)
 }
 
-func MockGetTimeNow(f func() time.Time) (restore func()) {
-	old := timeNow
-	timeNow = f
-	return func() {
-		timeNow = old
-	}
-}
-
 func (n *Notice) GetLastOccurred() time.Time {
 	return n.lastOccurred
 }

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -72,7 +72,3 @@ var (
 func (s *State) NumNotices() int {
 	return len(s.notices)
 }
-
-func (n *Notice) GetLastOccurred() time.Time {
-	return n.lastOccurred
-}

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -65,8 +65,6 @@ var (
 	ErrBadWarningMessage    = errBadWarningMessage
 	ErrNoWarningFirstAdded  = errNoWarningFirstAdded
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
-
-	CompareDates = compareDates
 )
 
 // NumNotices returns the total bumber of notices, including expired ones that
@@ -76,10 +74,10 @@ func (s *State) NumNotices() int {
 }
 
 func MockGetTimeNow(f func() time.Time) (restore func()) {
-	old := getTimeNow
-	getTimeNow = f
+	old := timeNow
+	timeNow = f
 	return func() {
-		getTimeNow = old
+		timeNow = old
 	}
 }
 

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -65,6 +65,8 @@ var (
 	ErrBadWarningMessage    = errBadWarningMessage
 	ErrNoWarningFirstAdded  = errNoWarningFirstAdded
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
+
+	CompareDates = compareDates
 )
 
 // NumNotices returns the total bumber of notices, including expired ones that

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -72,3 +72,15 @@ var (
 func (s *State) NumNotices() int {
 	return len(s.notices)
 }
+
+func MockGetTimeNow(f func() time.Time) (restore func()) {
+	old := getTimeNow
+	getTimeNow = f
+	return func() {
+		getTimeNow = old
+	}
+}
+
+func (n *Notice) GetLastOccurred() time.Time {
+	return n.lastOccurred
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -245,7 +245,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if now.IsZero() {
 		now = timeNow()
 		/**
-		 *Ensure that two notices never have the same sent time.
+		 * Ensure that two notices never have the same sent time.
 		 *
 		 * Since the Notices API receives an "after:" parameter with the
 		 * date and time of the last received notice to filter all the

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -245,10 +245,10 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if now.IsZero() {
 		now = timeNow()
 		// ensure that two notices never have the same sent time
-		if !now.After(s.noticeLastTimestamp) {
-			now = s.noticeLastTimestamp.Add(time.Nanosecond)
+		if !now.After(s.lastNoticeTimestamp) {
+			now = s.lastNoticeTimestamp.Add(time.Nanosecond)
 		}
-		s.noticeLastTimestamp = now
+		s.lastNoticeTimestamp = now
 	}
 	now = now.UTC()
 	newOrRepeated := false

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -230,42 +230,16 @@ type AddNoticeOptions struct {
 
 var getTimeNow = time.Now
 
-func compareValues(v1, v2 int) int {
-	if v1 > v2 {
-		return 1
-	}
-	if v1 < v2 {
-		return -1
-	}
-	return 0
-}
-
 func compareDates(date1, date2 time.Time) int {
 	// time.Time.Compare() was added in Go v1.20 :-(
 
-	if val := compareValues(date1.Year(), date2.Year()); val != 0 {
-		return val
-	}
-	if val := compareValues(int(date1.Month()), int(date2.Month())); val != 0 {
-		return val
-	}
-	if val := compareValues(date1.Day(), date2.Day()); val != 0 {
-		return val
-	}
-	if val := compareValues(date1.Hour(), date2.Hour()); val != 0 {
-		return val
-	}
-	if val := compareValues(date1.Minute(), date2.Minute()); val != 0 {
-		return val
-	}
-	if val := compareValues(date1.Second(), date2.Second()); val != 0 {
-		return val
-	}
-	if date1.Nanosecond() > date2.Nanosecond() {
-		return 1
-	}
-	if date1.Nanosecond() < date2.Nanosecond() {
+	dif := date1.Sub(date2)
+
+	switch {
+	case dif < 0:
 		return -1
+	case dif > 0:
+		return +1
 	}
 	return 0
 }

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -244,7 +244,19 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	now := options.Time
 	if now.IsZero() {
 		now = timeNow()
-		// ensure that two notices never have the same sent time
+		/**
+		 *Ensure that two notices never have the same sent time.
+		 *
+		 * Since the Notices API receives an "after:" parameter with the
+		 * date and time of the last received notice to filter all the
+		 * previous notices and avoid duplicates, if two or more notices
+		 * have the same date and time, only the first will be emitted,
+		 * and the others will be silently discarded. This can happen in
+		 * systems that don't guarantee a granularity of one nanosecond
+		 * in their timers, which can happen in some not-so-old devices,
+		 * where the HPET is used instead of internal high resolution
+		 * timers, or in other architectures different from the X86_64.
+		 */
 		if !now.After(s.lastNoticeTimestamp) {
 			now = s.lastNoticeTimestamp.Add(time.Nanosecond)
 		}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -228,22 +228,6 @@ type AddNoticeOptions struct {
 	Time time.Time
 }
 
-var getTimeNow = time.Now
-
-func compareDates(date1, date2 time.Time) int {
-	// time.Time.Compare() was added in Go v1.20 :-(
-
-	dif := date1.Sub(date2)
-
-	switch {
-	case dif < 0:
-		return -1
-	case dif > 0:
-		return +1
-	}
-	return 0
-}
-
 // AddNotice records an occurrence of a notice with the specified type and key
 // and options.
 func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
@@ -259,7 +243,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 
 	now := options.Time
 	if now.IsZero() {
-		now = getTimeNow()
+		now = timeNow()
 		// ensure that two notices never have the same sent time
 		if !now.After(s.noticeLastDate) {
 			now = s.noticeLastDate.Add(time.Nanosecond)

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -261,7 +261,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if now.IsZero() {
 		now = getTimeNow()
 		// ensure that two notices never have the same sent time
-		if compareDates(now, s.noticeLastDate) <= 0 {
+		if !now.After(s.noticeLastDate) {
 			now = s.noticeLastDate.Add(time.Nanosecond)
 		}
 		s.noticeLastDate = now

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -230,6 +230,46 @@ type AddNoticeOptions struct {
 
 var getTimeNow = time.Now
 
+func compareValues(v1, v2 int) int {
+	if v1 > v2 {
+		return 1
+	}
+	if v1 < v2 {
+		return -1
+	}
+	return 0
+}
+
+func compareDates(date1, date2 time.Time) int {
+	// time.Time.Compare() was added in Go v1.20 :-(
+
+	if val := compareValues(date1.Year(), date2.Year()); val != 0 {
+		return val
+	}
+	if val := compareValues(int(date1.Month()), int(date2.Month())); val != 0 {
+		return val
+	}
+	if val := compareValues(date1.Day(), date2.Day()); val != 0 {
+		return val
+	}
+	if val := compareValues(date1.Hour(), date2.Hour()); val != 0 {
+		return val
+	}
+	if val := compareValues(date1.Minute(), date2.Minute()); val != 0 {
+		return val
+	}
+	if val := compareValues(date1.Second(), date2.Second()); val != 0 {
+		return val
+	}
+	if date1.Nanosecond() > date2.Nanosecond() {
+		return 1
+	}
+	if date1.Nanosecond() < date2.Nanosecond() {
+		return -1
+	}
+	return 0
+}
+
 // AddNotice records an occurrence of a notice with the specified type and key
 // and options.
 func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
@@ -247,7 +287,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if now.IsZero() {
 		now = getTimeNow()
 		// ensure that two notices never have the same sent time
-		if now.Compare(s.noticeLastDate) <= 0 {
+		if compareDates(now, s.noticeLastDate) <= 0 {
 			now = s.noticeLastDate.Add(time.Nanosecond)
 		}
 		s.noticeLastDate = now

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -245,10 +245,10 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if now.IsZero() {
 		now = timeNow()
 		// ensure that two notices never have the same sent time
-		if !now.After(s.noticeLastDate) {
-			now = s.noticeLastDate.Add(time.Nanosecond)
+		if !now.After(s.noticeLastTimestamp) {
+			now = s.noticeLastTimestamp.Add(time.Nanosecond)
 		}
-		s.noticeLastDate = now
+		s.noticeLastTimestamp = now
 	}
 	now = now.UTC()
 	newOrRepeated := false

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -228,6 +228,8 @@ type AddNoticeOptions struct {
 	Time time.Time
 }
 
+var getTimeNow = time.Now
+
 // AddNotice records an occurrence of a notice with the specified type and key
 // and options.
 func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
@@ -243,7 +245,12 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 
 	now := options.Time
 	if now.IsZero() {
-		now = time.Now()
+		now = getTimeNow()
+		// ensure that two notices never have the same sent time
+		if now.Compare(s.noticeLastDate) <= 0 {
+			now = s.noticeLastDate.Add(time.Nanosecond)
+		}
+		s.noticeLastDate = now
 	}
 	now = now.UTC()
 	newOrRepeated := false

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -721,12 +721,12 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(notice2 == notice3, Equals, false)
 
 	// ensure that the notices are ordered in time
-	c.Assert(notice1.GetLastOccurred().Compare(testDate), Equals, 0)
-	c.Assert(notice1.GetLastOccurred().Compare(notice2.GetLastOccurred()), Equals, -1)
-	c.Assert(notice1.GetLastOccurred().Compare(notice3.GetLastOccurred()), Equals, -1)
-	c.Assert(notice2.GetLastOccurred().Compare(notice3.GetLastOccurred()), Equals, -1)
-	c.Assert(notice4.GetLastOccurred().Compare(testDate2), Equals, 0)
-	c.Assert(notice4.GetLastOccurred().Compare(notice3.GetLastOccurred()), Equals, 1)
+	c.Assert(state.CompareDates(notice1.GetLastOccurred(), testDate), Equals, 0)
+	c.Assert(state.CompareDates(notice1.GetLastOccurred(), notice2.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice1.GetLastOccurred(), notice3.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice2.GetLastOccurred(), notice3.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice4.GetLastOccurred(), testDate2), Equals, 0)
+	c.Assert(state.CompareDates(notice4.GetLastOccurred(), notice3.GetLastOccurred()), Equals, 1)
 
 	json1, err := notice1.MarshalJSON()
 	c.Assert(err, IsNil)
@@ -758,12 +758,12 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure that the notices are ordered in time even after JSON marshall/unmarshall
-	c.Assert(notice1b.GetLastOccurred().Compare(testDate), Equals, 0)
-	c.Assert(notice1b.GetLastOccurred().Compare(notice2b.GetLastOccurred()), Equals, -1)
-	c.Assert(notice1b.GetLastOccurred().Compare(notice3b.GetLastOccurred()), Equals, -1)
-	c.Assert(notice2b.GetLastOccurred().Compare(notice3b.GetLastOccurred()), Equals, -1)
-	c.Assert(notice4b.GetLastOccurred().Compare(testDate2), Equals, 0)
-	c.Assert(notice4b.GetLastOccurred().Compare(notice3b.GetLastOccurred()), Equals, 1)
+	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), testDate), Equals, 0)
+	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), notice2b.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice2b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, -1)
+	c.Assert(state.CompareDates(notice4b.GetLastOccurred(), testDate2), Equals, 0)
+	c.Assert(state.CompareDates(notice4b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, 1)
 }
 
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -774,12 +774,15 @@ func (s *noticesSuite) TestCompareDates(c *C) {
 	testDate4 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
 	testDate5 := time.Date(2024, time.March, 10, 10, 23, 4, 30, time.UTC)
 	testDate6 := time.Date(2024, time.May, 12, 12, 25, 6, 41, time.UTC)
+	testDate7 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
+	testDate8 := time.Date(2024, time.April, 11, 11, 24, 5, 41, time.UTC)
 
 	c.Assert(state.CompareDates(testDate0, testDate1), Equals, 0)
 	c.Assert(state.CompareDates(testDate0, testDate2), Equals, 1)
 	c.Assert(state.CompareDates(testDate0, testDate3), Equals, -1)
 	c.Assert(state.CompareDates(testDate4, testDate5), Equals, 1)
 	c.Assert(state.CompareDates(testDate4, testDate6), Equals, -1)
+	c.Assert(state.CompareDates(testDate7, testDate8), Equals, -1)
 
 }
 

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -721,12 +721,14 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(notice2 == notice3, Equals, false)
 
 	// ensure that the notices are ordered in time
-	c.Assert(state.CompareDates(notice1.GetLastOccurred(), testDate), Equals, 0)
-	c.Assert(state.CompareDates(notice1.GetLastOccurred(), notice2.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice1.GetLastOccurred(), notice3.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice2.GetLastOccurred(), notice3.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice4.GetLastOccurred(), testDate2), Equals, 0)
-	c.Assert(state.CompareDates(notice4.GetLastOccurred(), notice3.GetLastOccurred()), Equals, 1)
+	c.Assert(notice1.GetLastOccurred().Before(testDate), Equals, false)
+	c.Assert(notice1.GetLastOccurred().After(testDate), Equals, false)
+	c.Assert(notice1.GetLastOccurred().Before(notice2.GetLastOccurred()), Equals, true)
+	c.Assert(notice1.GetLastOccurred().Before(notice3.GetLastOccurred()), Equals, true)
+	c.Assert(notice2.GetLastOccurred().Before(notice3.GetLastOccurred()), Equals, true)
+	c.Assert(notice4.GetLastOccurred().Before(testDate2), Equals, false)
+	c.Assert(notice4.GetLastOccurred().After(testDate2), Equals, false)
+	c.Assert(notice4.GetLastOccurred().After(notice3.GetLastOccurred()), Equals, true)
 
 	json1, err := notice1.MarshalJSON()
 	c.Assert(err, IsNil)
@@ -758,32 +760,14 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure that the notices are ordered in time even after JSON marshall/unmarshall
-	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), testDate), Equals, 0)
-	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), notice2b.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice1b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice2b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, -1)
-	c.Assert(state.CompareDates(notice4b.GetLastOccurred(), testDate2), Equals, 0)
-	c.Assert(state.CompareDates(notice4b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, 1)
-}
-
-func (s *noticesSuite) TestCompareDates(c *C) {
-	testDate0 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	testDate1 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	testDate2 := time.Date(2023, time.May, 12, 12, 25, 6, 41, time.UTC)
-	testDate3 := time.Date(2025, time.April, 10, 10, 23, 4, 30, time.UTC)
-	testDate4 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	testDate5 := time.Date(2024, time.March, 10, 10, 23, 4, 30, time.UTC)
-	testDate6 := time.Date(2024, time.May, 12, 12, 25, 6, 41, time.UTC)
-	testDate7 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	testDate8 := time.Date(2024, time.April, 11, 11, 24, 5, 41, time.UTC)
-
-	c.Assert(state.CompareDates(testDate0, testDate1), Equals, 0)
-	c.Assert(state.CompareDates(testDate0, testDate2), Equals, 1)
-	c.Assert(state.CompareDates(testDate0, testDate3), Equals, -1)
-	c.Assert(state.CompareDates(testDate4, testDate5), Equals, 1)
-	c.Assert(state.CompareDates(testDate4, testDate6), Equals, -1)
-	c.Assert(state.CompareDates(testDate7, testDate8), Equals, -1)
-
+	c.Assert(notice1b.GetLastOccurred().Before(testDate), Equals, false)
+	c.Assert(notice1b.GetLastOccurred().After(testDate), Equals, false)
+	c.Assert(notice1b.GetLastOccurred().Before(notice2b.GetLastOccurred()), Equals, true)
+	c.Assert(notice1b.GetLastOccurred().Before(notice3b.GetLastOccurred()), Equals, true)
+	c.Assert(notice2b.GetLastOccurred().Before(notice3b.GetLastOccurred()), Equals, true)
+	c.Assert(notice4b.GetLastOccurred().Before(testDate2), Equals, false)
+	c.Assert(notice4b.GetLastOccurred().After(testDate2), Equals, false)
+	c.Assert(notice4b.GetLastOccurred().After(notice3b.GetLastOccurred()), Equals, true)
 }
 
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -685,9 +685,7 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	defer st.Unlock()
 
 	testDate := time.Date(2024, time.April, 11, 11, 24, 5, 20, time.UTC)
-	restore := state.MockGetTimeNow(func() time.Time {
-		return testDate
-	})
+	restore := state.MockTime(testDate)
 	defer restore()
 
 	id1, err := st.AddNotice(nil, state.ChangeUpdateNotice, "123", nil)
@@ -706,9 +704,7 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(notice3, NotNil)
 
 	testDate2 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	restore2 := state.MockGetTimeNow(func() time.Time {
-		return testDate2
-	})
+	restore2 := state.MockTime(testDate2)
 	defer restore2()
 
 	id4, err := st.AddNotice(nil, state.ChangeUpdateNotice, "ABC", nil)

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -766,6 +766,23 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 	c.Assert(state.CompareDates(notice4b.GetLastOccurred(), notice3b.GetLastOccurred()), Equals, 1)
 }
 
+func (s *noticesSuite) TestCompareDates(c *C) {
+	testDate0 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
+	testDate1 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
+	testDate2 := time.Date(2023, time.May, 12, 12, 25, 6, 41, time.UTC)
+	testDate3 := time.Date(2025, time.April, 10, 10, 23, 4, 30, time.UTC)
+	testDate4 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
+	testDate5 := time.Date(2024, time.March, 10, 10, 23, 4, 30, time.UTC)
+	testDate6 := time.Date(2024, time.May, 12, 12, 25, 6, 41, time.UTC)
+
+	c.Assert(state.CompareDates(testDate0, testDate1), Equals, 0)
+	c.Assert(state.CompareDates(testDate0, testDate2), Equals, 1)
+	c.Assert(state.CompareDates(testDate0, testDate3), Equals, -1)
+	c.Assert(state.CompareDates(testDate4, testDate5), Equals, 1)
+	c.Assert(state.CompareDates(testDate4, testDate6), Equals, -1)
+
+}
+
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
 func noticeToMap(c *C, notice *state.Notice) map[string]any {
 	buf, err := json.Marshal(notice)

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -90,15 +90,15 @@ type State struct {
 	lastNoticeId int
 	// lastHandlerId is not serialized, it's only used during runtime
 	// for registering runtime callbacks
-	lastHandlerId int
+	lastHandlerId       int
+	lastNoticeTimestamp time.Time
 
-	backend             Backend
-	data                customData
-	changes             map[string]*Change
-	tasks               map[string]*Task
-	warnings            map[string]*Warning
-	notices             map[noticeKey]*Notice
-	noticeLastTimestamp time.Time
+	backend  Backend
+	data     customData
+	changes  map[string]*Change
+	tasks    map[string]*Task
+	warnings map[string]*Warning
+	notices  map[noticeKey]*Notice
 
 	noticeCond *sync.Cond
 
@@ -173,7 +173,7 @@ type marshalledState struct {
 	LastLaneId   int `json:"last-lane-id"`
 	LastNoticeId int `json:"last-notice-id"`
 
-	NoticeLastTimestamp time.Time `json:"notice-last-timestamp,omitempty"`
+	LastNoticeTimestamp time.Time `json:"last-notice-timestamp,omitempty"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -191,7 +191,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		LastLaneId:   s.lastLaneId,
 		LastNoticeId: s.lastNoticeId,
 
-		NoticeLastTimestamp: s.noticeLastTimestamp,
+		LastNoticeTimestamp: s.lastNoticeTimestamp,
 	})
 }
 
@@ -212,7 +212,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
 	s.lastNoticeId = unmarshalled.LastNoticeId
-	s.noticeLastTimestamp = unmarshalled.NoticeLastTimestamp
+	s.lastNoticeTimestamp = unmarshalled.LastNoticeTimestamp
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -173,7 +173,7 @@ type marshalledState struct {
 	LastLaneId   int `json:"last-lane-id"`
 	LastNoticeId int `json:"last-notice-id"`
 
-	NoticeLastDate time.Time `json:"notice-last-date,omitempty"`
+	NoticeLastTimestam time.Time `json:"notice-last-timestamp,omitempty"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -191,7 +191,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		LastLaneId:   s.lastLaneId,
 		LastNoticeId: s.lastNoticeId,
 
-		NoticeLastDate: s.noticeLastTimestamp,
+		NoticeLastTimestamp: s.noticeLastTimestamp,
 	})
 }
 
@@ -212,7 +212,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
 	s.lastNoticeId = unmarshalled.LastNoticeId
-	s.noticeLastTimestamp = unmarshalled.NoticeLastDate
+	s.noticeLastTimestamp = unmarshalled.NoticeLastTimestamp
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -92,12 +92,13 @@ type State struct {
 	// for registering runtime callbacks
 	lastHandlerId int
 
-	backend  Backend
-	data     customData
-	changes  map[string]*Change
-	tasks    map[string]*Task
-	warnings map[string]*Warning
-	notices  map[noticeKey]*Notice
+	backend        Backend
+	data           customData
+	changes        map[string]*Change
+	tasks          map[string]*Task
+	warnings       map[string]*Warning
+	notices        map[noticeKey]*Notice
+	noticeLastDate time.Time
 
 	noticeCond *sync.Cond
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -92,13 +92,13 @@ type State struct {
 	// for registering runtime callbacks
 	lastHandlerId int
 
-	backend        Backend
-	data           customData
-	changes        map[string]*Change
-	tasks          map[string]*Task
-	warnings       map[string]*Warning
-	notices        map[noticeKey]*Notice
-	noticeLastDate time.Time
+	backend             Backend
+	data                customData
+	changes             map[string]*Change
+	tasks               map[string]*Task
+	warnings            map[string]*Warning
+	notices             map[noticeKey]*Notice
+	noticeLastTimestamp time.Time
 
 	noticeCond *sync.Cond
 
@@ -191,7 +191,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		LastLaneId:   s.lastLaneId,
 		LastNoticeId: s.lastNoticeId,
 
-		NoticeLastDate: s.noticeLastDate,
+		NoticeLastDate: s.noticeLastTimestamp,
 	})
 }
 
@@ -212,7 +212,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
 	s.lastNoticeId = unmarshalled.LastNoticeId
-	s.noticeLastDate = unmarshalled.NoticeLastDate
+	s.noticeLastTimestamp = unmarshalled.NoticeLastDate
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -172,6 +172,8 @@ type marshalledState struct {
 	LastTaskId   int `json:"last-task-id"`
 	LastLaneId   int `json:"last-lane-id"`
 	LastNoticeId int `json:"last-notice-id"`
+
+	NoticeLastDate time.Time `json:"notice-last-date,omitempty"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -188,6 +190,8 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		LastChangeId: s.lastChangeId,
 		LastLaneId:   s.lastLaneId,
 		LastNoticeId: s.lastNoticeId,
+
+		NoticeLastDate: s.noticeLastDate,
 	})
 }
 
@@ -208,6 +212,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
 	s.lastNoticeId = unmarshalled.LastNoticeId
+	s.noticeLastDate = unmarshalled.NoticeLastDate
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -173,7 +173,7 @@ type marshalledState struct {
 	LastLaneId   int `json:"last-lane-id"`
 	LastNoticeId int `json:"last-notice-id"`
 
-	NoticeLastTimestam time.Time `json:"notice-last-timestamp,omitempty"`
+	NoticeLastTimestamp time.Time `json:"notice-last-timestamp,omitempty"`
 }
 
 // MarshalJSON makes State a json.Marshaller


### PR DESCRIPTION
When a client wants to receive the notices using the /v2/notices interface, it usually will first receive all the old notifications, store the date and time of the last notification, and in the next calls use that date and time to get the next notices, and avoid getting the old notices over and over again.

Unfortunately, if, due to chance, two or more notifications have the same date and time, this scheme will fail, because after receiving the first one, the call will return it, and when the client asks for the next, it will filter from the date/time of the last notice sent, so the second notice with the same timestamp won't be sent. This can happen if the timer used for timestamps doesn't have enough granularity.

This patch fixes this by ensuring that no notice has the same date/time value for lastReceived, by adding one or more nanoseconds when required.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
