### PR TITLE
wrappers: proxy missing enable+disabledSvcs to service agent

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -140,12 +140,20 @@ func (c *userServiceClient) stopServices(services ...string) error {
 	return err
 }
 
-func (c *userServiceClient) startServices(services ...string) error {
+// startServices attempts to start the provided list of services on each available
+// system user. 'disabledServices' can be used to filter services that should be ignored on a per-user basis.
+func (c *userServiceClient) startServices(enable bool, disabledServices map[int][]string, services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
 
-	startFailures, stopFailures, err := c.cli.ServicesStart(ctx, services, client.ClientServicesStartOptions{})
+	startFailures, stopFailures, err := c.cli.ServicesStart(ctx, services, client.ClientServicesStartOptions{
+		Enable:           enable,
+		DisabledServices: disabledServices,
+	})
 	for _, f := range startFailures {
+		if err == nil {
+			err = fmt.Errorf(fmt.Sprintf("Could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+		}
 		c.inter.Notify(fmt.Sprintf("Could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
 	for _, f := range stopFailures {
@@ -382,8 +390,13 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, flags *
 	}
 
 	if len(userServices) != 0 {
+		var disabledUserSvcs map[int][]string
+		if disabledSvcs != nil {
+			disabledUserSvcs = disabledSvcs.UserServices
+		}
+
 		timings.Run(tm, "start-user-services", "start user services", func(nested timings.Measurer) {
-			err = cli.startServices(userServices...)
+			err = cli.startServices(flags.Enable, disabledUserSvcs, userServices...)
 		})
 		// let the cleanup know some services may have been started
 		servicesStarted = true


### PR DESCRIPTION
This properly proxies the enable request to the user-session agent, along with the disabled-services for user services (however not used yet, will be used by https://github.com/snapcore/snapd/pull/13905)

