### PR TITLE
tests: add noble to qemu-nested backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -322,6 +322,9 @@ backends:
             - ubuntu-22.04-64:
                   username: ubuntu
                   password: ubuntu
+            - ubuntu-24.04-64:
+                  username: ubuntu
+                  password: ubuntu
 
     qemu:
         memory: 4G


### PR DESCRIPTION
Allow locally testing nested spread tests on noble using qemu-nested.