### PR TITLE
tests/core20-kernel-failover: use kernel from beta channel

### DIFF
--- a/tests/nested/core/core20-kernel-failover/task.yaml
+++ b/tests/nested/core/core20-kernel-failover/task.yaml
@@ -31,7 +31,7 @@ prepare: |
   if tests.nested is-nested uc22; then
     version=22
   fi
-  snap download pc-kernel --channel="$version/edge" --basename=pc-kernel
+  snap download pc-kernel --channel="$version/beta" --basename=pc-kernel
   case "$PROBLEM_TYPE" in
       crash)
           uc20_build_initramfs_kernel_snap pc-kernel.snap "$PWD" --inject-kernel-panic-in-initramfs


### PR DESCRIPTION
The one from edge will always fail if we have FDE, make sure that there are no false negatives because of that.