### PR TITLE
tests: update snapd testing tools with spread log filter

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -281,6 +281,11 @@ slots:
 	s.plug = consumer.Plugs["plug"]
 	producer := snaptest.MockInfo(c, producerYaml4, nil)
 	s.slot = producer.Slots["slot"]
+
+	s.AddCleanup(ifacestate.MockSnapdAppArmorServiceIsDisabled(func() bool {
+		// pretend the snapd.apparmor.service is enabled
+		return false
+	}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *C) {

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -85,8 +85,15 @@ jobs:
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           fi
+          CHANGE_ID="${{ github.event.number }}"
+          if [ -z "$PR_ID" ]; then
+            CHANGE_ID="main"
+          fi
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}"
+          # The log-filter tool is used to filter the spread logs to be stored
+          FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"
 
-          (set -o pipefail; spread $RUN_TESTS | tee spread.log)
+          (set -o pipefail; spread $RUN_TESTS | ./utils/log-filter $FILTER_PARAMS | tee spread.log)
 
     - name: Discard spread workers
       if: always()

--- a/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
@@ -1,0 +1,51 @@
+summary: test for the log filter tool
+
+details: |
+    This test checks the log-filter tool is able to read the spread output
+    and filter the log following a set of rules. It is also checked that the
+    output of the log-filter tool is the same than spread.
+
+backends: [google]
+
+# Github actions agents are just running ubuntu jammy
+systems: [ubuntu-22.04-64]
+
+prepare: |
+    wget https://storage.googleapis.com/snapd-spread-tests/dependencies/spread-log-filter.tar.xz
+    tar -xf spread-log-filter.tar.xz
+
+restore: |
+    rm -rf spread-log-filter.tar.xz ./*.log
+
+execute: |
+    log-filter --help | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+    log-filter -h | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+
+    # Run the tool for a real log    
+    # The output should:
+    # 1. the output should go to test.filtered.log file
+    # 2. exclude: Preparing, Restoring, Error, Warning
+    # 3. show: debug lines with ###DEBUG
+    # 4. show: failed tests for google-nested
+    log-filter -o test.filtered.log -e Error -e Restoring -e Preparing -f "Debug=###DEBUG" -f "Failed=google-nested:" < spread-log-filter.log > output.log
+
+    # Check the stdout is the same than the stdin
+    diff -Z spread-log-filter.log output.log
+
+    # Check exclude
+    test "$(grep -c Restoring test.filtered.log)" -eq 0
+    test "$(grep -c Preparing test.filtered.log)" -eq 0
+    test "$(grep -c Error test.filtered.log)" -eq 0
+
+    # Check the non excluded
+    test "$(grep -c 'Debug output' test.filtered.log)" -eq "$(grep -c 'Debug output' spread-log-filter.log)"
+
+    # Check the filters
+    test "$(grep -c '###DEBUG' test.filtered.log)" -eq "$(grep -c '###DEBUG' spread-log-filter.log)"
+    grep -A 1 'Failed suite prepare: 4' test.filtered.log | MATCH 'Failed suite restore: 1'
+
+    # Check no repeated
+    test "$(grep -c 'Failed suite prepare: 4' test.filtered.log)" -eq 1
+    test "$(grep -c 'Executing' test.filtered.log)" -eq "$(grep -c 'Executing' spread-log-filter.log)"
+    test "$(grep -c 'Aborted tasks' test.filtered.log)" -eq 1
+

--- a/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
@@ -2,7 +2,7 @@ summary: smoke test for the remote.retry tool
 
 details: |
     This test checks the remote.retry tool properly handles retrying
-    a command in the remote instance. Also verifies that on failure
+    a command in the remote instance. Also Verifies that on failure
     the exit code from the final attempt is returned.   
 
 backends: [google]

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+import argparse
+import io
+import re
+import sys
+
+DEBUG = 'Debug'
+ERROR = 'Error'
+FAILED = 'Failed'
+WARNING = 'WARNING:'
+
+OPERATIONS = [
+    'Preparing', 'Executing', 'Restoring',
+    'Rebooting', 'Discarding', 'Allocating', 'Waiting',
+    'Allocated', 'Connecting', 'Connected', 'Sending',
+    ERROR, DEBUG, WARNING, FAILED, 'Successful', 'Aborted'
+    ]
+SUPPORTED_RULES = [ ERROR, DEBUG, FAILED, WARNING]
+
+def match_date(date):
+    return re.match(r'\d{4}-\d{2}-\d{2}', date)
+
+def match_time(time):
+    return re.match(r'\d{2}:\d{2}:\d{2}', time)
+
+def print_line(line: str):
+    if not line:
+        print()
+    else:
+        print(line.strip())
+
+def write_line(line: str, to_stream: io.TextIOWrapper):
+    if not line:
+        to_stream.write('\n')
+    else:
+        to_stream.write(line.strip() + '\n')
+
+
+# Debug line starts with the operation
+def is_line(line, operation):
+    if not line:
+        return False
+
+    parts = line.strip().split(' ')
+    return len(parts) > 2 and \
+        match_date(parts[0]) and \
+        match_time(parts[1]) and \
+        parts[2] == operation
+
+def is_line_excluded(line, exclude_lines):
+    if not line:
+        return False
+    
+    parts = line.strip().split(' ')
+    return len(parts) > 2 and \
+        match_date(parts[0]) and \
+        match_time(parts[1]) and \
+        parts[2] in exclude_lines
+
+def is_detail_start(line):
+    return is_line(line, DEBUG) or \
+        is_line(line, ERROR) or \
+        is_line(line, WARNING) or \
+        is_line(line, FAILED)
+
+# Error/Debug/Failed output finishes when a new other line starts
+def is_detail_finished(line: str) -> bool:
+    parts = line.strip().split(' ')
+    return len(parts) > 3 and \
+        match_date(parts[0]) and \
+        match_time(parts[1]) and \
+        parts[2] in OPERATIONS
+
+
+def compile_rules(rules, operation):
+    patterns = []
+    regex_list = []
+
+    for rule in rules:
+        parts = rule.split('=',1)
+        if len(parts) != 2:
+            raise ValueError("Error: Rule '{}' does not follow the OPERATION=PATTERN format".format(rule))
+
+        rule_operation = parts[0]
+        rule_pattern = parts[1]
+
+        if rule_operation not in SUPPORTED_RULES:
+            raise ValueError("Error: Rule operation '{}' not in supported list: {}".format(rule_operation, SUPPORTED_RULES))
+
+        if operation == rule_operation:
+            patterns.append(rule_pattern)
+
+    for pattern in patterns:
+        regex_list.append(re.compile(pattern))
+    return regex_list
+
+
+def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
+        if not regex_list:
+            write_line(line, to_stream)
+        else:
+            for regex in regex_list:
+                matches = regex.findall(line)
+                for match in matches:
+                    write_line(match, to_stream)
+
+def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: list, to_stream: io.TextIOWrapper) -> str:
+    """Process lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    write_line(start_line, to_stream)
+    for line in sys.stdin:
+        print_line(line)
+
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if is_detail_finished(line):
+            return line
+
+        # Print all the lines
+        process_detail_line(line, regex_list,  to_stream)
+
+            
+def skip_detail(from_stream: io.TextIOWrapper) -> str:
+    """Skip lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    for line in sys.stdin:
+        print_line(line)
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if is_detail_finished(line):
+            return line
+
+def process_spread_output(output_file, exclude_lines, filter_rules):
+    error_regex = compile_rules(filter_rules, ERROR)
+    debug_regex = compile_rules(filter_rules, DEBUG)
+    failed_regex = compile_rules(filter_rules, FAILED)
+    warning_regex = compile_rules(filter_rules, WARNING)
+
+    with open(output_file, "w") as myfile:
+        for line in sys.stdin:
+            print_line(line)
+
+            while is_detail_start(line):
+                regex_list = []
+                if is_line(line, DEBUG):
+                    if DEBUG in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = debug_regex
+                
+                if is_line(line, ERROR):
+                    if ERROR in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = error_regex
+
+                if is_line(line, WARNING):
+                    if WARNING in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = warning_regex
+
+                if is_line(line, FAILED):
+                    if FAILED in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = failed_regex
+                    
+                line = process_detail(sys.stdin, line, regex_list, myfile)
+
+            if not exclude_lines or not is_line_excluded(line, exclude_lines):
+                write_line(line, myfile)
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+This tool is used to save a filtered version of the spread output. It parses the spread output and filters
+sections and debug/error details to the file passed as parameter (all the lines are printed).
+When a output file is not provided the debug output is sent to spread_filtered.log
+""")
+    parser.add_argument(
+        "-o",
+        "--output-file", 
+        metavar="PATH",
+        default="spread.filtered.log",
+        help="path to the filtered output file"
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude", 
+        action="append",
+        default=[],
+        choices=OPERATIONS,
+        help="A line section to exclude from the output"
+    )
+    parser.add_argument(
+        "-f",
+        "--filter", 
+        action="append",
+        metavar="OPERATION=PATTERN",
+        default=[],
+        help="It is used to extract specific data from errors. Allowed operations are Error, Debug, Failed and WARNING:"
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = _make_parser()
+    args = parser.parse_args()
+    process_spread_output(args.output_file, args.exclude, args.filter)
+    

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import io
 import re
 import sys
+import typing
 
 DEBUG = 'Debug'
 ERROR = 'Error'
@@ -18,19 +20,19 @@ OPERATIONS = [
     ]
 SUPPORTED_RULES = [ ERROR, DEBUG, FAILED, WARNING]
 
-def match_date(date):
+def match_date(date: str) -> re.Match[str] | None:
     return re.match(r'\d{4}-\d{2}-\d{2}', date)
 
-def match_time(time):
+def match_time(time: str) -> re.Match[str] | None:
     return re.match(r'\d{2}:\d{2}:\d{2}', time)
 
-def print_line(line: str):
+def print_line(line: str) -> None:
     if not line:
         print()
     else:
         print(line.strip())
 
-def write_line(line: str, to_stream: io.TextIOWrapper):
+def write_line(line: str, to_stream: typing.TextIO) -> None:
     if not line:
         to_stream.write('\n')
     else:
@@ -38,27 +40,27 @@ def write_line(line: str, to_stream: io.TextIOWrapper):
 
 
 # Debug line starts with the operation
-def is_line(line, operation):
+def is_line(line: str, operation: str) -> bool:
     if not line:
         return False
 
     parts = line.strip().split(' ')
     return len(parts) > 2 and \
-        match_date(parts[0]) and \
-        match_time(parts[1]) and \
+        bool(match_date(parts[0])) and \
+        bool(match_time(parts[1])) and \
         parts[2] == operation
 
-def is_line_excluded(line, exclude_lines):
+def is_line_excluded(line: str, exclude_lines: set[str]) -> bool:
     if not line:
         return False
-    
+
     parts = line.strip().split(' ')
     return len(parts) > 2 and \
-        match_date(parts[0]) and \
-        match_time(parts[1]) and \
+        bool(match_date(parts[0])) and \
+        bool(match_time(parts[1])) and \
         parts[2] in exclude_lines
 
-def is_detail_start(line):
+def is_detail_start(line: str) -> bool:
     return is_line(line, DEBUG) or \
         is_line(line, ERROR) or \
         is_line(line, WARNING) or \
@@ -68,12 +70,12 @@ def is_detail_start(line):
 def is_detail_finished(line: str) -> bool:
     parts = line.strip().split(' ')
     return len(parts) > 3 and \
-        match_date(parts[0]) and \
-        match_time(parts[1]) and \
+        bool(match_date(parts[0])) and \
+        bool(match_time(parts[1])) and \
         parts[2] in OPERATIONS
 
 
-def compile_rules(rules, operation):
+def compile_rules(rules: list[str], operation: str) -> list[re.Pattern[str]]:
     patterns = []
     regex_list = []
 
@@ -96,7 +98,7 @@ def compile_rules(rules, operation):
     return regex_list
 
 
-def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
+def process_detail_line(line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> None:
         if not regex_list:
             write_line(line, to_stream)
         else:
@@ -105,7 +107,7 @@ def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper
                 for match in matches:
                     write_line(match, to_stream)
 
-def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: list, to_stream: io.TextIOWrapper) -> str:
+def process_detail(from_stream: typing.TextIO, start_line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> str:
     """Process lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -122,9 +124,10 @@ def process_detail(from_stream: io.TextIOWrapper, start_line: str, regex_list: l
 
         # Print all the lines
         process_detail_line(line, regex_list,  to_stream)
+    return "" # XXX: is this sensible?
 
-            
-def skip_detail(from_stream: io.TextIOWrapper) -> str:
+
+def skip_detail(from_stream: typing.TextIO) -> str:
     """Skip lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -136,8 +139,9 @@ def skip_detail(from_stream: io.TextIOWrapper) -> str:
         # Check if the detail is finished
         if is_detail_finished(line):
             return line
+    return "" # XXX: is this sensible?
 
-def process_spread_output(output_file, exclude_lines, filter_rules):
+def process_spread_output(output_file: str, exclude_lines: set[str], filter_rules: list[str]) -> None:
     error_regex = compile_rules(filter_rules, ERROR)
     debug_regex = compile_rules(filter_rules, DEBUG)
     failed_regex = compile_rules(filter_rules, FAILED)
@@ -176,14 +180,13 @@ def process_spread_output(output_file, exclude_lines, filter_rules):
                         continue
                     else:
                         regex_list = failed_regex
-                    
+
                 line = process_detail(sys.stdin, line, regex_list, myfile)
 
             if not exclude_lines or not is_line_excluded(line, exclude_lines):
                 write_line(line, myfile)
 
-def _make_parser():
-    # type: () -> argparse.ArgumentParser
+def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="""
 This tool is used to save a filtered version of the spread output. It parses the spread output and filters


### PR DESCRIPTION
This change includes a new tool used in snapd-testing-tools used to filter spread logs to be sent to COS.

This new tool reads the input from spread output and filters the data following defined rules.  Currently it is filtering data to avoid sending the complete logs to COS.

The new tool sends to the stdout the full imput .