### PR TITLE
o/snapstate: fix more racy operations in fake backend

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -675,7 +675,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			}
 			hit = info.Revision
 		}
-		f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{
+		f.fakeBackend.appendOp(&fakeOp{
 			op:     "storesvc-snap-action:action",
 			action: *a,
 			revno:  hit,
@@ -1340,7 +1340,7 @@ func (f *fakeSnappyBackend) RemoveSnapSaveData(info *snap.Info, _ snap.Device) e
 }
 
 func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool, opts *dirs.SnapDirOptions) error {
-	f.ops = append(f.ops, fakeOp{
+	f.appendOp(&fakeOp{
 		op:             "remove-snap-data-dir",
 		name:           info.InstanceName(),
 		path:           snap.BaseDataDir(info.SnapName()),
@@ -1350,7 +1350,7 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 }
 
 func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error {
-	f.ops = append(f.ops, fakeOp{
+	f.appendOp(&fakeOp{
 		op:   "remove-snap-mount-units",
 		name: s.ContainerName(),
 	})
@@ -1358,7 +1358,7 @@ func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo,
 }
 
 func (f *fakeSnappyBackend) RemoveSnapDir(s snap.PlaceInfo, otherInstances bool) error {
-	f.ops = append(f.ops, fakeOp{
+	f.appendOp(&fakeOp{
 		op:             "remove-snap-dir",
 		name:           s.InstanceName(),
 		path:           snap.BaseDir(s.SnapName()),


### PR DESCRIPTION
There are more of those.

```
==================
WARNING: DATA RACE
Read at 0x00c000160580 by goroutine 24:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).appendOp()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1506 +0x104
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).UndoCopySnapData()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1267 +0x11a
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).undoCopySnapData()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/handlers.go:1843 +0x8f1
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).undoCopySnapData-fm()
      <autogenerated>:1 +0x4d
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/state/taskrunner.go:220 +0xb3
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x51
  gopkg.in/tomb%2ev2.(*Tomb).Go.func2()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x47

Previous write at 0x00c000160580 by goroutine 77:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeSnappyBackend).RemoveSnapDataDir()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/backend_test.go:1343 +0x27a
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).undoCopySnapData()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/snapstate/handlers.go:1865 +0xa4a
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).undoCopySnapData-fm()
      <autogenerated>:1 +0x4d
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/state/taskrunner.go:220 +0xb3
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x51
  gopkg.in/tomb%2ev2.(*Tomb).Go.func2()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x47
```

and fake store:

```
==================
WARNING: DATA RACE
Read at 0x00c0003b13e0 by goroutine 2273:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeStore).Download()
      /home/maciek/work/canonical/snapd/overlord/snapstate/backend_test.go:744 +0x23d
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap.func1()
      /home/maciek/work/canonical/snapd/overlord/snapstate/handlers.go:842 +0x241
  github.com/snapcore/snapd/timings.Run()
      /home/maciek/work/canonical/snapd/timings/helpers.go:26 +0x7e
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap()
      /home/maciek/work/canonical/snapd/overlord/snapstate/handlers.go:841 +0x574
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap-fm()
      <autogenerated>:1 +0x47
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/maciek/work/canonical/snapd/overlord/state/taskrunner.go:220 +0xa2
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x3b
  gopkg.in/tomb%2ev2.(*Tomb).Go.gowrap2()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x44

Previous write at 0x00c0003b13e0 by goroutine 2274:
  github.com/snapcore/snapd/overlord/snapstate_test.(*fakeStore).Download()
      /home/maciek/work/canonical/snapd/overlord/snapstate/backend_test.go:744 +0x331
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap.func1()
      /home/maciek/work/canonical/snapd/overlord/snapstate/handlers.go:842 +0x241
  github.com/snapcore/snapd/timings.Run()
      /home/maciek/work/canonical/snapd/timings/helpers.go:26 +0x7e
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap()
      /home/maciek/work/canonical/snapd/overlord/snapstate/handlers.go:841 +0x574
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).doPreDownloadSnap-fm()
      <autogenerated>:1 +0x47
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).run.func1()
      /home/maciek/work/canonical/snapd/overlord/state/taskrunner.go:220 +0xa2
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x3b
  gopkg.in/tomb%2ev2.(*Tomb).Go.gowrap2()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x44
```