### PR TITLE
o/snapstate: fix race in fake backend operations

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1150,7 +1150,7 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx b
 		vitalityRank = linkCtx.ServiceOptions.VitalityRank
 	}
 
-	op := fakeOp{
+	op := &fakeOp{
 		op:   "link-snap",
 		path: info.MountDir(),
 
@@ -1160,11 +1160,11 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx b
 
 	if info.MountDir() == f.linkSnapFailTrigger {
 		op.op = "link-snap.failed"
-		f.ops = append(f.ops, op)
+		f.appendOp(op)
 		return boot.RebootInfo{RebootRequired: false}, errors.New("fail")
 	}
 
-	f.appendOp(&op)
+	f.appendOp(op)
 
 	reboot := false
 	if f.linkSnapMaybeReboot {


### PR DESCRIPTION
Fix a race when appending an operations during failure scenarios in fake backend's LinkSnap.

Reported by -race:

```
==================
WARNING: DATA RACE
Read at 0x00c0004822c0 by goroutine 1597:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).appendOp()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1506 +0x104
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).ForeignTask()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1416 +0x1c4
  github.com/snapcore/snapd/overlord/snapstate_test.AddForeignTaskHandlers.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/snapstate_test.go:366 +0x118
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/state/taskrunner.go:220 +0xa2
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x3b
  gopkg.in/tomb%2ev2.(*Tomb).Go.gowrap2()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x44

Previous write at 0x00c0004822c0 by goroutine 1598:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).LinkSnap()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1163 +0x484
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doLinkSnap()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/handlers.go:2213 +0x1ca7
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doLinkSnap-fm()
      <autogenerated>:1 +0x47
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/state/taskrunner.go:220 +0xa2
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x3b
  gopkg.in/tomb%2ev2.(*Tomb).Go.gowrap2()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159
      +0x44
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
