### PR TITLE
snapdtool: fix unit tests when running on distro using /usr/libexec/snapd

### DIFF
--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -354,7 +354,7 @@ func (s *toolSuite) TestInternalToolPathSnapdSnapNotExecutable(c *C) {
 	// the internal one is not executable
 	p, err := snapdtool.InternalToolPath("snapd")
 	c.Assert(err, IsNil)
-	c.Check(p, Equals, filepath.Join(dirs.GlobalRootDir, "/usr/lib/snapd/snapd"))
+	c.Check(p, Equals, filepath.Join(dirs.DistroLibExecDir, "snapd"))
 }
 
 func (s *toolSuite) TestInternalToolPathWithLibexecdirLocation(c *C) {


### PR DESCRIPTION
Distros like openSUSE Tumbleweed or Fedora use /usr/libexec/snapd. Update the test to account for the correct path.
