### PR TITLE
o/snapstate,tests: discard previous component on a component refresh

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -406,5 +406,9 @@ func (b Backend) UnlinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revis
 		}
 	}
 
+	// Try also to remove the <snap_rev>/ subdirectory, as this might be
+	// the only installed component. But simply ignore if not empty.
+	os.Remove(filepath.Dir(linkPath))
+
 	return nil
 }

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -1028,8 +1028,42 @@ func (s *linkSuite) TestUnlinkComponentIdempotent(c *C) {
 
 	err := s.be.UnlinkComponent(cpi, snapRev)
 	c.Assert(err, IsNil)
-	c.Assert(linkPath, testutil.FileAbsent)
 	c.Assert(cpi.MountDir(), testutil.FilePresent)
+	// <snap_rev>/<comp_name>/ should be gone
+	c.Assert(linkPath, testutil.FileAbsent)
+	c.Assert(filepath.Dir(linkPath), testutil.FileAbsent)
+
+	err = s.be.UnlinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+}
+
+func (s *linkSuite) TestUnlinkTwoComponents(c *C) {
+	compName := "mycomp"
+	compRev := snap.R(-2)
+	snapName := "mysnap"
+	snapRev := snap.R(2)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapName)
+	compRevPath := filepath.Join(dirs.SnapMountDir, snapName,
+		"components", snapRev.String())
+	linkPath := filepath.Join(compRevPath, compName)
+	target := filepath.Join("../mnt", compName, compRev.String())
+
+	c.Assert(os.MkdirAll(cpi.MountDir(), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(linkPath), 0755), IsNil)
+	c.Assert(osutil.AtomicSymlink(target, linkPath), IsNil)
+
+	// Simulate another component installed (dangling symlink, but
+	// that does not matter)
+	target2 := filepath.Join("../mnt", "other-comp", "1")
+	c.Assert(osutil.AtomicSymlink(target2,
+		filepath.Join(compRevPath, "other-comp")), IsNil)
+
+	err := s.be.UnlinkComponent(cpi, snapRev)
+	c.Assert(err, IsNil)
+	c.Assert(cpi.MountDir(), testutil.FilePresent)
+	// Only last subdir of <snap_rev>/<comp_name>/ should be gone
+	c.Assert(linkPath, testutil.FileAbsent)
+	c.Assert(filepath.Dir(linkPath), testutil.FilePresent)
 
 	err = s.be.UnlinkComponent(cpi, snapRev)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -267,15 +267,16 @@ func (b Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
 
 func (b Backend) RemoveComponentDir(cpi snap.ContainerPlaceInfo) error {
 	compMountDir := cpi.MountDir()
-	// Remove /snap/<snap_instance>/components/mnt/<snap_rev>/<comp_name>/<comp_rev>
-	os.Remove(compMountDir)
-	// and /snap/<snap_instance>/components/mnt/<snap_rev>/<comp_name> (might fail
-	// if there are other revisions for this component)
-	os.Remove(filepath.Dir(compMountDir))
-
-	// TODO should we check here if there are other components installed
-	// for this snap revision or for other revisions and if not delete
-	// <snap_rev>/ and maybe also components/mnt/<snap_rev>/?
+	// Remove last 3 directories of
+	// /snap/<snap_instance>/components/mnt/<comp_name>/ if they
+	// are empty (last one should be). Note that subdirectories with snap
+	// revisions are handled by UnlinkComponent.
+	for i := 0; i < 3; i++ {
+		compMountDir = filepath.Dir(compMountDir)
+		if err := os.Remove(compMountDir); err != nil {
+			break
+		}
+	}
 
 	return nil
 }

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -232,7 +232,7 @@ func (b Backend) RemoveComponentFiles(cpi snap.ContainerPlaceInfo, installRecord
 		return err
 	}
 
-	// Remove /snap/<snap_instance>/components/<snap_rev>/<comp_name>
+	// Remove /snap/<snap_instance>/components/mnt/<comp_name>/<comp_rev>
 	if err := os.RemoveAll(cpi.MountDir()); err != nil {
 		return err
 	}
@@ -244,10 +244,6 @@ func (b Backend) RemoveComponentFiles(cpi snap.ContainerPlaceInfo, installRecord
 			return err
 		}
 	}
-
-	// TODO should we check here if there are other components installed
-	// for this snap revision or for other revisions and if not delete
-	// <snap_rev>/ and maybe also components/<snap_rev>/?
 
 	return nil
 }
