### PR TITLE
o/snapstate: in hybrid systems re-refresh before reboot if possible

### DIFF
--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -260,6 +260,13 @@ func (rm *RestartManager) rebootDidNotHappen() error {
 // pendingForSystemRestart returns true if the change has tasks that are set to
 // wait pending a manual system restart. It is registered with the prune logic.
 func (rm *RestartManager) pendingForSystemRestart(chg *state.Change) bool {
+	return rm.pendingForSystemRestartConsidering(chg, nil)
+}
+
+// pendingForSystemRestart returns true if the change has tasks in the
+// considerTasks that are set to wait pending a manual system restart. It is
+// registered with the prune logic.
+func (rm *RestartManager) pendingForSystemRestartConsidering(chg *state.Change, considerTasks map[string]bool) bool {
 	if chg.IsReady() {
 		return false
 	}
@@ -268,6 +275,11 @@ func (rm *RestartManager) pendingForSystemRestart(chg *state.Change) bool {
 	}
 	for _, t := range chg.Tasks() {
 		if t.Status() != state.WaitStatus {
+			continue
+		}
+
+		// if we're considering only a subset, ignore tasks not in it
+		if considerTasks != nil && !considerTasks[t.ID()] {
 			continue
 		}
 
@@ -534,8 +546,14 @@ func FinishTaskWithRestart(t *state.Task, status state.Status, restartType Resta
 
 // PendingForChange checks if a system restart is pending for a change.
 func PendingForChange(st *state.State, chg *state.Change) bool {
+	return PendingForChangeConsidering(st, chg, nil)
+}
+
+// PendingForChangeConsidering checks if a system restart is pending for a
+// change, ignoring tasks other than the task IDs supplied.
+func PendingForChangeConsidering(st *state.State, chg *state.Change, considerTasks map[string]bool) bool {
 	rm := restartManager(st, "internal error: cannot request a restart before RestartManager initialization")
-	return rm.pendingForSystemRestart(chg)
+	return rm.pendingForSystemRestartConsidering(chg, considerTasks)
 }
 
 // TaskWaitForRestart can be used for tasks that need to wait for a pending

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -260,13 +260,13 @@ func (rm *RestartManager) rebootDidNotHappen() error {
 // pendingForSystemRestart returns true if the change has tasks that are set to
 // wait pending a manual system restart. It is registered with the prune logic.
 func (rm *RestartManager) pendingForSystemRestart(chg *state.Change) bool {
-	return rm.pendingForSystemRestartConsidering(chg, nil)
+	return rm.pendingForSystemRestartTasks(chg, nil)
 }
 
-// pendingForSystemRestart returns true if the change has tasks in the
-// considerTasks that are set to wait pending a manual system restart. It is
-// registered with the prune logic.
-func (rm *RestartManager) pendingForSystemRestartConsidering(chg *state.Change, considerTasks map[string]bool) bool {
+// pendingForSystemRestart returns true if the change has tasks set to wait,
+// if considerTasks is non-nil only those tasks are considered. It is registered
+// with the prune logic.
+func (rm *RestartManager) pendingForSystemRestartTasks(chg *state.Change, considerTasks map[string]bool) bool {
 	if chg.IsReady() {
 		return false
 	}
@@ -546,14 +546,14 @@ func FinishTaskWithRestart(t *state.Task, status state.Status, restartType Resta
 
 // PendingForChange checks if a system restart is pending for a change.
 func PendingForChange(st *state.State, chg *state.Change) bool {
-	return PendingForChangeConsidering(st, chg, nil)
+	return PendingForChangeTasks(st, chg, nil)
 }
 
-// PendingForChangeConsidering checks if a system restart is pending for a
+// PendingForChangeTasks checks if a system restart is pending for a
 // change, ignoring tasks other than the task IDs supplied.
-func PendingForChangeConsidering(st *state.State, chg *state.Change, considerTasks map[string]bool) bool {
+func PendingForChangeTasks(st *state.State, chg *state.Change, considerTasks map[string]bool) bool {
 	rm := restartManager(st, "internal error: cannot request a restart before RestartManager initialization")
-	return rm.pendingForSystemRestartConsidering(chg, considerTasks)
+	return rm.pendingForSystemRestartTasks(chg, considerTasks)
 }
 
 // TaskWaitForRestart can be used for tasks that need to wait for a pending

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4282,7 +4282,8 @@ func changeReadyUpToTask(task *state.Task, considerTasks map[string]bool) bool {
 // true if any of the snaps failed to refresh.
 //
 // It does this by advancing through the given task's change's tasks, and keeping
-// track of the instance names from every SnapSetup in "download-snap" tasks it finds.
+// track of the instance names from every SnapSetup in "download-snap" tasks it
+// finds, ignoring tasks in considerTasks (e.g., unrelated tasks in split refresh).
 // It stops when finding the given task, and resetting things when finding a different
 // re-refresh task (that indicates the end of a batch that isn't the given one).
 func refreshedSnaps(reTask *state.Task, considerTasks map[string]bool) (snapNames []string, failed bool, err error) {
@@ -4408,7 +4409,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	// the restart to happen before proceeding, otherwise we will be blocking
 	// any restart that is waiting to occur. We handle this here as this
 	// task is dynamically added.
-	if restart.PendingForChangeConsidering(st, t.Change(), considerTasks) {
+	if restart.PendingForChangeTasks(st, t.Change(), considerTasks) {
 		return restart.TaskWaitForRestart(t)
 	}
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4260,13 +4260,14 @@ func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// changeReadyUpToTask returns whether all other change's tasks are Ready.
-func changeReadyUpToTask(task *state.Task) bool {
+// changeReadyUpToTask returns whether all the tasks in considerTasks, or all
+// of the change's tasks if considerTasks is nil, are Ready.
+func changeReadyUpToTask(task *state.Task, considerTasks map[string]bool) bool {
 	me := task.ID()
 	change := task.Change()
 	for _, task := range change.Tasks() {
-		if me == task.ID() {
-			// ignore self
+		if me == task.ID() || (considerTasks != nil && !considerTasks[task.ID()]) {
+			// ignore self and tasks meant to be considered
 			continue
 		}
 		if !task.Status().Ready() {
@@ -4284,7 +4285,7 @@ func changeReadyUpToTask(task *state.Task) bool {
 // track of the instance names from every SnapSetup in "download-snap" tasks it finds.
 // It stops when finding the given task, and resetting things when finding a different
 // re-refresh task (that indicates the end of a batch that isn't the given one).
-func refreshedSnaps(reTask *state.Task) (snapNames []string, failed bool, err error) {
+func refreshedSnaps(reTask *state.Task, considerTasks map[string]bool) (snapNames []string, failed bool, err error) {
 	// NOTE nothing requires reTask to be a check-rerefresh task, nor even to be in
 	// a refresh-ish change, but it doesn't make much sense to call this otherwise.
 	tid := reTask.ID()
@@ -4305,6 +4306,12 @@ func refreshedSnaps(reTask *state.Task) (snapNames []string, failed bool, err er
 		// Ignore tasks on '0' lane, they are not refreshes anyway.
 		taskLanes := task.Lanes()
 		if len(taskLanes) == 1 && taskLanes[0] == 0 {
+			continue
+		}
+
+		// ignore tasks that we're explicitly not considering (e.g., refreshes of
+		// essential tasks in hybrid systems, see splitRefresh in snapstate.go)
+		if considerTasks != nil && !considerTasks[task.ID()] {
 			continue
 		}
 
@@ -4354,6 +4361,9 @@ func refreshedSnaps(reTask *state.Task) (snapNames []string, failed bool, err er
 // reRefreshSetup holds the necessary details to re-refresh snaps that need it
 type reRefreshSetup struct {
 	UserID int `json:"user-id,omitempty"`
+	// TaskIDs holds the task IDs that the re-refresh task should wait for
+	// before running.
+	TaskIDs []string `json:"task-ids,omitempty"`
 	*Flags
 }
 
@@ -4381,19 +4391,32 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		logger.Panicf("Re-refresh task has %d tasks waiting for it.", numHaltTasks)
 	}
 
-	// Is there a restart pending for the current change? Then wait for
-	// restart to happen before proceeding, otherwise we will be blocking
+	var re reRefreshSetup
+	if err := t.Get("rerefresh-setup", &re); err != nil {
+		return err
+	}
+
+	var considerTasks map[string]bool
+	if re.TaskIDs != nil {
+		considerTasks = make(map[string]bool, len(re.TaskIDs))
+		for _, id := range re.TaskIDs {
+			considerTasks[id] = true
+		}
+	}
+
+	// Is there a restart pending for one of the relevant tasks? Then wait for
+	// the restart to happen before proceeding, otherwise we will be blocking
 	// any restart that is waiting to occur. We handle this here as this
 	// task is dynamically added.
-	if restart.PendingForChange(st, t.Change()) {
+	if restart.PendingForChangeConsidering(st, t.Change(), considerTasks) {
 		return restart.TaskWaitForRestart(t)
 	}
 
-	if !changeReadyUpToTask(t) {
+	if !changeReadyUpToTask(t, considerTasks) {
 		return &state.Retry{After: reRefreshRetryTimeout, Reason: "pending refreshes"}
 	}
 
-	snaps, failed, err := refreshedSnaps(t)
+	snaps, failed, err := refreshedSnaps(t, considerTasks)
 	if err != nil {
 		return err
 	}
@@ -4441,11 +4464,6 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		if err := AddCurrentTrackingToValidationSetsStack(st); err != nil {
 			return err
 		}
-	}
-
-	var re reRefreshSetup
-	if err := t.Get("rerefresh-setup", &re); err != nil {
-		return err
 	}
 
 	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -281,7 +281,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshWaitOnPendingRestart(c *C) {
 
 // wrapper around snapstate.RefreshedSnaps for easier testing
 func refreshedSnaps(c *C, task *state.Task) string {
-	snaps, _, err := snapstate.RefreshedSnaps(task)
+	snaps, _, err := snapstate.RefreshedSnaps(task, nil)
 	c.Assert(err, IsNil)
 	sort.Strings(snaps)
 	return strings.Join(snaps, ",")
@@ -440,7 +440,7 @@ func (s *reRefreshSuite) TestLaneSnapsInvalidSetup(c *C) {
 	task := s.state.NewTask("check-rerefresh", "...")
 	chg.AddTask(task)
 
-	snaps, _, err := snapstate.RefreshedSnaps(task)
+	snaps, _, err := snapstate.RefreshedSnaps(task, nil)
 	c.Check(snaps, HasLen, 0)
 	c.Check(err, ErrorMatches, `internal error: expected SnapSetup for download-snap: no state entry for key "snap-setup"`)
 }


### PR DESCRIPTION
In hybrid systems where we do refreshes of apps before the reboot and essential snaps after, check if a re-refresh is necessary after the apps are done instead of waiting for all (and therefore a reboot). This is possible because currently essential snaps don't use epochs and don't require re-refreshes. If an app has a dependency that requires a reboot (like the model base), then the check-rerefresh task needs to wait for that refresh to complete. Since, if we're waiting for the reboot, there isn't much to gain in resolving the app's dependencies to only wait for those, the check-rerefresh preserves the old behavior in that case to keep things simple.
