### PR TITLE
overlord/snapstate/backend: mock depmod

### DIFF
--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -71,6 +71,8 @@ func (s *setupSuite) SetUpTest(c *C) {
 	})
 
 	s.umount = testutil.MockCommand(c, "umount", "")
+	depmod := testutil.MockCommand(c, "depmod", `echo "depmod default mock" >&2; exit 1`)
+	s.AddCleanup(func() { depmod.Restore() })
 }
 
 func (s *setupSuite) TearDownTest(c *C) {
@@ -658,6 +660,9 @@ func (s *setupSuite) TestSetupAndRemoveKernelModulesComponents(c *C) {
 	kernRev := snap.R(33)
 	toInstall := createKModsComps(c, 1, 2, ksnap, kernRev)
 
+	depmod := testutil.MockCommand(c, "depmod", "")
+	defer depmod.Restore()
+
 	// Set-up and then remove
 	s.testSetupKernelModulesComponents(c, toInstall, nil, ksnap, kernRev, "")
 	s.testRemoveKernelModulesComponents(c, toInstall, nil, ksnap, kernRev, "")
@@ -666,6 +671,9 @@ func (s *setupSuite) TestSetupAndRemoveKernelModulesComponents(c *C) {
 func (s *setupSuite) TestSetupAndRemoveKernelModulesComponentsWithInstalled(c *C) {
 	ksnap := "kernel"
 	kernRev := snap.R(33)
+
+	depmod := testutil.MockCommand(c, "depmod", "")
+	defer depmod.Restore()
 
 	// Set-up
 	firstInstalled := createKModsComps(c, 1, 2, ksnap, kernRev)
@@ -770,6 +778,9 @@ func (s *setupSuite) testRemoveKernelModulesComponents(c *C, toRemove, finalComp
 func (s *setupSuite) TestRemoveKernelModulesComponentsFails(c *C) {
 	ksnap := "kernel"
 	kernRev := snap.R(33)
+
+	depmod := testutil.MockCommand(c, "depmod", "")
+	defer depmod.Restore()
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// Fail in the penultimate invocation, which disables the unit


### PR DESCRIPTION
The tests seem to call real depmod which fails when building on LP:

```
----------------------------------------------------------------------
FAIL: setup_test.go:770: setupSuite.TestRemoveKernelModulesComponentsFails

setup_test.go:786:
    s.testSetupKernelModulesComponents(c, firstInstalled, nil, ksnap, kernRev, "")
setup_test.go:709:
    c.Assert(err, IsNil)
... value *exec.Error = &exec.Error{Name:"depmod", Err:(*errors.errorString)(0x4000118380)} ("exec: \"depmod\": executable file not found in $PATH")

----------------------------------------------------------------------
FAIL: setup_test.go:656: setupSuite.TestSetupAndRemoveKernelModulesComponents

setup_test.go:662:
    // Set-up and then remove
    s.testSetupKernelModulesComponents(c, toInstall, nil, ksnap, kernRev, "")
setup_test.go:709:
    c.Assert(err, IsNil)
... value *exec.Error = &exec.Error{Name:"depmod", Err:(*errors.errorString)(0x4000118380)} ("exec: \"depmod\": executable file not found in $PATH")

----------------------------------------------------------------------
FAIL: setup_test.go:666: setupSuite.TestSetupAndRemoveKernelModulesComponentsWithInstalled

setup_test.go:672:
    s.testSetupKernelModulesComponents(c, firstInstalled, nil, ksnap, kernRev, "")
setup_test.go:709:
    c.Assert(err, IsNil)
... value *exec.Error = &exec.Error{Name:"depmod", Err:(*errors.errorString)(0x4000118380)} ("exec: \"depmod\": executable file not found in $PATH")

OOPS: 164 passed, 3 FAILED
```

Make sure to have a default mock which fails and a mock the appropriate variant in tests which require it.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
