### PR TITLE
check-pr-title.py: allow parenthesis before colon in PR titles

### DIFF
--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -53,7 +53,7 @@ def check_pr_title(pr_number: int):
     # package, otherpackage/subpackage: this is a title
     # tests/regression/lp-12341234: foo
     # [RFC] foo: bar
-    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\]{}]+: .*", title):
+    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\](){}]+: .*", title):
         raise InvalidPRTitle(title)
 
 


### PR DESCRIPTION
This will make CI happy for dependabot PRs which have descriptions like:

"build(deps): bump golang.org/x/net from 0.9.0 to 0.23.0 in /tests/lib/muinstaller"