### PR TITLE
tests: update go version used in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,9 +76,9 @@ jobs:
         COVERAGE_OUT=.coverage/coverage.txt ./run-checks --unit
         gocover-cobertura < .coverage/coverage.txt > .coverage/coverage.xml
 
-    - name: Install TICS dependencies snap
+    - name: Install TICS dependencies
       run: |
-          sudo snap refresh --classic --channel=latest/stable go
+          sudo snap refresh --channel=latest/stable go
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
     - name: TICS scan

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,13 +76,15 @@ jobs:
         COVERAGE_OUT=.coverage/coverage.txt ./run-checks --unit
         gocover-cobertura < .coverage/coverage.txt > .coverage/coverage.xml
 
+    - name: Install TICS dependencies snap
+      run: |
+          sudo snap refresh --classic --channel=latest/stable go
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+
     - name: TICS scan
       run: |
         set -x
         export TICSAUTHTOKEN="${{ secrets.TICSAUTHTOKEN }}"
-
-        # Install staticcheck dependency
-        go install honnef.co/go/tools/cmd/staticcheck@latest
 
         # Install and run TICS
         curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh


### PR DESCRIPTION
To run the statick tools it is required the latest go version.
