### PR TITLE
 packaging/fedora: attempt deal with a broken FIPS Go toolchain on RHELs

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -569,12 +569,10 @@ BUILDTAGS="${BUILDTAGS} nomanagers"
     # attempt to deal with Go toolchain differences between Fedora and RHEL, where
     # Go is a FIPS compliant fork which pulls in openssl though dlopen()
 
-    # snap-exec does not need CGO and can be built with Go toolchain only
-    %gobuild_static_nocgo -o bin/snap-exec $GOFLAGS %{import_path}/cmd/snap-exec
-
     # on RHEL9 the Go FIPS enabled goolchain appears to be broken when building with
     # no_openssl, so disable CGO completely, but do not set no_openssl build tag
-    # as the no_openssl builds do not build at all
+    # as the no_openssl builds do not build at all, note that the binary produced this way
+    # is not static, and still expects an interpreter
     %gobuild_static_nocgo -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
 
 %if 0%{?rhel} >= 7
@@ -584,6 +582,10 @@ BUILDTAGS="${BUILDTAGS} nomanagers"
     # disable that functionality for statically built binaries
     BUILDTAGS="${BUILDTAGS} no_openssl"
 %endif
+
+    # snap-exec does not need CGO but we need a purely static binary to deal with bare base
+    %gobuild_static -o bin/snap-exec $GOFLAGS %{import_path}/cmd/snap-exec
+
     # snap-update-ns requires CGO to build the C bootstrap code
     %gobuild_static -o bin/snap-update-ns $GOFLAGS %{import_path}/cmd/snap-update-ns
 )

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -71,21 +71,21 @@
 # Until we have a way to add more extldflags to gobuild macro...
 # Always use external linking when building static binaries.
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?amzn2023}
-%define gobuild_static(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags -static'" -a -v -x %{?**};
+%define gobuild_static(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags -static'" -a -v %{?**};
 %endif
 %if 0%{?rhel} == 7
 # no pass PIE flags due to https://bugzilla.redhat.com/show_bug.cgi?id=1634486
-%define gobuild_static(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags -static'" -a -v -x %{?**};
+%define gobuild_static(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags -static'" -a -v %{?**};
 %endif
 
 # These macros are missing BUILDTAGS in RHEL 8/9, see RHBZ#1825138
 %if 0%{?rhel} >= 8 || 0%{?amzn2023}
-%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags'" -a -v -x %{?**};
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags'" -a -v %{?**};
 %endif
 
 # These macros are not defined in RHEL 7
 %if 0%{?rhel} == 7
-%define gobuild(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags'" -a -v -x %{?**};
+%define gobuild(o:) go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -linkmode external -extldflags '%__global_ldflags'" -a -v %{?**};
 %define gotest() go test -compiler gc %{?**};
 %endif
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -793,17 +793,19 @@ prepare: |
         apt-get update && apt-get install -y eatmydata
     fi
 
+    # Enable EPEL see https://docs.fedoraproject.org/en-US/epel/
     case "$SPREAD_SYSTEM" in
         centos-7-*)
-            # make sure EPEL is enabled
             yum install -y epel-release
             ;;
         centos-8-*)
             # enable powertools repository
             dnf config-manager --set-enabled powertools
-            # CentOS Stream requires EPEL Next too, see https://docs.fedoraproject.org/en-US/epel/
             dnf install -y epel-release epel-next-release
             ;;
+        centos-9-*)
+            dnf config-manager --set-enabled crb
+            dnf install -y epel-release epel-next-release
     esac
 
     case "$SPREAD_SYSTEM" in


### PR DESCRIPTION


Explicitly adding no_openssl tag apparently breaks the build with recent
versions of the Go toolchain (observed with 1.22) like so:

```
crypto/tls
/usr/lib/golang/src/crypto/tls/handshake_client_tls13.go:44:20: undefined: supportsHKDF
```

However, simply building code without no_openssl where relevant causes runtime
segfaults:

```
goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x66a130, 0xc0000a36f8)
    /usr/lib/golang/src/runtime/cgocall.go:157 +0x5c fp=0xc0000a36d0 sp=0xc0000a3698 pc=0x405c5c
vendor/github.com/golang-fips/openssl-fips/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL()
    _cgo_gotypes.go:677 +0x49 fp=0xc0000a36f8 sp=0xc0000a36d0 pc=0x55b549
vendor/github.com/golang-fips/openssl-fips/openssl.init.0()
    /usr/lib/golang/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl.go:68 +0xdd fp=0xc0000a3730 sp=0xc0000a36f8 pc=0x55c67d
runtime.doInit(0xbcf3a0)
```

This we selectively apply no-CGO build setup for snap-exec and snapctl. The
snapctl binary does http, and this will rely on crypto from the Go standard
library, which is fine as the communication happens only over a local HTTP
UNIX socket to snapd. However, since snap-update-ns needs C for the early
bootstrap bits, we must pass no_openssl as needed.