### PR TITLE
o/devicestate, o/ifacestate: fix mocking in unit tests

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -127,6 +127,9 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 		return &fakeSeed{}, nil
 	})
 	s.AddCleanup(restore)
+
+	mcmd := testutil.MockCommand(c, "snap", "echo 'snap is not mocked'; exit 1")
+	s.AddCleanup(mcmd.Restore)
 }
 
 const (

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -281,6 +281,11 @@ slots:
 	s.plug = consumer.Plugs["plug"]
 	producer := snaptest.MockInfo(c, producerYaml4, nil)
 	s.slot = producer.Slots["slot"]
+
+	s.AddCleanup(ifacestate.MockSnapdAppArmorServiceIsDisabled(func() bool {
+		// pretend the snapd.apparmor.service is enabled
+		return false
+	}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *C) {


### PR DESCRIPTION
Some unit tests fail unexpectedly on hosts where snapd has been installed through the package, but its services have not been enabled (or started).


