### PR TITLE
many: add ubuntu core debug options

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -188,6 +188,7 @@ purge() {
     rm -rf /var/lib/snapd/dbus-1/services/*
     rm -rf /var/lib/snapd/dbus-1/system-services/*
     rm -rf /var/lib/snapd/desktop/applications/*
+    rm -rf /var/lib/snapd/environment/*
     rm -rf /var/lib/snapd/seccomp/bpf/*
     rm -rf /var/lib/snapd/device/*
     rm -rf /var/lib/snapd/assertions/*

--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -24,6 +24,7 @@ RequiresMountsFor=/var/cache/apparmor /var/lib/snapd/apparmor/profiles
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/snapd/snapd-apparmor start
+EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 RemainAfterExit=yes
 
 [Install]

--- a/data/systemd/snapd.autoimport.service.in
+++ b/data/systemd/snapd.autoimport.service.in
@@ -9,6 +9,7 @@ ConditionKernelCommandLine=|snapd_recovery_mode
 [Service]
 Type=oneshot
 ExecStart=@bindir@/snap auto-import
+EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/data/systemd/snapd.failure.service.in
+++ b/data/systemd/snapd.failure.service.in
@@ -4,4 +4,5 @@ Description=Failure handling of the snapd snap
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/snapd/snap-failure snapd
+EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 # X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -17,6 +17,7 @@ OnFailure=snapd.failure.service
 OOMScoreAdjust=-900
 ExecStart=@libexecdir@/snapd/snapd
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
+EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 Restart=always
 WatchdogSec=5m
 Type=notify

--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -10,5 +10,6 @@ Type=oneshot
 ExecStart=@libexecdir@/snapd/snap-repair run
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Environment=SNAP_REPAIR_FROM_TIMER=1
+EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 # There is no need to start this, the timer will run it
 # X-Snapd-Snap: do-not-start

--- a/overlord/configstate/configcore/debug.go
+++ b/overlord/configstate/configcore/debug.go
@@ -1,0 +1,162 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
+)
+
+const (
+	optionDebugSnapdLog            = "debug.snapd.log"
+	optionDebugSystemdLogLevel     = "debug.systemd.log-level"
+	coreOptionDebugSnapdLog        = "core." + optionDebugSnapdLog
+	coreOptionDebugSystemdLogLevel = "core." + optionDebugSystemdLogLevel
+)
+
+func init() {
+	supportedConfigurations[coreOptionDebugSnapdLog] = true
+	supportedConfigurations[coreOptionDebugSystemdLogLevel] = true
+}
+
+func validateDebugSnapdLogSetting(tr RunTransaction) error {
+	return validateBoolFlag(tr, optionDebugSnapdLog)
+}
+
+func handleDebugSnapdLogConfiguration(tr RunTransaction, opts *fsOnlyContext) error {
+	// Run only if the option changed to avoid extra filesystem access
+	if !strutil.ListContains(tr.Changes(), coreOptionDebugSnapdLog) {
+		return nil
+	}
+
+	debugLog, err := coreCfg(tr, optionDebugSnapdLog)
+	if err != nil {
+		return err
+	}
+
+	rootDir := dirs.GlobalRootDir
+	if opts != nil {
+		rootDir = opts.RootDir
+	}
+	envDir := filepath.Join(dirs.SnapdStateDir(rootDir), "environment")
+
+	snapdEnvPath := filepath.Join(envDir, "snapd.conf")
+
+	switch debugLog {
+	case "true":
+		if err := os.Mkdir(envDir, 0755); err != nil && !os.IsExist(err) {
+			return err
+		}
+		if err := osutil.EnsureFileState(snapdEnvPath, &osutil.MemoryFileState{
+			Content: []byte("SNAPD_DEBUG=1\n"),
+			Mode:    os.FileMode(0644),
+		}); err != nil {
+			return err
+		}
+	case "false", "":
+		// We simply remove the env file as for the moment we use it
+		// just for SNAPD_DEBUG. If we change that we will need to
+		// locate the variable in the file and remove just that.
+		if err := os.Remove(snapdEnvPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	default:
+		return fmt.Errorf("%s must be true of false, not: %q", optionDebugSnapdLog, debugLog)
+	}
+
+	// TODO change logger to debug enabled. Change
+	// tests/core/debug/task.yaml too when this is done.
+
+	return nil
+}
+
+func validateDebugSystemdLogLevelSetting(tr RunTransaction) error {
+	value, err := coreCfg(tr, optionDebugSystemdLogLevel)
+	if err != nil {
+		return err
+	}
+
+	switch value {
+	case "emerg", "alert", "crit", "err", "warning", "notice", "info", "debug",
+		"0", "1", "2", "3", "45", "6", "7", "":
+		// noop
+	default:
+		return fmt.Errorf("%q is not a valid value for %s (see systemd(1))",
+			value, optionDebugSystemdLogLevel)
+	}
+	return nil
+}
+
+func handleDebugSystemdLogLevelConfiguration(tr RunTransaction, opts *fsOnlyContext) error {
+	// Run only if the option changed to avoid extra filesystem
+	// access / systemctl calls
+	if !strutil.ListContains(tr.Changes(), coreOptionDebugSystemdLogLevel) {
+		return nil
+	}
+
+	logLevel, err := coreCfg(tr, optionDebugSystemdLogLevel)
+	if err != nil {
+		return err
+	}
+
+	var sysd systemd.Systemd
+	confDir := ""
+	if opts != nil {
+		confDir = dirs.SnapSystemdConfDirUnder(opts.RootDir)
+		sysd = systemd.NewEmulationMode(opts.RootDir)
+	} else {
+		confDir = dirs.SnapSystemdConfDir
+		sysd = systemd.New(systemd.SystemMode, &sysdLogger{})
+	}
+	confFile := filepath.Join(confDir, "20-debug_systemd_log-level.conf")
+
+	if logLevel == "" {
+		// On unsetting, remove the file.
+		if err := os.Remove(confFile); err != nil {
+			// Should be here, show a warning
+			logger.Noticef("warning: while removing %q: %v", confFile, err)
+		}
+		// and set log level to the default
+		logLevel = "info"
+	} else {
+		// Otherwise, write persistent configuration
+		if err := os.MkdirAll(confDir, 0755); err != nil && !os.IsExist(err) {
+			return err
+		}
+		confData := fmt.Sprintf("[Manager]\nLogLevel=%s\n", logLevel)
+		if err := osutil.EnsureFileState(confFile, &osutil.MemoryFileState{
+			Content: []byte(confData),
+			Mode:    os.FileMode(0644),
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Set log level for the current systemd instance
+	return sysd.SetLogLevel(logLevel)
+}

--- a/overlord/configstate/configcore/debug_test.go
+++ b/overlord/configstate/configcore/debug_test.go
@@ -1,0 +1,193 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package configcore_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type debugSuite struct {
+	configcoreSuite
+
+	snapdEnvPath       string
+	systemdLogConfPath string
+}
+
+var _ = Suite(&debugSuite{})
+
+func (s *debugSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	envDir := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "environment")
+	s.snapdEnvPath = filepath.Join(envDir, "snapd.conf")
+	s.systemdLogConfPath = filepath.Join(dirs.SnapSystemdConfDir,
+		"20-debug_systemd_log-level.conf")
+
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *debugSuite) testConfigureDebugSnapdLogGoodVals(c *C, valChanges bool) {
+	for _, val := range []string{"true", "false", ""} {
+		prevVal := val
+		if valChanges {
+			if val == "true" {
+				prevVal = "false"
+			} else {
+				prevVal = "true"
+			}
+		}
+		err := configcore.Run(coreDev, &mockConf{
+			state:   s.state,
+			conf:    map[string]interface{}{"debug.snapd.log": prevVal},
+			changes: map[string]interface{}{"debug.snapd.log": val},
+		})
+
+		c.Assert(err, IsNil)
+
+		switch val {
+		case "true":
+			c.Check(s.snapdEnvPath, testutil.FileEquals, "SNAPD_DEBUG=1\n")
+		case "false", "":
+			c.Check(s.snapdEnvPath, testutil.FileAbsent)
+		}
+	}
+}
+
+func (s *debugSuite) TestConfigureDebugSnapdLogGoodVals(c *C) {
+	valChanges := true
+	s.testConfigureDebugSnapdLogGoodVals(c, valChanges)
+}
+
+func (s *debugSuite) TestConfigureDebugSnapdLogGoodValsNoChange(c *C) {
+	valChanges := false
+	s.testConfigureDebugSnapdLogGoodVals(c, valChanges)
+}
+
+func (s *debugSuite) TestConfigureDebugSnapdLogBadVals(c *C) {
+	for _, val := range []string{"1", "foo"} {
+		err := configcore.Run(coreDev, &mockConf{
+			state:   s.state,
+			conf:    map[string]interface{}{"debug.snapd.log": ""},
+			changes: map[string]interface{}{"debug.snapd.log": val},
+		})
+		c.Assert(err, ErrorMatches,
+			"debug.snapd.log can only be set to 'true' or 'false'")
+
+		c.Check(s.snapdEnvPath, testutil.FileAbsent)
+	}
+}
+
+func (s *debugSuite) TestConfigureSystemdLogLevelGoodVals(c *C) {
+	var systemctlArgs []string
+	numCalls := 0
+	systemctlMock := systemd.MockSystemctl(func(args ...string) (buf []byte, err error) {
+		systemctlArgs = args
+		numCalls++
+		return nil, nil
+	})
+	defer systemctlMock()
+
+	validVals := []string{"emerg", "alert", "crit", "err", "warning", "notice", "info", "debug",
+		"0", "1", "2", "3", "45", "6", "7", ""}
+	for _, val := range validVals {
+		conf := &mockConf{
+			state:   s.state,
+			conf:    map[string]interface{}{"debug.systemd.log-level": ""},
+			changes: map[string]interface{}{"debug.systemd.log-level": val},
+		}
+		err := configcore.Run(coreDev, conf)
+
+		c.Assert(err, IsNil)
+
+		if val == "" {
+			// Unsetting should remove the file and set log level
+			// to the default
+			c.Check(s.systemdLogConfPath, testutil.FileAbsent)
+			val = "info"
+		} else {
+			confData := fmt.Sprintf("[Manager]\nLogLevel=%s\n", val)
+			c.Check(s.systemdLogConfPath, testutil.FileEquals, confData)
+		}
+
+		// Check call to systemctl
+		c.Check(systemctlArgs, DeepEquals, []string{"log-level", val})
+	}
+}
+
+func (s *debugSuite) TestConfigureSystemdLogLevelBadVals(c *C) {
+	systemctlMock := systemd.MockSystemctl(func(args ...string) (buf []byte, err error) {
+		c.Error("systemctl should not be called in this test")
+		return nil, nil
+	})
+	defer systemctlMock()
+
+	for _, val := range []string{"foo", "8", "-1"} {
+		conf := &mockConf{
+			state:   s.state,
+			conf:    map[string]interface{}{"debug.systemd.log-level": "info"},
+			changes: map[string]interface{}{"debug.systemd.log-level": val},
+		}
+		err := configcore.Run(coreDev, conf)
+
+		c.Check(err, ErrorMatches,
+			fmt.Sprintf(`%q is not a valid value for debug\.systemd\.log\-level.*`, val))
+		c.Check(s.systemdLogConfPath, testutil.FileAbsent)
+	}
+}
+
+func (s *debugSuite) TestConfigureSystemdLogLevelOldSystemd(c *C) {
+	var systemctlArgs []string
+	systemctlMock := systemd.MockSystemctl(func(args ...string) (buf []byte, err error) {
+		systemctlArgs = args
+		return nil, errors.New("old systemd")
+	})
+	defer systemctlMock()
+
+	sysdAnalyzeCmd := testutil.MockCommand(c, "systemd-analyze", "")
+	defer sysdAnalyzeCmd.Restore()
+
+	val := "debug"
+	err := configcore.Run(coreDev, &mockConf{
+		state:   s.state,
+		conf:    map[string]interface{}{"debug.systemd.log-level": ""},
+		changes: map[string]interface{}{"debug.systemd.log-level": val},
+	})
+	c.Assert(err, IsNil)
+
+	confData := fmt.Sprintf("[Manager]\nLogLevel=%s\n", val)
+	c.Check(s.systemdLogConfPath, testutil.FileEquals, confData)
+
+	// Check calls
+	c.Check(systemctlArgs, DeepEquals, []string{"log-level", val})
+	c.Check(sysdAnalyzeCmd.Calls(), DeepEquals, [][]string{{"systemd-analyze", "set-log-level", val}})
+}

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -66,6 +66,12 @@ func init() {
 
 	// kernel.{,dangerous-}cmdline-append
 	addWithStateHandler(validateCmdlineAppend, handleCmdlineAppend, &flags{modeenvOnlyConfig: true})
+
+	// debug.snapd.log
+	addWithStateHandler(validateDebugSnapdLogSetting, handleDebugSnapdLogConfiguration, nil)
+
+	// debug.systemd.log-level
+	addWithStateHandler(validateDebugSystemdLogLevelSetting, handleDebugSystemdLogLevelConfiguration, coreOnly)
 }
 
 // RunTransaction is an interface describing how to access

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -646,6 +646,7 @@ install -d -p %{buildroot}%{_sharedstatedir}/snapd/dbus-1/services
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/dbus-1/system-services
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/desktop/applications
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/device
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/environment
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/hostfs
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/inhibit
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -403,6 +403,7 @@ fi
 %dir %{_sharedstatedir}/snapd/desktop
 %dir %{_sharedstatedir}/snapd/desktop/applications
 %dir %{_sharedstatedir}/snapd/device
+%dir %{_sharedstatedir}/snapd/environment
 %dir %{_sharedstatedir}/snapd/hostfs
 %dir %{_sharedstatedir}/snapd/inhibit
 %dir %{_sharedstatedir}/snapd/lib

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -238,3 +238,7 @@ func (s *emulation) Umount(whatOrWhere string) error {
 func (s *emulation) Run(command []string, opts *RunOptions) ([]byte, error) {
 	return nil, &notImplementedError{"Run"}
 }
+
+func (s *emulation) SetLogLevel(logLevel string) error {
+	return &notImplementedError{"SetLogLevel"}
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -440,6 +440,8 @@ type Systemd interface {
 	CurrentTasksCount(unit string) (uint64, error)
 	// Run a command
 	Run(command []string, opts *RunOptions) ([]byte, error)
+	// Set log level for the system
+	SetLogLevel(logLevel string) error
 }
 
 // KeyringMode describes how the kernel keyring is setup, see systemd.exec(5)
@@ -1744,4 +1746,9 @@ func (s *systemd) Run(command []string, opts *RunOptions) ([]byte, error) {
 		return nil, fmt.Errorf("cannot run %q: %v", command, osutil.OutputErrCombine(stdout, stderr, err))
 	}
 	return stdout, nil
+}
+
+func (s *systemd) SetLogLevel(logLevel string) error {
+	_, err := s.systemctl("log-level", logLevel)
+	return err
 }

--- a/tests/core/debug/task.yaml
+++ b/tests/core/debug/task.yaml
@@ -1,0 +1,54 @@
+summary: Check that UC debug settings work
+
+details: |
+  Check that UC debug settings enable logging for snapd and
+  setting the log level for systemd as expected.
+
+# Some systemctl calls are not supported on UC16
+systems: [-ubuntu-core-16-*]
+
+execute: |
+  get_log_level() {
+      if os.query is-core-le 18; then
+          systemd-analyze get-log-level
+      else
+          systemctl log-level
+      fi
+  }
+
+  if [ "$SPREAD_REBOOT" = 0 ]; then
+      # Remove the variable introduced by prepare.sh
+      sed -i 's/SNAPD_DEBUG=1//' /etc/systemd/system/snapd.service.d/local.conf
+      systemctl daemon-reload
+      systemctl restart snapd
+      NOMATCH SNAPD_DEBUG=1 < /proc/"$(pgrep snapd)"/environ
+
+      # Check enable/disable snapd debug traces
+      snap set system debug.snapd.log=true
+      MATCH SNAPD_DEBUG=1 < /var/lib/snapd/environment/snapd.conf
+      systemctl restart snapd
+      MATCH SNAPD_DEBUG=1 < /proc/"$(pgrep snapd)"/environ
+      snap set system debug.snapd.log=false
+      not test -f /var/lib/snapd/environment/snapd.conf
+      systemctl restart snapd
+      NOMATCH SNAPD_DEBUG=1 < /proc/"$(pgrep snapd)"/environ
+
+      # Check set systemd log level
+      log_level=$(get_log_level)
+      test "$log_level" = info
+      snap set system debug.systemd.log-level=debug
+      MATCH LogLevel=debug < /etc/systemd/system.conf.d/20-debug_systemd_log-level.conf
+      log_level=$(get_log_level)
+      test "$log_level" = debug
+
+      # Reboot to check log-level is as expected when systemd restarts
+      REBOOT
+  else
+      log_level=$(get_log_level)
+      test "$log_level" = debug
+
+      snap set system debug.systemd.log-level=info
+      MATCH LogLevel=info < /etc/systemd/system.conf.d/20-debug_systemd_log-level.conf
+      log_level=$(get_log_level)
+      test "$log_level" = info
+  fi


### PR DESCRIPTION
- debug.snapd.log to enable debug traces for snapd service. This is
  done by creating an environment file used by the snapd service.
- debug.systemd.log-level to be able to set systemd log level, by
  adding a configuration file to /etc/systemd/system.conf.d/.