### PR TITLE
daemon: fix notices API tests on non Ubuntu

### DIFF
--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -937,19 +937,19 @@ func (s *noticesSuite) testAddNoticeBadRequest(c *C, body, errorMatch string) {
 }
 
 func (s *noticesSuite) TestAddNoticesSnapCmdNoReexec(c *C) {
-	s.testAddNoticesSnapCmd(c, "/usr/bin/snap", false)
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap"), false)
 }
 
 func (s *noticesSuite) TestAddNoticesSnapCmdReexecSnapd(c *C) {
-	s.testAddNoticesSnapCmd(c, "/snap/snapd/11/usr/bin/snap", false)
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "snapd/11/usr/bin/snap"), false)
 }
 
 func (s *noticesSuite) TestAddNoticesSnapCmdReexecCore(c *C) {
-	s.testAddNoticesSnapCmd(c, "/snap/core/12/usr/bin/snap", false)
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "core/12/usr/bin/snap"), false)
 }
 
 func (s *noticesSuite) TestAddNoticesSnapCmdUnknownBinary(c *C) {
-	s.testAddNoticesSnapCmd(c, "/snap/bad-c0re/12/usr/bin/snap", true)
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "bad-c0re/12/usr/bin/snap"), true)
 }
 
 func (s *noticesSuite) testAddNoticesSnapCmd(c *C, exePath string, shouldFail bool) {
@@ -958,7 +958,7 @@ func (s *noticesSuite) testAddNoticesSnapCmd(c *C, exePath string, shouldFail bo
 	// mock request coming from snap command
 	restore := daemon.MockOsReadlink(func(path string) (string, error) {
 		c.Check(path, Equals, "/proc/100/exe")
-		return filepath.Join(dirs.GlobalRootDir, exePath), nil
+		return exePath, nil
 	})
 	defer restore()
 


### PR DESCRIPTION
Snap mount location is hardcoded, but os-release is not mocked, so host paths are assumed.

Failed like so:

```
----------------------------------------------------------------------
FAIL: api_notices_test.go:947: noticesSuite.TestAddNoticesSnapCmdReexecCore

api_notices_test.go:948:
    s.testAddNoticesSnapCmd(c, "/snap/core/12/usr/bin/snap", false)
api_base_test.go:648:
    c.Assert(rsp.Type, check.Equals, daemon.ResponseTypeSync, check.Commentf("expected sync resp: %#v, result: %+v", rsp, rsp.Result))
... obtained daemon.ResponseType = "error"
... expected daemon.ResponseType = "sync"
... expected sync resp: &daemon.respJSON{Type:"error", Status:403, StatusText:"", Result:(*daemon.errorResult)(0xc0007911d0), Change:"", Sources:[]string(nil), SuggestedCurrency:"", WarningTimestamp:<nil>, WarningCount:0, Maintenance:(*daemon.errorResult)(nil)}, result: &{Message:only snap command can record notices Kind:login-required Value:<nil>}
... Difference:
...     "error" != "sync"

```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
