### PR TITLE
build-aux/snap: ship snap-debug-info.sh script

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -87,6 +87,8 @@ parts:
           git diff
         ) > $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/dirty-git-tree-info.txt
       fi
+      # copy helper for collecting debug output
+      cp -av debug-tools/snap-debug-info.sh $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/
 
   # xdelta is used to enable delta downloads (even if the host does not have it)
   xdelta3:


### PR DESCRIPTION
Ship the current version of snap-debug-info.sh script inside the snapd snapd, so that folks no longer need to download it from snapd github repository.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
