### PR TITLE
cmd/snap-seccomp: define GNU_SOURCE for fallocate

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -19,7 +19,7 @@
 
 package main
 
-//#cgo CFLAGS: -D_FILE_OFFSET_BITS=64
+//#cgo CFLAGS: -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 //#cgo pkg-config: libseccomp
 //#cgo LDFLAGS:
 //


### PR DESCRIPTION
Snap-seccomp stopped building on Arch since glibc got updated which revealed a source code problem in our code with a missing _GNU_SOURCE define.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
