### PR TITLE
interfaces/opengl: enable use of nvidia container toolkit CDI config generation

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -48,6 +48,9 @@ const openglConnectedPlugAppArmor = `
 # libdrm data files
 /usr/share/libdrm/amdgpu.ids r,
 
+# The nvidia container toolkit needs to traverse the top level libs directory
+# in order to discover the libraries and generate a CDI config
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/} r,
 # Bi-arch distribution nvidia support
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,


### PR DESCRIPTION
The nvidia container toolkit needs to traverse the top level libs directory in order to discover the libraries and generate a CDI config.  This change enables reading the directory listing, without actually being able to read the files themselves which are not specifically allowed by pattern.

This enhancement enables the use of nvidia support in the docker snap on classic systems.

Ref: https://github.com/NVIDIA/nvidia-container-toolkit/issues/82#issuecomment-2047596685
Ref: https://github.com/NVIDIA/nvidia-container-toolkit/issues/82#issuecomment-2047716550
Ref: https://github.com/docker-snap/docker-snap/issues/127