### PR TITLE
data/selinux: update policy to allow stat of /run/systemd/container

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -761,6 +761,10 @@ kernel_unmount_proc(snappy_confine_t)
 seutil_read_file_contexts(snappy_confine_t)
 term_mount_pty_fs(snappy_confine_t)
 
+# check if /run/systemd/container
+# note, it's unlikely we're ever going to need to read that file on Fedora
+init_search_pid_dirs(snappy_confine_t)
+
 # device group
 fs_manage_cgroup_dirs(snappy_confine_t)
 fs_manage_cgroup_files(snappy_confine_t)


### PR DESCRIPTION
Since 3cfa28a0fc snap-confine checks if the system is running in a container. It does so by reading /run/systemd/container. Extend the SELinux to allow basic search operations within /run/systemd. It is unlikely anyone runs snapd in a container where the SELinux is enabled on the host, so the actual file read permissions are likely not needed.
