### PR TITLE
many: include prompt prefix in apparmor rules

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -148,9 +148,12 @@ func isStopping() (bool, error) {
 }
 
 func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
+	extraData := interfaces.SystemKeyExtraData{
+		PromptingFlagEnabled: features.AppArmorPrompting.IsEnabled(),
+	}
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	mismatch, err := interfaces.SystemKeyMismatch(features.AppArmorPrompting.IsEnabled())
+	mismatch, err := interfaces.SystemKeyMismatch(extraData)
 	if err == nil && !mismatch {
 		return nil
 	}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -149,7 +149,7 @@ func isStopping() (bool, error) {
 
 func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	extraData := interfaces.SystemKeyExtraData{
-		PromptingFlagEnabled: features.AppArmorPrompting.IsEnabled(),
+		AppArmorPrompting: features.AppArmorPrompting.IsEnabled(),
 	}
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -148,9 +148,12 @@ func isStopping() (bool, error) {
 }
 
 func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
+	// check if AppArmor prompting is currently supported and enabled
+	currentAppArmorPrompting := features.AppArmorPrompting.IsEnabled() && features.AppArmorPrompting.IsSupported()
+
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	mismatch, err := interfaces.SystemKeyMismatch()
+	mismatch, err := interfaces.SystemKeyMismatch(currentAppArmorPrompting)
 	if err == nil && !mismatch {
 		return nil
 	}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -148,12 +148,9 @@ func isStopping() (bool, error) {
 }
 
 func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
-	// check if AppArmor prompting is currently supported and enabled
-	currentAppArmorPrompting := features.AppArmorPrompting.IsEnabled() && features.AppArmorPrompting.IsSupported()
-
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	mismatch, err := interfaces.SystemKeyMismatch(currentAppArmorPrompting)
+	mismatch, err := interfaces.SystemKeyMismatch(features.AppArmorPrompting.IsEnabled())
 	if err == nil && !mismatch {
 		return nil
 	}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -91,8 +91,8 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 }`))
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 	c.Assert(err, IsNil)
-	currentAppArmorPrompting := false
-	err = interfaces.WriteSystemKey(currentAppArmorPrompting)
+	promptingFlagEnabled := false
+	err = interfaces.WriteSystemKey(promptingFlagEnabled)
 	c.Assert(err, IsNil)
 
 	s.AddCleanup(snap.MockIsStdoutTTY(false))

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -91,7 +91,8 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 }`))
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 	c.Assert(err, IsNil)
-	err = interfaces.WriteSystemKey()
+	currentAppArmorPrompting := false
+	err = interfaces.WriteSystemKey(currentAppArmorPrompting)
 	c.Assert(err, IsNil)
 
 	s.AddCleanup(snap.MockIsStdoutTTY(false))

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -91,8 +91,8 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 }`))
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 	c.Assert(err, IsNil)
-	promptingFlagEnabled := false
-	err = interfaces.WriteSystemKey(promptingFlagEnabled)
+	extraData := interfaces.SystemKeyExtraData{}
+	err = interfaces.WriteSystemKey(extraData)
 	c.Assert(err, IsNil)
 
 	s.AddCleanup(snap.MockIsStdoutTTY(false))

--- a/features/export_test.go
+++ b/features/export_test.go
@@ -35,15 +35,3 @@ func MockReleaseSystemctlSupportsUserUnits(f func() bool) (restore func()) {
 	releaseSystemctlSupportsUserUnits = f
 	return r
 }
-
-func MockApparmorKernelFeatures(f func() ([]string, error)) (restore func()) {
-	r := testutil.Backup(&apparmorKernelFeatures)
-	apparmorKernelFeatures = f
-	return r
-}
-
-func MockApparmorParserFeatures(f func() ([]string, error)) (restore func()) {
-	r := testutil.Backup(&apparmorParserFeatures)
-	apparmorParserFeatures = f
-	return r
-}

--- a/features/features.go
+++ b/features/features.go
@@ -175,14 +175,14 @@ var featuresSupportedCallbacks = map[SnapdFeature]func() (bool, string){
 	AppArmorPrompting: func() (bool, string) {
 		kernelFeatures, err := apparmorKernelFeatures()
 		if err != nil {
-			return false, fmt.Sprintf("error checking apparmor kernel features: %v", err)
+			return false, fmt.Sprintf("cannot check apparmor kernel features: %v", err)
 		}
 		if !strutil.ListContains(kernelFeatures, "policy:permstable32:prompt") {
 			return false, "apparmor kernel features do not support prompting"
 		}
 		parserFeatures, err := apparmorParserFeatures()
 		if err != nil {
-			return false, fmt.Sprintf("error checking apparmor parser features: %v", err)
+			return false, fmt.Sprintf("cannot check apparmor parser features: %v", err)
 		}
 		if !strutil.ListContains(parserFeatures, "prompt") {
 			return false, "apparmor parser does not support the prompt qualifier"

--- a/features/features.go
+++ b/features/features.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -152,8 +151,6 @@ var featuresExported = map[SnapdFeature]bool{
 
 var (
 	releaseSystemctlSupportsUserUnits = release.SystemctlSupportsUserUnits
-	apparmorKernelFeatures            = apparmor.KernelFeatures
-	apparmorParserFeatures            = apparmor.ParserFeatures
 )
 
 // featuresSupportedCallbacks maps features to a callback function which may be
@@ -175,27 +172,8 @@ var featuresSupportedCallbacks = map[SnapdFeature]func() (bool, string){
 		}
 		return true, ""
 	},
-	// AppArmorPrompting requires AppArmor parser and kernel support for
-	// prompting, as well as a newer version of snapd with all the
-	// prompting components in place. TODO: change this callback once ready.
-	AppArmorPrompting: func() (bool, string) {
-		kernelFeatures, err := apparmorKernelFeatures()
-		if err != nil {
-			return false, fmt.Sprintf("cannot check apparmor kernel features: %v", err)
-		}
-		if !strutil.ListContains(kernelFeatures, "policy:permstable32:prompt") {
-			return false, "apparmor kernel features do not support prompting"
-		}
-		parserFeatures, err := apparmorParserFeatures()
-		if err != nil {
-			return false, fmt.Sprintf("cannot check apparmor parser features: %v", err)
-		}
-		if !strutil.ListContains(parserFeatures, "prompt") {
-			return false, "apparmor parser does not support the prompt qualifier"
-		}
-		return false, "requires newer version of snapd"
-		// TODO: return true once snapd supports prompting
-	},
+	// AppArmorPrompting requires that AppArmor supports prompting.
+	AppArmorPrompting: apparmor.PromptingSupported,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features.go
+++ b/features/features.go
@@ -147,6 +147,7 @@ var featuresExported = map[SnapdFeature]bool{
 
 	RefreshAppAwarenessUX: true,
 	AspectsConfiguration:  true,
+	AppArmorPrompting:     true,
 }
 
 // featuresSupportedCallbacks maps features to a callback function which may be
@@ -240,6 +241,16 @@ func (f SnapdFeature) ControlFile() string {
 // ConfigOption returns the snap name and configuration option associated with this feature.
 func (f SnapdFeature) ConfigOption() (snapName, confName string) {
 	return "core", "experimental." + f.String()
+}
+
+// IsSupported returns true if the feature's supported callback returns true,
+// or if it has no supportedCallback.
+func (f SnapdFeature) IsSupported() bool {
+	if callback, exists := featuresSupportedCallbacks[f]; exists {
+		supported, _ := callback() // discard unsupported reason
+		return supported
+	}
+	return true
 }
 
 // IsEnabled checks if a given exported snapd feature is enabled.

--- a/features/features.go
+++ b/features/features.go
@@ -150,6 +150,12 @@ var featuresExported = map[SnapdFeature]bool{
 	AppArmorPrompting:     true,
 }
 
+var (
+	releaseSystemctlSupportsUserUnits = release.SystemctlSupportsUserUnits
+	apparmorKernelFeatures            = apparmor.KernelFeatures
+	apparmorParserFeatures            = apparmor.ParserFeatures
+)
+
 // featuresSupportedCallbacks maps features to a callback function which may be
 // run to determine if the feature is supported and, if not, return false along
 // with a reason why the feature is unsupported. If a function has no callback
@@ -191,12 +197,6 @@ var featuresSupportedCallbacks = map[SnapdFeature]func() (bool, string){
 		// TODO: return true once snapd supports prompting
 	},
 }
-
-var (
-	releaseSystemctlSupportsUserUnits = release.SystemctlSupportsUserUnits
-	apparmorKernelFeatures            = apparmor.KernelFeatures
-	apparmorParserFeatures            = apparmor.ParserFeatures
-)
 
 // String returns the name of a snapd feature.
 // The function panics for bogus feature values.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -183,20 +183,20 @@ func (*featureSuite) TestAppArmorPromptingSupportedCallback(c *C) {
 			expectedReason: "apparmor parser does not support the prompt qualifier",
 		},
 		{
+			// Kernel error
+			kernelFeatures: []string{"foo", "bar", "policy:permstable32:prompt"},
+			kernelError:    fmt.Errorf("bad kernel"),
+			parserFeatures: []string{"baz", "qux", "prompt"},
+			parserError:    nil,
+			expectedReason: "cannot check apparmor kernel features: bad kernel",
+		},
+		{
 			// Parser error
 			kernelFeatures: []string{"foo", "bar", "policy:permstable32:prompt"},
 			kernelError:    nil,
 			parserFeatures: []string{"baz", "qux", "prompt"},
 			parserError:    fmt.Errorf("bad parser"),
 			expectedReason: "cannot check apparmor parser features: bad parser",
-		},
-		{
-			// Kernel error
-			kernelFeatures: []string{"foo", "bar", "policy:permstable32:prompt"},
-			kernelError:    fmt.Errorf("bad kernel"),
-			parserFeatures: []string{"baz", "qux", "prompt"},
-			parserError:    fmt.Errorf("bad parser"),
-			expectedReason: "cannot check apparmor kernel features: bad kernel",
 		},
 	} {
 		restore := apparmor.MockFeatures(t.kernelFeatures, t.kernelError, t.parserFeatures, t.parserError)

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -199,13 +199,13 @@ func (*featureSuite) TestAppArmorPromptingSupportedCallback(c *C) {
 	parserError = fmt.Errorf("bad parser")
 	supported, reason = callback()
 	c.Check(supported, Equals, false)
-	c.Check(reason, Matches, "error checking apparmor parser features.*")
+	c.Check(reason, Matches, "cannot check apparmor parser features.*")
 
 	// Kernel error
 	kernelError = fmt.Errorf("bad kernel")
 	supported, reason = callback()
 	c.Check(supported, Equals, false)
-	c.Check(reason, Matches, "error checking apparmor kernel features.*")
+	c.Check(reason, Matches, "cannot check apparmor kernel features.*")
 }
 
 func (*featureSuite) TestIsSupported(c *C) {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -48,6 +48,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
+	snapd_features "github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -957,6 +958,20 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 					repl = ""
 				}
 				tagSnippets = strings.Replace(tagSnippets, "###HOME_IX###", repl, -1)
+
+				// Use prompt prefix if prompting is supported and enabled
+				repl = ""
+				if snapd_features.AppArmorPrompting.IsEnabled() {
+					// If prompting flag not set, no change in behavior
+					if snapd_features.AppArmorPrompting.IsSupported() {
+						// Prompting support requires apparmor kernel and parser
+						// features, and these are only checked once during
+						// startup, so checking IsSupported() will be consistent
+						// within a given snapd run.
+						repl = "prompt "
+					}
+				}
+				tagSnippets = strings.Replace(tagSnippets, "###PROMPT###", repl, -1)
 
 				// Conditionally add privilege dropping policy
 				if len(snapInfo.SystemUsernames) > 0 {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -676,6 +676,9 @@ func addUpdateNSProfile(snapInfo *snap.Info, snippets string, content map[string
 	}
 }
 
+// Allow optional trailing ' ' after "###PROMPT###"
+var promptReplacer = regexp.MustCompile("###PROMPT### ?")
+
 func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName string, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
 	// If base is specified and it doesn't match the core snaps (not
 	// specifying a base should use the default core policy since in this
@@ -963,7 +966,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 				if spec.UsePromptPrefix() {
 					repl = "prompt "
 				}
-				tagSnippets = strings.Replace(tagSnippets, "###PROMPT###", repl, -1)
+				tagSnippets = promptReplacer.ReplaceAllLiteralString(tagSnippets, repl)
 
 				// Conditionally add privilege dropping policy
 				if len(snapInfo.SystemUsernames) > 0 {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -2674,6 +2674,42 @@ func (s *backendSuite) TestHomeIxRule(c *C) {
 				spec.SetSuppressHomeIx()
 			}
 			spec.AddSnippet("needle rwkl###HOME_IX###,")
+			return nil
+		}
+
+		snapInfo := s.InstallSnap(c, tc.opts, "", ifacetest.SambaYamlV1, 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		data, err := os.ReadFile(profile)
+		c.Assert(err, IsNil)
+
+		c.Assert(string(data), testutil.Contains, tc.expected)
+		s.RemoveSnap(c, snapInfo)
+	}
+}
+
+func (s *backendSuite) TestPromptPrefix(c *C) {
+	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
+	defer restoreTemplate()
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer restore()
+	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
+	defer restore()
+
+	for _, tc := range []struct {
+		opts     interfaces.ConfinementOptions
+		expected string
+	}{
+		{
+			opts:     interfaces.ConfinementOptions{},
+			expected: "\nneedle rwkl,",
+		},
+		{
+			opts:     interfaces.ConfinementOptions{AppArmorPrompting: true},
+			expected: "\nprompt needle rwkl,",
+		},
+	} {
+		s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+			spec.AddSnippet("###PROMPT### needle rwkl,")
 			return nil
 		}
 

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017-2018 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -107,6 +107,9 @@ type Specification struct {
 
 	// Same as the above, but for the pycache deny rule which breaks docker
 	suppressPycacheDeny bool
+
+	// Include prompt prefix for relevant rules when generating security profiles.
+	usePromptPrefix bool
 
 	// Unconfined profile mode allows a profile to be applied without any
 	// real confinement
@@ -755,6 +758,12 @@ func (spec *Specification) SetSuppressPtraceTrace() {
 // by any of the interfaces in the spec.
 func (spec *Specification) SuppressPtraceTrace() bool {
 	return spec.suppressPtraceTrace
+}
+
+// UsePromptPrefix returns whether the prompt prefix should be included for
+// relevant rules when generating security profiles.
+func (spec *Specification) UsePromptPrefix() bool {
+	return spec.usePromptPrefix
 }
 
 // SetUsesSysModuleCapability records that some interface has granted the

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -69,6 +69,9 @@ type ConfinementOptions struct {
 	// as systemd provides a mount namespace which will clash with the
 	// one snapd sets up.
 	ExtraLayouts []snap.Layout
+	// AppArmorPrompting indicates whether the prompt prefix should be used in
+	// relevant rules when generating AppArmor security profiles.
+	AppArmorPrompting bool
 }
 
 // SecurityBackendOptions carries extra flags that affect initialization of the
@@ -110,7 +113,7 @@ type SecurityBackend interface {
 	Remove(snapName string) error
 
 	// NewSpecification returns a new specification associated with this backend.
-	NewSpecification(*SnapAppSet) Specification
+	NewSpecification(*SnapAppSet, ConfinementOptions) Specification
 
 	// SandboxFeatures returns a list of tags that identify sandbox features.
 	SandboxFeatures() []string

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -56,25 +56,25 @@ owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snap and toplevel hidden directories in @{HOME}.
-###PROMPT###owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
-###PROMPT###owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
-###PROMPT###owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
-###PROMPT###owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
-###PROMPT###owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
 
 # Allow creating a few files not caught above
-###PROMPT###owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
+###PROMPT### owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
 
 # Allow access to @{HOME}/snap/ to allow directory traversals from
 # @{HOME}/snap/@{SNAP_INSTANCE_NAME} through @{HOME}/snap to @{HOME}.
 # While this leaks snap names, it fixes usability issues for snaps
 # that require this transitional interface.
-###PROMPT###owner @{HOME}/snap/ r,
+###PROMPT### owner @{HOME}/snap/ r,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).
-###PROMPT###owner /run/user/[0-9]*/gvfs/{,**} r,
-###PROMPT###owner /run/user/[0-9]*/gvfs/*/**  w,
+###PROMPT### owner /run/user/[0-9]*/gvfs/{,**} r,
+###PROMPT### owner /run/user/[0-9]*/gvfs/*/**  w,
 
 # Disallow writes to the well-known directory included in
 # the user's PATH on several distributions
@@ -85,13 +85,13 @@ audit deny @{HOME}/bin wl,
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
 capability dac_read_search,
-###PROMPT###@{HOME}/               r,
-###PROMPT###@{HOME}/[^s.]**        r,
-###PROMPT###@{HOME}/s[^n]**        r,
-###PROMPT###@{HOME}/sn[^a]**       r,
-###PROMPT###@{HOME}/sna[^p]**      r,
-###PROMPT###@{HOME}/snap[^/]**     r,
-###PROMPT###@{HOME}/{s,sn,sna}{,/} r,
+###PROMPT### @{HOME}/               r,
+###PROMPT### @{HOME}/[^s.]**        r,
+###PROMPT### @{HOME}/s[^n]**        r,
+###PROMPT### @{HOME}/sn[^a]**       r,
+###PROMPT### @{HOME}/sna[^p]**      r,
+###PROMPT### @{HOME}/snap[^/]**     r,
+###PROMPT### @{HOME}/{s,sn,sna}{,/} r,
 `
 
 type homeInterface struct {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -56,25 +56,25 @@ owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snap and toplevel hidden directories in @{HOME}.
-owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
-owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
-owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
-owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
-owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/sna[^p]**           rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/snap[^/]**          rwkl###HOME_IX###,
 
 # Allow creating a few files not caught above
-owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
+###PROMPT###owner @{HOME}/{s,sn,sna}{,/} rwkl###HOME_IX###,
 
 # Allow access to @{HOME}/snap/ to allow directory traversals from
 # @{HOME}/snap/@{SNAP_INSTANCE_NAME} through @{HOME}/snap to @{HOME}.
 # While this leaks snap names, it fixes usability issues for snaps
 # that require this transitional interface.
-owner @{HOME}/snap/ r,
+###PROMPT###owner @{HOME}/snap/ r,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).
-owner /run/user/[0-9]*/gvfs/{,**} r,
-owner /run/user/[0-9]*/gvfs/*/**  w,
+###PROMPT###owner /run/user/[0-9]*/gvfs/{,**} r,
+###PROMPT###owner /run/user/[0-9]*/gvfs/*/**  w,
 
 # Disallow writes to the well-known directory included in
 # the user's PATH on several distributions
@@ -85,13 +85,13 @@ audit deny @{HOME}/bin wl,
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
 capability dac_read_search,
-@{HOME}/               r,
-@{HOME}/[^s.]**        r,
-@{HOME}/s[^n]**        r,
-@{HOME}/sn[^a]**       r,
-@{HOME}/sna[^p]**      r,
-@{HOME}/snap[^/]**     r,
-@{HOME}/{s,sn,sna}{,/} r,
+###PROMPT###@{HOME}/               r,
+###PROMPT###@{HOME}/[^s.]**        r,
+###PROMPT###@{HOME}/s[^n]**        r,
+###PROMPT###@{HOME}/sn[^a]**       r,
+###PROMPT###@{HOME}/sna[^p]**      r,
+###PROMPT###@{HOME}/snap[^/]**     r,
+###PROMPT###@{HOME}/{s,sn,sna}{,/} r,
 `
 
 type homeInterface struct {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -52,7 +52,7 @@ const homeConnectedPlugAppArmor = `
 # Note, @{HOME} is the user's $HOME, not the snap's $HOME
 
 # Allow read access to toplevel $HOME for the user
-owner @{HOME}/ r,
+###PROMPT### owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snap and toplevel hidden directories in @{HOME}.

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -146,7 +146,7 @@ func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `###PROMPT### owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `audit deny @{HOME}/bin wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
@@ -172,7 +172,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
-	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `###PROMPT### owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `audit deny @{HOME}/bin wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -156,7 +156,7 @@ func setupHostDBusConf(snapInfo *snap.Info) error {
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	snapName := appSet.InstanceName()
 	// Get the snippets that apply to this snap
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain dbus specification for snap %q: %s", snapName, err)
 	}
@@ -242,7 +242,7 @@ func addContent(securityTag string, snippet string, content map[string]osutil.Fi
 	}
 }
 
