### PR TITLE
tests/main: add missing test details

### DIFF
--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,4 +1,9 @@
-summary: Run snap sign to sign a model assertion
+summary: Run `snap sign` to sign a model assertion
+
+details: |
+    Check that `snap sign` command can sign a model assertion using
+    keys created manually through `snap create-key`. Also check that the
+    model can be passed to `snap sign` as a file or piped through stdin.
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 # amazon: requires extra gpg-agent setup

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,5 +1,10 @@
 summary: Ensure security profile re-generation works with system-key
 
+details: |
+    Check that security profile are re-generated when a system-key
+    version mismatch is detected. Also check that `snap run` waits
+    for system-key updates unless when it can talk to snapd.
+
 prepare: |
     echo "Make backup of fstab"
     cp /etc/fstab /tmp/fstab.save

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that sockets for user services are created correctly
 
+details: |
+    Check that socket activiations for snap user services are created
+    correctly when the experimental user-daemons flag is enabled.
+
 systems:
     # Ubuntu 14.04's systemd doesn't have user@.service
     - -ubuntu-14.04-*

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -1,5 +1,10 @@
 summary: Check that snap user services are started on install in existing sessions
 
+details: |
+    Check that snap user services are started on install in existing
+    sessions when the experimental user-daemons flag is enabled. Also
+    Check that the services are stopped when the snap is removed.
+
 systems:
     # Ubuntu 14.04's systemd doesn't have user@.service
     - -ubuntu-14.04-*

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -1,9 +1,9 @@
 summary: Check that snap user services are started on install in existing sessions
 
 details: |
-    Check that snap user services are started on install in existing
-    sessions when the experimental user-daemons flag is enabled. Also
-    Check that the services are stopped when the snap is removed.
+    Check that sockets are created and activated correctly for snap user services when a
+    service snap is installed and the experimental user-daemons flag is enabled. Also
+    check that the services are stopped when the snap is removed.
 
 systems:
     # Ubuntu 14.04's systemd doesn't have user@.service

--- a/tests/main/snap-user-service-upgrade-failure/task.yaml
+++ b/tests/main/snap-user-service-upgrade-failure/task.yaml
@@ -1,5 +1,9 @@
 summary: On upgrade failures, user session daemons are restarted
 
+details: |
+    Check that snapd restarts the user session daemons when snap
+    refresh fails.
+
 systems:
     # Ubuntu 14.04's systemd doesn't have user@.service
     - -ubuntu-14.04-*

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,5 +1,10 @@
 summary: Check that snap userd can autostart user session applications
 
+details: |
+    Check that `snap userd --autostart` detects and starts snap user
+    session applications which have the `autostart` property if the specified
+    desktop files exist under $SNAP_USER_DATA/.config/autostart/.
+
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
     rm -f ~/snap/test-snapd-xdg-autostart/current/.config/autostart/foo.desktop

--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -1,4 +1,8 @@
-summary: Check that core refresh will create the userd dbus serivce file
+summary: Check that core refresh will create the userd dbus service file
+
+details: |
+    Check that snapd will create the userd dbus service file if
+    it is missing when the core snap is refreshed.
 
 # only run on systems that re-exec
 systems: [ubuntu-1*, ubuntu-2*, debian-*]
@@ -8,7 +12,7 @@ environment:
     SNAPD_NO_MEMORY_LIMIT: 1
 
 restore: |
-    # Remove the locale revision of core, if we installed one.
+    # Remove the local revision of core, if we installed one.
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
         snap revert core


### PR DESCRIPTION
Affected tests:

- tests/main/snap-sign/task.yaml
- tests/main/snap-system-key/task.yaml
- tests/main/snap-user-service-socket-activation/task.yaml
- tests/main/snap-user-service-start-on-install/task.yaml
- tests/main/snap-user-service-upgrade-failure/task.yaml
- tests/main/snap-userd-desktop-app-autostart/task.yaml
- tests/main/snap-userd-reexec/task.yaml