### PR TITLE
daemon: attach affected-snaps data to tasks

### DIFF
--- a/daemon/export_api_general_test.go
+++ b/daemon/export_api_general_test.go
@@ -56,3 +56,11 @@ func MockWarningsAccessors(okay func(*state.State, time.Time) int, all func(*sta
 type (
 	ChangeInfo = changeInfo
 )
+
+func MockSnapstateSnapsAffectedByTask(f func(t *state.Task) ([]string, error)) (restore func()) {
+	old := snapstateSnapsAffectedByTask
+	snapstateSnapsAffectedByTask = f
+	return func() {
+		snapstateSnapsAffectedByTask = old
+	}
+}

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -76,7 +76,8 @@ func RegisterAffectedSnapsByKind(kind string, f AffectedSnapsFunc) {
 	affectedSnapsByKind[kind] = f
 }
 
-func affectedSnaps(t *state.Task) ([]string, error) {
+// SnapsAffectedByTask returns a list of names of snaps affected by the given task.
+func SnapsAffectedByTask(t *state.Task) ([]string, error) {
 	// snapstate's own styled tasks
 	if t.Has("snap-setup") || t.Has("snap-setup-task") {
 		snapsup, err := TaskSnapSetup(t)
@@ -281,7 +282,7 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 			continue
 		}
 
-		snaps, err := affectedSnaps(task)
+		snaps, err := SnapsAffectedByTask(task)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -567,3 +567,19 @@ func SetPreseed(snapmgr *SnapManager, value bool) {
 func SplitEssentialUpdates(deviceCtx DeviceContext, updates []minimalInstallInfo) (essential, nonEssential []MinimalInstallInfo) {
 	return splitEssentialUpdates(deviceCtx, updates)
 }
+
+func MockAffectedSnapsByAttr(value map[string]AffectedSnapsFunc) (restore func()) {
+	old := affectedSnapsByAttr
+	affectedSnapsByAttr = value
+	return func() {
+		affectedSnapsByAttr = old
+	}
+}
+
+func MockAffectedSnapsByKind(value map[string]AffectedSnapsFunc) (restore func()) {
+	old := affectedSnapsByKind
+	affectedSnapsByKind = value
+	return func() {
+		affectedSnapsByKind = old
+	}
+}


### PR DESCRIPTION
This PR is an iteration based on #13902 which allows `/v2/changes` API caller to associate each task with the relevant affected snaps which is useful in the case change progress tracking per snap when a change is associated with multiple snaps.

This exact use case is needed by snapd-desktop-integration.

Note: When this is merged, The [REST API docs](https://snapcraft.io/docs/snapd-api#heading--changes) need to be updated as well.