### PR TITLE
o/hookstate/ctlcmd: queue service commands if run from default-configure hook

### DIFF
--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -149,7 +149,7 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	if !context.IsEphemeral() && context.HookName() == "configure" {
+	if !context.IsEphemeral() && (context.HookName() == "configure" || context.HookName() == "default-configure") {
 		return queueCommand(context, tts)
 	}
 

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -689,6 +689,17 @@ func (s *servicectlSuite) TestQueuedCommandsOrderingConfigureHook(c *C) {
 	s.testQueuedCommandsOrdering(c, hook, singleTransaction)
 }
 
+// NOTE: It is tricky to get snap name for all task kinds in the case of configure hook
+// so this test is left commented out just for clarity, but it will fail.
+// This is a non-issue for configure hook since the command tasks are queued at the very
+// end of the change unlike the default-configure hook.
+//
+// func (s *servicectlSuite) TestQueuedCommandsOrderingConfigureHookSingleTransaction(c *C) {
+// 	const hook = "configure"
+// 	const singleTransaction = true
+// 	s.testQueuedCommandsOrdering(c, hook, singleTransaction)
+// }
+
 func (s *servicectlSuite) testQueueCommandsConfigureHookFinalTask(c *C, finalTaskKind string) {
 	s.st.Lock()
 

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -547,7 +547,7 @@ func (s *servicectlSuite) TestQueuedCommandsConfigureHook(c *C) {
 }
 
 func (s *servicectlSuite) TestQueuedCommandsDefaultConfigureHook(c *C) {
-	const hook = "configure"
+	const hook = "default-configure"
 	s.testQueuedCommands(c, hook)
 }
 

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -30,7 +30,7 @@ var (
 	shortStartHelp = i18n.G("Start services")
 	longStartHelp  = i18n.G(`
 The start command starts the given services of the snap. If executed from the
-"configure" hook, the services will be started after the hook finishes.`)
+"configure" hook or "default-configure" hook, the services will be started after the hook finishes.`)
 )
 
 func init() {


### PR DESCRIPTION
This PR queues `snapctl` services' commands to be run after the `default-configure` similar to what is done for configure hook #4070. This is to avoid a problem where the service doesn't see a new value if it uses `snapctl get ...`, because it's still not committed by `default-configure` hook similar to what was described in [LP#2047949](https://bugs.launchpad.net/snapd/+bug/2047949) .

Fixes: https://bugs.launchpad.net/snapd/+bug/2047949