@@ -271,11 +267,16 @@ func (b Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
 
 func (b Backend) RemoveComponentDir(cpi snap.ContainerPlaceInfo) error {
 	compMountDir := cpi.MountDir()
-	// Remove /snap/<snap_instance>/components/<snap_rev>/<comp_name>
+	// Remove /snap/<snap_instance>/components/mnt/<snap_rev>/<comp_name>/<comp_rev>
 	os.Remove(compMountDir)
-	// and /snap/<snap_instance>/components/<snap_rev> (might fail
-	// if there are other components installed for this revision)
+	// and /snap/<snap_instance>/components/mnt/<snap_rev>/<comp_name> (might fail
+	// if there are other revisions for this component)
 	os.Remove(filepath.Dir(compMountDir))
+
+	// TODO should we check here if there are other components installed
+	// for this snap revision or for other revisions and if not delete
+	// <snap_rev>/ and maybe also components/mnt/<snap_rev>/?
+
 	return nil
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -88,6 +88,9 @@ type fakeOp struct {
 
 	compsToInstall, currentComps []*snap.ComponentSideInfo
 	compsToRemove, finalComps    []*snap.ComponentSideInfo
+
+	containerName     string
+	containerFileName string
 }
 
 type fakeOps []fakeOp
@@ -931,7 +934,9 @@ func (f *fakeSnappyBackend) RemoveKernelSnapSetup(instanceName string, rev snap.
 func (f *fakeSnappyBackend) SetupComponent(compFilePath string, compPi snap.ContainerPlaceInfo, dev snap.Device, meter progress.Meter) (installRecord *backend.InstallRecord, err error) {
 	meter.Notify("setup-component")
 	f.appendOp(&fakeOp{
-		op: "setup-component",
+		op:                "setup-component",
+		containerName:     compPi.ContainerName(),
+		containerFileName: compPi.Filename(),
 	})
 	if strings.HasSuffix(compPi.ContainerName(), "+broken") {
 		return nil, fmt.Errorf("cannot set-up component %q", compPi.ContainerName())
@@ -968,7 +973,9 @@ func (f *fakeSnappyBackend) RemoveKernelModulesComponentsSetup(compsToRemove, fi
 func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error {
 	meter.Notify("undo-setup-component")
 	f.appendOp(&fakeOp{
-		op: "undo-setup-component",
+		op:                "undo-setup-component",
+		containerName:     cpi.ContainerName(),
+		containerFileName: cpi.Filename(),
 	})
 	if strings.HasSuffix(cpi.ContainerName(), "+brokenundo") {
 		return fmt.Errorf("cannot undo set-up of component %q", cpi.ContainerName())
@@ -978,7 +985,9 @@ func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, inst
 
 func (f *fakeSnappyBackend) RemoveComponentDir(cpi snap.ContainerPlaceInfo) error {
 	f.appendOp(&fakeOp{
-		op: "remove-component-dir",
+		op:                "remove-component-dir",
+		containerName:     cpi.ContainerName(),
+		containerFileName: cpi.Filename(),
 	})
 	return nil
 }

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -174,6 +174,14 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 			compSi.Component, revisionStr))
 	addTask(linkSnap)
 
+	// clean-up previous revision of the component if present
+	if compInstalled {
+		discardComp := st.NewTask("discard-component", fmt.Sprintf(i18n.G(
+			"Discard previous revision for component %q"),
+			compSi.Component))
+		addTask(discardComp)
+	}
+
 	installSet := state.NewTaskSet(tasks...)
 	installSet.MarkEdge(prepare, BeginEdge)
 	installSet.MarkEdge(linkSnap, MaybeRebootEdge)

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -67,6 +67,9 @@ func expectedComponentInstallTasks(opts int) []string {
 	}
 	// link-component is always present
 	startTasks = append(startTasks, "link-component")
+	if opts&compOptIsActive != 0 {
+		startTasks = append(startTasks, "discard-component")
+	}
 
 	return startTasks
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -48,6 +48,8 @@ type (
 	TooSoonError = tooSoonError
 )
 
+var SetTaskComponentSetup = setTaskComponentSetup
+
 const (
 	None         = none
 	Full         = full

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -48,7 +48,7 @@ type (
 	TooSoonError = tooSoonError
 )
 
-var SetTaskComponentSetup = setTaskComponentSetup
+var ComponentSetupTask = componentSetupTask
 
 const (
 	None         = none

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -110,29 +110,35 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 	return &snapsup, nil
 }
 
-// SetTaskSnapSetup writes the given SnapSetup to the provided task's
-// snap-setup-task Task, or to the task itself if the task does not have a
-// snap-setup-task (i.e. it _is_ the snap-setup-task)
-func SetTaskSnapSetup(t *state.Task, snapsup *SnapSetup) error {
+func snapSetupTask(t *state.Task) (*state.Task, error) {
 	if t.Has("snap-setup") {
-		// this is the snap-setup-task so just write to the task directly
-		t.Set("snap-setup", snapsup)
+		// this is the snap-setup-task so just return the task directly
+		return t, nil
 	} else {
-		// this task isn't the snap-setup-task, so go get that and write to that
-		// one
+		// this task isn't the snap-setup-task, so go get that
 		var id string
 		err := t.Get("snap-setup-task", &id)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		ts := t.State().Task(id)
 		if ts == nil {
-			return fmt.Errorf("internal error: tasks are being pruned")
+			return nil, fmt.Errorf("internal error: tasks are being pruned")
 		}
-		ts.Set("snap-setup", snapsup)
+		return ts, nil
 	}
+}
 
+// SetTaskSnapSetup writes the given SnapSetup to the provided task's
+// snap-setup-task Task, or to the task itself if the task does not have a
+// snap-setup-task (i.e. it _is_ the snap-setup-task)
+func SetTaskSnapSetup(t *state.Task, snapsup *SnapSetup) error {
+	ts, err := snapSetupTask(t)
+	if err != nil {
+		return err
+	}
+	ts.Set("snap-setup", snapsup)
 	return nil
 }
 
@@ -4899,10 +4905,11 @@ func (m *SnapManager) doSetupKernelSnap(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings.Save(st)
 
 	// Needed so the old drivers tree can be removed later
-	snapsup.PreviousKernelRev = snapSt.Current
-	if err := SetTaskSnapSetup(t, snapsup); err != nil {
+	setupTask, err := snapSetupTask(t)
+	if err != nil {
 		return err
 	}
+	setupTask.Set("previous-kernel-rev", snapSt.Current)
 
 	// Make sure we won't be rerun
 	t.SetStatus(state.DoneStatus)
@@ -4947,7 +4954,7 @@ func (m *SnapManager) doCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) error 
 	defer st.Unlock()
 
 	perfTimings := state.TimingsForTask(t)
-	snapsup, snapst, err := snapSetupAndState(t)
+	_, snapst, err := snapSetupAndState(t)
 	if err != nil {
 		return err
 	}
@@ -4959,14 +4966,24 @@ func (m *SnapManager) doCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) error 
 
 	// Now after the reboot triggered after linking the new snap, we can
 	// remove the old drivers tree if this was not the first installation.
-	if !snapsup.PreviousKernelRev.Unset() {
+	setupTask, err := snapSetupTask(t)
+	if err != nil {
+		return err
+	}
+	var prevKernelRev snap.Revision
+	err = setupTask.Get("previous-kernel-rev", &prevKernelRev)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	if !prevKernelRev.Unset() {
 		st.Unlock()
 		pm := NewTaskProgressAdapterUnlocked(t)
 		timings.Run(perfTimings, "discard-old-kernel-snap-setup",
 			fmt.Sprintf("discard previous kernel snap set-up %q", currInfo.InstanceName()),
 			func(timings.Measurer) {
 				err = m.backend.RemoveKernelSnapSetup(
-					currInfo.InstanceName(), snapsup.PreviousKernelRev, pm)
+					currInfo.InstanceName(), prevKernelRev, pm)
 			})
 		st.Lock()
 		if err != nil {
@@ -4987,7 +5004,7 @@ func (m *SnapManager) undoCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) erro
 	defer st.Unlock()
 
 	perfTimings := state.TimingsForTask(t)
-	snapsup, snapst, err := snapSetupAndState(t)
+	_, snapst, err := snapSetupAndState(t)
 	if err != nil {
 		return err
 	}
@@ -4997,15 +5014,25 @@ func (m *SnapManager) undoCleanupOldKernelSnap(t *state.Task, _ *tomb.Tomb) erro
 		return err
 	}
 
+	setupTask, err := snapSetupTask(t)
+	if err != nil {
+		return err
+	}
+	var prevKernelRev snap.Revision
+	err = setupTask.Get("previous-kernel-rev", &prevKernelRev)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
 	// Now we must re-do the previous revision kernel drivers tree
-	if !snapsup.PreviousKernelRev.Unset() {
+	if !prevKernelRev.Unset() {
 		st.Unlock()
 		pm := NewTaskProgressAdapterUnlocked(t)
 		timings.Run(perfTimings, "undo-remove-old-kernel-snap-setup",
 			fmt.Sprintf("undo cleanup of previous kernel snap %q", currInfo.InstanceName()),
 			func(timings.Measurer) {
 				err = m.backend.SetupKernelSnap(
-					currInfo.InstanceName(), snapsup.PreviousKernelRev, pm)
+					currInfo.InstanceName(), prevKernelRev, pm)
 			})
 		st.Lock()
 		if err != nil {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -560,7 +560,6 @@ func infoForCompUndo(t *state.Task) (*snap.ComponentSideInfo, string, error) {
 }
 
 func (m *SnapManager) doDiscardComponent(t *state.Task, _ *tomb.Tomb) error {
-
 	compSideInfo, instanceName, err := infoForCompUndo(t)
 	if err != nil {
 		return err

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -381,8 +381,9 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 		return err
 	}
 
-	// set information for undoUnlinkCurrentComponent in the task
-	t.Set("unlinked-component", unlinkedComp)
+	// set information for undoUnlinkCurrentComponent in the change
+	t.Change().Set(fmt.Sprintf("unlinked-component-%s",
+		unlinkedComp.SideInfo.Component.String()), unlinkedComp)
 
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
@@ -399,7 +400,7 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 	defer st.Unlock()
 
 	// snapSt is a copy of the current state
-	_, snapsup, snapSt, err := compSetupAndState(t)
+	compsup, snapsup, snapSt, err := compSetupAndState(t)
 	if err != nil {
 		return err
 	}
@@ -411,7 +412,8 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 	}
 
 	var unlinkedComp sequence.ComponentState
-	err = t.Get("unlinked-component", &unlinkedComp)
+	err = t.Change().Get(fmt.Sprintf("unlinked-component-%s",
+		compsup.CompSideInfo.Component.String()), &unlinkedComp)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_components_discard_test.go
+++ b/overlord/snapstate/handlers_components_discard_test.go
@@ -1,0 +1,134 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	. "gopkg.in/check.v1"
+)
+
+type discardCompSnapSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&discardCompSnapSuite{})
+
+func (s *discardCompSnapSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+}
+
+func (s *discardCompSnapSuite) TestDoDiscardComponent(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+	ci, compPath := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+
+	s.state.Lock()
+
+	t := s.state.NewTask("discard-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath)
+	t.Set("component-setup", compsup)
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	compDiscardRev := snap.R(5)
+	csiToDiscard := snap.NewComponentSideInfo(cref, compDiscardRev)
+	cs := sequence.NewComponentState(csiToDiscard, snap.TestComponent)
+	chg.Set(fmt.Sprintf("unlinked-component-%s", cs.SideInfo.Component.String()), cs)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err(), IsNil)
+	s.state.Unlock()
+
+	// Ensure backend calls have happened with the expected data
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op:                "undo-setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_5.comp",
+		},
+		{
+			op:                "remove-component-dir",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_5.comp",
+		},
+	})
+}
+
+func (s *discardCompSnapSuite) TestDoDiscardComponentNoUnlinkedComp(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+	ci, compPath := createTestComponent(c, snapName, compName)
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string) (*snap.ComponentInfo, error) {
+		return ci, nil
+	}))
+
+	s.state.Lock()
+
+	t := s.state.NewTask("discard-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath)
+	t.Set("component-setup", compsup)
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	// No unlinked component in the change
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	c.Check(chg.Err().Error(), Equals, "cannot perform the following tasks:\n"+
+		"- task desc (no state entry for key \"unlinked-component-mysnap+mycomp\")")
+	s.state.Unlock()
+
+	c.Check(s.fakeBackend.ops, IsNil)
+}

--- a/overlord/snapstate/handlers_components_discard_test.go
+++ b/overlord/snapstate/handlers_components_discard_test.go
@@ -60,8 +60,9 @@ func (s *discardCompSnapSuite) TestDoDiscardComponent(c *C) {
 	compDiscardRev := snap.R(5)
 	csiToDiscard := snap.NewComponentSideInfo(cref, compDiscardRev)
 	csToDiscard := sequence.NewComponentState(csiToDiscard, snap.TestComponent)
-	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath, csToDiscard)
+	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath)
 	t.Set("component-setup", compsup)
+	t.Set("unlinked-component", *csToDiscard)
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -109,7 +110,7 @@ func (s *discardCompSnapSuite) TestDoDiscardComponentNoUnlinkedComp(c *C) {
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
 	// No unlinked component in the task
-	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath, nil)
+	compsup := snapstate.NewComponentSetup(csi, snap.TestComponent, compPath)
 	t.Set("component-setup", compsup)
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
@@ -122,7 +123,7 @@ func (s *discardCompSnapSuite) TestDoDiscardComponentNoUnlinkedComp(c *C) {
 
 	s.state.Lock()
 	c.Check(chg.Err().Error(), Equals, "cannot perform the following tasks:\n"+
-		"- task desc (internal error: no component to discard)")
+		"- task desc (internal error: no component to discard: no state entry for key \"unlinked-component\")")
 	s.state.Unlock()
 
 	c.Check(s.fakeBackend.ops, IsNil)

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -291,6 +291,68 @@ func (s *linkCompSnapSuite) TestDoUnlinkCurrentComponentOtherCompPresent(c *C) {
 	s.testDoUnlinkCurrentComponent(c, snapName, snapRev, compName, compRev)
 }
 
+func (s *linkCompSnapSuite) TestDoUnlinkCurrentComponentTwoTasks(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+
+	s.state.Lock()
+	// state must contain the component
+	setStateWithOneComponent(s.state, snapName, snapRev, compName, compRev)
+	s.state.Unlock()
+
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+
+	s.state.Lock()
+
+	ts := s.state.NewTask("nop", "first task")
+	t := s.state.NewTask("unlink-current-component", "task desc")
+	t.WaitFor(ts)
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	ts.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
+	ts.Set("snap-setup", ssu)
+	t.Set("snap-setup-task", ts.ID())
+	t.Set("component-setup-task", ts.ID())
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(ts)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(chg.Err(), IsNil)
+	// undo information has been stored in the setup task
+	var unlinkedComp sequence.ComponentState
+	c.Assert(ts.Get("unlinked-component", &unlinkedComp), IsNil)
+	c.Assert(&unlinkedComp, DeepEquals,
+		sequence.NewComponentState(csi, snap.TestComponent))
+	// the link has been removed
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op: "unlink-component",
+			path: filepath.Join(
+				dirs.SnapMountDir, snapName, "components",
+				"mnt", compName, compRev.String()),
+		},
+	})
+	// state is modified as expected
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Assert(snapst.CurrentComponentSideInfo(cref), IsNil)
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+
+	s.state.Unlock()
+}
+
 func (s *linkCompSnapSuite) testDoUnlinkThenUndoUnlinkCurrentComponent(c *C, snapName string, snapRev snap.Revision, compName string, compRev snap.Revision) {
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
 	ssu := createTestSnapSetup(si, snapstate.Flags{})

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -239,7 +240,7 @@ func (s *linkCompSnapSuite) testDoUnlinkCurrentComponent(c *C, snapName string, 
 	// undo information has been stored
 	var storedCs sequence.ComponentState
 	cs := sequence.NewComponentState(csi, snap.TestComponent)
-	t.Get("unlinked-component", &storedCs)
+	c.Assert(t.Change().Get(fmt.Sprintf("unlinked-component-%s", cref.String()), &storedCs), IsNil)
 	c.Assert(&storedCs, DeepEquals, cs)
 	// the link has been removed
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -323,7 +324,7 @@ func (s *linkCompSnapSuite) testDoUnlinkThenUndoUnlinkCurrentComponent(c *C, sna
 	// undo information was stored
 	var storedCs sequence.ComponentState
 	cs := sequence.NewComponentState(csi, snap.TestComponent)
-	t.Get("unlinked-component", &storedCs)
+	c.Assert(t.Change().Get(fmt.Sprintf("unlinked-component-%s", cref.String()), &storedCs), IsNil)
 	c.Assert(&storedCs, DeepEquals, cs)
 	// the link has been removed and then re-created
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -64,7 +64,7 @@ func (s *linkCompSnapSuite) testDoLinkComponent(c *C, snapName string, snapRev s
 	t := s.state.NewTask("link-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, "", nil))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -140,7 +140,7 @@ func (s *linkCompSnapSuite) testDoLinkThenUndoLinkComponent(c *C, snapName strin
 	t := s.state.NewTask("link-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, "", nil))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -223,7 +223,7 @@ func (s *linkCompSnapSuite) testDoUnlinkCurrentComponent(c *C, snapName string, 
 	t := s.state.NewTask("unlink-current-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, "", nil))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -237,9 +237,9 @@ func (s *linkCompSnapSuite) testDoUnlinkCurrentComponent(c *C, snapName string, 
 
 	c.Check(chg.Err(), IsNil)
 	// undo information has been stored
-	var csu snapstate.ComponentSetup
-	c.Assert(t.Get("component-setup", &csu), IsNil)
-	c.Assert(csu.UnlinkedComp, DeepEquals,
+	var unlinkedComp sequence.ComponentState
+	c.Assert(t.Get("unlinked-component", &unlinkedComp), IsNil)
+	c.Assert(&unlinkedComp, DeepEquals,
 		sequence.NewComponentState(csi, snap.TestComponent))
 	// the link has been removed
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -300,7 +300,7 @@ func (s *linkCompSnapSuite) testDoUnlinkThenUndoUnlinkCurrentComponent(c *C, sna
 	t := s.state.NewTask("unlink-current-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
 	csi := snap.NewComponentSideInfo(cref, compRev)
-	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, "", nil))
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.TestComponent, ""))
 	t.Set("snap-setup", ssu)
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
@@ -321,9 +321,9 @@ func (s *linkCompSnapSuite) testDoUnlinkThenUndoUnlinkCurrentComponent(c *C, sna
 	c.Check(chg.Err().Error(), Equals, "cannot perform the following tasks:\n"+
 		"- provoking undo link (error out)")
 	// undo information was stored
-	var csu snapstate.ComponentSetup
-	c.Assert(t.Get("component-setup", &csu), IsNil)
-	c.Assert(csu.UnlinkedComp, DeepEquals,
+	var unlinkedComp sequence.ComponentState
+	c.Assert(t.Get("unlinked-component", &unlinkedComp), IsNil)
+	c.Assert(&unlinkedComp, DeepEquals,
 		sequence.NewComponentState(csi, snap.TestComponent))
 	// the link has been removed and then re-created
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{

--- a/overlord/snapstate/handlers_components_mount_test.go
+++ b/overlord/snapstate/handlers_components_mount_test.go
@@ -76,7 +76,9 @@ func (s *mountCompSnapSuite) TestDoMountComponent(c *C) {
 	// Ensure backend calls have happened with the expected data
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:                "setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 	})
 	// File not removed
@@ -127,13 +129,19 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponent(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:                "setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 		{
-			op: "undo-setup-component",
+			op:                "undo-setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 		{
-			op: "remove-component-dir",
+			op:                "remove-component-dir",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 	})
 }
@@ -177,10 +185,14 @@ func (s *mountCompSnapSuite) TestDoMountComponentSetupFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:                "setup-component",
+			containerName:     "mysnap+broken",
+			containerFileName: "mysnap+broken_7.comp",
 		},
 		{
-			op: "remove-component-dir",
+			op:                "remove-component-dir",
+			containerName:     "mysnap+broken",
+			containerFileName: "mysnap+broken_7.comp",
 		},
 	})
 }
@@ -231,10 +243,14 @@ func (s *mountCompSnapSuite) TestDoUndoMountComponentFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:                "setup-component",
+			containerName:     "mysnap+brokenundo",
+			containerFileName: "mysnap+brokenundo_7.comp",
 		},
 		{
-			op: "undo-setup-component",
+			op:                "undo-setup-component",
+			containerName:     "mysnap+brokenundo",
+			containerFileName: "mysnap+brokenundo_7.comp",
 		},
 	})
 }
