### PR TITLE
notify: Dont send refresh complete notification if snap refresh observe is connected

### DIFF
--- a/overlord/snapstate/agentnotify/agentnotify.go
+++ b/overlord/snapstate/agentnotify/agentnotify.go
@@ -61,7 +61,7 @@ func notifyLinkSnap(st *state.State, snapsup *snapstate.SnapSetup) error {
 	// closed an application that had a auto-refresh ready.
 	if snapsup.Flags.IsContinuedAutoRefresh {
 		logger.Debugf("notifying user client about continued refresh for %q", snapsup.InstanceName())
-		sendClientFinishRefreshNotification(st, snapsup)
+		maybeSendClientFinishRefreshNotification(st, snapsup)
 	}
 
 	return nil
@@ -77,7 +77,7 @@ var asyncFinishRefreshNotification = func(refreshInfo *userclient.FinishedSnapRe
 	}()
 }
 
-var sendClientFinishRefreshNotification = func(st *state.State, snapsup *snapstate.SnapSetup) {
+var maybeSendClientFinishRefreshNotification = func(st *state.State, snapsup *snapstate.SnapSetup) {
 	tr := config.NewTransaction(st)
 	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
 	if err != nil && !config.IsNoOption(err) {

--- a/overlord/snapstate/agentnotify/agentnotify.go
+++ b/overlord/snapstate/agentnotify/agentnotify.go
@@ -91,7 +91,7 @@ var sendClientFinishRefreshNotification = func(st *state.State, snapsup *snapsta
 
 	markerExists, err := snapstate.HasActiveConnection(st, "snap-refresh-observe")
 	if err != nil {
-		logger.Noticef("Cannot send notification about pending refresh: %v", err)
+		logger.Noticef("Cannot send notification about finished refresh: %v", err)
 		return
 	}
 	if markerExists {

--- a/overlord/snapstate/agentnotify/agentnotify.go
+++ b/overlord/snapstate/agentnotify/agentnotify.go
@@ -22,7 +22,6 @@ package agentnotify
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/logger"
@@ -90,7 +89,6 @@ var sendClientFinishRefreshNotification = func(st *state.State, snapsup *snapsta
 		return
 	}
 
-	fmt.Println("Checking hasActiveConnection")
 	markerExists, err := snapstate.HasActiveConnection(st, "snap-refresh-observe")
 	if err != nil {
 		logger.Noticef("Cannot send notification about pending refresh: %v", err)

--- a/overlord/snapstate/agentnotify/agentnotify.go
+++ b/overlord/snapstate/agentnotify/agentnotify.go
@@ -81,7 +81,7 @@ var sendClientFinishRefreshNotification = func(st *state.State, snapsup *snapsta
 	tr := config.NewTransaction(st)
 	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
 	if err != nil && !config.IsNoOption(err) {
-		logger.Noticef("Cannot send notification about pending refresh: %v", err)
+		logger.Noticef("Cannot send notification about finished refresh: %v", err)
 		return
 	}
 	if experimentalRefreshAppAwarenessUX {

--- a/overlord/snapstate/agentnotify/agentnotify_test.go
+++ b/overlord/snapstate/agentnotify/agentnotify_test.go
@@ -24,11 +24,13 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/agentnotify"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	userclient "github.com/snapcore/snapd/usersession/client"
 )
 
 func TestAgentNotify(t *testing.T) { TestingT(t) }
@@ -48,7 +50,7 @@ func (s *agentNotifySuite) TestNotifyAgentOnLinkChange(c *C) {
 	defer s.st.Unlock()
 
 	var callCount int
-	r := agentnotify.MockSendClientFinishRefreshNotification(func(st *state.State, snapsup *snapstate.SnapSetup) {
+	r := agentnotify.MockMaybeSendClientFinishRefreshNotification(func(st *state.State, snapsup *snapstate.SnapSetup) {
 		c.Check(snapsup.InstanceName(), Equals, "some-snap")
 		callCount++
 	})
@@ -82,4 +84,70 @@ func (s *agentNotifySuite) TestNotifyAgentOnLinkChange(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(callCount, Equals, tc.expectedCallCount)
 	}
+}
+
+func (s *agentNotifySuite) TestMaybeAsyncFinishedRefreshNotification(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	var connCheckCalled int
+	restore := agentnotify.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
+		connCheckCalled++
+		c.Check(iface, Equals, "snap-refresh-observe")
+		// no snap has the marker interface connected
+		return false, nil
+	})
+	defer restore()
+
+	sendInfo := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "pkg"},
+	}
+	expectedInfo := userclient.FinishedSnapRefreshInfo{
+		InstanceName: "pkg",
+	}
+	notificationCalled := 0
+	restore = agentnotify.MockAsyncFinishRefreshNotification(func(info *userclient.FinishedSnapRefreshInfo) {
+		notificationCalled++
+		c.Check(info.InstanceName, Equals, expectedInfo.InstanceName)
+	})
+	defer restore()
+
+	tr := config.NewTransaction(s.st)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
+	tr.Commit()
+
+	agentnotify.MaybeSendClientFinishedRefreshNotification(s.st, sendInfo)
+	// no notification as refresh-appawareness-ux is enabled
+	// i.e. notices + warnings fallback is used instead
+	c.Check(connCheckCalled, Equals, 0)
+	c.Check(notificationCalled, Equals, 0)
+
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+
+	agentnotify.MaybeSendClientFinishedRefreshNotification(s.st, sendInfo)
+	// notification sent as refresh-appawareness-ux is now disabled
+	c.Check(connCheckCalled, Equals, 1)
+	c.Check(notificationCalled, Equals, 1)
+}
+
+func (s *agentNotifySuite) TestMaybeAsyncFinishedRefreshNotificationSkips(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	var connCheckCalled int
+	restore := agentnotify.MockHasActiveConnection(func(st *state.State, iface string) (bool, error) {
+		connCheckCalled++
+		c.Check(iface, Equals, "snap-refresh-observe")
+		// marker interface found
+		return true, nil
+	})
+	defer restore()
+
+	restore = agentnotify.MockAsyncFinishRefreshNotification(func(info *userclient.FinishedSnapRefreshInfo) {
+		c.Fatal("shouldn't trigger Finished refresh notification because marker interface is connected")
+	})
+	defer restore()
+
+	agentnotify.MaybeSendClientFinishedRefreshNotification(s.st, &snapstate.SnapSetup{})
 }

--- a/overlord/snapstate/agentnotify/agentnotify_test.go
+++ b/overlord/snapstate/agentnotify/agentnotify_test.go
@@ -48,7 +48,7 @@ func (s *agentNotifySuite) TestNotifyAgentOnLinkChange(c *C) {
 	defer s.st.Unlock()
 
 	var callCount int
-	r := agentnotify.MockSendClientFinishRefreshNotification(func(snapsup *snapstate.SnapSetup) {
+	r := agentnotify.MockSendClientFinishRefreshNotification(func(st *state.State, snapsup *snapstate.SnapSetup) {
 		c.Check(snapsup.InstanceName(), Equals, "some-snap")
 		callCount++
 	})

--- a/overlord/snapstate/agentnotify/export_test.go
+++ b/overlord/snapstate/agentnotify/export_test.go
@@ -23,14 +23,30 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
+	userclient "github.com/snapcore/snapd/usersession/client"
 )
 
 var (
-	NotifyAgentOnLinkageChange = notifyAgentOnLinkageChange
+	NotifyAgentOnLinkageChange                 = notifyAgentOnLinkageChange
+	MaybeSendClientFinishedRefreshNotification = maybeSendClientFinishRefreshNotification
 )
 
-func MockSendClientFinishRefreshNotification(f func(*state.State, *snapstate.SnapSetup)) (restore func()) {
-	r := testutil.Backup(&sendClientFinishRefreshNotification)
-	sendClientFinishRefreshNotification = f
+func MockMaybeSendClientFinishRefreshNotification(f func(*state.State, *snapstate.SnapSetup)) (restore func()) {
+	r := testutil.Backup(&maybeSendClientFinishRefreshNotification)
+	maybeSendClientFinishRefreshNotification = f
 	return r
+}
+
+func MockAsyncFinishRefreshNotification(f func(*userclient.FinishedSnapRefreshInfo)) (restore func()) {
+	r := testutil.Backup(&asyncFinishRefreshNotification)
+	asyncFinishRefreshNotification = f
+	return r
+}
+
+func MockHasActiveConnection(fn func(st *state.State, iface string) (bool, error)) (restore func()) {
+	old := snapstate.HasActiveConnection
+	snapstate.HasActiveConnection = fn
+	return func() {
+		snapstate.HasActiveConnection = old
+	}
 }

--- a/overlord/snapstate/agentnotify/export_test.go
+++ b/overlord/snapstate/agentnotify/export_test.go
@@ -21,6 +21,7 @@ package agentnotify
 
 import (
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -28,7 +29,7 @@ var (
 	NotifyAgentOnLinkageChange = notifyAgentOnLinkageChange
 )
 
-func MockSendClientFinishRefreshNotification(f func(*snapstate.SnapSetup)) (restore func()) {
+func MockSendClientFinishRefreshNotification(f func(*state.State, *snapstate.SnapSetup)) (restore func()) {
 	r := testutil.Backup(&sendClientFinishRefreshNotification)
 	sendClientFinishRefreshNotification = f
 	return r

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -744,24 +744,13 @@ var asyncPendingRefreshNotification = func(ctx context.Context, refreshInfo *use
 // The notification is sent only if no snap has the marker "snap-refresh-observe"
 // interface connected and the "refresh-app-awareness-ux" experimental flag is disabled.
 func maybeAsyncPendingRefreshNotification(ctx context.Context, st *state.State, refreshInfo *userclient.PendingSnapRefreshInfo) {
-	tr := config.NewTransaction(st)
-	experimentalRefreshAppAwarenessUX, err := features.Flag(tr, features.RefreshAppAwarenessUX)
-	if err != nil && !config.IsNoOption(err) {
-		logger.Noticef("Cannot send notification about pending refresh: %v", err)
-		return
-	}
-	if experimentalRefreshAppAwarenessUX {
-		// use notices + warnings fallback flow instead
-		return
-	}
 
-	markerExists, err := HasActiveConnection(st, "snap-refresh-observe")
+	sendNotification, err := ShouldSendNotificationsToTheUser(st)
 	if err != nil {
 		logger.Noticef("Cannot send notification about pending refresh: %v", err)
 		return
 	}
-	if markerExists {
-		// found snap with marker interface, skip notification
+	if !sendNotification {
 		return
 	}
 	asyncPendingRefreshNotification(ctx, refreshInfo)


### PR DESCRIPTION
The new Refresh Awareness specification moves all the work of showing refresh progress and notifications into a specific snap. To detect when that snap is available or not, snapd checks if there is a snap with the snap-refresh-observe interface connected. In that case, it presumes that it will manage all the notifications, and won't send any by itself.

Unfortunately, only the "Pending refresh" notification checks this case, while the "Refresh complete" notification doesn't. This results in duplicated notifications.

This patch fixes this.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
