### PR TITLE
store: fix race condition warning in test

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -116,6 +116,8 @@ func IsTransferSpeedError(err error) (ok bool, speed float64) {
 }
 
 func (w *TransferSpeedMonitoringWriter) MeasuredWindowsCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.measuredWindows
 }
 


### PR DESCRIPTION
The race detector is failing in a test access:

```
WARNING: DATA RACE
Read at 0x00c000202060 by goroutine 17:
  github.com/snapcore/snapd/store.(*TransferSpeedMonitoringWriter).MeasuredWindowsCount()
      /home/mute/go/src/github.com/snapcore/snapd/store/export_test.go:119 +0x3a5
  github.com/snapcore/snapd/store_test.(*storeDownloadSuite).TestTransferSpeedMonitoringWriterHappy()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_download_test.go:910 +0x3d9
  runtime.call16()
      /usr/local/go1.20/src/runtime/asm_amd64.s:728 +0x48
  reflect.Value.Call()
      /usr/local/go1.20/src/reflect/value.go:370 +0xc7
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xadd
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xec

Previous write at 0x00c000202060 by goroutine 21:
  github.com/snapcore/snapd/store.(*TransferSpeedMonitoringWriter).reset()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_download.go:370 +0x150
  github.com/snapcore/snapd/store.(*TransferSpeedMonitoringWriter).Monitor.func1()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_download.go:409 +0x50

Goroutine 17 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x5c4
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x16b
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x439
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x3e6
  gopkg.in/check%2ev1.Run()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x49
  gopkg.in/check%2ev1.RunAll()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x12b
  gopkg.in/check%2ev1.TestingT()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x565
  github.com/snapcore/snapd/store_test.TestStore()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_test.go:61 +0x2e
  testing.tRunner()
      /usr/local/go1.20/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go1.20/src/testing/testing.go:1629 +0x47

Goroutine 21 (finished) created at:
  github.com/snapcore/snapd/store.(*TransferSpeedMonitoringWriter).Monitor()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_download.go:396 +0x12e
  github.com/snapcore/snapd/store_test.(*storeDownloadSuite).TestTransferSpeedMonitoringWriterHappy()
      /home/mute/go/src/github.com/snapcore/snapd/store/store_download_test.go:894 +0xc4
  runtime.call16()
      /usr/local/go1.20/src/runtime/asm_amd64.s:728 +0x48
  reflect.Value.Call()
      /usr/local/go1.20/src/reflect/value.go:370 +0xc7
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xadd
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/mute/go/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xec
```