### PR TITLE
tests: add missing dependency to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,9 +89,10 @@ jobs:
         . ./install_tics.sh
 
         TICSQServer -project snapd -tmpdir /tmp/tics -branchdir "${{ github.workspace }}/src/github.com/snapcore/snapd"
+        tar -cvzf tics-logs.tar.gz /tmp/tics
 
     - name: Uploading TICS logs
       uses: actions/upload-artifact@v4
       with:
         name: tics-logs.tar.gz
-        path: ${{ github.workspace }}/src/github.com/snapcore/snapd/tics-logs.tar.gz
+        path: tics-logs.tar.gz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -81,7 +81,10 @@ jobs:
         set -x
         export TICSAUTHTOKEN="${{ secrets.TICSAUTHTOKEN }}"
 
-        # Install the TICS
+        # Install staticcheck dependency
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+
+        # Install and run TICS
         curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
         . ./install_tics.sh
 
@@ -91,4 +94,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: tics-logs.tar.gz
-        path: tics-logs.tar.gz
+        path: ${{ github.workspace }}/src/github.com/snapcore/snapd/tics-logs.tar.gz


### PR DESCRIPTION
Before running TiCS, It is required to install staticcheck, which is the Go analyser we use for compiler warnings.

Also it is updated the logs path to be uploaded as an artifact
