### PR TITLE
i/apparmor: fix snap-update-ns with ecrypfs home

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1001,6 +1001,12 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /run/snapd/lock/###SNAP_INSTANCE_NAME###.lock rwk,
   /run/snapd/lock/.lock rwk,
 
+  # While the base abstraction has rules for encryptfs encrypted home and
+  # private directories, it is missing rules for directory read on the toplevel
+  # directory of the mount (LP: #1848919)
+  owner @{HOME}/.Private/ r,
+  owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
+
   # Allow reading stored mount namespaces,
   /run/snapd/ns/ r,
   /run/snapd/ns/###SNAP_INSTANCE_NAME###.mnt r,


### PR DESCRIPTION
Ever since snapd 2.62 was released, snap-update-ns requires opening the home directory of the user for some validation and sanity checking. This is now affected by a bug in base policy regarding ecryptfs. Add the similar workaround we have in other templates.

Fixes: https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2062330
Fixes: https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2062173