@@ -278,13 +294,19 @@ func (s *mountCompSnapSuite) TestDoMountComponentMountFails(c *C) {
 	// ensure undo was called the right way
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op: "setup-component",
+			op:                "setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 		{
-			op: "undo-setup-component",
+			op:                "undo-setup-component",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 		{
-			op: "remove-component-dir",
+			op:                "remove-component-dir",
+			containerName:     "mysnap+mycomp",
+			containerFileName: "mysnap+mycomp_7.comp",
 		},
 	})
 }

--- a/overlord/snapstate/handlers_components_test.go
+++ b/overlord/snapstate/handlers_components_test.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	. "gopkg.in/check.v1"
+)
+
+type handlersComponentsSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&handlersComponentsSuite{})
+
+func (s *handlersComponentsSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+}
+
+func (s *handlersComponentsSuite) TestSetTaskComponentSetupFirstTask(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make a new task which will be the component-setup-task for
+	// other tasks and write a ComponentSetup to it
+	t := s.state.NewTask("prepare-component", "test")
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	compRev := snap.R(7)
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	compsup := snapstate.NewComponentSetup(csi, snap.KernelModulesComponent, "", nil)
+	t.Set("component-setup", compsup)
+	s.state.NewChange("sample", "...").AddTask(t)
+
+	// mutate it and rewrite it with the helper
+	compsup.CompSideInfo.Revision = snap.R(8)
+	err := snapstate.SetTaskComponentSetup(t, compsup)
+	c.Assert(err, IsNil)
+
+	// get a fresh version of this task from state to check that the task's
+	// component-setup has the changes in it
+	newT := s.state.Task(t.ID())
+	c.Assert(newT, Not(IsNil))
+	var newcompsup snapstate.ComponentSetup
+	err = newT.Get("component-setup", &newcompsup)
+	c.Assert(err, IsNil)
+	c.Assert(newcompsup.Revision(), Equals, compsup.CompSideInfo.Revision)
+}
+
+func (s *handlersComponentsSuite) TestSetTaskComponentSetupLaterTask(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t := s.state.NewTask("prepare-component", "test")
+
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	compRev := snap.R(7)
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	compsup := snapstate.NewComponentSetup(csi, snap.KernelModulesComponent, "", nil)
+	// setup component-setup for the first task
+	t.Set("component-setup", compsup)
+
+	// make a new task and reference the first one in component-setup-task
+	t2 := s.state.NewTask("next-task-comp", "test2")
+	t2.Set("component-setup-task", t.ID())
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+	chg.AddTask(t2)
+
+	// mutate it and rewrite it with the helper
+	compsup.CompSideInfo.Revision = snap.R(8)
+	err := snapstate.SetTaskComponentSetup(t2, compsup)
+	c.Assert(err, IsNil)
+
+	// check that the original task's component-setup is different now
+	newT := s.state.Task(t.ID())
+	c.Assert(newT, Not(IsNil))
+	var newcompsup snapstate.ComponentSetup
+	err = newT.Get("component-setup", &newcompsup)
+	c.Assert(err, IsNil)
+	c.Assert(newcompsup.Revision(), Equals, compsup.CompSideInfo.Revision)
+}

