### PR TITLE
wrappers: wrappers: cleanup and improve how we start/undo start services

### DIFF
--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -3434,7 +3434,9 @@ func (s *servicesTestSuite) TestStartServicesStopsServicesIncludingActivation(c 
 	s.systemctlRestorer()
 	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		s.sysdLog = append(s.sysdLog, cmd)
-		if len(cmd) == 2 && cmd[0] == "start" && cmd[1] == "snap.hello-snap.svc1.sock1.socket" {
+		// Inject an error into the last socket of the last service so we can see the full
+		// 'undo' logic chain
+		if len(cmd) == 3 && cmd[1] == "start" && cmd[2] == "snap.hello-snap.svc2.sock2.socket" {
 			return []byte("no"), fmt.Errorf("mock error")
 		}
 		return []byte("ActiveState=inactive\n"), nil
@@ -3480,19 +3482,24 @@ func (s *servicesTestSuite) TestStartServicesStopsServicesIncludingActivation(c 
 		{"daemon-reload"},
 		{"--user", "--global", "--no-reload", "enable", "snap.hello-snap.svc2.sock1.socket", "snap.hello-snap.svc2.sock2.socket"},
 
-		// Start phase for service activation units, we have rigged the game by making sure this stage fails,
-		// so only one of the services will attempt to start
+		// Start phase for system service activation units
 		{"start", "snap.hello-snap.svc1.sock1.socket"},
+		{"start", "snap.hello-snap.svc1.sock2.socket"},
 
-		// Stop phase, where we attempt to stop the activation units and the primary services
-		// We first attempt to stop the user services, then the system services
+		// Start phase for user service activation units, we have rigged the system here to
+		// fail on this step, so we can test undo logic.
+		{"--user", "--no-reload", "enable", "snap.hello-snap.svc2.sock1.socket", "snap.hello-snap.svc2.sock2.socket"},
+		{"--user", "daemon-reload"},
+		{"--user", "start", "snap.hello-snap.svc2.sock1.socket"},
+		{"--user", "start", "snap.hello-snap.svc2.sock2.socket"},
+
+		// It failed, we attempt to stop all started user services again
 		{"--user", "stop", "snap.hello-snap.svc2.sock1.socket"},
 		{"--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock1.socket"},
-		{"--user", "stop", "snap.hello-snap.svc2.sock2.socket"},
-		{"--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.sock2.socket"},
-		{"--user", "stop", "snap.hello-snap.svc2.service"},
-		{"--user", "show", "--property=ActiveState", "snap.hello-snap.svc2.service"},
+		{"--user", "--no-reload", "disable", "snap.hello-snap.svc2.sock1.socket", "snap.hello-snap.svc2.sock2.socket"},
+		{"--user", "daemon-reload"},
 
+		// Stop system services again
 		{"stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.hello-snap.svc1.service"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock2.socket"},
@@ -3945,15 +3952,14 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(svcs, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc1Name, svc2Name},
 		{"daemon-reload"},
 		{"start", svc1Name},
 		{"start", svc2Name}, // one of the services fails
-		{"stop", svc2Name},
+		{"stop", svc2Name, svc1Name},
 		{"show", "--property=ActiveState", svc2Name},
-		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc1Name, svc2Name},
 		{"daemon-reload"},
@@ -4003,19 +4009,17 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 14, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 12, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName, svc3Name},
+		{"stop", svc3SocketName, svc2SocketName, svc3Name, svc2Name, svc1Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2SocketName, svc2Name},
 		{"show", "--property=ActiveState", svc2SocketName},
+		{"show", "--property=ActiveState", svc3Name},
 		{"show", "--property=ActiveState", svc2Name},
-		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
@@ -4068,18 +4072,16 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"start", svc2SocketName},
 		{"start", svc3SocketName},
 		{"start", svc1Name}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName, svc3Name},
+		{"stop", svc3SocketName, svc2SocketName, svc3Name, svc2Name, svc1Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2SocketName, svc2Name},
 		{"show", "--property=ActiveState", svc2SocketName},
+		{"show", "--property=ActiveState", svc3Name},
 		{"show", "--property=ActiveState", svc2Name},
-		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 	}, Commentf("calls: %v", sysdLog))
 }
@@ -4120,7 +4122,7 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(svcs, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "some user services failed to start")
-	c.Assert(sysdLog, HasLen, 14, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--user", "--global", "--no-reload", "enable", svc1Name, svc2Name},
 		{"--user", "--no-reload", "enable", "snap.hello-snap.svc1.service", "snap.hello-snap.svc2.service"},
@@ -4132,11 +4134,7 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 		{"--user", "show", "--property=ActiveState", svc1Name},
 		{"--user", "--no-reload", "disable", "snap.hello-snap.svc1.service", "snap.hello-snap.svc2.service"},
 		{"--user", "daemon-reload"},
-		// StartServices ensures everything is stopped
-		{"--user", "stop", svc2Name},
-		{"--user", "show", "--property=ActiveState", svc2Name},
-		{"--user", "stop", svc1Name},
-		{"--user", "show", "--property=ActiveState", svc1Name},
+		// and we disable previously enabled user-services
 		{"--user", "--global", "--no-reload", "disable", svc1Name, svc2Name},
 	}, Commentf("calls: %v", sysdLog))
 }
