### PR TITLE
o/hookstate: changes to enable running component hooks from the HookManager 

### DIFF
--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -100,9 +100,45 @@ func (c *Context) InstanceName() string {
 	return c.setup.Snap
 }
 
+// HookSource returns a string that identifies the source of a hook. This could
+// either be a snap or a component. Snaps will be in the form "<snap_instance>".
+// Components will be in the form "<snap_name>+<component_name>_<instance_key>".
+// The "_<instance_key>" suffix will be omitted if the snap does not have an
+// instance key.
+func (c *Context) HookSource() string {
+	if c.setup.Component == "" {
+		return c.setup.Snap
+	}
+
+	return snap.SnapComponentName(c.setup.Snap, c.setup.Component)
+}
+
+// IsComponentHook returns true if this context is associated with a component
+// hook.
+func (c *Context) IsComponentHook() bool {
+	return !c.IsSnapHook()
+}
+
+// IsSnapHook returns true if this context is associated with a snap hook.
+func (c *Context) IsSnapHook() bool {
+	return c.setup.Component == ""
+}
+
+// InstanceName returns the name of the component containing the hook. If the hook
+// is not associated with a component, it returns an empty string.
+func (c *Context) ComponentName() string {
+	return c.setup.Component
+}
+
 // SnapRevision returns the revision of the snap containing the hook.
 func (c *Context) SnapRevision() snap.Revision {
 	return c.setup.Revision
+}
+
+// ComponentRevision returns the revision of the snap component containing the
+// hook. This returned revision is only valid if the hook is a component hook.
+func (c *Context) ComponentRevision() snap.Revision {
+	return c.setup.ComponentRevision
 }
 
 // Task returns the task associated with the hook or (nil, false) if the context is ephemeral

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -102,9 +102,7 @@ func (c *Context) InstanceName() string {
 
 // HookSource returns a string that identifies the source of a hook. This could
 // either be a snap or a component. Snaps will be in the form "<snap_instance>".
-// Components will be in the form "<snap_name>+<component_name>_<instance_key>".
-// The "_<instance_key>" suffix will be omitted if the snap does not have an
-// instance key.
+// Components will be in the form "<snap_instance>+<component_name>".
 func (c *Context) HookSource() string {
 	if c.setup.Component == "" {
 		return c.setup.Snap
@@ -124,8 +122,8 @@ func (c *Context) IsSnapHook() bool {
 	return c.setup.Component == ""
 }
 
-// InstanceName returns the name of the component containing the hook. If the hook
-// is not associated with a component, it returns an empty string.
+// ComponentName returns the name of the component containing the hook. If the
+// hook is not associated with a component, it returns an empty string.
 func (c *Context) ComponentName() string {
 	return c.setup.Component
 }

--- a/overlord/hookstate/context_test.go
+++ b/overlord/hookstate/context_test.go
@@ -60,7 +60,7 @@ func (s *contextSuite) SetUpTest(c *C) {
 		Revision:          snap.R(1),
 		Hook:              "test-hook",
 		Component:         "test-component",
-		ComponentRevision: snap.R(1),
+		ComponentRevision: snap.R(2),
 	}
 	s.componentContext, err = NewContext(s.componentTask, s.componentTask.State(), s.componentSetup, nil, "")
 	c.Check(err, IsNil)
@@ -73,7 +73,7 @@ func (s *contextSuite) TestHookSetup(c *C) {
 	c.Check(s.context.IsComponentHook(), Equals, false)
 
 	c.Check(s.componentContext.ComponentName(), Equals, "test-component")
-	c.Check(s.componentContext.ComponentRevision(), Equals, snap.R(1))
+	c.Check(s.componentContext.ComponentRevision(), Equals, snap.R(2))
 	c.Check(s.componentContext.IsSnapHook(), Equals, false)
 	c.Check(s.componentContext.IsComponentHook(), Equals, true)
 }

--- a/overlord/hookstate/context_test.go
+++ b/overlord/hookstate/context_test.go
@@ -86,7 +86,7 @@ func (s *contextSuite) TestHookSource(c *C) {
 	s.componentContext.setup.Snap = "test-snap_instance-key"
 	defer func() { s.componentContext.setup.Snap = "test-snap" }()
 
-	c.Check(s.componentContext.HookSource(), Equals, "test-snap+test-component_instance-key")
+	c.Check(s.componentContext.HookSource(), Equals, "test-snap_instance-key+test-component")
 }
 
 func (s *contextSuite) TestSetAndGet(c *C) {

--- a/overlord/hookstate/context_test.go
+++ b/overlord/hookstate/context_test.go
@@ -35,6 +35,10 @@ type contextSuite struct {
 	task    *state.Task
 	state   *state.State
 	setup   *HookSetup
+
+	componentContext *Context
+	componentSetup   *HookSetup
+	componentTask    *state.Task
 }
 
 var _ = Suite(&contextSuite{})
@@ -49,11 +53,40 @@ func (s *contextSuite) SetUpTest(c *C) {
 	var err error
 	s.context, err = NewContext(s.task, s.task.State(), s.setup, nil, "")
 	c.Check(err, IsNil)
+
+	s.componentTask = s.state.NewTask("test-component-task", "my test component task")
+	s.componentSetup = &HookSetup{
+		Snap:              "test-snap",
+		Revision:          snap.R(1),
+		Hook:              "test-hook",
+		Component:         "test-component",
+		ComponentRevision: snap.R(1),
+	}
+	s.componentContext, err = NewContext(s.componentTask, s.componentTask.State(), s.componentSetup, nil, "")
+	c.Check(err, IsNil)
 }
 
 func (s *contextSuite) TestHookSetup(c *C) {
 	c.Check(s.context.HookName(), Equals, "test-hook")
 	c.Check(s.context.InstanceName(), Equals, "test-snap")
+	c.Check(s.context.IsSnapHook(), Equals, true)
+	c.Check(s.context.IsComponentHook(), Equals, false)
+
+	c.Check(s.componentContext.ComponentName(), Equals, "test-component")
+	c.Check(s.componentContext.ComponentRevision(), Equals, snap.R(1))
+	c.Check(s.componentContext.IsSnapHook(), Equals, false)
+	c.Check(s.componentContext.IsComponentHook(), Equals, true)
+}
+
+func (s *contextSuite) TestHookSource(c *C) {
+	c.Check(s.context.HookSource(), Equals, "test-snap")
+	c.Check(s.componentContext.HookSource(), Equals, "test-snap+test-component")
+
+	// insert an instance key for a quick test
+	s.componentContext.setup.Snap = "test-snap_instance-key"
+	defer func() { s.componentContext.setup.Snap = "test-snap" }()
+
+	c.Check(s.componentContext.HookSource(), Equals, "test-snap+test-component_instance-key")
 }
 
 func (s *contextSuite) TestSetAndGet(c *C) {

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -102,7 +102,7 @@ type HookSetup struct {
 
 	// ComponentRevision is the revision of the component that the hook is
 	// associated with. Only valid if Component is not empty.
-	ComponentRevision snap.Revision `json:"component-revision,omitempty"`
+	ComponentRevision snap.Revision `json:"component-revision"`
 }
 
 // Manager returns a new HookManager.

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -80,13 +80,28 @@ type HandlerGenerator func(*Context) Handler
 
 // HookSetup is a reference to a hook within a specific snap.
 type HookSetup struct {
-	Snap        string        `json:"snap"`
-	Revision    snap.Revision `json:"revision"`
-	Hook        string        `json:"hook"`
-	Timeout     time.Duration `json:"timeout,omitempty"`
-	Optional    bool          `json:"optional,omitempty"`     // do not error if script is missing
-	Always      bool          `json:"always,omitempty"`       // run handler even if script is missing
-	IgnoreError bool          `json:"ignore-error,omitempty"` // do not run handler's Error() on error
+	Snap     string        `json:"snap"`
+	Revision snap.Revision `json:"revision"`
+	Hook     string        `json:"hook"`
+	Timeout  time.Duration `json:"timeout,omitempty"`
+
+	// Optional is true if we should not error if the script is missing.
+	Optional bool `json:"optional,omitempty"`
+
+	// Always is true if we should run the handler even if the script is
+	// missing.
+	Always bool `json:"always,omitempty"`
+
+	// IgnoreError is true if we should not run the handler's Error() on error.
+	IgnoreError bool `json:"ignore-error,omitempty"`
+
+	// Component is the component name that the hook is associated with. If the
+	// hook is not associated with a component, the string will be empty.
+	Component string `json:"component,omitempty"`
+
+	// ComponentRevision is the revision of the component that the hook is
+	// associated with. Only valid if Component is not empty.
+	ComponentRevision snap.Revision `json:"component-revision,omitempty"`
 }
 
 // Manager returns a new HookManager.

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -344,6 +344,9 @@ func (m *HookManager) runHookGuardForRestarting(context *Context) error {
 }
 
 func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hooksup *HookSetup, tomb *tomb.Tomb) error {
+	// for now, we will only support hijacking snap hooks, not component hooks.
+	// if we ever add components to the snapd snap, we might need to handle
+	// hijacking component hooks as well.
 	mustHijack := context.IsSnapHook() && m.hijacked(hooksup.Hook, hooksup.Snap) != nil
 	hookExists := false
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 type hijackFunc func(ctx *Context) error
@@ -343,8 +344,9 @@ func (m *HookManager) runHookGuardForRestarting(context *Context) error {
 }
 
 func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hooksup *HookSetup, tomb *tomb.Tomb) error {
-	mustHijack := m.hijacked(hooksup.Hook, hooksup.Snap) != nil
+	mustHijack := context.IsSnapHook() && m.hijacked(hooksup.Hook, hooksup.Snap) != nil
 	hookExists := false
+
 	if !mustHijack {
 		// not hijacked, snap must be installed
 		if !snapst.IsInstalled() {
@@ -356,9 +358,24 @@ func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hoo
 			return fmt.Errorf("cannot read %q snap details: %v", hooksup.Snap, err)
 		}
 
-		hookExists = info.Hooks[hooksup.Hook] != nil
-		if !hookExists && !hooksup.Optional {
-			return fmt.Errorf("snap %q has no %q hook", hooksup.Snap, hooksup.Hook)
+		if context.IsSnapHook() {
+			hookExists = info.Hooks[hooksup.Hook] != nil
+			if !hookExists && !hooksup.Optional {
+				return fmt.Errorf("snap %q has no %q hook", hooksup.Snap, hooksup.Hook)
+			}
+		} else {
+			comp, err := snapst.CurrentComponentInfo(naming.ComponentRef{
+				SnapName:      info.SnapName(),
+				ComponentName: hooksup.Component,
+			})
+			if err != nil {
+				return fmt.Errorf(`cannot read "%s+%s" component details: %v`, info.SnapName(), hooksup.Component, err)
+			}
+
+			hookExists = comp.Hooks[hooksup.Hook] != nil
+			if !hookExists && !hooksup.Optional {
+				return fmt.Errorf(`component "%s+%s" has no %q hook`, info.SnapName(), hooksup.Component, hooksup.Hook)
+			}
 		}
 	}
 
@@ -449,7 +466,7 @@ func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hoo
 }
 
 func runHookImpl(c *Context, tomb *tomb.Tomb) ([]byte, error) {
-	return runHookAndWait(c.InstanceName(), c.SnapRevision(), c.HookName(), c.ID(), c.Timeout(), tomb)
+	return runHookAndWait(c.HookSource(), c.SnapRevision(), c.HookName(), c.ID(), c.Timeout(), tomb)
 }
 
 var runHook = runHookImpl
@@ -488,8 +505,8 @@ func snapCmd() string {
 
 var defaultHookTimeout = 10 * time.Minute
 
-func runHookAndWait(snapName string, revision snap.Revision, hookName, hookContext string, timeout time.Duration, tomb *tomb.Tomb) ([]byte, error) {
-	argv := []string{snapCmd(), "run", "--hook", hookName, "-r", revision.String(), snapName}
+func runHookAndWait(hookSource string, revision snap.Revision, hookName, hookContext string, timeout time.Duration, tomb *tomb.Tomb) ([]byte, error) {
+	argv := []string{snapCmd(), "run", "--hook", hookName, "-r", revision.String(), hookSource}
 	if timeout == 0 {
 		timeout = defaultHookTimeout
 	}

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -34,6 +34,7 @@ import (
 
 func init() {
 	snapstate.SetupInstallHook = SetupInstallHook
+	snapstate.SetupInstallComponentHook = SetupInstallComponentHook
 	snapstate.SetupPreRefreshHook = SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = SetupPostRefreshHook
 	snapstate.SetupRemoveHook = SetupRemoveHook
@@ -48,6 +49,20 @@ func SetupInstallHook(st *state.State, snapName string) *state.Task {
 	}
 
 	summary := fmt.Sprintf(i18n.G("Run install hook of %q snap if present"), hooksup.Snap)
+	task := HookTask(st, summary, hooksup, nil)
+
+	return task
+}
+
+func SetupInstallComponentHook(st *state.State, snap, component string) *state.Task {
+	hooksup := &HookSetup{
+		Snap:      snap,
+		Component: component,
+		Hook:      "install",
+		Optional:  true,
+	}
+
+	summary := fmt.Sprintf(i18n.G(`Run install hook of "%s+%s" component if present`), hooksup.Snap, hooksup.Component)
 	task := HookTask(st, summary, hooksup, nil)
 
 	return task

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -38,9 +38,11 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -1305,4 +1307,149 @@ func (s *parallelInstancesHookManagerSuite) TestHookTaskEnsureHookRan(c *C) {
 	c.Check(s.change.Status(), Equals, state.DoneStatus)
 
 	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+}
+
+type componentHookManagerSuite struct {
+	baseHookManagerSuite
+}
+
+var _ = Suite(&componentHookManagerSuite{})
+
+func (s *baseHookManagerSuite) setUpComponent(c *C, instanceName string, componentName string, hookName string) {
+	hooksup := &hookstate.HookSetup{
+		Snap:              instanceName,
+		Hook:              hookName,
+		Revision:          snap.R(1),
+		ComponentRevision: snap.R(1),
+		Component:         componentName,
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.task = hookstate.HookTask(s.state, "test-hook-task", hooksup, nil)
+
+	s.change = s.state.NewChange("run-test-hook", "...")
+	s.change.AddTask(s.task)
+
+	snapName, instanceKey := snap.SplitInstanceName(instanceName)
+
+	sideInfo := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}
+
+	componentSideInfo := &snap.ComponentSideInfo{
+		Component: naming.ComponentRef{
+			SnapName:      snapName,
+			ComponentName: componentName,
+		},
+		Revision: snap.R(1),
+	}
+
+	const componentYaml = `
+component: %s+%s
+type: test
+`
+
+	const snapYaml = `
+name: %s
+version: 1.0
+components:
+  %s:
+    type: test
+    hooks:
+      %s:
+`
+
+	snapInfo := snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf(snapYaml, snapName, componentName, hookName), sideInfo)
+	snaptest.MockComponent(c, fmt.Sprintf(componentYaml, snapName, componentName), snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
+
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{{
+			Snap: sideInfo,
+			Components: []*sequence.ComponentState{{
+				SideInfo: componentSideInfo,
+				CompType: snap.TestComponent,
+			}},
+		}}),
+		Current:     snap.R(1),
+		InstanceKey: instanceKey,
+	})
+}
+
+func (s *componentHookManagerSuite) SetUpTest(c *C) {
+	s.commonSetUpTest(c)
+	s.mockHandler = hooktest.NewMockHandler()
+}
+
+func (s *componentHookManagerSuite) TestComponentHookTaskEnsure(c *C) {
+	s.setUpComponent(c, "test-snap", "test-component", "install")
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.command.Calls(), DeepEquals, [][]string{{
+		"snap", "run", "--hook", "install", "-r", "1", "test-snap+test-component",
+	}})
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.DoneStatus)
+	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
+	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+}
+
+func (s *componentHookManagerSuite) TestComponentHookTaskEnsureInstance(c *C) {
+	s.setUpComponent(c, "test-snap_instance", "test-component", "install")
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.command.Calls(), DeepEquals, [][]string{{
+		"snap", "run", "--hook", "install", "-r", "1", "test-snap_instance+test-component",
+	}})
+
+	fmt.Println(s.change.Err())
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.DoneStatus)
+	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
+	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+}
+
+func (s *componentHookManagerSuite) TestComponentHookWithoutHookIsError(c *C) {
+	s.setUpComponent(c, "test-snap", "test-component", "install")
+
+	s.state.Lock()
+
+	var hooksup hookstate.HookSetup
+	err := s.task.Get("hook-setup", &hooksup)
+	c.Assert(err, IsNil)
+
+	hooksup.Hook = "missing-hook"
+	s.task.Set("hook-setup", &hooksup)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.ErrorStatus)
+	c.Check(s.change.Status(), Equals, state.ErrorStatus)
+	checkTaskLogContains(c, s.task, `.*component "test-snap\+test-component" has no "missing-hook" hook.*`)
 }

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -193,7 +193,7 @@ func (s *hookManagerSuite) TestHookSetupJsonMarshal(c *C) {
 	hookSetup := &hookstate.HookSetup{Snap: "snap-name", Revision: snap.R(1), Hook: "hook-name"}
 	out, err := json.Marshal(hookSetup)
 	c.Assert(err, IsNil)
-	c.Check(string(out), Equals, "{\"snap\":\"snap-name\",\"revision\":\"1\",\"hook\":\"hook-name\"}")
+	c.Check(string(out), Equals, "{\"snap\":\"snap-name\",\"revision\":\"1\",\"hook\":\"hook-name\",\"component-revision\":\"unset\"}")
 }
 
 func (s *hookManagerSuite) TestHookSetupJsonUnmarshal(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -881,6 +881,10 @@ var SetupInstallHook = func(st *state.State, snapName string) *state.Task {
 	panic("internal error: snapstate.SetupInstallHook is unset")
 }
 
+var SetupInstallComponentHook = func(st *state.State, snap, component string) *state.Task {
+	panic("internal error: snapstate.SetupInstallComponentHook is unset")
+}
+
 var SetupPreRefreshHook = func(st *state.State, snapName string) *state.Task {
 	panic("internal error: snapstate.SetupPreRefreshHook is unset")
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -183,12 +183,14 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
 	oldSetupInstallHook := snapstate.SetupInstallHook
+	oldSetupInstallComponentHook := snapstate.SetupInstallComponentHook
 	oldSetupPreRefreshHook := snapstate.SetupPreRefreshHook
 	oldSetupPostRefreshHook := snapstate.SetupPostRefreshHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
 	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	oldEnsureSnapAbsentFromQuotaGroup := snapstate.EnsureSnapAbsentFromQuotaGroup
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
+	snapstate.SetupInstallComponentHook = hookstate.SetupInstallComponentHook
 	snapstate.SetupPreRefreshHook = hookstate.SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = hookstate.SetupPostRefreshHook
 	snapstate.SetupRemoveHook = hookstate.SetupRemoveHook
@@ -226,6 +228,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 
 	s.BaseTest.AddCleanup(func() {
 		snapstate.SetupInstallHook = oldSetupInstallHook
+		snapstate.SetupInstallComponentHook = oldSetupInstallComponentHook
 		snapstate.SetupPreRefreshHook = oldSetupPreRefreshHook
 		snapstate.SetupPostRefreshHook = oldSetupPostRefreshHook
 		snapstate.SetupRemoveHook = oldSetupRemoveHook


### PR DESCRIPTION
This change largely updates the hookstate package to enable running component hooks. At a high level, we add fields to the HookSetup struct to convey that a hook comes from a component, and we handle those properly.