### PR TITLE
features,s/apparmor: add checks for prompt support in apparmor parser and kernel

### DIFF
--- a/features/export_test.go
+++ b/features/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -16,9 +16,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package features
+
+import (
+	"github.com/snapcore/snapd/testutil"
+)
 
 // NumberOfFeature returns the number of known features.
 func NumberOfFeatures() int {
 	return int(lastFeature)
+}
+
+var FeaturesSupportedCallbacks = featuresSupportedCallbacks
+
+func MockReleaseSystemctlSupportsUserUnits(f func() bool) (restore func()) {
+	r := testutil.Backup(&releaseSystemctlSupportsUserUnits)
+	releaseSystemctlSupportsUserUnits = f
+	return r
+}
+
+func MockApparmorKernelFeatures(f func() ([]string, error)) (restore func()) {
+	r := testutil.Backup(&apparmorKernelFeatures)
+	apparmorKernelFeatures = f
+	return r
+}
+
+func MockApparmorParserFeatures(f func() ([]string, error)) (restore func()) {
+	r := testutil.Backup(&apparmorParserFeatures)
+	apparmorParserFeatures = f
+	return r
 }

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2018 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -366,6 +366,14 @@ func probeKernelFeatures() ([]string, error) {
 			}
 		}
 	}
+	if data, err := os.ReadFile(filepath.Join(rootPath, featuresSysPath, "policy", "permstable32")); err == nil {
+		permstableFeatures := strings.Fields(string(data))
+		for _, feat := range permstableFeatures {
+			features = append(features, fmt.Sprintf("policy:permstable32:%s", feat))
+		}
+	}
+	// Features must be sorted
+	sort.Strings(features)
 	return features, nil
 }
 
@@ -411,6 +419,10 @@ func probeParserFeatures() ([]string, error) {
 			feature: "unconfined",
 			flags:   []string{"unconfined"},
 			probe:   "# test unconfined",
+		},
+		{
+			feature: "prompt",
+			probe:   "prompt /foo r,",
 		},
 	}
 	_, internal, err := AppArmorParser()

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -251,20 +251,71 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	// Pretend that apparmor kernel features directory contains some entries.
 	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo"), 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "bar"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "xyz"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"bar", "foo"})
+	c.Check(features, DeepEquals, []string{"bar", "foo", "xyz"})
 
 	// Also test sub-features features
 	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo", "baz"), 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo", "qux"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux"})
+	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux", "xyz"})
+
+	// Also test that prompt feature is read from permstable32 if it exists
+	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
+	for _, testCase := range []struct {
+		permstableContent string
+		expectedSuffixes  []string
+	}{
+		{
+			"allow deny prompt fizz buzz",
+			[]string{"allow", "buzz", "deny", "fizz", "prompt"},
+		},
+		{
+			"allow  deny prompt fizz   buzz ",
+			[]string{"allow", "buzz", "deny", "fizz", "prompt"},
+		},
+		{
+			"allow  deny\nprompt fizz \n  buzz",
+			[]string{"allow", "buzz", "deny", "fizz", "prompt"},
+		},
+		{
+			"allow  deny\nprompt fizz \n  buzz\n ",
+			[]string{"allow", "buzz", "deny", "fizz", "prompt"},
+		},
+		{
+			"fizz",
+			[]string{"fizz"},
+		},
+		{
+			"\n\n\nfizz\n\nbuzz",
+			[]string{"buzz", "fizz"},
+		},
+		{
+			"fizz\tbuzz",
+			[]string{"buzz", "fizz"},
+		},
+		{
+			"fizz buzz\r\n",
+			[]string{"buzz", "fizz"},
+		},
+	} {
+		c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32"), []byte(testCase.permstableContent), 0644), IsNil)
+		features, err = apparmor.ProbeKernelFeatures()
+		c.Assert(err, IsNil)
+		expected := []string{"bar", "foo", "foo:baz", "foo:qux", "policy"}
+		for _, suffix := range testCase.expectedSuffixes {
+			expected = append(expected, fmt.Sprintf("policy:permstable32:%s", suffix))
+		}
+		expected = append(expected, "xyz")
+		c.Check(features, DeepEquals, expected, Commentf("test case: %+v", testCase))
+	}
 }
 
 func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
-	var features = []string{"unsafe", "include-if-exists", "qipcrtr-socket", "mqueue", "cap-bpf", "cap-audit-read", "xdp", "userns", "unconfined"}
+	var features = []string{"unsafe", "include-if-exists", "qipcrtr-socket", "mqueue", "cap-bpf", "cap-audit-read", "xdp", "userns", "unconfined", "prompt"}
 	// test all combinations of features
 	for i := 0; i < int(math.Pow(2, float64(len(features)))); i++ {
 		expFeatures := []string{}
@@ -336,6 +387,9 @@ profile snap-test {
 profile snap-test flags=(unconfined) {
  # test unconfined
 }
+profile snap-test {
+ prompt /foo r,
+}
 `)
 	}
 
@@ -387,7 +441,7 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	c.Check(features, DeepEquals, []string{"network", "policy"})
 	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "mqueue", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
+	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "mqueue", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
 }
 
 func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {
@@ -427,7 +481,7 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	c.Check(features, DeepEquals, []string{"network", "policy"})
 	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "mqueue", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
+	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "mqueue", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
 
 	// this makes probing fails but is not done again
 	err = os.RemoveAll(d)


### PR DESCRIPTION
This PR splits off a portion of the work from #13670 related to AppArmor feature support for prompting.

Notably, this also adjusts the apparmor kernel and parser feature probing, since the `prompt` kernel feature support is marked as the `prompt` string occurring in `/sys/kernel/security/apparmor/features/policy/permstable32`.

This file, on my system, contains the following:
```
$ cat /sys/kernel/security/apparmor/features/policy/permstable32
allow deny subtree cond kill complain prompt audit quiet hide xindex tag label
```

If this should be extended to other features besides `prompt`, I'm happy to add those as well -- the current handling is specific to `prompt` but could be generalized.