-func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{appSet: appSet}
 }
 

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,6 +18,10 @@
  */
 
 package interfaces
+
+import (
+	"github.com/snapcore/snapd/testutil"
+)
 
 type ByConnRef byConnRef
 
@@ -77,3 +81,15 @@ var (
 	SystemKeyVersion = systemKeyVersion
 	LabelExpr        = labelExpr
 )
+
+func MockApparmorSupportsPrompting(f func(features []string) bool) (restore func()) {
+	restoreKernel := testutil.Backup(&apparmorKernelFeaturesSupportPrompting)
+	apparmorKernelFeaturesSupportPrompting = f
+	restoreParser := testutil.Backup(&apparmorParserFeaturesSupportPrompting)
+	apparmorParserFeaturesSupportPrompting = f
+	restore = func() {
+		restoreKernel()
+		restoreParser()
+	}
+	return restore
+}

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -20,6 +20,7 @@
 package interfaces
 
 import (
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -82,7 +83,7 @@ var (
 	LabelExpr        = labelExpr
 )
 
-func MockApparmorPromptingSupportedByFeatures(f func(kernelFeatures []string, parserFeatures []string) (bool, string)) (restore func()) {
+func MockApparmorPromptingSupportedByFeatures(f func(apparmorFeatures *apparmor.FeaturesSupported) (bool, string)) (restore func()) {
 	restore = testutil.Backup(&apparmorPromptingSupportedByFeatures)
 	apparmorPromptingSupportedByFeatures = f
 	return restore

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -82,14 +82,8 @@ var (
 	LabelExpr        = labelExpr
 )
 
-func MockApparmorSupportsPrompting(f func(features []string) bool) (restore func()) {
-	restoreKernel := testutil.Backup(&apparmorKernelFeaturesSupportPrompting)
-	apparmorKernelFeaturesSupportPrompting = f
-	restoreParser := testutil.Backup(&apparmorParserFeaturesSupportPrompting)
-	apparmorParserFeaturesSupportPrompting = f
-	restore = func() {
-		restoreKernel()
-		restoreParser()
-	}
+func MockApparmorPromptingSupportedByFeatures(f func(kernelFeatures []string, parserFeatures []string) (bool, string)) (restore func()) {
+	restore = testutil.Backup(&apparmorPromptingSupportedByFeatures)
+	apparmorPromptingSupportedByFeatures = f
 	return restore
 }

--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -76,7 +76,7 @@ func (b *TestSecurityBackend) Remove(snapName string) error {
 	return b.RemoveCallback(snapName)
 }
 
-func (b *TestSecurityBackend) NewSpecification(*interfaces.SnapAppSet) interfaces.Specification {
+func (b *TestSecurityBackend) NewSpecification(*interfaces.SnapAppSet, interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{}
 }
 

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -119,10 +119,10 @@ func (b *Backend) setupModprobe(appSet *interfaces.SnapAppSet, spec *Specificati
 // The devMode is ignored.
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
-func (b *Backend) Setup(appSet *interfaces.SnapAppSet, confinement interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	snapName := appSet.InstanceName()
 	// Get the snippets that apply to this snap
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain kmod specification for snap %q: %s", snapName, err)
 	}
@@ -212,7 +212,7 @@ func prepareModprobeDirContents(spec *Specification, appSet *interfaces.SnapAppS
 	}
 }
 
-func (b *Backend) NewSpecification(*interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet, interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{}
 }
 

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2023 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -59,10 +59,10 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 }
 
 // Setup creates mount mount profile files specific to a given snap.
-func (b *Backend) Setup(appSet *interfaces.SnapAppSet, confinement interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	// Record all changes to the mount system for this snap.
 	snapName := appSet.InstanceName()
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain mount security snippets for snap %q: %s", snapName, err)
 	}
@@ -71,7 +71,7 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, confinement interfaces.Co
 
 	spec.(*Specification).AddOvername(snapInfo)
 	spec.(*Specification).AddLayout(snapInfo)
-	spec.(*Specification).AddExtraLayouts(confinement.ExtraLayouts)
+	spec.(*Specification).AddExtraLayouts(opts.ExtraLayouts)
 	content := deriveContent(spec.(*Specification), snapInfo)
 	// synchronize the content with the filesystem
 	glob := fmt.Sprintf("snap.%s.*fstab", snapName)
@@ -139,7 +139,7 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]osutil.F
 }
 
 // NewSpecification returns a new mount specification.
-func (b *Backend) NewSpecification(*interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet, interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{}
 }
 

--- a/interfaces/polkit/backend.go
+++ b/interfaces/polkit/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -61,7 +61,7 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	snapName := appSet.InstanceName()
 	// Get the policies that apply to this snap
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain polkit specification for snap %q: %s", snapName, err)
 	}
@@ -115,7 +115,7 @@ func deriveContent(spec *Specification, appSet *interfaces.SnapAppSet) map[strin
 	return content
 }
 
-func (b *Backend) NewSpecification(*interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet, interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{}
 }
 

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -912,7 +912,7 @@ func (r *Repository) Interfaces() *Interfaces {
 }
 
 // SnapSpecification returns the specification of a given snap in a given security system.
-func (r *Repository) SnapSpecification(securitySystem SecuritySystem, appSet *SnapAppSet) (Specification, error) {
+func (r *Repository) SnapSpecification(securitySystem SecuritySystem, appSet *SnapAppSet, opts ConfinementOptions) (Specification, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -929,7 +929,7 @@ func (r *Repository) SnapSpecification(securitySystem SecuritySystem, appSet *Sn
 		return nil, fmt.Errorf("cannot handle interfaces of snap %q, security system %q is not known", snapName, securitySystem)
 	}
 
-	spec := backend.NewSpecification(appSet)
+	spec := backend.NewSpecification(appSet, opts)
 
 	// XXX: If either of the AddConnected{Plug,Slot} methods for a connection
 	// fail resiliently as-in they can never succeed (such as the case where a

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1236,12 +1236,14 @@ func (s *RepositorySuite) TestSnapSpecification(c *C) {
 	slotAppSet, err := interfaces.NewSnapAppSet(s.slot.Snap, nil)
 	c.Assert(err, IsNil)
 
+	emptyOpts := interfaces.ConfinementOptions{}
+
 	// Snaps should get static security now
-	spec, err := repo.SnapSpecification(testSecurity, plugAppSet)
+	spec, err := repo.SnapSpecification(testSecurity, plugAppSet, emptyOpts)
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static plug snippet"})
 
-	spec, err = repo.SnapSpecification(testSecurity, slotAppSet)
+	spec, err = repo.SnapSpecification(testSecurity, slotAppSet, emptyOpts)
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static slot snippet"})
 
@@ -1251,14 +1253,14 @@ func (s *RepositorySuite) TestSnapSpecification(c *C) {
 	c.Assert(err, IsNil)
 
 	// Snaps should get static and connection-specific security now
-	spec, err = repo.SnapSpecification(testSecurity, plugAppSet)
+	spec, err = repo.SnapSpecification(testSecurity, plugAppSet, emptyOpts)
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
 		"static plug snippet",
 		"connection-specific plug snippet",
 	})
 
-	spec, err = repo.SnapSpecification(testSecurity, slotAppSet)
+	spec, err = repo.SnapSpecification(testSecurity, slotAppSet, emptyOpts)
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
 		"static slot snippet",
@@ -1291,14 +1293,16 @@ func (s *RepositorySuite) TestSnapSpecificationFailureWithConnectionSnippets(c *
 	plugAppSet, err := interfaces.NewSnapAppSet(s.plug.Snap, nil)
 	c.Assert(err, IsNil)
 
-	spec, err := repo.SnapSpecification(testSecurity, plugAppSet)
+	emptyOpts := interfaces.ConfinementOptions{}
+
+	spec, err := repo.SnapSpecification(testSecurity, plugAppSet, emptyOpts)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for consumer")
 	c.Assert(spec, IsNil)
 
 	slotAppSet, err := interfaces.NewSnapAppSet(s.slot.Snap, nil)
 	c.Assert(err, IsNil)
 
-	spec, err = repo.SnapSpecification(testSecurity, slotAppSet)
+	spec, err = repo.SnapSpecification(testSecurity, slotAppSet, emptyOpts)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for provider")
 	c.Assert(spec, IsNil)
 }
@@ -1327,14 +1331,16 @@ func (s *RepositorySuite) TestSnapSpecificationFailureWithPermanentSnippets(c *C
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap, nil)
 	c.Assert(err, IsNil)
 
-	spec, err := repo.SnapSpecification(testSecurity, appSet)
+	emptyOpts := interfaces.ConfinementOptions{}
+
+	spec, err := repo.SnapSpecification(testSecurity, appSet, emptyOpts)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for consumer")
 	c.Assert(spec, IsNil)
 
 	appSet, err = interfaces.NewSnapAppSet(s.slot.Snap, nil)
 	c.Assert(err, IsNil)
 
-	spec, err = repo.SnapSpecification(testSecurity, appSet)
+	spec, err = repo.SnapSpecification(testSecurity, appSet, emptyOpts)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for provider")
 	c.Assert(spec, IsNil)
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -250,7 +250,7 @@ func parallelCompile(compiler Compiler, profiles []string) error {
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	snapName := appSet.InstanceName()
 	// Get the snippets that apply to this snap
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain seccomp specification for snap %q: %s", snapName, err)
 	}
@@ -386,7 +386,7 @@ func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, a
 }
 
 // NewSpecification returns an empty seccomp specification.
-func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{appSet: appSet}
 }
 

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -204,7 +204,11 @@ func WriteSystemKey(extraData SystemKeyExtraData) error {
 
 	// AppArmorPrompting should be true if the given extra data prompting value
 	// is true and if the AppArmor kernel and parser features support prompting.
-	promptingSupported, _ := apparmorPromptingSupportedByFeatures(sk.AppArmorFeatures, sk.AppArmorParserFeatures)
+	apparmorFeatures := apparmor.FeaturesSupported{
+		KernelFeatures: sk.AppArmorFeatures,
+		ParserFeatures: sk.AppArmorParserFeatures,
+	}
+	promptingSupported, _ := apparmorPromptingSupportedByFeatures(&apparmorFeatures)
 	sk.AppArmorPrompting = extraData.AppArmorPrompting && promptingSupported
 
 	sks, err := json.Marshal(sk)
@@ -295,7 +299,11 @@ func SystemKeyMismatch(extraData SystemKeyExtraData) (bool, error) {
 	// then parser mtime will differ and we'll return true anyway. If parser
 	// features are the same, then we can use the disk parser features to check
 	// if AppArmorPrompting should be set.
-	promptingSupported, _ := apparmorPromptingSupportedByFeatures(mySystemKey.AppArmorFeatures, parserFeatures)
+	apparmorFeatures := apparmor.FeaturesSupported{
+		KernelFeatures: mySystemKey.AppArmorFeatures,
+		ParserFeatures: parserFeatures,
+	}
+	promptingSupported, _ := apparmorPromptingSupportedByFeatures(&apparmorFeatures)
 	mySystemKey.AppArmorPrompting = extraData.AppArmorPrompting && promptingSupported
 
 	ok, err := SystemKeysMatch(mySystemKey, diskSystemKey)

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -332,7 +332,7 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchAppArmorPromptingHappy(c 
 }
 `, testCase.prevValue)))
 
-		restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(kernelFeatures []string, parserFeatures []string) (bool, string) {
+		restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(apparmorFeatures *apparmor.FeaturesSupported) (bool, string) {
 			return testCase.supported, ""
 		})
 
@@ -473,7 +473,7 @@ func (s *systemKeySuite) TestSystemKeysMatch(c *C) {
 }
 
 func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
-	restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(kernelFeatures []string, parserFeatures []string) (bool, string) {
+	restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(apparmorFeatures *apparmor.FeaturesSupported) (bool, string) {
 		return true, ""
 	})
 	defer restore()

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -326,10 +325,10 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchAppArmorPromptingHappy(c 
 		s.AddCleanup(interfaces.MockSystemKey(fmt.Sprintf(`
 {
 "build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
-"apparmor-prompting-supported": %s,
-"apparmor-prompting-supported-and-enabled": %s
+"apparmor-prompting-supported": %t,
+"apparmor-prompting-supported-and-enabled": %t
 }
-`, strconv.FormatBool(testCase.supported), strconv.FormatBool(testCase.supportedAndEnabled))))
+`, testCase.supported, testCase.supportedAndEnabled)))
 
 		err = interfaces.WriteSystemKey(testCase.supportedAndEnabled)
 		c.Assert(err, IsNil)