@@ -4665,15 +4663,14 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2Timer, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2Timer}, // this call fails
-		{"stop", svc2Timer, svc2Name},
+		{"stop", svc2Timer, svc2Name, svc1Name},
 		{"show", "--property=ActiveState", svc2Timer},
 		{"show", "--property=ActiveState", svc2Name},
-		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc2Timer, svc1Name},
 		{"daemon-reload"},

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -3500,9 +3500,11 @@ func (s *servicesTestSuite) TestStartServicesStopsServicesIncludingActivation(c 
 		{"--user", "daemon-reload"},
 
 		// Stop system services again
-		{"stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.hello-snap.svc1.service"},
+		{"stop", "snap.hello-snap.svc1.sock1.socket"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"},
+		{"stop", "snap.hello-snap.svc1.sock2.socket"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock2.socket"},
+		{"stop", "snap.hello-snap.svc1.service"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.service"},
 
 		// Disable phase, where the activation units are being disabled
@@ -3952,14 +3954,15 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(svcs, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc1Name, svc2Name},
 		{"daemon-reload"},
 		{"start", svc1Name},
 		{"start", svc2Name}, // one of the services fails
-		{"stop", svc2Name, svc1Name},
+		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
+		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc1Name, svc2Name},
 		{"daemon-reload"},
@@ -4009,17 +4012,21 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 12, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 16, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName, svc2SocketName, svc3Name, svc2Name, svc1Name},
+		{"stop", svc3SocketName},
 		{"show", "--property=ActiveState", svc3SocketName},
+		{"stop", svc2SocketName},
 		{"show", "--property=ActiveState", svc2SocketName},
+		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
+		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
+		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
@@ -4072,16 +4079,20 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 13, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"start", svc2SocketName},
 		{"start", svc3SocketName},
 		{"start", svc1Name}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName, svc2SocketName, svc3Name, svc2Name, svc1Name},
+		{"stop", svc3SocketName},
 		{"show", "--property=ActiveState", svc3SocketName},
+		{"stop", svc2SocketName},
 		{"show", "--property=ActiveState", svc2SocketName},
+		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
+		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
+		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 	}, Commentf("calls: %v", sysdLog))
 }
@@ -4663,14 +4674,16 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2Timer, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2Timer}, // this call fails
-		{"stop", svc2Timer, svc2Name, svc1Name},
+		{"stop", svc2Timer},
 		{"show", "--property=ActiveState", svc2Timer},
+		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
+		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
 		{"--no-reload", "disable", svc2Timer, svc1Name},
 		{"daemon-reload"},

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -3500,11 +3500,9 @@ func (s *servicesTestSuite) TestStartServicesStopsServicesIncludingActivation(c 
 		{"--user", "daemon-reload"},
 
 		// Stop system services again
-		{"stop", "snap.hello-snap.svc1.sock1.socket"},
+		{"stop", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket", "snap.hello-snap.svc1.service"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock1.socket"},
-		{"stop", "snap.hello-snap.svc1.sock2.socket"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.sock2.socket"},
-		{"stop", "snap.hello-snap.svc1.service"},
 		{"show", "--property=ActiveState", "snap.hello-snap.svc1.service"},
 
 		// Disable phase, where the activation units are being disabled
@@ -4012,19 +4010,17 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 16, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 14, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName},
+		{"stop", svc3SocketName, svc3Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"stop", svc2SocketName},
-		{"show", "--property=ActiveState", svc2SocketName},
-		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2Name},
+		{"stop", svc2SocketName, svc2Name},
+		{"show", "--property=ActiveState", svc2SocketName},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
@@ -4079,18 +4075,16 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 13, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"start", svc2SocketName},
 		{"start", svc3SocketName},
 		{"start", svc1Name}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName},
+		{"stop", svc3SocketName, svc3Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"stop", svc2SocketName},
-		{"show", "--property=ActiveState", svc2SocketName},
-		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2Name},
+		{"stop", svc2SocketName, svc2Name},
+		{"show", "--property=ActiveState", svc2SocketName},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
@@ -4674,14 +4668,13 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	opts := &wrappers.StartServicesOptions{Enable: true}
 	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2Timer, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2Timer}, // this call fails
-		{"stop", svc2Timer},
+		{"stop", svc2Timer, svc2Name},
 		{"show", "--property=ActiveState", svc2Timer},
-		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},


### PR DESCRIPTION
Cleans up the StartServices function, and improves how we start services that are affected by activated units, and also how we undo start of those. 