--- a/overlord/snapstate/handlers_setup_kernel_test.go
+++ b/overlord/snapstate/handlers_setup_kernel_test.go
@@ -65,9 +65,9 @@ func (s *setupKernelSnapSuite) TestSetupKernelSnap(c *C) {
 	s.state.Lock()
 	c.Check(chg.Err(), IsNil)
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	var prevRev snap.Revision
-	c.Check(chg.Get("previous-kernel-rev", &prevRev), IsNil)
-	c.Check(prevRev, Equals, snap.R(0))
+	var snapsup snapstate.SnapSetup
+	c.Check(t.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.PreviousKernelRev, Equals, snap.R(0))
 	s.state.Unlock()
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -107,9 +107,9 @@ func (s *setupKernelSnapSuite) TestUndoSetupKernelSnap(c *C) {
 	s.state.Lock()
 	c.Check(chg.Err(), ErrorMatches, `(?s).*provoking undo kernel setup.*`)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
-	var prevRev snap.Revision
-	c.Check(chg.Get("previous-kernel-rev", &prevRev), IsNil)
-	c.Check(prevRev, Equals, snap.R(0))
+	var snapsup snapstate.SnapSetup
+	c.Check(t.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.PreviousKernelRev, Equals, snap.R(0))
 	s.state.Unlock()
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -141,11 +141,11 @@ func (s *setupKernelSnapSuite) TestRemoveKernelSnapSetup(c *C) {
 			RealName: "mykernel",
 			Revision: snap.R(33),
 		},
-		SnapPath: testSnap,
+		SnapPath:          testSnap,
+		PreviousKernelRev: snap.R(30),
 	})
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
-	chg.Set("previous-kernel-rev", snap.R(33))
 
 	s.state.Unlock()
 
