### PR TITLE
packaging: make sure that /var/lib/snapd/environment exists

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -123,6 +123,7 @@ install::
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/dbus-1/system-services
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/desktop/applications
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/device
+	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/environment
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/hostfs
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/inhibit
 	install -m 755 -d $(DESTDIR)/$(sharedstatedir)/snapd/lib/gl


### PR DESCRIPTION
Have the snapd packaging helper create /var/lib/snapd/environment. This fixes RPM build on openSUSE:

```
RPM build errors:
    Directory not found: /usr/src/packages/BUILDROOT/snapd-1337.2.63-0.x86_64/var/lib/snapd/environment
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
