### PR TITLE
tests: add details to some of the tests in main suite

### DIFF
--- a/tests/main/try-non-fatal/task.yaml
+++ b/tests/main/try-non-fatal/task.yaml
@@ -1,5 +1,11 @@
 summary: Checks that removing the base directory of a tried snap works.
 
+details: |
+    The snap try command can be used to install a snap without creating the
+    squashfs file, which for large snaps is very costly. The test shows that
+    even if the directory holding try-mode snap's files is removed, snapd does
+    not malfunction but instead shows the snap as in "broken" state.
+
 systems: [-ubuntu-core-*]
 
 execute: |

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -1,6 +1,11 @@
 summary: Check that snaps vanishing are handled gracefully
 
 details: |
+    The snap try command can be used to install a snap without creating the
+    squashfs file, which for large snaps is very costly. The test shows that
+    even if the directory holding try-mode snap's files is removed, snapd does
+    not malfunction and allows the snap to be removed correctly.
+
     Note that this test is subtly different from tests/regression/lp-1764977.
     See the description of that test for details.
 

--- a/tests/main/try-snap-is-optional/task.yaml
+++ b/tests/main/try-snap-is-optional/task.yaml
@@ -1,5 +1,11 @@
 summary: Check that try command works when snap dir is omitted
 
+details: |
+    The snap try command can be executed without an argument, to imply that the
+    current working directory is the root of the unpacked snap structure. The
+    test uses "snap try" to install one of the test packages and ensures that it
+    shows up as in "try" mode according to "snap list"
+
 systems: [-ubuntu-core-*]
 
 execute: |

--- a/tests/main/try-twice-with-daemon/task.yaml
+++ b/tests/main/try-twice-with-daemon/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that try command works when daemon line is added to snap.yaml
 
+details: |
+    This test shows that a snap application can be converted from an app to a
+    service between one revision of a snap installed with "snap try", and another.
+
 systems: [-ubuntu-core-*]
 
 environment:

--- a/tests/main/try-with-hooks/task.yaml
+++ b/tests/main/try-with-hooks/task.yaml
@@ -1,5 +1,11 @@
 summary: Reproduce a known issue of snap try failure with hooks
 
+details: |
+  This regression test shows an existing issue, that has not been fixed, with
+  the meaning of pre-refresh hooks when used in a "snap try" installed snap
+  package, where the difference between old and new revisions is lost due to the
+  nature of the technical implementation of try.
+
 prepare: |
   cp -a "$TESTSLIB"/snaps/basic ./
   # in case the snap is modified to have the hook

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,5 +1,10 @@
 summary: Check that try command works
 
+details: |
+    The snap try command can be used to install a snap without creating the
+    squashfs file, which for large snaps is very costly. The test shows that
+    snap try works for snaps using strict, devmode and classic confinement.
+
 # s390x does not have /dev/kmsg
 # ubuntu-14.04: systemd-run not supported
 systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x, -centos-*, -ubuntu-14.04*]

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,16 +1,24 @@
 summary: Integration tests for the snap-bootstrap binary
 
 details: |
+    When working on a core system, snapd contains logic to install the system
+    from scratch, creating partitions and file systems as necessary. The test
+    uses snapd internal API loaded through a helper Go program, to exercise that
+    in a hybrid unit/integration test, and observe the outcome.
+
+    This test focuses on the first installation scenario, with encrypted file
+    systems. A similar test looks at the first installation scenario without
+    encryption and yet another test looks at re-installation.
+
     This test checks the snap-bootstrap binary. First it is used
-    uc20-create-partitions tool and validated partitions and 
-    ubuntu-* key files are created. Then the unsealed and save keys
-    are validated in run and recovery modes, and also it is possible to
-    add/remove new keys. Finally check the disk-mapping.json has
-    expected contents.
+    uc20-create-partitions tool and validated partitions and ubuntu-* key files
+    are created. Then the unsealed and save keys are validated in run and
+    recovery modes, and also it is possible to add/remove new keys. Finally
+    check the disk-mapping.json has expected contents.
 
 # use the same system and tooling as uc20
 # TODO: revert skip for ubuntu-23*
