### PR TITLE
seccomp-support: check filter length value before reading

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -148,6 +148,9 @@ static void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes,
 		die("%s filter may only be empty in unrestricted profiles",
 		    what);
 	}
+	if (len_bytes > MAX_BPF_SIZE) {
+		die("%s filter size too big %u", what, len_bytes);
+	}
 	prog->len = len_bytes / sizeof(struct sock_filter);
 	prog->filter = malloc(len_bytes);
 	if (prog->filter == NULL) {


### PR DESCRIPTION
PR #13443 made coverity to report a new issue because of tainted input (hdr.len_deny_filter) being used in `sc_must_read_filter_from_file`. Whilst it is a false positive in our scenario (hdr.len_deny_filter is already checked in `sc_must_read_and_validate_header_from_file` ), I think it may be worth to make this check explicit in `sc_must_read_filter_from_file` even if it is duplicated. 