@@ -486,8 +485,8 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 		],
 		"apparmor-parser-features": [],
 		"apparmor-parser-mtime": 1589907589,
-		"apparmor-prompting-supported": %s,
-		"apparmor-prompting-supported-and-enabled": %s,
+		"apparmor-prompting-supported": %t,
+		"apparmor-prompting-supported-and-enabled": %t,
 		"build-id": "cb94e5eeee4cf7ecda53f8308a984cb155b55732",
 		"cgroup-version": "1",
 		"nfs-home": false,
@@ -504,7 +503,7 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 			"user_notif"
 		],
 		"version": 12
-	}`, strconv.FormatBool(promptingSupported), strconv.FormatBool(promptingSupportedAndEnabled))
+	}`, promptingSupported, promptingSupportedAndEnabled)
 
 	// write the mocked system key to disk
 	restore := interfaces.MockSystemKey(systemKeyJSON)

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -332,8 +332,8 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchAppArmorPromptingHappy(c 
 }
 `, testCase.prevValue)))
 
-		restore := interfaces.MockApparmorSupportsPrompting(func(features []string) bool {
-			return testCase.supported
+		restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(kernelFeatures []string, parserFeatures []string) (bool, string) {
+			return testCase.supported, ""
 		})
 
 		extraData = interfaces.SystemKeyExtraData{
@@ -473,9 +473,10 @@ func (s *systemKeySuite) TestSystemKeysMatch(c *C) {
 }
 
 func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
-	interfaces.MockApparmorSupportsPrompting(func(features []string) bool {
-		return true
+	restore := interfaces.MockApparmorPromptingSupportedByFeatures(func(kernelFeatures []string, parserFeatures []string) (bool, string) {
+		return true, ""
 	})
+	defer restore()
 	appArmorPrompting := true
 	extraData := interfaces.SystemKeyExtraData{
 		AppArmorPrompting: appArmorPrompting,
@@ -523,7 +524,7 @@ func (s *systemKeySuite) TestSystemKeysUnmarshalSame(c *C) {
 	}`, appArmorPrompting)
 
 	// write the mocked system key to disk