@@ -183,14 +183,14 @@ func (s *setupKernelSnapSuite) TestUndoRemoveKernelSnapSetup(c *C) {
 			RealName: "mykernel",
 			Revision: snap.R(33),
 		},
-		SnapPath: testSnap,
+		SnapPath:          testSnap,
+		PreviousKernelRev: snap.R(30),
 	})
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
 	terr := s.state.NewTask("error-trigger", "provoking undo kernel cleanup")
 	terr.WaitFor(t)
 	chg.AddTask(terr)
-	chg.Set("previous-kernel-rev", snap.R(33))
 
 	s.state.Unlock()
 

--- a/overlord/snapstate/handlers_setup_kernel_test.go
+++ b/overlord/snapstate/handlers_setup_kernel_test.go
@@ -65,9 +65,9 @@ func (s *setupKernelSnapSuite) TestSetupKernelSnap(c *C) {
 	s.state.Lock()
 	c.Check(chg.Err(), IsNil)
 	c.Check(t.Status(), Equals, state.DoneStatus)
-	var snapsup snapstate.SnapSetup
-	c.Check(t.Get("snap-setup", &snapsup), IsNil)
-	c.Check(snapsup.PreviousKernelRev, Equals, snap.R(0))
+	var prevKernelRev snap.Revision
+	c.Check(t.Get("previous-kernel-rev", &prevKernelRev), IsNil)
+	c.Check(prevKernelRev, Equals, snap.R(0))
 	s.state.Unlock()
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -107,9 +107,9 @@ func (s *setupKernelSnapSuite) TestUndoSetupKernelSnap(c *C) {
 	s.state.Lock()
 	c.Check(chg.Err(), ErrorMatches, `(?s).*provoking undo kernel setup.*`)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
-	var snapsup snapstate.SnapSetup
-	c.Check(t.Get("snap-setup", &snapsup), IsNil)
-	c.Check(snapsup.PreviousKernelRev, Equals, snap.R(0))
+	var prevKernelRev snap.Revision
+	c.Check(t.Get("previous-kernel-rev", &prevKernelRev), IsNil)
+	c.Check(prevKernelRev, Equals, snap.R(0))
 	s.state.Unlock()
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -141,9 +141,9 @@ func (s *setupKernelSnapSuite) TestRemoveKernelSnapSetup(c *C) {
 			RealName: "mykernel",
 			Revision: snap.R(33),
 		},
-		SnapPath:          testSnap,
-		PreviousKernelRev: snap.R(30),
+		SnapPath: testSnap,
 	})
