### PR TITLE
tests/regression: skip lp-1848567 if internal parser is used

### DIFF
--- a/tests/regression/lp-1848567/task.yaml
+++ b/tests/regression/lp-1848567/task.yaml
@@ -20,7 +20,8 @@ prepare: |
   snap connect test-snapd-app:sound-themes test-snapd-gtk-common-themes:sound-themes
 
 execute: |
-  if snap debug sandbox-features --required apparmor:kernel:mount; then
+  # When using the internal parser, the profile may include features which are not yet supported by the host parser.
+  if snap debug sandbox-features --required apparmor:kernel:mount && ! snap debug sandbox-features --required apparmor:parser:snapd-internal; then
     # Re-compile the apparmor profile for snap-update-ns for the
     # test-snapd-app snap while ensuring that the profile is not loaded
     # into kernel memory and that the compiler is not using any existing


### PR DESCRIPTION
The test uses host parser unconditionally, which may not understand future syntax that is present in cases when apparmor is carried by snapd snap package.
