### PR TITLE
o/snapstate: don't make apps wait for reboot on classic w/ kernel

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -388,6 +388,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "some-snap-with-new-base-id":
 		name = "some-snap-with-new-base"
 		base = "core22"
+	case "some-snap-with-core18-base":
+		name = "some-snap-with-core18-base"
+		base = "core18"
 	case "core-snap-id":
 		name = "core"
 		typ = snap.TypeOS
@@ -561,8 +564,8 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 	if len(currentSnaps) == 0 && len(actions) == 0 {
 		return nil, nil, nil
 	}
-	if len(actions) > 4 {
-		panic("fake SnapAction unexpectedly called with more than 3 actions")
+	if len(actions) > 7 {
+		panic("fake SnapAction unexpectedly called with more than 7 actions")
 	}
 
 	curByInstanceName := make(map[string]*store.CurrentSnap, len(currentSnaps))

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -139,6 +139,8 @@ var (
 	ArrangeSnapToWaitForBaseIfPresent    = arrangeSnapToWaitForBaseIfPresent
 	ArrangeSnapTaskSetsLinkageAndRestart = arrangeSnapTaskSetsLinkageAndRestart
 	ReRefreshSummary                     = reRefreshSummary
+
+	MaybeFindTasksetForSnap = maybeFindTasksetForSnap
 )
 
 const (
@@ -560,4 +562,8 @@ func SetRestoredMonitoring(snapmgr *SnapManager, value bool) {
 
 func SetPreseed(snapmgr *SnapManager, value bool) {
 	snapmgr.preseed = value
+}
+
+func SplitEssentialUpdates(deviceCtx DeviceContext, updates []minimalInstallInfo) (essential, nonEssential []MinimalInstallInfo) {
+	return splitEssentialUpdates(deviceCtx, updates)
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -391,7 +391,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 	ts, err := UpdateWithDeviceContext(st, snapName, nil, userID, flags, nil, deviceCtx, "")
 	if err != nil {
 		if conflErr, ok := err.(*ChangeConflictError); ok {
-			// If we aren't seeded, then it's to early to do any updates and we cannot
+			// If we aren't seeded, then it's too early to do any updates and we cannot
 			// handle this during seeding, so expect the ChangeConflictError in this scenario.
 			if conflErr.ChangeKind == "seed" {
 				t.Logf("cannot update %q during seeding, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -348,7 +348,7 @@ func arrangeSnapTaskSetsLinkageAndRestart(st *state.State, providedDeviceCtx Dev
 	lanesByTsToMerge := make(map[*state.TaskSet][]int)
 	beforeTss := make(map[snap.Type]*state.TaskSet)
 	afterTss := make(map[snap.Type]*state.TaskSet)
-	// chainEssentialTs takes a task-set that needs to be 'chained' unto the previous (unless its the first),
+	// chainEssentialTs takes a task-set that needs to be 'chained' unto the previous (unless it's the first),
 	// a snap type to specify which type of snap is being chained, and two operational flags.
 	// <transactional>: If set, means that the task-set should be part of the essential snap transaction. Lanes
 	// from the task-set will be merged. This behaviour is disabled for UC16 to not introduce any new changes.
@@ -398,7 +398,7 @@ func arrangeSnapTaskSetsLinkageAndRestart(st *state.State, providedDeviceCtx Dev
 
 	bootSnapType := bootBaseSnapType(byTypeTss)
 
-	// Then we link in the boot-base, to run after snapd, it could run in it's
+	// Then we link in the boot-base, to run after snapd, it could run in its
 	// entirety before a reboot, as we expect boot-bases to be 'simple' and not
 	// have any hooks.
 	if ts := byTypeTss[bootSnapType]; ts != nil {

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -213,7 +213,7 @@ var snapActionFields = jsonutil.StructFields((*storeSnap)(nil))
 // SnapAction queries the store for snap information for the given
 // install/refresh actions, given the context information about
 // current installed snaps in currentSnaps. If the request was overall
-// successul (200) but there were reported errors it will return both
+// successful (200) but there were reported errors it will return both
 // the snap infos and an SnapActionError.
 // Orthogonally and at the same time it can be used to fetch or update
 // assertions by passing an AssertionQuery whose ToResolve specifies


### PR DESCRIPTION
Refreshes that include essential snaps are organised in a way that allows us to reboot a single time. However, on classic systems with kernel/gadget snaps this means that apps must wait for a reboot which. To prevent apps from blocking until then, this change splits a refresh into two mostly independent tasksets. One with essential snaps which is still organised according to the single reboot and another with apps and their bases which can complete before the reboot. Some constraints on this are snapd which is always refreshed first and we an app may depend on the model base in which case it must wait for that. This doesn't include change an auto-refresh or a spread test yet, those will be added in future PRs.