### PR TITLE
github,many: add support for running unit tests on other systems

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -351,6 +351,7 @@ jobs:
         name: coverage-files
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 
+  # TODO run unit tests of C code
   unit-tests-special:
     needs: [static-checks]
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -478,6 +478,71 @@ jobs:
         name: coverage-files
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 
+
+  unit-tests-cross-distro:
+    needs: [static-checks]
+    env:
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /usr/sbin:/usr/bin:/sbin:/bin
+      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          # TODO add arch?
+          - fedora:39
+          - opensuse/tumbleweed
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: |
+        # approximation to handle both typical foo:bar (tagged) and foo/bar
+        # (with implicit :latest)
+        distroname="$(echo "${{ matrix.distro }}" | tr : - | tr / -)"
+        case "${{ matrix.distro }}" in
+        fedora:*)
+            dnf install -y rpmdevtools
+            dnf install -y $(rpmspec -q --buildrequires "./packaging/$distroname/snapd.spec")
+            # TODO these are needed only by cmd/snap-seccomp unit tests, and
+            # should be added to BuildRequires
+            dnf install -y glibc-devel.i686 glibc-static.i686
+            ;;
+        opensuse/*)
+            zypper --non-interactive install -y rpmdevtools rpm-build git
+            zypper --non-interactive install -y $(rpmspec -q --buildrequires "./packaging/$distroname/snapd.spec")
+            ;;
+        *)
+            echo "Unsupported distribution variant ${{ matrix.distro }}"
+            exit 1
+            ;;
+        esac
+    - name: Set up test user
+      run: |
+        useradd test-user
+        chown -R test-user:test-user $PWD
+
+    - name: Unit tests (Go)
+      run: |
+        su test-user sh -c "SKIP_DIRTY_CHECK=1 ./run-checks --unit"
+
+    - name: Unit tests (C)
+      run: |
+        su test-user sh -c "./mkversion.sh 1337-git && cd ./cmd && ./autogen.sh && make -j && make check"
+
+
   code-coverage:
     needs: [unit-tests, unit-tests-special]
     runs-on: ubuntu-20.04

--- a/overlord/ifacestate/udevmonitor/udevmon_test.go
+++ b/overlord/ifacestate/udevmonitor/udevmon_test.go
@@ -33,11 +33,23 @@ import (
 
 func TestHotplug(t *testing.T) { TestingT(t) }
 
-type udevMonitorSuite struct{}
+type udevMonitorSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&udevMonitorSuite{})
 
+func (s *udevMonitorSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	cmd := testutil.MockCommand(c, "udevadm", `echo "udev not mocked in tests"; exit 1`)
+	s.AddCleanup(cmd.Restore)
+}
+
 func (s *udevMonitorSuite) TestSmoke(c *C) {
+	cmd := testutil.MockCommand(c, "udevadm", `exit 0`)
+	s.AddCleanup(cmd.Restore)
+
 	mon := udevmonitor.New(nil, nil, nil)
 	c.Assert(mon, NotNil)
 	c.Assert(mon.Connect(), IsNil)

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -125,6 +125,7 @@ BuildRequires: make
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.9}
 BuildRequires:  systemd
 BuildRequires:  fakeroot
+BuildRequires:  squashfs-tools
 %{?systemd_requires}
 
 Requires:       snap-confine%{?_isa} = %{version}-%{release}

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -124,6 +124,7 @@ ExclusiveArch:  %{ix86} x86_64 %{arm} aarch64 ppc64le s390x
 BuildRequires: make
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.9}
 BuildRequires:  systemd
+BuildRequires:  fakeroot
 %{?systemd_requires}
 
 Requires:       snap-confine%{?_isa} = %{version}-%{release}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -113,6 +113,8 @@ type SquashfsTestSuite struct {
 var _ = Suite(&SquashfsTestSuite{})
 
 func (s *SquashfsTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
 	d := c.MkDir()
 	dirs.SetRootDir(d)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
@@ -137,6 +139,8 @@ func (s *SquashfsTestSuite) TearDownTest(c *C) {
 	outbuf, err := io.ReadAll(s.outf)
 	c.Assert(err, IsNil)
 	c.Check(string(outbuf), Equals, "")
+
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *SquashfsTestSuite) TestFileHasSquashfsHeader(c *C) {


### PR DESCRIPTION
Add support for running unit tests on other systems, especially those where we run unit tests as part of the package build process, and ones where the snap mount dir isn't /snap, or libexecdir isn't /usr/lib/snapd.
