### PR TITLE
tests: fix snap run test for debian-sid

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -53,7 +53,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
-    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora || os.query is-ubuntu-ge 24.04; then
+    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora || os.query is-ubuntu-ge 24.04 || os.query is-debian sid; then
         MATCH "Cannot find executable 'invalid'" < stderr
     else
         MATCH "Can't stat 'invalid': No such file or directory" < stderr


### PR DESCRIPTION
The snap-run test started failing on debian-sid because there was
a change to the message emitted when running strace with an
invalid option.

```
+ MATCH 'Can'\''t stat '\''invalid'\'': No such file or directory'
grep error: pattern not found, got:
/usr/bin/strace: Cannot find executable 'invalid'
error: exit status 1
```