### PR TITLE
tests: new regression test to reproduce lp-2061981

### DIFF
--- a/tests/regression/lp-2061981/task.yaml
+++ b/tests/regression/lp-2061981/task.yaml
@@ -1,0 +1,42 @@
+summary: Ensure that the personal-files interface works with a non-standard home dir
+
+details: |
+    Check that the personal-files interface works with a non-standard home directory
+    like /home/department/user_name. The issue raise shows how the snap connected
+    to the personal-files interface returns an error like:
+    cannot use invalid home directory "/home/department/user_name": permission denied
+
+systems: [ubuntu-22.04-64]
+
+environment:
+    TEST_USER: test2
+    TEST_USER_HOME: /home/subdir/test2
+
+prepare: |
+    useradd --create-home --home-dir "$TEST_USER_HOME" "$TEST_USER"
+    tests.cleanup defer rmdir /home/subdir
+    tests.cleanup defer userdel --remove "$TEST_USER"
+    mkdir "$TEST_USER_HOME"/other-subdir
+    touch "$TEST_USER_HOME"/other-subdir/testfile
+    chown -R "$TEST_USER" -R "$TEST_USER_HOME"
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    tests.session prepare -u "$TEST_USER"
+    tests.cleanup defer tests.session restore -u "$TEST_USER"
+
+restore: |
+    tests.cleanup restore
+
+debug: |
+    set +x
+    journalctl | grep DENIED
+    cat /etc/apparmor.d/tunables/home
+    cat /etc/apparmor.d/tunables/home.d/snapd
+    set -e
+
+execute: |
+    snap set system homedirs="$(dirname "$TEST_USER_HOME")"
+    snap connect test-snapd-sh:personal-files
+
+    tests.session -u "$TEST_USER" exec test-snapd-sh.with-personal-files-plug -c 'ls other-subdir/' | MATCH testfile

--- a/tests/regression/lp-2061981/test-snapd-sh/bin/sh
+++ b/tests/regression/lp-2061981/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/regression/lp-2061981/test-snapd-sh/meta/snap.yaml
+++ b/tests/regression/lp-2061981/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+plugs:
+    personal-files:
+        write: [$HOME/other-subdir]
+
+apps:
+    with-personal-files-plug:
+        command: bin/sh
+        plugs: [personal-files]


### PR DESCRIPTION
Running this test is possible to reproduce the following error:

lp issue: https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2061981

reproduce: > spread -debug google:ubuntu-22.04-64:tests/regression/lp-2061981

error:
cannot update snap namespace: cannot expand mount entry (none $HOME/.missing none x-snapd.kind=ensure-dir,x-snapd.must-exist-dir=$HOME 0 0): cannot use invalid home directory "/home/myhome/test2": permission denied