-systems: [ubuntu-20.*,ubuntu-22.*]
+systems: [ubuntu-20.*, ubuntu-22.*]
 
 environment:
     SNAPD_DEBUG: "1"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -1,5 +1,15 @@
 summary: Integration tests for the bootstrap.Run autodetect
 
+details: |
+    When working on a core system, snapd contains logic to install the system
+    from scratch, creating partitions and file systems as necessary. The test
+    uses snapd internal API loaded through a helper Go program, to exercise that
+    in a hybrid unit/integration test, and observe the outcome.
+
+    This test focuses on the re-installation scenario. A similar test looks at
+    the first installation scenario and yet another test looks at creating
+    encrypted file systems.
+
 # use the same system and tooling as uc20
 systems: [ubuntu-2*]
 

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -1,5 +1,15 @@
 summary: Integration tests for the bootstrap.Run
 
+details: |
+    When working on a core system, snapd contains logic to install the system
+    from scratch, creating partitions and file systems as necessary. The test
+    uses snapd internal API loaded through a helper Go program, to exercise that
+    in a hybrid unit/integration test, and observe the outcome.
+
+    This test focuses on the first installation scenario. A similar test looks
+    at the re-installation scenario and yet another test looks at creating
+    encrypted file systems.
+
 # use the same system and tooling as uc20/uc22
 systems: [ubuntu-2*]
 

--- a/tests/main/unhandled-task/task.yaml
+++ b/tests/main/unhandled-task/task.yaml
@@ -1,5 +1,13 @@
 summary: Check that unknown tasks are aborted
 
+details: |
+    Snapd can, in theory, freely move in "time" by refreshing itself and
+    reverting to the earlier revision. It is possible to introduce an update
+    that defines a change with a new task that old snapd did not know about. The
+    test crafts a particular state file, which contains a task with an fake,
+    unknown handler name in order to check that such tasks do not cause snapd to
+    malfunction entirely, which would make rollback impossible.
+
 prepare: |
     snap install --devmode jq
 

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -1,10 +1,11 @@
 summary: Ensure upgrades from snapd 2.15 work
 
 details: |
-    Check that upgrading core from a very old version (2.15) to the
-    current one works. Verify that snap confine profiles are fine
-    after upgrade and ensure that the old/obsolete snap-confine
-    apparmor profile was removed
+    The test ensures that users starting with that snapd 2.15 can successfully
+    update to a locally built Debian package, and end up with functioning snapd.
+    This checks the transition of so-called conf-files handling application
+    permission profiles for snap-confine, which could end up outdated if the
+    version from snapd 2.15 is retained after the update.
 
 systems: [ubuntu-16.04-64]
 
@@ -58,7 +59,7 @@ execute: |
 
     echo "Install a test snap"
     snap install test-snapd-sh
-    
+
     echo "upgrade to current snapd"
     apt install -y "$GOHOME"/snapd*.deb
 

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -1,9 +1,14 @@
 summary: Check that the refresh data copy works.
 
 details: |
-    Check that when a snap is refreshed, the user data gets copied
-    and when the snap is removed with --purge, all the user and
-    root data is gone
+    Snapd implements a system, where a refreshed snap's data associated with a
+    particular revision is copied to the revision that a snap is being refreshed
+    to. This allows the snap to perform destructive data manipulations, like
+    schema changes, while simultaneously allowing the user to revert to the
+    previously used revision for both the application code and user data.
+
+    The test checks that snap user data is correctly copied for both root and
+    non-root users.
 
 execute: |
     echo "For an installed snap"

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -1,5 +1,11 @@
 summary: check the container validator logs on error
 
+details: |
+    Snapd contains logic to validate the contents of the squashfs and ensure
+    that files are readable and that application entry points are executable.
+    The test mounts a snap with violates those rules to test that snapd detects
+    and reports the problems accurately.
+
 environment:
     SNAP: test-snapd-validate-container-failures
 

