### PR TITLE
tests: improve the debug output for spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -674,7 +674,7 @@ debug-each: |
     # Keep it as the last step in debug-each
     echo '# tasks executed on system'
     if [ -f "$RUNTIME_STATE_PATH/runs" ]; then
-        echo "EXECUTED_TESTS=$(cat "$RUNTIME_STATE_PATH/runs)"
+        echo "EXECUTED_TESTS=$(cat $RUNTIME_STATE_PATH/runs)"
     fi
     # Add new line at the end of the debug output
     echo ''

--- a/spread.yaml
+++ b/spread.yaml
@@ -602,6 +602,8 @@ debug-each: |
         echo
 
         remote.exec "sudo journalctl --no-pager -u snapd" || true
+
+        exit
     fi
 
     echo "# definition of snapd.service"
@@ -671,8 +673,11 @@ debug-each: |
 
     # Keep it as the last step in debug-each
     echo '# tasks executed on system'
-    # since the runs file does not have a newline at EOF, add one 
-    echo "" | cat "$RUNTIME_STATE_PATH/runs" - || true
+    if [ -f "$RUNTIME_STATE_PATH/runs" ]; then
+        echo "EXECUTED_TESTS=$(cat "$RUNTIME_STATE_PATH/runs)"
+    fi
+    # Add new line at the end of the debug output
+    echo ''
 
 rename:
     # Move content into a directory, so that deltas computed by repack benefit


### PR DESCRIPTION
This change has 2 improvements:
1. reduce the amount of debug output in nested tests, just show useful information about the nested vm
2. add identifier for the list of tests executed (this will make esasier to query for that list)