+	t.Set("previous-kernel-rev", snap.R(30))
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
 
@@ -183,9 +183,9 @@ func (s *setupKernelSnapSuite) TestUndoRemoveKernelSnapSetup(c *C) {
 			RealName: "mykernel",
 			Revision: snap.R(33),
 		},
-		SnapPath:          testSnap,
-		PreviousKernelRev: snap.R(30),
+		SnapPath: testSnap,
 	})
+	t.Set("previous-kernel-rev", snap.R(30))
 	chg := s.state.NewChange("test change", "change desc")
 	chg.AddTask(t)
 	terr := s.state.NewTask("error-trigger", "provoking undo kernel cleanup")

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -148,6 +148,9 @@ type SnapSetup struct {
 	// DownloadBlobDir is the directory where the snap blob is downloaded to. If
 	// empty, dir.SnapBlobDir is used.
 	DownloadBlobDir string `json:"download-blob-dir,omitempty"`
+
+	// PreviousKernelRev is needed for cleaning-up tasks when refreshing a kernel snap
+	PreviousKernelRev snap.Revision `json:"previous-kernel-revision,omitempty"`
 }
 
 func (snapsup *SnapSetup) InstanceName() string {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -681,6 +681,9 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)
 	runner.AddHandler("link-component", m.doLinkComponent, m.undoLinkComponent)
