### PR TITLE
i/prompting: implement path pattern expansion

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -41,12 +41,11 @@ type Constraints struct {
 // ValidateForInterface returns nil if the constraints are valid for the given
 // interface, otherwise returns an error.
 func (c *Constraints) ValidateForInterface(iface string) error {
-	prefix := "invalid constraints"
 	if c.PathPattern == nil {
-		return fmt.Errorf("%s: no path pattern", prefix)
+		return fmt.Errorf("invalid constraints: no path pattern")
 	}
 	if err := c.validatePermissions(iface); err != nil {
-		return fmt.Errorf("%s: %w", prefix, err)
+		return fmt.Errorf("invalid constraints: %w", err)
 	}
 	return nil
 }
@@ -87,7 +86,11 @@ func (c *Constraints) Match(path string) (bool, error) {
 	if c.PathPattern == nil {
 		return false, fmt.Errorf("invalid constraints: no path pattern")
 	}
-	return PathPatternMatch(c.PathPattern.String(), path)
+	match, err := PathPatternMatch(c.PathPattern.String(), path)
+	if err != nil {
+		return false, fmt.Errorf("invalid constraints: %w", err)
+	}
+	return match, nil
 }
 
 // RemovePermission removes every instance of the given permission from the

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -34,14 +34,21 @@ var (
 )
 
 type Constraints struct {
-	PathPattern string   `json:"path-pattern,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	PathPattern *PathPattern `json:"path-pattern,omitempty"`
+	Permissions []string     `json:"permissions,omitempty"`
 }
 
 // ValidateForInterface returns nil if the constraints are valid for the given
 // interface, otherwise returns an error.
 func (c *Constraints) ValidateForInterface(iface string) error {
-	return c.validatePermissions(iface)
+	prefix := "invalid constraints"
+	if c.PathPattern == nil {
+		return fmt.Errorf("%s: no path pattern", prefix)
+	}
+	if err := c.validatePermissions(iface); err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return nil
 }
 
 // validatePermissions checks that the permissions for the given constraints
@@ -77,7 +84,10 @@ func (c *Constraints) validatePermissions(iface string) error {
 //
 // If the constraints or path are invalid, returns an error.
 func (c *Constraints) Match(path string) (bool, error) {
-	return PathPatternMatch(c.PathPattern, path)
+	if c.PathPattern == nil {
+		return false, fmt.Errorf("invalid constraints: no path pattern")
+	}
+	return PathPatternMatch(c.PathPattern.String(), path)
 }
 
 // RemovePermission removes every instance of the given permission from the

--- a/interfaces/prompting/patterns.go
+++ b/interfaces/prompting/patterns.go
@@ -79,7 +79,7 @@ type patternSequence []patternComponent
 
 func (s patternSequence) Next() bool {
 	for i := len(s) - 1; i >= 0; i-- {
-		if !(s)[i].Next() {
+		if !s[i].Next() {
 			return false
 		}
 	}

--- a/interfaces/prompting/patterns.go
+++ b/interfaces/prompting/patterns.go
@@ -20,10 +20,318 @@
 package prompting
 
 import (
+	"fmt"
+	"io"
+	"regexp"
 	"strings"
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
 )
+
+// Limit the number of expanded path patterns for a particular pattern.
+// When fully expanded, the number of patterns for a given unexpanded pattern
+// may not exceed this limit.
+const maxExpandedPatterns = 1000
+
+// The default previously-expanded prefixes to which new patterns or expanded
+// groups are concatenated. This must be a slice containing the empty string,
+// since at the beginning of the pattern, we have only one prefix to which to
+// concatenate, and that prefix is the empty string. Importantly, this cannot
+// be an empty slice, since concatenating every entry in an empty slice with
+// every entry in a slice of expanded patterns would again result in an empty
+// slice.
+var defaultPrefixes = []string{""}
+
+// ExpandPathPattern expands all groups in the given path pattern.
+//
+// Groups are enclosed by '{' '}'. Returns a list of all the expanded path
+// patterns, or an error if the given pattern is invalid.
+func ExpandPathPattern(pattern string) ([]string, error) {
+	if len(pattern) == 0 {
+		return nil, fmt.Errorf(`invalid path pattern: pattern has length 0`)
+	}
+	if strings.HasSuffix(pattern, `\`) && !strings.HasSuffix(pattern, `\\`) {
+		return nil, fmt.Errorf(`invalid path pattern: trailing unescaped '\' character: %q`, pattern)
+	}
+	reader := strings.NewReader(pattern)
+	currPrefixes := defaultPrefixes
+	currLiteralStart := 0
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			// No more runes
+			break
+		}
+		if r == '\\' {
+			// Skip next rune.
+			reader.ReadRune() // Since suffix is not '\\', must have next rune
+			continue
+		}
+		if r == '}' {
+			return nil, fmt.Errorf(`invalid path pattern: unmatched '}' character: %q`, pattern)
+		}
+		if r != '{' {
+			continue
+		}
+		// Saw start of new group, so get the string from currLiteralStart to
+		// the opening '{' of the new group. Do this before expanding.
+		infix := prevStringFromIndex(reader, currLiteralStart)
+		groupExpanded, err := expandPathPatternRecursively(reader)
+		if err != nil {
+			return nil, err
+		}
+		// Now that group has been expanded, record index of next rune in reader
+		currLiteralStart = indexOfNextRune(reader)
+		newCount := len(currPrefixes) * len(groupExpanded)
+		if newCount > maxExpandedPatterns {
+			return nil, fmt.Errorf("invalid path pattern: exceeded maximum number of expanded path patterns (%d): %q", maxExpandedPatterns, pattern)
+		}
+		newExpanded := make([]string, 0, newCount)
+		for _, prefix := range currPrefixes {
+			for _, suffix := range groupExpanded {
+				newExpanded = append(newExpanded, prefix+infix+suffix)
+			}
+		}
+		currPrefixes = newExpanded
+	}
+	expanded := currPrefixes
+	if len(expanded) == 1 && expanded[0] == "" {
+		// Didn't expand any groups, so return whole pattern.
+		return []string{cleanPattern(pattern)}, nil
+	}
+	// Append trailing literal string, if any, to all previously-expanded
+	// patterns, and clean the resulting patterns.
+	alreadySeen := make(map[string]bool, len(expanded))
+	uniqueExpanded := make([]string, 0, len(expanded))
+	suffix := pattern[currLiteralStart:]
+	for _, prefix := range expanded {
+		cleaned := cleanPattern(prefix + suffix)
+		if alreadySeen[cleaned] {
+			continue
+		}
+		alreadySeen[cleaned] = true
+		uniqueExpanded = append(uniqueExpanded, cleaned)
+	}
+	return uniqueExpanded, nil
+}
+
+// Return the substring from the given start index until the index of the
+// previous rune read by the reader.
+func prevStringFromIndex(reader *strings.Reader, startIndex int) string {
+	if err := reader.UnreadRune(); err != nil {
+		panic(err) // should only occur if used incorrectly internally
+	}
+	defer reader.ReadRune() // re-read rune so index is unchanged
+	currIndex := indexOfNextRune(reader)
+	buf := make([]byte, currIndex-startIndex)
+	reader.ReadAt(buf, int64(startIndex))
+	return string(buf)
+}
+
+// Return the byte index of the next rune in the reader.
+func indexOfNextRune(reader *strings.Reader) int {
+	index, _ := reader.Seek(0, io.SeekCurrent)
+	return int(index)
+}
+
+// Expands the contents of a group in the path pattern read by the given reader
+// until a '}' is seen. Also takes the current number of groups seen prior to
+// the group which this function call will expand.
+//
+// The reader current position of the reader should be the rune immediately
+// following the opening '{' character of the group.
+//
+// Returns the list of expanded strings. Whenever a ',' character is
+// encountered, cuts off the current sub-pattern and begins a new one.
+// Any '\'-escaped '{', ',', and '}' characters are treated as literals.
+//
+// If the pattern terminates before a non-escaped '}' is seen, returns an error.
+func expandPathPatternRecursively(reader *strings.Reader) ([]string, error) {
+	// Record total list of expanded patterns, to which other lists are appended
+	expanded := []string{}
+	alreadySeenExpanded := make(map[string]bool)
+	// Within the current group option, record the current list of previously-
+	// expanded prefixes, and the start index of the subpattern following the
+	// most recent group.
+	currPrefixes := defaultPrefixes
+	currSubpatternStart := indexOfNextRune(reader)
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			break
+		}
+		if r == '\\' {
+			// Skip next rune.
+			reader.ReadRune() // Since suffix is not '\\', must have next rune
+			continue
+		}
+		if r == '{' {
+			infix := prevStringFromIndex(reader, currSubpatternStart)
+			groupExpanded, err := expandPathPatternRecursively(reader)
+			if err != nil {
+				return nil, err
+			}
+			// Now that group has been expanded, record index of next rune in reader
+			currSubpatternStart = indexOfNextRune(reader)
+			newCount := len(currPrefixes) * len(groupExpanded)
+			if newCount > maxExpandedPatterns {
+				return nil, fmt.Errorf("invalid path pattern: exceeded maximum number of expanded path patterns (%d): %q", maxExpandedPatterns, origPatternFromReader(reader))
+			}
+			alreadySeen := make(map[string]bool, newCount)
+			newPrefixes := make([]string, 0, newCount)
+			for _, prefix := range currPrefixes {
+				for _, suffix := range groupExpanded {
+					newPrefix := prefix + infix + suffix
+					if alreadySeen[newPrefix] {
+						continue
+					}
+					alreadySeen[newPrefix] = true
+					newPrefixes = append(newPrefixes, newPrefix)
+				}
+			}
+			currPrefixes = newPrefixes
+			continue
+		}
+		if r == ',' || r == '}' {
+			suffix := prevStringFromIndex(reader, currSubpatternStart)
+			newCount := len(expanded) + len(currPrefixes)
+			if newCount > maxExpandedPatterns {
+				return nil, fmt.Errorf("invalid path pattern: exceeded maximum number of expanded path patterns (%d): %q", maxExpandedPatterns, origPatternFromReader(reader))
+			}
+			newExpanded := make([]string, len(expanded), newCount)
+			copy(newExpanded, expanded)
+			expanded = newExpanded
+			for _, prefix := range currPrefixes {
+				newSubPattern := prefix + suffix
+				if alreadySeenExpanded[newSubPattern] {
+					continue
+				}
+				alreadySeenExpanded[newSubPattern] = true
+				expanded = append(expanded, newSubPattern)
+			}
+			currPrefixes = defaultPrefixes
+			currSubpatternStart = indexOfNextRune(reader)
+		}
+		if r == '}' {
+			return expanded, nil
+		}
+	}
+	// Group missing closing '}' character, so return an error.
+	return nil, fmt.Errorf(`invalid path pattern: unmatched '{' character: %q`, origPatternFromReader(reader))
+}
+
+func origPatternFromReader(reader *strings.Reader) string {
+	origPatternBuf := make([]byte, reader.Size())
+	reader.ReadAt(origPatternBuf, 0)
+	return string(origPatternBuf)
+}
+
+var (
+	duplicateSlashes    = regexp.MustCompile(`(^|[^\\])/+`)
+	charsDoublestar     = regexp.MustCompile(`([^/\\])\*\*+`)
+	doublestarChars     = regexp.MustCompile(`([^\\])\*\*+([^/])`)
+	duplicateDoublestar = regexp.MustCompile(`/\*\*(/\*\*)+`) // relies on charsDoublestar running first
+	starsAnyMaybeStars  = regexp.MustCompile(`([^\\])\*+(\?\**)+`)
+)
+
+func cleanPattern(pattern string) string {
+	pattern = duplicateSlashes.ReplaceAllString(pattern, `${1}/`)
+	pattern = charsDoublestar.ReplaceAllString(pattern, `${1}*`)
+	pattern = doublestarChars.ReplaceAllString(pattern, `${1}*${2}`)
+	pattern = duplicateDoublestar.ReplaceAllString(pattern, `/**`)
+	pattern = starsAnyMaybeStars.ReplaceAllStringFunc(pattern, func(s string) string {
+		deleteStars := func(r rune) rune {
+			if r == '*' {
+				return -1
+			}
+			return r
+		}
+		return strings.Map(deleteStars, s) + "*"
+	})
+	if strings.HasSuffix(pattern, "/**/*") {
+		// Strip trailing "/*" from suffix
+		return pattern[:len(pattern)-len("/*")]
+	}
+	return pattern
+}
+
+type countStack []int
+
+func (c *countStack) push(x int) {
+	*c = append(*c, x)
+}
+
+func (c *countStack) pop() int {
+	x := (*c)[len(*c)-1]
+	*c = (*c)[:len(*c)-1]
+	return x
+}
+
+// ValidatePathPattern returns nil if the pattern is valid, otherwise an error.
+func ValidatePathPattern(pattern string) error {
+	if pattern == "" || pattern[0] != '/' {
+		return fmt.Errorf("invalid path pattern: must start with '/': %q", pattern)
+	}
+	depth := 0
+	var currentGroupStack countStack
+	var currentOptionStack countStack
+	// Final currentOptionCount will be total expanded patterns for full pattern
+	currentGroupCount := 0
+	currentOptionCount := 1
+	reader := strings.NewReader(pattern)
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			// No more runes
+			break
+		}
+		switch r {
+		case '{':
+			depth++
+			if depth >= maxExpandedPatterns {
+				return fmt.Errorf("invalid path pattern: nested group depth exceeded maximum number of expanded path patterns (%d): %q", maxExpandedPatterns, pattern)
+			}
+			currentGroupStack.push(currentGroupCount)
+			currentOptionStack.push(currentOptionCount)
+			currentGroupCount = 0
+			currentOptionCount = 1
+		case ',':
+			if depth == 0 {
+				// Ignore commas outside of groups
+				break
+			}
+			currentGroupCount += currentOptionCount
+			currentOptionCount = 1
+		case '}':
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("invalid path pattern: unmatched '}' character: %q", pattern)
+			}
+			currentGroupCount += currentOptionCount
+			currentOptionCount = currentOptionStack.pop() // option count of parent
+			currentOptionCount *= currentGroupCount       // parent option count * current group count
+			currentGroupCount = currentGroupStack.pop()   // group count of parent
+		case '\\':
+			// Skip next rune
+			_, _, err = reader.ReadRune()
+			if err != nil {
+				return fmt.Errorf(`invalid path pattern: trailing unescaped '\' character: %q`, pattern)
+			}
+		case '[', ']':
+			return fmt.Errorf("invalid path pattern: cannot contain unescaped '[' or ']': %q", pattern)
+		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("invalid path pattern: unmatched '{' character: %q", pattern)
+	}
+	if currentOptionCount > maxExpandedPatterns {
+		return fmt.Errorf("invalid path pattern: exceeded maximum number of expanded path patterns (%d): %q expands to %d patterns", maxExpandedPatterns, pattern, currentOptionCount)
+	}
+	if !doublestar.ValidatePattern(pattern) {
+		return fmt.Errorf("invalid path pattern: %q", pattern)
+	}
+	return nil
+}
 
 // PathPatternMatch returns true if the given pattern matches the given path.
 //

--- a/interfaces/prompting/patterns_test.go
+++ b/interfaces/prompting/patterns_test.go
@@ -413,7 +413,7 @@ func (s *patternsSuite) TestPathPatternNext(c *C) {
 	} {
 		pathPattern, err := prompting.ParsePathPattern(testCase.pattern)
 		c.Check(err, IsNil, Commentf("testcase: %+v", testCase))
-		expanded := make([]string, 0, pathPattern.NumConfigurations())
+		expanded := make([]string, 0, pathPattern.NumExpansions())
 		for {
 			pattern, final := pathPattern.Next()
 			expanded = append(expanded, pattern)


### PR DESCRIPTION
Path patterns may include arbitrary nested groups, delimited by '{' and '}', up to a limit on the total number of groups. In order to compare the precedence of path patterns which match a given path, these path patterns must be expanded until no groups remain, and thus the particular group-free patterns which was resolved from the original patterns when matching the path can be compared.

This PR is based on #13866, and is split from the original path pattern PR #13730.