### PR TITLE
api: Add snap info to each task

### DIFF
--- a/client/change.go
+++ b/client/change.go
@@ -65,6 +65,10 @@ type Task struct {
 
 	SpawnTime time.Time `json:"spawn-time,omitempty"`
 	ReadyTime time.Time `json:"ready-time,omitempty"`
+
+	SnapName     string `json:"snap-name,omitempty"`
+	InstanceName string `json:"instance-name,omitempty"`
+	Revision     string `json:"revision,omitempty"`
 }
 
 type TaskProgress struct {

--- a/client/change_test.go
+++ b/client/change_test.go
@@ -107,7 +107,7 @@ func (cs *clientSuite) TestClientChangeError(c *check.C) {
   "summary": "...",
   "status": "Error",
   "ready": true,
-  "tasks": [{"kind": "bar", "summary": "...", "status": "Error", "progress": {"done": 1, "total": 1}, "log": ["ERROR: something broke"]}],
+  "tasks": [{"kind": "bar", "summary": "...", "status": "Error", "progress": {"done": 1, "total": 1}, "log": ["ERROR: something broke"], "snap-name": "a_snap", "instance-name": "instance_value", "revision": "891"}],
   "err": "error message"
 }}`
 
@@ -119,11 +119,14 @@ func (cs *clientSuite) TestClientChangeError(c *check.C) {
 		Summary: "...",
 		Status:  "Error",
 		Tasks: []*client.Task{{
-			Kind:     "bar",
-			Summary:  "...",
-			Status:   "Error",
-			Progress: client.TaskProgress{Done: 1, Total: 1},
-			Log:      []string{"ERROR: something broke"},
+			Kind:         "bar",
+			Summary:      "...",
+			Status:       "Error",
+			Progress:     client.TaskProgress{Done: 1, Total: 1},
+			Log:          []string{"ERROR: something broke"},
+			SnapName:     "a_snap",
+			InstanceName: "instance_value",
+			Revision:     "891",
 		}},
 		Err:   "error message",
 		Ready: true,

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
@@ -336,6 +337,10 @@ type taskInfo struct {
 
 	SpawnTime time.Time  `json:"spawn-time,omitempty"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
+
+	SnapName     string `json:"snap-name,omitempty"`
+	InstanceName string `json:"instance-name,omitempty"`
+	Revision     string `json:"revision,omitempty"`
 }
 
 type taskInfoProgress struct {
@@ -380,6 +385,12 @@ func change2changeInfo(chg *state.Change) *changeInfo {
 				Total: total,
 			},
 			SpawnTime: t.SpawnTime(),
+		}
+		snapsup, err := snapstate.TaskSnapSetup(t)
+		if err == nil {
+			taskInfo.SnapName = snapsup.SnapName()
+			taskInfo.InstanceName = snapsup.InstanceName()
+			taskInfo.Revision = snapsup.Revision().String()
 		}
 		readyTime := t.ReadyTime()
 		if !readyTime.IsZero() {


### PR DESCRIPTION
In order to allow Refresh Awareness to be able to link a task to the corresponding snap being refreshed when a single notice contains several snaps, it is a must to include that info into each task.

This patch adds the snap name, snap instance and snap revision (when available) into each task.

This is only required if a change sent through the notices interface to inform about a snap being auto-refreshed after being closed by the user, can hold tasks for more than one snap. If it is guaranteed that only one snap is assigned to a change, then this isn't needed.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