+	// We cannot undo much after a component file is removed. And it is the
+	// last task anyway.
+	runner.AddHandler("discard-component", m.doDiscardComponent, nil)
 	runner.AddHandler("prepare-kernel-modules-components", m.doSetupKernelModules, m.doRemoveKernelModulesSetup)
 
 	// control serialisation

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -148,9 +148,6 @@ type SnapSetup struct {
 	// DownloadBlobDir is the directory where the snap blob is downloaded to. If
 	// empty, dir.SnapBlobDir is used.
 	DownloadBlobDir string `json:"download-blob-dir,omitempty"`
-
-	// PreviousKernelRev is needed for cleaning-up tasks when refreshing a kernel snap
-	PreviousKernelRev snap.Revision `json:"previous-kernel-revision,omitempty"`
 }
 
 func (snapsup *SnapSetup) InstanceName() string {

--- a/tests/main/component/task.yaml
+++ b/tests/main/component/task.yaml
@@ -56,6 +56,7 @@ execute: |
           prev_comp_inst_path=/var/lib/snapd/snaps/snap-with-comps+comp1_${prev_comp_rev}.comp
           mount | not MATCH "^${prev_comp_inst_path/+/\\+} on ${prev_mnt_point} .*"
           not stat "$prev_comp_inst_path"
+          not stat "$prev_mnt_point"
       fi
   }
 

