### PR TITLE
testutil: increase settle timeout when running -race

### DIFF
--- a/testutil/timeouts.go
+++ b/testutil/timeouts.go
@@ -20,6 +20,7 @@
 package testutil
 
 import (
+	"os"
 	"runtime"
 	"time"
 )
@@ -31,12 +32,15 @@ var runtimeGOARCH = runtime.GOARCH
 //
 // This should only be used in tests and is a bit of a guess.
 func HostScaledTimeout(t time.Duration) time.Duration {
-	switch runtimeGOARCH {
-	case "riscv64":
+	switch {
+	case runtimeGOARCH == "riscv64":
 		// virt riscv64 builders are 5x times slower than
 		// armhf when building golang-1.14. These tests
 		// timeout, hence bump timeouts by 6x
 		return t * 6
+	case os.Getenv("GO_TEST_RACE") == "1":
+		// the -race detector makes test execution time 2-20x slower
+		return t * 5
 	default:
 		return t
 	}


### PR DESCRIPTION
One of the tests I added in [this PR](https://github.com/snapcore/snapd/pull/13852) has quite a few tasks so it was failing to settle when running with the go race detector. Testing it locally, the tests take 10x longer which is in line with what [the official docs state](https://go.dev/doc/articles/race_detector#:~:text=The%20cost%20of%20race%20detection%20varies%20by%20program%2C%20but%20for%20a%20typical%20program%2C%20memory%20usage%20may%20increase%20by%205%2D10x%20and%20execution%20time%20by%202%2D20x). This PR increases settle timeout when running the test suite with the go race detector on. 