### PR TITLE
tests: kill process in interface-process-control as early as possible

### DIFF
--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -48,3 +48,6 @@ execute: |
     fi
     MATCH "Permission denied" < process-kill.error
     kill -s 0 "$pid"
+    
+    # Test passed, clean (kill) process now
+    tests.cleanup pop


### PR DESCRIPTION
Cleaning (killing) the spawned process was deferred to restore but spread waits for execute script to finish completely which causes the test to hang for the whole time of the process (sleep 5m).

If the test is successful we could speed up the process by popping the clean command.

This fix speeds up the test by 5 minutes.