-	restore := interfaces.MockSystemKey(systemKeyJSON)
+	restore = interfaces.MockSystemKey(systemKeyJSON)
 	defer restore()
 	err := interfaces.WriteSystemKey(extraData)
 	c.Assert(err, IsNil)

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -61,11 +61,11 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 //
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
-func (b *Backend) Setup(appSet *interfaces.SnapAppSet, confinement interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	// Record all the extra systemd services for this snap.
 	snapName := appSet.InstanceName()
 	// Get the services that apply to this snap
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain systemd services for snap %q: %s", snapName, err)
 	}
@@ -155,7 +155,7 @@ func (b *Backend) Remove(snapName string) error {
 }
 
 // NewSpecification returns a new systemd specification.
-func (b *Backend) NewSpecification(*interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet, interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{}
 }
 

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -78,7 +78,7 @@ func snapDeviceCgroupSelfManageFilePath(snapName string) string {
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
 	snapName := appSet.InstanceName()
-	spec, err := repo.SnapSpecification(b.Name(), appSet)
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain udev specification for snap %q: %w", snapName, err)
 	}
@@ -214,7 +214,7 @@ func (b *Backend) deriveContent(spec *Specification) (content []string) {
 	return content
 }
 
-func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet) interfaces.Specification {
+func (b *Backend) NewSpecification(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) interfaces.Specification {
 	return &Specification{appSet: appSet}
 }
 

--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017-2022 Canonical Ltd
+ * Copyright (C) 2017-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,9 +20,12 @@
 package configcore
 
 import (
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -35,6 +38,8 @@ var (
 	AddFSOnlyHandler     = addFSOnlyHandler
 	FilesystemOnlyApply  = filesystemOnlyApply
 	UpdateHomedirsConfig = updateHomedirsConfig
+
+	DoExperimentalApparmorPromptingDaemonRestart = doExperimentalApparmorPromptingDaemonRestart
 )
 
 type PlainCoreConfig = plainCoreConfig
@@ -96,5 +101,11 @@ func MockApparmorReloadAllSnapProfiles(f func() error) func() {
 func MockLoggerSimpleSetup(f func(opts *logger.LoggerOptions) error) func() {
 	r := testutil.Backup(&loggerSimpleSetup)
 	loggerSimpleSetup = f
+	return r
+}
+
+func MockRestartRequest(f func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo)) func() {
+	r := testutil.Backup(&restartRequest)
+	restartRequest = f
 	return r
 }

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -28,8 +28,8 @@ import (
 
 var restartRequest = restart.Request
 
-// Trigger a security profile regeneration by restarting snapd if a change in
-// the experimental apparmor-prompting flag causes a need to do so.
+// Trigger a security profile regeneration by restarting snapd if the
+// experimental apparmor-prompting flag changed.
 func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnlyContext) error {
 	st := c.State()
 

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/restart"
+)
+
+// Trigger a security profile regeneration by restarting snapd if a change in
+// the experimental apparmor-prompting flag causes a need to do so.
+func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnlyContext) error {
+	st := c.State()
+
+	snap, confName := features.AppArmorPrompting.ConfigOption()
+
+	var prompting bool
+	err := c.Get(snap, confName, &prompting)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	var prevPrompting bool
+	err = c.GetPristine(snap, confName, &prevPrompting)
+	if err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if prompting == prevPrompting {
+		return nil
+	}
+
+	// XXX: what if apparmor-prompting flag value unchanged but support changed?
+	// Prompting support (currently) depends only on AppArmor kernel and parser
+	// features, which are checked only once at startup, so this cannot occur.
+
+	if !features.AppArmorPrompting.IsSupported() {
+		// prompting flag changed, but prompting unsupported, so no need to
+		// regenerate security profiles via a restart.
+		return nil
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	restart.Request(st, restart.RestartDaemon, nil)
+
+	return nil
+}

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -26,6 +26,8 @@ import (
 	"github.com/snapcore/snapd/overlord/restart"
 )
 
+var restartRequest = restart.Request
+
 // Trigger a security profile regeneration by restarting snapd if a change in
 // the experimental apparmor-prompting flag causes a need to do so.
 func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnlyContext) error {
@@ -55,7 +57,7 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 	st.Lock()
 	defer st.Unlock()
 
-	restart.Request(st, restart.RestartDaemon, nil)
+	restartRequest(st, restart.RestartDaemon, nil)
 
 	return nil
 }

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -47,15 +47,10 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 		return nil
 	}
 
-	// XXX: what if apparmor-prompting flag value unchanged but support changed?
-	// Prompting support (currently) depends only on AppArmor kernel and parser
-	// features, which are checked only once at startup, so this cannot occur.
-
-	if !features.AppArmorPrompting.IsSupported() {
-		// prompting flag changed, but prompting unsupported, so no need to
-		// regenerate security profiles via a restart.
-		return nil
-	}
+	// No matter whether prompting is supported or not, request a restart of
+	// snapd, since it may be the case that AppArmor has been updated and the
+	// kernel or parser support for prompting has changed, and this isn't picked
+	// up without re-probing the AppArmor features, which occurs during startup.
 
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -58,7 +58,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartNoPrist
 		rt.Set(snap, confName, expectedRestart)
 		s.state.Unlock()
 
-		// Sanity check set values
+		// Precondition check set values
 		var value bool
 		err := rt.GetPristine(snap, confName, &value)
 		c.Check(config.IsNoOption(err), Equals, true)
@@ -125,7 +125,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartWithPri
 		rt.Set(snap, confName, testCase.final)
 		s.state.Unlock()
 