--- a/tests/main/component/task.yaml
+++ b/tests/main/component/task.yaml
@@ -23,6 +23,11 @@ execute: |
   # Install local component function
   # $1: expected component revision
   install_comp() {
+      # x1 is the snap revision
+      # Find out previous comp rev
+      symlink=$SNAP_MOUNT_DIR/snap-with-comps/components/x1/comp1
+      prev_comp_rev=$(basename "$(readlink "$symlink")")
+
       comp_rev=$1
       chg_id=$(snap install --no-wait --dangerous snap-with-comps+comp1_1.0.comp)
       snap watch "$chg_id"
@@ -37,8 +42,6 @@ execute: |
       stat "$comp_inst_path"
 
       # Component is mounted (note that we need to escape the "+" in the path)
-      # x1 is the snap revision
-      symlink=$SNAP_MOUNT_DIR/snap-with-comps/components/x1/comp1
       mnt_point=$SNAP_MOUNT_DIR/snap-with-comps/components/mnt/comp1/${comp_rev}
       mount | MATCH "^${comp_inst_path/+/\\+} on ${mnt_point} .*"
       # And symlinked
@@ -46,6 +49,14 @@ execute: |
       readlink -f "$symlink" | MATCH "$mnt_point"
       # and is seen from snap app
       snap-with-comps.test
+
+      # Old component is not mounted and has been removed
+      if [ -n "$prev_comp_rev" ]; then
+          prev_mnt_point=$SNAP_MOUNT_DIR/snap-with-comps/components/mnt/comp1/${prev_comp_rev}
+          prev_comp_inst_path=/var/lib/snapd/snaps/snap-with-comps+comp1_${prev_comp_rev}.comp
+          mount | not MATCH "^${prev_comp_inst_path/+/\\+} on ${prev_mnt_point} .*"
+          not stat "$prev_comp_inst_path"
+      fi
   }
 
   # Install, then reinstall local component
@@ -56,9 +67,7 @@ execute: |
   # For the moment, remove the snap and then manually the components
   snap remove snap-with-comps
   cd /etc/systemd/system/
-  systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x1.mount'
   systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
   cd -
-  rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x1.mount'
   rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
   rm -rf "$SNAP_MOUNT_DIR"/snap-with-comps/


### PR DESCRIPTION
Only one can be installed in the system at the same time.