### PR TITLE
tests: use lxd snap from candidate in spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -43,7 +43,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
-    LXD_SNAP_CHANNEL: "latest/edge"
+    LXD_SNAP_CHANNEL: "latest/candidate"
     UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -55,8 +55,7 @@ run_muinstaller() {
     fi
 
     # build the muinstaller snap
-    # TODO: Consider reverting to latest/candidate when Snapcraft 8.0.5, which includes the fix to deal with LXD 5.21.0 version naming change, becomes available
-    snap install snapcraft --edge --classic
+    snap install snapcraft --candidate --classic
     "${TESTSTOOLS}/lxd-state" prepare-snap
     (cd "${TESTSLIB}/muinstaller" && snapcraft)
 

--- a/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
+++ b/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
@@ -24,9 +24,6 @@ environment:
   # build the snap with lxd
   SNAPCRAFT_BUILD_ENVIRONMENT: lxd
 
-  # pin LXD to 5.20/stable to ensure to prevent snapcraft problem with handling new version naming that may include "LTS"
-  LXD_SNAP_CHANNEL: 5.20/stable
-
 prepare: |
   # load the fuse kernel module before installing lxd
   modprobe fuse

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -97,8 +97,7 @@ execute: |
   cp -a ./"$SEED_DIR"/system-seed/ /var/lib/snapd/seed
 
   # build the muinstaller snap
-  # TODO: Consider reverting to latest/candidate when Snapcraft 8.0.5, which includes the fix to deal with LXD 5.21.0 version naming change, becomes available
-  snap install snapcraft --edge --classic
+  snap install snapcraft --candidate --classic
   "$TESTSTOOLS"/lxd-state prepare-snap
   (cd "$TESTSLIB"/muinstaller && snapcraft)
   MUINSTALLER_SNAP="$(find "$TESTSLIB"/muinstaller/ -maxdepth 1 -name '*.snap')"


### PR DESCRIPTION
This is the revert of the change
https://github.com/snapcore/snapd/pull/13716
