### PR TITLE
tests: add ubuntu noble to the google-nested-dev backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -305,6 +305,10 @@ backends:
                   image: ubuntu-2204-64-virt-enabled
                   storage: 20G
                   workers: 8
+            - ubuntu-24.04-64:
+                  image: ubuntu-2404-64-virt-enabled
+                  storage: 20G
+                  workers: 8
 
     qemu-nested:
         memory: 4G


### PR DESCRIPTION
This is required to run beta validation on uc24
