### PR TITLE
api-snaps: add refresh-observe access to /v2/snaps/{name}

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -51,7 +51,7 @@ var (
 		Path:        "/v2/snaps/{name}",
 		GET:         getSnapInfo,
 		POST:        postSnap,
-		ReadAccess:  openAccess{},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -970,6 +970,7 @@ func (s *snapsSuite) TestRemoveManyWithPurge(c *check.C) {
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
 }
 func (s *snapsSuite) TestSnapInfoOneIntegration(c *check.C) {
+	s.expectSnapsReadAccess()
 	d := s.daemon(c)
 
 	// we have v0 [r5] installed
@@ -1226,6 +1227,7 @@ UnitFileState=enabled
 }
 
 func (s *snapsSuite) TestSnapInfoNotFound(c *check.C) {
+	s.expectSnapsReadAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
@@ -1234,6 +1236,7 @@ func (s *snapsSuite) TestSnapInfoNotFound(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoNoneFound(c *check.C) {
+	s.expectSnapsReadAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
@@ -1242,6 +1245,7 @@ func (s *snapsSuite) TestSnapInfoNoneFound(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoIgnoresRemoteErrors(c *check.C) {
+	s.expectSnapsReadAccess()
 	s.daemon(c)
 	s.err = errors.New("weird")
 
@@ -1253,6 +1257,7 @@ func (s *snapsSuite) TestSnapInfoIgnoresRemoteErrors(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoReturnsHolds(c *check.C) {
+	s.expectSnapsReadAccess()
 	d := s.daemon(c)
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 
@@ -1331,6 +1336,7 @@ func (s *snapsSuite) TestSnapManyInfosReturnsHolds(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoReturnsRefreshInhibitProceedTime(c *check.C) {
+	s.expectSnapsReadAccess()
 	d := s.daemon(c)
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 

--- a/tests/main/interfaces-snap-refresh-observe/task.yaml
+++ b/tests/main/interfaces-snap-refresh-observe/task.yaml
@@ -35,8 +35,8 @@ execute: |
     # TODO: Check it can only access /v2/snaps?select=refresh-inhibited
     echo "Check snap can access snaps /v2/snaps"
     api-client --socket /run/snapd-snap.socket "/v2/snaps" | jq '."status-code"' | MATCH '^200$'
-    echo "But not a specific snap /v2/snaps/<instance-name>"
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | jq '."status-code"' | MATCH '^403$'
+    echo "And also a specific snap /v2/snaps/<instance-name>"
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | jq '."status-code"' | MATCH '^200$'
 
     echo "Without snap-refresh-observe the snap cannot access those API endpoints"
     snap disconnect api-client:snap-refresh-observe
@@ -45,3 +45,4 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/changes" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/snaps" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | jq '."status-code"' | MATCH '^403$'


### PR DESCRIPTION
Access to /v2/snaps/{name} is required for snap-refresh-observe because it is needed to get the path for the XXXXX.desktop file, which is needed for the icon and the visible name.

It should not be a problem because /v2/snaps is already enabled.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