-		// Sanity check set values
+		// Precondition check set values
 		var value bool
 		err := rt.GetPristine(snap, confName, &value)
 		c.Check(err, Equals, nil)

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -1,0 +1,180 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type promptingSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&promptingSuite{})
+
+func (s *promptingSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartNoPristine(c *C) {
+	doRestartChan := make(chan bool, 1)
+	restore := configcore.MockRestartRequest(func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo) {
+		c.Check(st, Equals, s.state)
+		c.Check(t, Equals, restart.RestartDaemon)
+		c.Check(rebootInfo, IsNil)
+		doRestartChan <- true
+	})
+	defer restore()
+
+	snap, confName := features.AppArmorPrompting.ConfigOption()
+
+	for _, expectedRestart := range []bool{true, false} {
+		s.state.Lock()
+		rt := configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+		rt.Set(snap, confName, expectedRestart)
+		s.state.Unlock()
+
+		// Sanity check set values
+		var value bool
+		err := rt.GetPristine(snap, confName, &value)
+		c.Check(config.IsNoOption(err), Equals, true)
+		c.Check(value, Equals, false)
+		err = rt.Get(snap, confName, &value)
+		c.Check(err, IsNil)
+		c.Check(value, Equals, expectedRestart)
+
+		err = configcore.DoExperimentalApparmorPromptingDaemonRestart(rt, nil)
+		c.Check(err, IsNil)
+
+		var observedRestart bool
+		select {
+		case <-doRestartChan:
+			observedRestart = true
+		default:
+			observedRestart = false
+		}
+		c.Check(observedRestart, Equals, expectedRestart)
+	}
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartWithPristine(c *C) {
+	doRestartChan := make(chan bool, 1)
+	restore := configcore.MockRestartRequest(func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo) {
+		c.Check(st, Equals, s.state)
+		c.Check(t, Equals, restart.RestartDaemon)
+		c.Check(rebootInfo, IsNil)
+		doRestartChan <- true
+	})
+	defer restore()
+
+	snap, confName := features.AppArmorPrompting.ConfigOption()
+
+	testCases := []struct {
+		initial bool
+		final   bool
+	}{
+		{
+			false,
+			false,
+		},
+		{
+			false,
+			true,
+		},
+		{
+			true,
+			false,
+		},
+		{
+			true,
+			true,
+		},
+	}
+	for _, testCase := range testCases {
+		s.state.Lock()
+		rt := configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+		// Set value which will be read as pristine
+		rt.Set(snap, confName, testCase.initial)
+		rt.Commit()
+		// Set value which will be read as current
+		rt = configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+		rt.Set(snap, confName, testCase.final)
+		s.state.Unlock()
+
+		// Sanity check set values
+		var value bool
+		err := rt.GetPristine(snap, confName, &value)
+		c.Check(err, Equals, nil)
+		c.Check(value, Equals, testCase.initial, Commentf("initial: %v, final: %v", testCase.initial, testCase.final))
+		err = rt.Get(snap, confName, &value)
+		c.Check(err, IsNil)
+		c.Check(value, Equals, testCase.final, Commentf("initial: %v, final: %v", testCase.initial, testCase.final))
+
+		err = configcore.DoExperimentalApparmorPromptingDaemonRestart(rt, nil)
+		c.Check(err, IsNil)
+
+		expectedRestart := testCase.initial != testCase.final
+		var observedRestart bool
+		select {
+		case <-doRestartChan:
+			observedRestart = true
+		default:
+			observedRestart = false
+		}
+		c.Check(observedRestart, Equals, expectedRestart, Commentf("with initial value %v and final value %v, expected %v but observed %v", testCase.initial, testCase.final, expectedRestart, observedRestart))
+	}
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartErrors(c *C) {
+	restore := configcore.MockRestartRequest(func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo) {
+		c.Errorf("unexpected restart requested")
+	})
+	defer restore()
+
+	snap, confName := features.AppArmorPrompting.ConfigOption()
+
+	// Check that failed Get returns an error
+	s.state.Lock()
+	rt := configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+	rt.Set(snap, confName, "invalid")
+	s.state.Unlock()
+
+	err := configcore.DoExperimentalApparmorPromptingDaemonRestart(rt, nil)
+	c.Check(err, Not(IsNil))
+
+	// Check that failed GetPristine returns an error
+	s.state.Lock()
+	rt = configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+	rt.Set(snap, confName, "invalid")
+	rt.Commit()
+	rt = configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+	rt.Set(snap, confName, true)
+	s.state.Unlock()
+
+	err = configcore.DoExperimentalApparmorPromptingDaemonRestart(rt, nil)
+	c.Check(err, Not(IsNil))
+}

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -2,7 +2,7 @@
 //go:build !nomanagers
 
 /*
- * Copyright (C) 2020-2022 Canonical Ltd
+ * Copyright (C) 2020-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,6 +72,9 @@ func init() {
 
 	// debug.systemd.log-level
 	addWithStateHandler(validateDebugSystemdLogLevelSetting, handleDebugSystemdLogLevelConfiguration, coreOnly)
+
+	// experimental.apparmor-prompting
+	addWithStateHandler(nil, doExperimentalApparmorPromptingDaemonRestart, nil)
 }
 
 // RunTransaction is an interface describing how to access

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -238,10 +238,10 @@ func (s *firstbootPreseedingClassic16Suite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "assertions"), 0755)
 	c.Assert(err, IsNil)
 
-	currentAppArmorPrompting := false
+	promptingFlagEnabled := false
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
-	c.Assert(interfaces.WriteSystemKey(currentAppArmorPrompting), IsNil)
+	c.Assert(interfaces.WriteSystemKey(promptingFlagEnabled), IsNil)
 
 	restoreRelease := release.MockOnClassic(true)
 	s.AddCleanup(restoreRelease)

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2019 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -238,8 +238,10 @@ func (s *firstbootPreseedingClassic16Suite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "assertions"), 0755)
 	c.Assert(err, IsNil)
 
+	currentAppArmorPrompting := false
+
 	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
-	c.Assert(interfaces.WriteSystemKey(), IsNil)
+	c.Assert(interfaces.WriteSystemKey(currentAppArmorPrompting), IsNil)
 
 	restoreRelease := release.MockOnClassic(true)
 	s.AddCleanup(restoreRelease)

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -238,10 +238,10 @@ func (s *firstbootPreseedingClassic16Suite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "assertions"), 0755)
 	c.Assert(err, IsNil)
 
-	promptingFlagEnabled := false
+	extraData := interfaces.SystemKeyExtraData{}
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
-	c.Assert(interfaces.WriteSystemKey(promptingFlagEnabled), IsNil)
+	c.Assert(interfaces.WriteSystemKey(extraData), IsNil)
 
 	restoreRelease := release.MockOnClassic(true)
 	s.AddCleanup(restoreRelease)

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -632,8 +632,10 @@ func (s *preseedingBaseSuite) SetUpTest(c *C, preseed, classic bool) {
 	// can use cleanup only after having called base SetUpTest
 	s.AddCleanup(r)
 
+	currentAppArmorPrompting := false
+
 	s.AddCleanup(interfaces.MockSystemKey(`{"build-id":"abcde"}`))
-	c.Assert(interfaces.WriteSystemKey(), IsNil)
+	c.Assert(interfaces.WriteSystemKey(currentAppArmorPrompting), IsNil)
 
 	s.cmdUmount = testutil.MockCommand(c, "umount", "")
 	s.cmdSystemctl = testutil.MockCommand(c, "systemctl", "")

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -632,10 +632,10 @@ func (s *preseedingBaseSuite) SetUpTest(c *C, preseed, classic bool) {
 	// can use cleanup only after having called base SetUpTest
 	s.AddCleanup(r)
 
-	currentAppArmorPrompting := false
+	promptingFlagEnabled := false
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"build-id":"abcde"}`))
-	c.Assert(interfaces.WriteSystemKey(currentAppArmorPrompting), IsNil)
+	c.Assert(interfaces.WriteSystemKey(promptingFlagEnabled), IsNil)
 
 	s.cmdUmount = testutil.MockCommand(c, "umount", "")
 	s.cmdSystemctl = testutil.MockCommand(c, "systemctl", "")

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -632,10 +632,10 @@ func (s *preseedingBaseSuite) SetUpTest(c *C, preseed, classic bool) {
 	// can use cleanup only after having called base SetUpTest
 	s.AddCleanup(r)
 
-	promptingFlagEnabled := false
+	extraData := interfaces.SystemKeyExtraData{}
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"build-id":"abcde"}`))
-	c.Assert(interfaces.WriteSystemKey(promptingFlagEnabled), IsNil)
+	c.Assert(interfaces.WriteSystemKey(extraData), IsNil)
 
 	s.cmdUmount = testutil.MockCommand(c, "umount", "")
 	s.cmdSystemctl = testutil.MockCommand(c, "systemctl", "")

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -184,7 +184,7 @@ func MockProfilesNeedRegeneration(fn func(m *InterfaceManager) bool) func() {
 }
 
 // MockWriteSystemKey mocks the function responsible for writing the system key.
-func MockWriteSystemKey(fn func(promptingFlagEnabled bool) error) func() {
+func MockWriteSystemKey(fn func(extraData interfaces.SystemKeyExtraData) error) func() {
 	old := writeSystemKey
 	writeSystemKey = fn
 	return func() { writeSystemKey = old }

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -184,7 +184,7 @@ func MockProfilesNeedRegeneration(fn func(m *InterfaceManager) bool) func() {
 }
 
 // MockWriteSystemKey mocks the function responsible for writing the system key.
-func MockWriteSystemKey(fn func(currentAppArmorPrompting bool) error) func() {
+func MockWriteSystemKey(fn func(promptingFlagEnabled bool) error) func() {
 	old := writeSystemKey
 	writeSystemKey = fn
 	return func() { writeSystemKey = old }

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -63,8 +64,19 @@ var (
 
 	BatchConnectTasks                = batchConnectTasks
 	FirstTaskAfterBootWhenPreseeding = firstTaskAfterBootWhenPreseeding
-	BuildConfinementOptions          = buildConfinementOptions
 )
+
+func NewInterfaceManagerWithAppArmorPrompting(useAppArmorPrompting bool) *InterfaceManager {
+	m := &InterfaceManager{}
+	m.useAppArmorPromptingChecker.Do(func() {
+		m.useAppArmorPromptingValue = useAppArmorPrompting
+	})
+	return m
+}
+
+func (m *InterfaceManager) BuildConfinementOptions(st *state.State, snapInfo *snap.Info, flags snapstate.Flags) (interfaces.ConfinementOptions, error) {
+	return m.buildConfinementOptions(st, snapInfo, flags)
+}
 
 type ConnectOpts = connectOpts
 
@@ -165,14 +177,14 @@ func (m *IdentityMapper) SystemSnapName() string {
 }
 
 // MockProfilesNeedRegeneration mocks the function checking if profiles need regeneration.
-func MockProfilesNeedRegeneration(fn func() bool) func() {
-	old := profilesNeedRegeneration
-	profilesNeedRegeneration = fn
-	return func() { profilesNeedRegeneration = old }
+func MockProfilesNeedRegeneration(fn func(m *InterfaceManager) bool) func() {
+	old := profilesNeedRegenerationImpl
+	profilesNeedRegenerationImpl = fn
+	return func() { profilesNeedRegenerationImpl = old }
 }
 
 // MockWriteSystemKey mocks the function responsible for writing the system key.
-func MockWriteSystemKey(fn func() error) func() {
+func MockWriteSystemKey(fn func(currentAppArmorPrompting bool) error) func() {
 	old := writeSystemKey
 	writeSystemKey = fn
 	return func() { writeSystemKey = old }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -31,6 +31,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/hotplug"
@@ -87,11 +88,16 @@ func buildConfinementOptions(st *state.State, snapInfo *snap.Info, flags snapsta
 		return interfaces.ConfinementOptions{}, fmt.Errorf("cannot get extra mount layouts of snap %q: %s", snapInfo.InstanceName(), err)
 	}
 
+	// TODO: Look up a previous value, rather than re-checking.
+	// XXX: Probably check system key or whether the listener is running.
+	apparmorPrompting := features.AppArmorPrompting.IsEnabled() && features.AppArmorPrompting.IsSupported()
+
 	return interfaces.ConfinementOptions{
-		DevMode:      flags.DevMode,
-		JailMode:     flags.JailMode,
-		Classic:      flags.Classic,
-		ExtraLayouts: extraLayouts,
+		DevMode:           flags.DevMode,
+		JailMode:          flags.JailMode,
+		Classic:           flags.Classic,
+		ExtraLayouts:      extraLayouts,
+		AppArmorPrompting: apparmorPrompting,
 	}, nil
 }
 

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -139,6 +139,7 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 	c.Check(opts.Classic, Equals, flags.Classic)
 	c.Check(opts.DevMode, Equals, flags.DevMode)
 	c.Check(opts.JailMode, Equals, flags.JailMode)
+	c.Check(opts.AppArmorPrompting, Equals, false) // XXX: is this guaranteed in the future?
 }
 
 func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -150,7 +150,15 @@ func (m *InterfaceManager) profilesNeedRegeneration() bool {
 }
 
 var profilesNeedRegenerationImpl = func(m *InterfaceManager) bool {
-	mismatch, err := interfaces.SystemKeyMismatch(m.useAppArmorPrompting())
+	// m.useAppArmorPrompting() is supported&&enabled, rather than simply
+	// enabled, but it is okay to use it in place of enabled, since if
+	// prompting is not supported, the system key values related to
+	// prompting will both be false anyway, and if it is supported, then
+	// supported&&enabled is equal to enabled.
+	extraData := interfaces.SystemKeyExtraData{
+		PromptingFlagEnabled: m.useAppArmorPrompting(),
+	}
+	mismatch, err := interfaces.SystemKeyMismatch(extraData)
 	if err != nil {
 		logger.Noticef("error trying to compare the snap system key: %v", err)
 		return true
@@ -249,10 +257,15 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 	}
 
 	if shouldWriteSystemKey {
-		// m.useAppArmorPrompting() is supported&&enabled, but use it in place
-		// of enabled, since if prompting is not supported, the system key
-		// values related to prompting will both be false anyway.
-		if err := writeSystemKey(m.useAppArmorPrompting()); err != nil {
+		// m.useAppArmorPrompting() is supported&&enabled, rather than simply
+		// enabled, but it is okay to use it in place of enabled, since if
+		// prompting is not supported, the system key values related to
+		// prompting will both be false anyway, and if it is supported, then
+		// supported&&enabled is equal to enabled.
+		extraData := interfaces.SystemKeyExtraData{
+			PromptingFlagEnabled: m.useAppArmorPrompting(),
+		}
+		if err := writeSystemKey(extraData); err != nil {
 			logger.Noticef("cannot write system key: %v", err)
 		}
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -249,6 +249,9 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 	}
 
 	if shouldWriteSystemKey {
+		// m.useAppArmorPrompting() is supported&&enabled, but use it in place
+		// of enabled, since if prompting is not supported, the system key
+		// values related to prompting will both be false anyway.
 		if err := writeSystemKey(m.useAppArmorPrompting()); err != nil {
 			logger.Noticef("cannot write system key: %v", err)
 		}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -150,13 +150,8 @@ func (m *InterfaceManager) profilesNeedRegeneration() bool {
 }
 
 var profilesNeedRegenerationImpl = func(m *InterfaceManager) bool {
-	// m.useAppArmorPrompting() is supported&&enabled, rather than simply
-	// enabled, but it is okay to use it in place of enabled, since if
-	// prompting is not supported, the system key values related to
-	// prompting will both be false anyway, and if it is supported, then
-	// supported&&enabled is equal to enabled.
 	extraData := interfaces.SystemKeyExtraData{
-		PromptingFlagEnabled: m.useAppArmorPrompting(),
+		AppArmorPrompting: m.useAppArmorPrompting(),
 	}
 	mismatch, err := interfaces.SystemKeyMismatch(extraData)
 	if err != nil {
@@ -257,13 +252,8 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 	}
 
 	if shouldWriteSystemKey {
-		// m.useAppArmorPrompting() is supported&&enabled, rather than simply
-		// enabled, but it is okay to use it in place of enabled, since if
-		// prompting is not supported, the system key values related to
-		// prompting will both be false anyway, and if it is supported, then
-		// supported&&enabled is equal to enabled.
 		extraData := interfaces.SystemKeyExtraData{
-			PromptingFlagEnabled: m.useAppArmorPrompting(),
+			AppArmorPrompting: m.useAppArmorPrompting(),
 		}
 		if err := writeSystemKey(extraData); err != nil {
 			logger.Noticef("cannot write system key: %v", err)

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -395,7 +395,7 @@ apps:
 	// function that writes the new system key with one always panics.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error { panic("should not attempt to write system key") })
+	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error { panic("should not attempt to write system key") })
 	defer restore()
 	// Put a fake system key in place, we just want to see that file being removed.
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
@@ -470,7 +470,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	// Pretend that security profiles are out of date.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error {
+	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error {
 		writeKey = true
 		return nil
 	})
@@ -518,7 +518,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	// Pretend that security profiles are out of date.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error {
+	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error {
 		writeKey = true
 		return nil
 	})

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -395,7 +395,7 @@ apps:
 	// function that writes the new system key with one always panics.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error { panic("should not attempt to write system key") })
+	restore = ifacestate.MockWriteSystemKey(func(extraData interfaces.SystemKeyExtraData) error { panic("should not attempt to write system key") })
 	defer restore()
 	// Put a fake system key in place, we just want to see that file being removed.
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
@@ -470,7 +470,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	// Pretend that security profiles are out of date.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error {
+	restore = ifacestate.MockWriteSystemKey(func(extraData interfaces.SystemKeyExtraData) error {
 		writeKey = true
 		return nil
 	})
@@ -518,7 +518,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	// Pretend that security profiles are out of date.
 	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func(promptingFlagEnabled bool) error {
+	restore = ifacestate.MockWriteSystemKey(func(extraData interfaces.SystemKeyExtraData) error {
 		writeKey = true
 		return nil
 	})

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -393,9 +393,9 @@ apps:
 
 	// Pretend that security profiles are out of date and mock the
 	// function that writes the new system key with one always panics.
-	restore = ifacestate.MockProfilesNeedRegeneration(func() bool { return true })
+	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func() error { panic("should not attempt to write system key") })
+	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error { panic("should not attempt to write system key") })
 	defer restore()
 	// Put a fake system key in place, we just want to see that file being removed.
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
@@ -468,9 +468,9 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	mockSnaps(c, st)
 
 	// Pretend that security profiles are out of date.
-	restore = ifacestate.MockProfilesNeedRegeneration(func() bool { return true })
+	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func() error {
+	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error {
 		writeKey = true
 		return nil
 	})
@@ -516,9 +516,9 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	mockSnaps(c, st)
 
 	// Pretend that security profiles are out of date.
-	restore = ifacestate.MockProfilesNeedRegeneration(func() bool { return true })
+	restore = ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func() error {
+	restore = ifacestate.MockWriteSystemKey(func(currentAppArmorPrompting bool) error {
 		writeKey = true
 		return nil
 	})
@@ -736,7 +736,7 @@ func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
 	defer dirs.SetRootDir("")
 
 	// security profiles do not need regeneration when crating the manager
-	restore := ifacestate.MockProfilesNeedRegeneration(func() bool { return false })
+	restore := ifacestate.MockProfilesNeedRegeneration(func(m *ifacestate.InterfaceManager) bool { return false })
 	defer restore()
 
 	backend := &ifacetest.TestSecurityBackendDiscardingLate{

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -62,6 +62,11 @@ type InterfaceManager struct {
 	// extras
 	extraInterfaces []interfaces.Interface
 	extraBackends   []interfaces.SecurityBackend
+
+	// AppArmor Prompting -- these values should never be used directly.
+	// Always check useAppArmorPrompting().
+	useAppArmorPromptingValue   bool
+	useAppArmorPromptingChecker sync.Once
 
 	preseed bool
 }
@@ -169,7 +174,7 @@ func (m *InterfaceManager) StartUp() error {
 	if _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
-	if profilesNeedRegeneration() {
+	if m.profilesNeedRegeneration() {
 		if err := m.regenerateAllSecurityProfiles(perfTimings); err != nil {
 			return err
 		}

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -178,30 +178,25 @@ func PromptingSupported() (bool, string) {
 	if err != nil {
 		return false, fmt.Sprintf("cannot check apparmor kernel features: %v", err)
 	}
-	if !KernelFeaturesSupportPrompting(kernelFeatures) {
-		return false, "apparmor kernel features do not support prompting"
-	}
 	parserFeatures, err := appArmorAssessment.ParserFeatures()
 	if err != nil {
 		return false, fmt.Sprintf("cannot check apparmor parser features: %v", err)
 	}
-	if !ParserFeaturesSupportPrompting(parserFeatures) {
+	return PromptingSupportedByFeatures(kernelFeatures, parserFeatures)
+}
+
+// PromptingSupportedByFeatures returns whether prompting is supported by the
+// given AppArmor kernel and parser features.
+func PromptingSupportedByFeatures(kernelFeatures []string, parserFeatures []string) (bool, string) {
+	if !strutil.ListContains(kernelFeatures, "policy:permstable32:prompt") {
+		return false, "apparmor kernel features do not support prompting"
+	}
+	if !strutil.ListContains(parserFeatures, "prompt") {
 		return false, "apparmor parser does not support the prompt qualifier"
 	}
-	// TODO: return true once snapd supports prompting
+	// TODO: return true once the prompting API is merged and ready
+	// return true, ""
 	return false, "requires newer version of snapd"
-}
-
-// KernelFeaturesSupportPrompting returns whether prompting is supported by the
-// given AppArmor kernel features.
-func KernelFeaturesSupportPrompting(kernelFeatures []string) bool {
-	return strutil.ListContains(kernelFeatures, "policy:permstable32:prompt")
-}
-
-// ParserFeaturesSupportPrompting returns whether prompting is supported by the
-// given AppArmor parser features.
-func ParserFeaturesSupportPrompting(parserFeatures []string) bool {
-	return strutil.ListContains(parserFeatures, "prompt")
 }
 
 // probe related code

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -170,6 +170,40 @@ func ParserMtime() int64 {
 	return mtime
 }
 
+// PromptingSupported returns true if prompting is supported by the system.
+// Otherwise, returns false, along with a string explaining why prompting is
+// unsupported.
+func PromptingSupported() (bool, string) {
+	kernelFeatures, err := appArmorAssessment.KernelFeatures()
+	if err != nil {
+		return false, fmt.Sprintf("cannot check apparmor kernel features: %v", err)
+	}
+	if !KernelFeaturesSupportPrompting(kernelFeatures) {
+		return false, "apparmor kernel features do not support prompting"
+	}
+	parserFeatures, err := appArmorAssessment.ParserFeatures()
+	if err != nil {
+		return false, fmt.Sprintf("cannot check apparmor parser features: %v", err)
+	}
+	if !ParserFeaturesSupportPrompting(parserFeatures) {
+		return false, "apparmor parser does not support the prompt qualifier"
+	}
+	// TODO: return true once snapd supports prompting
+	return false, "requires newer version of snapd"
+}
+
+// KernelFeaturesSupportPrompting returns whether prompting is supported by the
+// given AppArmor kernel features.
+func KernelFeaturesSupportPrompting(kernelFeatures []string) bool {
+	return strutil.ListContains(kernelFeatures, "policy:permstable32:prompt")
+}
+
+// ParserFeaturesSupportPrompting returns whether prompting is supported by the
+// given AppArmor parser features.
+func ParserFeaturesSupportPrompting(parserFeatures []string) bool {
+	return strutil.ListContains(parserFeatures, "prompt")
+}
+
 // probe related code
 
 var (

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -498,6 +498,64 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *apparmorSuite) TestPromptingSupported(c *C) {
+	goodKernelFeatures := []string{"policy:permstable32:prompt"}
+	goodParserFeatures := []string{"prompt"}
+
+	for _, testCase := range []struct {
+		kernelFeatures []string
+		kernelError    error
+		parserFeatures []string
+		parserError    error
+		expectedReason string
+	}{
+		{
+			kernelFeatures: []string{},
+			kernelError:    fmt.Errorf("foo"),
+			parserFeatures: []string{},
+			parserError:    fmt.Errorf("bar"),
+			expectedReason: "cannot check apparmor kernel features: foo",
+		},
+		{
+			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny"},
+			kernelError:    nil,
+			parserFeatures: []string{},
+			parserError:    fmt.Errorf("bar"),
+			expectedReason: "apparmor kernel features do not support prompting",
+		},
+		{
+			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt"},
+			kernelError:    nil,
+			parserFeatures: []string{},
+			parserError:    fmt.Errorf("bar"),
+			expectedReason: "cannot check apparmor parser features: bar",
+		},
+		{
+			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt"},
+			kernelError:    nil,
+			parserFeatures: []string{"mqueue"},
+			parserError:    nil,
+			expectedReason: "apparmor parser does not support the prompt qualifier",
+		},
+	} {
+		restore := apparmor.MockFeatures(testCase.kernelFeatures, testCase.kernelError, testCase.parserFeatures, testCase.parserError)
+		supported, reason := apparmor.PromptingSupported()
+		c.Check(supported, Equals, false)
+		c.Check(reason, Equals, testCase.expectedReason)
+		restore()
+	}
+
+	restore := apparmor.MockFeatures(goodKernelFeatures, nil, goodParserFeatures, nil)
+	defer restore()
+
+	supported, reason := apparmor.PromptingSupported()
+	// TODO: change this once snapd supports prompting
+	c.Check(supported, Equals, false)
+	c.Check(reason, Equals, "requires newer version of snapd")
+	// c.Check(supported, Equals, true)
+	// c.Check(reason, Equals, "")
+}
+
 func (s *apparmorSuite) TestValidateFreeFromAAREUnhappy(c *C) {
 	var testCases = []string{"a?", "*b", "c[c", "dd]", "e{", "f}", "g^", `h"`, "f\000", "g\x00"}
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -517,18 +517,18 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 			expectedReason: "cannot check apparmor kernel features: foo",
 		},
 		{
-			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny"},
-			kernelError:    nil,
-			parserFeatures: []string{},
-			parserError:    fmt.Errorf("bar"),
-			expectedReason: "apparmor kernel features do not support prompting",
-		},
-		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt"},
 			kernelError:    nil,
 			parserFeatures: []string{},
 			parserError:    fmt.Errorf("bar"),
 			expectedReason: "cannot check apparmor parser features: bar",
+		},
+		{
+			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny"},
+			kernelError:    nil,
+			parserFeatures: []string{},
+			parserError:    nil,
+			expectedReason: "apparmor kernel features do not support prompting",
 		},
 		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt"},

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -41,7 +41,7 @@ execute: |
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 300 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'systemctl show --property=Result snapd.service ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
+        retry --wait 1 -n 300 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show --property=Result snapd.service | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl start snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" ; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
         # Set SNAPD_PID so future checks use most recent PID
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -25,18 +25,10 @@ debug: |
 execute: |
     . /etc/os-release
 
-    # Necessary since we restart snapd many times
-    restart_snapd() {
-        systemctl stop snapd.service snapd.socket
-        systemctl reset-failed snapd.service snapd.socket
-        systemctl start snapd.service
-        retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
-    }
-
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show -P Result snapd.service | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl start snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
         # Set SNAPD_PID so future checks use most recent PID
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }
@@ -91,10 +83,6 @@ execute: |
 
     # Check that setting the same value multiple times does not restart snapd
     for value in true false; do
-        # Reset failed count
-        restart_snapd
-        check_snapd_restarted
-
         echo "Initially set value, which will trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
         check_snapd_restarted
@@ -116,6 +104,3 @@ execute: |
         echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     done
-
-    # Reset failed count, in case test is repeated multiple times
-    restart_snapd

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -27,11 +27,15 @@ execute: |
     . /etc/os-release
 
     # Necessary since we restart snapd many times
-    restart_snapd() {
-        systemctl stop snapd.service snapd.socket
-        systemctl reset-failed snapd.service snapd.socket
-        systemctl start snapd.service
-        retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+    reset_start_limit() {
+        if systemctl show --property=Result snapd.service | grep "start-limit-hit" ; then
+            systemctl stop snapd.service snapd.socket
+            systemctl reset-failed snapd.service snapd.socket
+            systemctl start snapd.service
+            retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+        else
+            false
+        fi
     }
 
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
@@ -57,34 +61,34 @@ execute: |
 
     echo "Ensure prompting is initially disabled"
     if snap get system experimental.apparmor-prompting | grep 'true' ; then
-        snap set system experimental.apparmor-prompting=false
+        snap set system experimental.apparmor-prompting=false || reset_start_limit
         check_snapd_restarted
         check_prompting_setting "false"
     fi
 
     echo "Enable prompting via snap client"
-    snap set system experimental.apparmor-prompting=true
+    snap set system experimental.apparmor-prompting=true || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to true via snap client"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via snap client"
-    snap set system experimental.apparmor-prompting=false
+    snap set system experimental.apparmor-prompting=false || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to false via snap client"
     check_snapd_restarted
     check_prompting_setting "false"
 
     echo "Enable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted"
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to true via curl"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted"
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to false via curl"
     check_snapd_restarted
@@ -92,12 +96,8 @@ execute: |
 
     # Check that setting the same value multiple times does not restart snapd
     for value in true false; do
-        # Reset failed count
-        restart_snapd
-        check_snapd_restarted
-
         echo "Initially set value, which will trigger a restart"
-        snap set system experimental.apparmor-prompting="$value"
+        snap set system experimental.apparmor-prompting="$value" || reset_start_limit
         check_snapd_restarted
         check_prompting_setting "$value"
 
@@ -119,6 +119,3 @@ execute: |
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
         check_prompting_setting "$value"
     done
-
-    # Reset failed count, in case test is repeated multiple times
-    restart_snapd

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -2,9 +2,10 @@ summary: Check that changing the experimental.apparmor-prompting flag causes sna
 
 details: |
     This test checks that snapd is restarted when the experimental.apparmor-prompting
-    flag is changed. This is necessary so that apparmor kernel and parser features
-    are re-probed, in case support for prompting has changed since snapd last
-    started.
+    flag is changed, and that snapd is not restarted when the flag is set to
+    the same value repeatedly. Restarting snapd when the flag changes is
+    necessary so that apparmor kernel and parser features are re-probed, in
+    case support for prompting has changed since snapd last started.
 
 systems:
   - ubuntu-16.04-*
@@ -17,84 +18,104 @@ prepare: |
         snap alias test-snapd-curl.curl curl
     fi
 
+debug: |
+    # Report system-info
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq
+
 execute: |
     . /etc/os-release
 
-    echo "Precondition check that snapd is active"
-    systemctl is-active snapd.service snapd.socket
+    # Necessary since we restart snapd many times
+    restart_snapd() {
+        systemctl stop snapd.service snapd.socket
+        systemctl reset-failed snapd.service snapd.socket
+        systemctl start snapd.service
+        retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+    }
 
-    # Explicitly disable prompting, whether or not it was enabled by default.
-    snap set system experimental.apparmor-prompting=false
-
-    systemctl is-active snapd.service snapd.socket
-    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
-    # Check that /v2/snaps/system/conf reports prompting flag set to false
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "false"
-    # Check that /v2/system-info reports prompting disabled
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "false"
-
-    check_restart_and_setting() {
-        # Wait a second to give snapd a chance to restart
-        sleep 1
-        # Check that snapd restarted
-        systemctl is-active snapd.service snapd.socket
-        NEW_SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
-        test ! "$NEW_SNAPD_PID" = "$SNAPD_PID"
+    # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
+    check_snapd_restarted() {
+        #shellcheck disable=SC2016
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'systemctl is-active snapd.service snapd.socket && test ! "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" = "$SNAPD_PID"'
         # Set SNAPD_PID so future checks use most recent PID
-        SNAPD_PID="$NEW_SNAPD_PID"
+        SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+    }
+
+    check_prompting_setting() {
+        # Check that snap CLI reports prompting flag set correctly
+        snap get system experimental.apparmor-prompting | MATCH "$1"
         # Check that /v2/snaps/system/conf reports prompting flag set correctly
         curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
         # Check that /v2/system-info reports prompting correctly
         curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
     }
 
-    # Enable prompting via snap client
+    echo "Precondition check that snapd is active"
+    retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+
+    echo "Ensure prompting is initially disabled"
+    if snap get system experimental.apparmor-prompting | grep 'true' ; then
+        snap set system experimental.apparmor-prompting=false
+        check_snapd_restarted
+        check_prompting_setting "false"
+    fi
+
+    echo "Enable prompting via snap client"
     snap set system experimental.apparmor-prompting=true
 
     echo "Check that snapd restarted after prompting set to true via snap client"
-    check_restart_and_setting "true"
+    check_snapd_restarted
+    check_prompting_setting "true"
 
-    # Disable prompting via snap client
+    echo "Disable prompting via snap client"
     snap set system experimental.apparmor-prompting=false
 
     echo "Check that snapd restarted after prompting set to false via snap client"
-    check_restart_and_setting "false"
+    check_snapd_restarted
+    check_prompting_setting "false"
 
-    # Enable prompting via API request
+    echo "Enable prompting via API request"
     curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted"
 
     echo "Check that snapd restarted after prompting set to true via curl"
-    check_restart_and_setting "true"
+    check_snapd_restarted
+    check_prompting_setting "true"
 
-    # Disable prompting via API request
+    echo "Disable prompting via API request"
     curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted"
 
     echo "Check that snapd restarted after prompting set to false via curl"
-    check_restart_and_setting "false"
+    check_snapd_restarted
+    check_prompting_setting "false"
 
     # Check that setting the same value multiple times does not restart snapd
     for value in true false; do
-        # Initially set value, which will trigger a restart
-        snap set system experimental.apparmor-prompting="$value"
-        # Wait a second to give snapd the chance to restart
-        sleep 1
-        systemctl is-active snapd.service snapd.socket
-        # Get PID after initial value set
-        SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+        # Reset failed count
+        restart_snapd
+        check_snapd_restarted
 
-        # Set same value again
+        echo "Initially set value, which will trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
-        # Wait a second to let snapd handle the change
+        check_snapd_restarted
+        check_prompting_setting "$value"
+
+        echo "Set same value again, which should not trigger a restart"
+        snap set system experimental.apparmor-prompting="$value"
+        # Wait a second to let snapd handle the change, in case it erroneously causes a restart
         sleep 1
         systemctl is-active snapd.service snapd.socket
-        # Check that snapd has not restarted
+        echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
-        # Set same value again
+        echo "Set same value again, which should not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
-        # Wait a second to let snapd handle the change
+        # Wait a second to let snapd handle the change, in case it erroneously causes a restart
         sleep 1
         systemctl is-active snapd.service snapd.socket
-        # Check that snapd has not restarted
+        echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     done
+
+    # Reset failed count, in case test is repeated multiple times
+    restart_snapd

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -20,8 +20,27 @@ prepare: |
         snap alias test-snapd-curl.curl curl
     fi
 
+restore: |
+    echo "Restore: Reset start limit so that other queries can succeed"
+    systemctl stop snapd.service snapd.socket || true
+    systemctl reset-failed snapd.service snapd.socket || true
+    systemctl start snapd.service || systemctl status snapd.service || true
+    retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+
 debug: |
-    # Report system-info
+    echo "Debug: Check if snapd service and socket are running"
+    systemctl is-active snapd.service snapd.socket || true
+    systemctl status snapd.service || true
+    echo "Debug: Check if snapd has start-limit-hit"
+    systemctl show --property=Result snapd.service snapd.socket || true
+
+    echo "Debug: Reset start limit so that other queries can succeed"
+    systemctl stop snapd.service snapd.socket || true
+    systemctl reset-failed snapd.service snapd.socket || true
+    systemctl start snapd.service || systemctl status snapd.service || true
+    retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+
+    echo "Debug: Report system info"
     curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq
 
 execute: |
@@ -32,9 +51,10 @@ execute: |
         if systemctl show --property=Result snapd.service | grep "start-limit-hit" ; then
             systemctl stop snapd.service snapd.socket
             systemctl reset-failed snapd.service snapd.socket
-            systemctl start snapd.service
+            systemctl start snapd.service || systemctl status snapd.service
             retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
         else
+            echo "Called reset_start_limit but start limit was not hit"
             false
         fi
     }
@@ -42,17 +62,16 @@ execute: |
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 300 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show --property=Result snapd.service | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl start snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" ; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
-        # Set SNAPD_PID so future checks use most recent PID
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show --property=Result snapd.service snapd.socket | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl restart snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" ; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket && systemctl status snapd.service'
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }
 
     check_prompting_setting() {
-        # Check that snap CLI reports prompting flag set correctly
+        echo "Check that snap CLI reports prompting flag set correctly"
         snap get system experimental.apparmor-prompting | MATCH "$1"
-        # Check that /v2/snaps/system/conf reports prompting flag set correctly
+        echo "Check that /v2/snaps/system/conf reports prompting flag set correctly"
         curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
-        # Check that /v2/system-info reports prompting correctly
+        echo "Check that /v2/system-info reports prompting correctly"
         curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
     }
 
@@ -95,14 +114,14 @@ execute: |
     check_snapd_restarted
     check_prompting_setting "false"
 
-    # Check that setting the same value multiple times does not restart snapd
+    echo "Check that setting the same value multiple times does not restart snapd"
     for value in true false; do
         echo "Initially set value, which will trigger a restart"
         snap set system experimental.apparmor-prompting="$value" || reset_start_limit
         check_snapd_restarted
         check_prompting_setting "$value"
 
-        echo "Set same value again, which should not trigger a restart"
+        echo "Set same value a second time, which should not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
         # snap changes blocks until the change is done, or errors if snapd is restarting
         snap changes
@@ -111,7 +130,7 @@ execute: |
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
         check_prompting_setting "$value"
 
-        echo "Set same value again, which should not trigger a restart"
+        echo "Set same value a third time, which should again not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
         # snap changes blocks until the change is done, or errors if snapd is restarting
         snap changes

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -36,7 +36,7 @@ execute: |
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'systemctl is-active snapd.service snapd.socket && test ! "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" = "$SNAPD_PID"'
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
         # Set SNAPD_PID so future checks use most recent PID
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }
@@ -102,16 +102,16 @@ execute: |
 
         echo "Set same value again, which should not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
-        # Wait a second to let snapd handle the change, in case it erroneously causes a restart
-        sleep 1
+        # snap changes blocks until the change is done, or errors if snapd is restarting
+        snap changes
         systemctl is-active snapd.service snapd.socket
         echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
         echo "Set same value again, which should not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
-        # Wait a second to let snapd handle the change, in case it erroneously causes a restart
-        sleep 1
+        # snap changes blocks until the change is done, or errors if snapd is restarting
+        snap changes
         systemctl is-active snapd.service snapd.socket
         echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -23,6 +23,7 @@ prepare: |
 restore: |
     echo "Restore: Reset start limit so that other queries can succeed"
     systemctl stop snapd.service snapd.socket || true
+    systemctl stop snapd.failure.service || true
     systemctl reset-failed snapd.service snapd.socket || true
     systemctl start snapd.service || systemctl status snapd.service || true
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
@@ -36,6 +37,7 @@ debug: |
 
     echo "Debug: Reset start limit so that other queries can succeed"
     systemctl stop snapd.service snapd.socket || true
+    systemctl stop snapd.failure.service || true
     systemctl reset-failed snapd.service snapd.socket || true
     systemctl start snapd.service || systemctl status snapd.service || true
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
@@ -50,6 +52,10 @@ execute: |
     reset_start_limit() {
         if systemctl show --property=Result snapd.service | grep "start-limit-hit" ; then
             systemctl stop snapd.service snapd.socket
+            # On core18, snapd.failure.service holds the state lock after a failure
+            # due to start-limit-hit, preventing snapd from progressing from
+            # "activating" to "active".
+            systemctl stop snapd.failure.service || true
             systemctl reset-failed snapd.service snapd.socket
             systemctl start snapd.service || systemctl status snapd.service
             retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
@@ -62,7 +68,15 @@ execute: |
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show --property=Result snapd.service snapd.socket | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl restart snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)" ; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket && systemctl status snapd.service'
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c '
+            if systemctl show --property=Result snapd.service snapd.socket | grep "start-limit-hit" || systemctl is-active snapd.service | grep "activating"; then
+                systemctl stop snapd.service snapd.socket;
+                systemctl stop snapd.failure.service;
+                systemctl reset-failed snapd.service snapd.socket;
+                systemctl restart snapd.service;
+            fi;
+            NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)";
+            test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket && systemctl status snapd.service'
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }
 

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -11,6 +11,7 @@ systems:
   - ubuntu-16.04-*
   - ubuntu-18.04-*
   - ubuntu-2*
+  - ubuntu-core-*
 
 prepare: |
     if ! command -v curl; then

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -1,0 +1,100 @@
+summary: Check that changing the experimental.apparmor-prompting flag causes snapd to restart
+
+details: |
+    This test checks that snapd is restarted when the experimental.apparmor-prompting
+    flag is changed. This is necessary so that apparmor kernel and parser features
+    are re-probed, in case support for prompting has changed since snapd last
+    started.
+
+systems:
+  - ubuntu-16.04-*
+  - ubuntu-18.04-*
+  - ubuntu-2*
+
+prepare: |
+    if ! command -v curl; then
+        snap install --devmode --edge test-snapd-curl
+        snap alias test-snapd-curl.curl curl
+    fi
+
+execute: |
+    . /etc/os-release
+
+    echo "Precondition check that snapd is active"
+    systemctl is-active snapd.service snapd.socket
+
+    # Explicitly disable prompting, whether or not it was enabled by default.
+    snap set system experimental.apparmor-prompting=false
+
+    systemctl is-active snapd.service snapd.socket
+    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+    # Check that /v2/snaps/system/conf reports prompting flag set to false
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "false"
+    # Check that /v2/system-info reports prompting disabled
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "false"
+
+    check_restart_and_setting() {
+        # Wait a second to give snapd a chance to restart
+        sleep 1
+        # Check that snapd restarted
+        systemctl is-active snapd.service snapd.socket
+        NEW_SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+        test ! "$NEW_SNAPD_PID" = "$SNAPD_PID"
+        # Set SNAPD_PID so future checks use most recent PID
+        SNAPD_PID="$NEW_SNAPD_PID"
+        # Check that /v2/snaps/system/conf reports prompting flag set correctly
+        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
+        # Check that /v2/system-info reports prompting correctly
+        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
+    }
+
+    # Enable prompting via snap client
+    snap set system experimental.apparmor-prompting=true
+
+    echo "Check that snapd restarted after prompting set to true via snap client"
+    check_restart_and_setting "true"
+
+    # Disable prompting via snap client
+    snap set system experimental.apparmor-prompting=false
+
+    echo "Check that snapd restarted after prompting set to false via snap client"
+    check_restart_and_setting "false"
+
+    # Enable prompting via API request
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted"
+
+    echo "Check that snapd restarted after prompting set to true via curl"
+    check_restart_and_setting "true"
+
+    # Disable prompting via API request
+    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted"
+
+    echo "Check that snapd restarted after prompting set to false via curl"
+    check_restart_and_setting "false"
+
+    # Check that setting the same value multiple times does not restart snapd
+    for value in true false; do
+        # Initially set value, which will trigger a restart
+        snap set system experimental.apparmor-prompting="$value"
+        # Wait a second to give snapd the chance to restart
+        sleep 1
+        systemctl is-active snapd.service snapd.socket
+        # Get PID after initial value set
+        SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+
+        # Set same value again
+        snap set system experimental.apparmor-prompting="$value"
+        # Wait a second to let snapd handle the change
+        sleep 1
+        systemctl is-active snapd.service snapd.socket
+        # Check that snapd has not restarted
+        test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+
+        # Set same value again
+        snap set system experimental.apparmor-prompting="$value"
+        # Wait a second to let snapd handle the change
+        sleep 1
+        systemctl is-active snapd.service snapd.socket
+        # Check that snapd has not restarted
+        test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+    done

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -26,10 +26,18 @@ debug: |
 execute: |
     . /etc/os-release
 
+    # Necessary since we restart snapd many times
+    restart_snapd() {
+        systemctl stop snapd.service snapd.socket
+        systemctl reset-failed snapd.service snapd.socket
+        systemctl start snapd.service
+        retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
+    }
+
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'if systemctl show -P Result snapd.service | grep "start-limit-hit" ; then systemctl stop snapd.service snapd.socket ; systemctl reset-failed snapd.service snapd.socket ; systemctl start snapd.service ; fi ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
+        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
         # Set SNAPD_PID so future checks use most recent PID
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }
@@ -84,6 +92,10 @@ execute: |
 
     # Check that setting the same value multiple times does not restart snapd
     for value in true false; do
+        # Reset failed count
+        restart_snapd
+        check_snapd_restarted
+
         echo "Initially set value, which will trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
         check_snapd_restarted
@@ -107,3 +119,6 @@ execute: |
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
         check_prompting_setting "$value"
     done
+
+    # Reset failed count, in case test is repeated multiple times
+    restart_snapd

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -14,6 +14,7 @@ systems:
   - ubuntu-core-*
 
 prepare: |
+    snap install jq
     if ! command -v curl; then
         snap install --devmode --edge test-snapd-curl
         snap alias test-snapd-curl.curl curl

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -41,7 +41,7 @@ execute: |
     # Check that snapd has restarted and now has a new PID, then set SNAPD_PID to that new PID.
     check_snapd_restarted() {
         #shellcheck disable=SC2016
-        retry --wait 1 -n 100 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
+        retry --wait 1 -n 300 --env SNAPD_PID="$SNAPD_PID" sh -x -c 'systemctl show --property=Result snapd.service ; NEW_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"; test ! "$NEW_PID" = "0" && test ! "$NEW_PID" = "$SNAPD_PID" && systemctl is-active snapd.service snapd.socket'
         # Set SNAPD_PID so future checks use most recent PID
         SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
     }

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -96,6 +96,7 @@ execute: |
         systemctl is-active snapd.service snapd.socket
         echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+        check_prompting_setting "$value"
 
         echo "Set same value again, which should not trigger a restart"
         snap set system experimental.apparmor-prompting="$value"
@@ -104,4 +105,5 @@ execute: |
         systemctl is-active snapd.service snapd.socket
         echo "Check that snapd has not restarted"
         test "$SNAPD_PID" = "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+        check_prompting_setting "$value"
     done


### PR DESCRIPTION
If AppArmor prompting is supported and enabled, include the `prompt` prefix in relevant AppArmor rules. For now, such rules are only those in the home interface, but rules with the `###PROMPT###` prefix from other interfaces will be automatically handled correctly as well when they are added.

Whether prompting is supported and enabled is included in the system key so that security profiles are automatically regenerated whenever `(supported && enabled)` changes.

In order to cause profile regeneration after the flag has been changed, a handler has been added to configcore which requests snapd to restart whenever the apparmor-prompting flag has changed. Since the `(supported && enabled)` value is part of the system key, the keys will differ (assuming that prompting is supported), so profiles will be automatically be regenerated. If prompting is not supported, then there is no need to regenerate profiles, and indeed the system key will be unchanged (assuming nothing else has changed).

We make sure to restart snapd anyway in case prompting support *has* changed, which will be reflected in a change of AppArmor kernel or parser features, requiring/causing a profile regeneration anyway due to a change in system key.