### PR TITLE
i/apparmor: allow snap-update-ns to traverse to /var/lib/snapd

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1059,6 +1059,8 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /tmp/ r,
   /usr/ r,
   /var/ r,
+  /var/lib/ r,
+  /var/lib/snapd/ r,
   /var/snap/ r,
 
   # Allow reading timezone data.


### PR DESCRIPTION
I've noticed this denial in one of my test systems:

  kwi 19 10:54:52 ubuntu-2204-cryptfs kernel: audit: type=1400
  audit(1713516892.723:323): apparmor="DENIED" operation="open" class="file"
  profile="snap-update-ns.chromium" name="/var/lib/snapd /" pid=8425 comm="5"
  requested_mask="r" denied_mask="r" fsuid=0 ouid=0

Given that snap-update-ns must access mount profiles and contains code to safely traverse a path without any symbolic links, I think the extra permissions is acceptable.

I did not audit the code to pinpoint the exact cause.
