### PR TITLE
tests: saving executed tests list as part of the tests error reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -755,7 +755,7 @@ jobs:
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
             issues_metadata='{"source_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error-debug --output spread-results.json --cut 100
+            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error-debug --output spread-results.json --cut 100 -dr "executed_tests=EXECUTED_TESTS=(.*)"
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Reporting spread error..."
@@ -923,7 +923,7 @@ jobs:
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
             issues_metadata='{"source_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error --output spread-results.json --cut 100
+            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error --output spread-results.json --cut 100 -dr "executed_tests=EXECUTED_TESTS=(.*)"
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Reporting spread error..."


### PR DESCRIPTION
The idea is to save which test were executed to be able to predict which test is causing the issues

Next step is to create a job to query the list of tests and try to determine if there is a previous test which is causing the problem.