### PR TITLE
wrappers: mount /usr/lib/snapd before udevd starts

### DIFF
--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -512,6 +512,7 @@ func (s *linkSuite) TestLinkSnapdSnapOnCore(c *C) {
 	mountUnit := fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system
 Before=snapd.service
+Before=systemd-udevd.service
 
 [Mount]
 What=%s/usr/lib/snapd

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -69,6 +69,7 @@ func writeSnapdToolingMountUnit(sysd systemd.Systemd, prefix string, opts *AddSn
 	content := []byte(fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system
 Before=snapd.service
+Before=systemd-udevd.service
 
 [Mount]
 What=%s/usr/lib/snapd

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -132,6 +132,7 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCore(c *C) {
 	mountUnit := fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system
 Before=snapd.service
+Before=systemd-udevd.service
 
 [Mount]
 What=%s/snap/snapd/1/usr/lib/snapd
@@ -252,6 +253,7 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCorePreseeding(c *C) {
 	mountUnit := fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system
 Before=snapd.service
+Before=systemd-udevd.service
 
 [Mount]
 What=%s/snap/snapd/1/usr/lib/snapd


### PR DESCRIPTION
We have udev rules that run /usr/lib/snapd/snap-device-helper, so we need to make sure that the binary is available before udevd starts.

In some devices, this has led to errors in the journal like:

`(udev-worker)[xxx]: <dev>: Process '/usr/lib/snapd/snap-device-helper snap_console-<profile>' failed with exit code 1.`