### PR TITLE
cmd/snap-confine: skip device cgroup setup when running inside a container

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -261,3 +261,44 @@ bool sc_wait_for_file(const char *path, size_t timeout_sec)
 	}
 	return false;
 }
+
+const char *run_systemd_container = "/run/systemd/container";
+
+static bool _sc_is_in_container(const char *p)
+{
+	// see what systemd-detect-virt --container does in, see:
+	// https://github.com/systemd/systemd/blob/5dcd6b1d55a1cfe247621d70f0e25d020de6e0ed/src/basic/virt.c#L749-L755
+	// https://systemd.io/CONTAINER_INTERFACE/
+	FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(p, "r");
+	if (in == NULL) {
+		return false;
+	}
+
+	char container[128] = { 0 };
+
+	if (fgets(container, sizeof(container), in) == NULL) {
+		/* nothing read or other error? */
+		return false;
+	}
+
+	size_t r = strlen(container);
+	// TODO add sc_str_chomp()?
+	if (r > 0 && container[r - 1] == '\n') {
+		/* replace trailing newline */
+		container[r - 1] = 0;
+		r--;
+	}
+
+	if (r == 0) {
+		/* empty or just a newline */
+		return false;
+	}
+
+	debug("detected container environment: %s", container);
+	return true;
+}
+
+bool sc_is_in_container(void)
+{
+	return _sc_is_in_container(run_systemd_container);
+}

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -281,7 +281,7 @@ static bool _sc_is_in_container(const char *p)
 		return false;
 	}
 
-	size_t r = strlen(container);
+	size_t r = strnlen(container, sizeof container);
 	// TODO add sc_str_chomp()?
 	if (r > 0 && container[r - 1] == '\n') {
 		/* replace trailing newline */

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -50,6 +50,11 @@ bool sc_is_debug_enabled(void);
 bool sc_is_reexec_enabled(void);
 
 /**
+ * Return true if executing inside a container.
+ **/
+bool sc_is_in_container(void);
+
+/**
  * sc_identity describes the user performing certain operation.
  *
  * UID and GID represent user and group accounts numbers and are controlled by

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -120,6 +120,9 @@
     # To find if apparmor is enabled
     /sys/module/apparmor/parameters/enabled r,
 
+    # For detecting if we're in a container
+    /run/systemd/container r,
+
     # Don't allow changing profile to unconfined or profiles that start with
     # '/'. Use 'unsafe' to support snap-exec on armhf and its reliance on
     # the environment for determining the capabilities of the architecture.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -733,10 +733,13 @@ static void enter_non_classic_execution_environment(sc_invocation *inv,
 	// device cgroup by itself.
 	struct sc_device_cgroup_options cgdevopts = { false, false };
 	sc_get_device_cgroup_setup(inv, &cgdevopts);
+	bool in_container = sc_is_in_container();
 	if (cgdevopts.self_managed) {
 		debug("device cgroup is self-managed by the snap");
 	} else if (cgdevopts.non_strict) {
 		debug("device cgroup skipped, snap in non-strict confinement");
+	} else if (in_container) {
+		debug("device cgroup skipped, executing inside a container");
 	} else {
 		sc_device_cgroup_mode mode = device_cgroup_mode_for_snap(inv);
 		sc_setup_device_cgroup(inv->security_tag, mode);


### PR DESCRIPTION
Do not attempt to set up a device access filtering through cgroups when we're executing inside a container. Especially, in the case of unprivileged containers, the whole set up may be impossible to execute completely, as running in a separate userns means snap-confine is not even able to mount the bpf filesystem and cannot execute bpf() syscalls.
