### PR TITLE
github, run-checks: split unit tests variants, add variant with -race

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -278,10 +278,6 @@ jobs:
           - latest/stable
         unit-scenario:
           - normal
-          - snapd_debug
-          - withbootassetstesting
-          - nosecboot
-          - faultinject
 
     steps:
     - name: Checkout code
@@ -348,6 +344,97 @@ jobs:
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
 
+    - name: Upload the coverage results
+      if: ${{ matrix.gochannel != 'latest/stable' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-files
+        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
+
+  unit-tests-special:
+    needs: [static-checks]
+    runs-on: ubuntu-22.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
+      GOROOT: ""
+      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+    strategy:
+      # we cache successful runs so it's fine to keep going
+      fail-fast: false
+      matrix:
+        gochannel:
+          - 1.18
+          - latest/stable
+        unit-scenario:
+          - snapd_debug
+          - withbootassetstesting
+          - nosecboot
+          - faultinject
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+
+    # Fetch base ref, needed for golangci-lint
+    - name: Fetching base ref ${{ github.base_ref }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd
+        git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+
+    - name: Download Debian dependencies
+      uses: actions/download-artifact@v3
+      with:
+        name: debian-dependencies
+        path: ./debian-deps/
+
+    - name: Copy dependencies
+      run: |
+        test -f ./debian-deps/cached-apt.tar
+        sudo tar xvf ./debian-deps/cached-apt.tar -C /
+
+    - name: Install Debian dependencies
+      run: |
+          sudo apt update
+          sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+
+    # golang latest ensures things work on the edge
+    - name: Install the go snap
+      run: |
+          sudo snap install --classic --channel=${{ matrix.gochannel }} go
+
+    - name: Get deps
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/ && ./get-deps.sh
+
+    - name: Build C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
+          ./autogen.sh
+          make -j$(nproc)
+
+    - name: Build Go
+      run: |
+          go build github.com/snapcore/snapd/...
+
+    - name: Test C
+      run: |
+          cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/ && make check
+
+    - name: Reset code coverage data
+      run: |
+          rm -rf ${{ github.workspace }}/.coverage/
+
     - name: Test Go (SNAPD_DEBUG=1)
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |
@@ -385,7 +472,7 @@ jobs:
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 
   code-coverage:
-    needs: [unit-tests]
+    needs: [unit-tests, unit-tests-special]
     runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -375,6 +375,7 @@ jobs:
           - withbootassetstesting
           - nosecboot
           - faultinject
+          - race
 
     steps:
     - name: Checkout code
@@ -463,6 +464,12 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+
+    - name: Test Go (-race)
+      if: ${{ matrix.unit-scenario == 'race' }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}

--- a/run-checks
+++ b/run-checks
@@ -385,20 +385,25 @@ if [ "$UNIT" = 1 ]; then
     go version
 
     tags=
+    race=
     if [ -n "${GO_BUILD_TAGS-}" ]; then
         echo "Using build tags: $GO_BUILD_TAGS"
         tags="-tags $GO_BUILD_TAGS"
     fi
+    if [ -n "${GO_TEST_RACE-}" ]; then
+        echo "Using go test -race"
+        race="-race"
+    fi
 
     echo Building
     # shellcheck disable=SC2086
-    go build -v $tags github.com/snapcore/snapd/...
+    go build -v $tags $race github.com/snapcore/snapd/...
 
     # tests
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
             # shellcheck disable=SC2046,SC2086
-            GOTRACEBACK=1 $goctest $tags -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest $tags $race -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
         coverage=""
         if [ -z "${SKIP_COVERAGE-}" ]; then
@@ -411,7 +416,7 @@ if [ "$UNIT" = 1 ]; then
         fi
 
         # shellcheck disable=SC2046,SC2086
-        GOTRACEBACK=1 $goctest $tags -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
+        GOTRACEBACK=1 $goctest $tags $race -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
     fi
 
     # python unit test for mountinfo.query and version-compare


### PR DESCRIPTION
Running unit tests with various build variants does not need to block test execution.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