--- a/tests/main/validate-container-happy/task.yaml
+++ b/tests/main/validate-container-happy/task.yaml
@@ -1,5 +1,12 @@
 summary: check the symlinks following the right track
 
+details: |
+    Snapd contains logic to validate the contents of a snap to ensure that
+    symbolic links follow certain restrictions. The test mounts a snap with
+    crafted symbolic link names and targets, containing spaces and the character
+    sequence ->, to check that snapd is not confused by that structure, and that
+    after mounting, the symlinks retain their properties.
+
 environment:
     SNAP: test-snapd-validate-container-happy
 

--- a/tests/main/vitality/task.yaml
+++ b/tests/main/vitality/task.yaml
@@ -18,7 +18,7 @@ execute: |
 
     echo "then the oom score is set to 899"
     systemctl show snap.test-snapd-go-webserver.webserver.service |MATCH "OOMScoreAdjust=-899"
-    snap remove test-snapd-go-webserver    
+    snap remove test-snapd-go-webserver
 
     echo "When installing a snap without vitality-hint set"
     snap unset core resilience.vitality-hint

--- a/tests/main/vitality/task.yaml
+++ b/tests/main/vitality/task.yaml
@@ -1,5 +1,11 @@
 summary: Test that the snap vitality score works
 
+details: |
+    Snapd offers a system to influence the out-of-memory behavior for snap
+    applications, that prefers to sacrifice a particular memory-hungry process
+    over another. The test sets up the so-called vitality hint, and observes how
+    the setting is carried over to the corresponding systemd setting.
+
 execute: |
     echo "On install of a service the oom score is 0"
     snap install test-snapd-go-webserver

--- a/tests/main/whoami/task.yaml
+++ b/tests/main/whoami/task.yaml
@@ -1,5 +1,10 @@
 summary: Checks for snap whoami
 
+details: |
+    The snap login command authenticates the calling user to the snap store.
+    Ensure that after the user is logged in, the snap whoami command can be used
+    to display the name and email associated with the store account.
+
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -1,5 +1,11 @@
 summary: Check that snap apps and services can write to writable areas.
 
+details: |
+    The confinement system allows snap applications to write to four locations:
+    snap data specific to the current revision, snap data common across
+    revisions, snap user data specific to the current revision and lastly snap
+    user data common across revisions.
+
 environment:
     # Ensure that running purely from the deb (without re-exec) works
     # correctly

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -1,5 +1,16 @@
 summary: Verify xdg-open forwarding requests to the desktop portal
 
+details: |
+    Snapd contains a system where XDG utility programs, that applications may
+    commonly call, are replaced with programs that communicate the request back
+    to snapd user session daemon, to present a question to the user.
+
+    The test exercises the xdg-open' program ability to open web URLs, file URLs
+    and files by path. In all cases the request is forwarded to the desktop
+    portal. The portal is configured to service the request with a test
+    application that records it, allowing the test to ensure all requests were
+    properly redirected.
+
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
 systems:

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -1,5 +1,14 @@
 summary: Ensure snap userd allows opening a URL via xdg-open
 
+details: |
+    Snapd contains a system where XDG utility programs, that applications may
+    commonly call, are replaced with programs that communicate the request back
+    to snapd user session daemon, to present a question to the user.
+
+    The test exercises the xdg-open' program ability to open a class of URLs and
+    ensures that in absence of the portal system, the older snapcraft-specific
+    helper is invoked.
+
 # Not supposed to work on Ubuntu Core systems as we don't have
 # a user session environment there
 systems:

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -1,5 +1,13 @@
 summary: Ensure snap userd allows settings via xdg-settings
 
+details: |
+    Snapd contains a system where XDG utility programs, that applications
+    may commonly call, are replaced with programs that communicate the request
+    back to snapd user session daemon, to present a question to the user.
+
+    The test exercises the xdg-settings' program ability to set the default web
+    browser and default URL scheme handler.
+
 # Not supposed to work on Ubuntu Core systems as we don't have
 # a user session environment there
 systems:


### PR DESCRIPTION
This adds details to tests from try-* all the way down to the end of the main/ directory.