### PR TITLE
HACKING, packaging: update dependencies and information on installing development dependencies

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -46,10 +46,15 @@ the `snapd` project, please see [Contributing to snapd](./CONTRIBUTING.md).
 Build dependencies can automatically be resolved using `build-dep` on Ubuntu:
 
     cd ~/snapd
-    sudo apt-get build-dep .
+    sudo apt build-dep .
 
 Package build dependencies for other distributions can be found under the
-[./packaging/](./packaging/) directory.
+[./packaging/](./packaging/) directory. Eg. for Fedora use:
+
+    cd packaging/fedora
+    sudo dnf install -y rpmdevtools
+    sudo dnf install -y $(rpmspec -q --buildrequires snapd.spec)
+    sudo dnf install glibc-static.i686 glibc-devel.i686
 
 Source dependencies are automatically retrieved at build time.
 Sometimes, it might be useful to pull them without building:

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -122,13 +122,15 @@ build_rpm() {
 
     # Cleanup all artifacts from previous builds
     rm -rf "$rpm_dir"/BUILD/*
+    # Install build dependencies
+    distro_install_package rpmdevtools
+    # shellcheck disable=SC2046
+    distro_install_package $(rpmspec -q --buildrequires --with testkeys \
+                             "$packaging_path/snapd.spec")
 
     # Build our source package
     unshare -n -- \
             rpmbuild --with testkeys -bs "$rpm_dir/SOURCES/snapd.spec"
-
-    # .. and we need all necessary build dependencies available
-    install_snapd_rpm_dependencies "$rpm_dir"/SRPMS/snapd-1337.*.src.rpm
 
     # And now build our binary package
     unshare -n -- \

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -124,9 +124,11 @@ build_rpm() {
     rm -rf "$rpm_dir"/BUILD/*
     # Install build dependencies
     distro_install_package rpmdevtools
+    # XXX we should pass --with testkeys for completeness, but older versions of
+    # rpmspec do not support it, and in any case testkeys does not result in any
+    # additional build packages
     # shellcheck disable=SC2046
-    distro_install_package $(rpmspec -q --buildrequires --with testkeys \
-                             "$packaging_path/snapd.spec")
+    distro_install_package $(rpmspec -q --buildrequires "$packaging_path/snapd.spec")
 
     # Build our source package
     unshare -n -- \


### PR DESCRIPTION
Update instructions on installing development dependencies. Include an example for Fedora.
