### PR TITLE
cmd/snap: improve error message on running a non-existing snap

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -820,6 +820,9 @@ func (s *RunSuite) TestSnapRunAppRetryNoInhibitHintFileThenOngoingRefreshMissing
 	restore = snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
 
+	// Mock that snap exists
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapname"), 0755), check.IsNil)
+
 	var waitWhileInhibitedCalled int
 	restore = snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
 		waitWhileInhibitedCalled++
@@ -1287,9 +1290,9 @@ func (s *RunSuite) TestSnapRunErorsForMissingApp(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "need the application to run as argument")
 }
 
-func (s *RunSuite) TestSnapRunErorrForUnavailableApp(c *check.C) {
+func (s *RunSuite) TestSnapRunErrorForUnavailableApp(c *check.C) {
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "not-there"})
-	c.Assert(err, check.ErrorMatches, fmt.Sprintf("cannot find current revision for snap not-there: readlink %s/not-there/current: no such file or directory", dirs.SnapMountDir))
+	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`snap "not-there" is not installed`))
 }
 
 func (s *RunSuite) TestSnapRunSaneEnvironmentHandling(c *check.C) {

--- a/cmd/snap/inhibit_test.go
+++ b/cmd/snap/inhibit_test.go
@@ -27,11 +27,14 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/snapcore/snapd/client"
 	snaprun "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -321,6 +324,9 @@ func (s *RunSuite) TestWaitWhileInhibitedNotInhibitHintFileOngoingRefresh(c *C) 
 	}
 	restore := snaprun.MockInhibitionFlow(&inhibitionFlow)
 	defer restore()
+
+	// Mock that snap exists
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapname"), 0755), IsNil)
 
 	_, _, hintLock, err := snaprun.WaitWhileInhibited(context.TODO(), snaprun.Client(), "snapname", "app")
 	c.Assert(err, testutil.ErrorIs, snaprun.ErrSnapRefreshConflict)

--- a/tests/main/snap-run-symlink-error/task.yaml
+++ b/tests/main/snap-run-symlink-error/task.yaml
@@ -27,5 +27,4 @@ execute: |
       echo "expected error code 46 but got $err"
       exit 1
     fi
-    MATCH "internal error, please report: running \"xxx\" failed: race condition detected, snap-run can only retry once" < output.txt
-    MATCH "cannot find current revision for snap xxx: readlink $SNAP_MOUNT_DIR/xxx/current: no such file or directory" < output.txt
+    MATCH "snap \"xxx\" is not installed" < output.txt


### PR DESCRIPTION
Due to the hint lockfile race detection logic introduced [here](https://github.com/snapcore/snapd/pull/13747/files#diff-2040a7ab4147eafb94c9b58c40202df922bd298e0ec3d152e322cef32f051db5R76-R82), snap run always shows race detected error when running snaps that don’t exist which can be confusing.
```bash
zeyad@z16:~$ snap run this-snap-does-not-exist
error: race condition detected, snap-run can only retry once
```
Discussion: https://chat.canonical.com/canonical/pl/p8x478mpiibttpudhsqm8zdnco

This PR fixes this by differentiating between snap not existing and a missing current symlink due to ongoing refresh.

Fixes: https://bugs.launchpad.net/snapd/+bug/2067034
