### PR TITLE
tests/lib/fakestore/store: do not hardcode port in fakestore unit tests

### DIFF
--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -122,6 +122,8 @@ func (s *Store) Start() error {
 		return err
 	}
 
+	s.url = fmt.Sprintf("http://%s", l.Addr())
+
 	go s.srv.Serve(l)
 	return nil
 }


### PR DESCRIPTION
The unit tests hardcode the port number, which occasionally seems to be occupied by something else when running the whole test suite on GH (most likely tests from another package). Have the port number be selected by the kernel.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
