### PR TITLE
o/ifacestate: properly undo setup-profiles on component installation

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2208,6 +2208,9 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, sn
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	// TODO: we'll need to update this to handle refreshing components once that
+	// work is done
+
 	s.o.TaskRunner().AddHandler("mock-link-component-n-witness", func(task *state.Task, tomb *tomb.Tomb) error { // do handler
 		s.state.Lock()
 		defer s.state.Unlock()
@@ -2235,6 +2238,7 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, sn
 	}, func(task *state.Task, tomb *tomb.Tomb) error { // undo handler
 		s.state.Lock()
 		defer s.state.Unlock()
+
 		var snapst snapstate.SnapState
 		err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
 		if err != nil && !errors.Is(err, state.ErrNoState) {
@@ -2246,9 +2250,11 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, sn
 			return err
 		}
 
-		snapst.Sequence.RemoveComponentForRevision(
+		removed := snapst.Sequence.RemoveComponentForRevision(
 			info.Revision, compsup.CompSideInfo.Component,
 		)
+
+		c.Check(removed, NotNil)
 
 		snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
 
@@ -2262,21 +2268,21 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, sn
 
 	change := s.state.NewChange("test", "")
 
-	task1 := s.state.NewTask("setup-profiles", "")
-	task1.Set("snap-setup", snapsup)
-	task1.Set("component-setup", compsup)
-	change.AddTask(task1)
+	setupTask := s.state.NewTask("setup-profiles", "")
+	setupTask.Set("snap-setup", snapsup)
+	setupTask.Set("component-setup", compsup)
+	change.AddTask(setupTask)
 
-	task2 := s.state.NewTask("mock-link-component-n-witness", "")
-	task2.Set("snap-setup", snapsup)
-	task2.Set("component-setup", compsup)
-	task2.WaitFor(task1)
-	change.AddTask(task2)
+	linkTask := s.state.NewTask("mock-link-component-n-witness", "")
+	linkTask.Set("snap-setup", snapsup)
+	linkTask.Set("component-setup", compsup)
+	linkTask.WaitFor(setupTask)
+	change.AddTask(linkTask)
 
-	task3 := s.state.NewTask("auto-connect", "")
-	task3.Set("snap-setup", snapsup)
-	task3.WaitFor(task2)
-	change.AddTask(task3)
+	autoConnectTask := s.state.NewTask("auto-connect", "")
+	autoConnectTask.Set("snap-setup", snapsup)
+	autoConnectTask.WaitFor(linkTask)
+	change.AddTask(autoConnectTask)
 
 	return change
 }
@@ -2444,6 +2450,12 @@ plugs:
   interface: network
  unrelated:
   interface: unrelated
+`
+
+const sampleComponentYaml = `
+component: snap+comp1
+type: test
+version: 1.0
 `
 
 var sampleSnapWithComponentsYaml = sampleSnapYaml + `
@@ -3990,12 +4002,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesInstallComponent(c *C) {
 
 	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
 
-	const compomentYaml = `
-component: snap+comp1
-type: test
-version: 1.0
-`
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+	compInfo := snaptest.MockComponent(c, sampleComponentYaml, snapInfo, snap.ComponentSideInfo{
 		Revision: snap.R(1),
 	})
 
@@ -4071,12 +4078,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesInstallComponentSnapHasPreexist
 	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
 	s.mockComponentForSnap(c, "comp2", "component: snap+comp2\ntype: test", snapInfo)
 
-	const compomentYaml = `
-component: snap+comp1
-type: test
-version: 1.0
-`
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+	compInfo := snaptest.MockComponent(c, sampleComponentYaml, snapInfo, snap.ComponentSideInfo{
 		Revision: snap.R(1),
 	})
 
@@ -4134,12 +4136,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUpdateSnapWithComponents(c *C) 
 
 	s.mockComponentForSnap(c, "comp2", "component: snap+comp2\ntype: test", snapInfo)
 
-	const compomentYaml = `
-component: snap+comp1
-type: test
-version: 1.0
-`
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+	compInfo := snaptest.MockComponent(c, sampleComponentYaml, snapInfo, snap.ComponentSideInfo{
 		Revision: snap.R(1),
 	})
 
@@ -4236,12 +4233,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesOfAffectedSnapWithComponents(c 
 
 	s.state.Unlock()
 
-	const compomentYaml = `
-component: snap+comp1
-type: test
-version: 1.0
-`
-	compInfo := snaptest.MockComponent(c, compomentYaml, snapInfo, snap.ComponentSideInfo{
+	compInfo := snaptest.MockComponent(c, sampleComponentYaml, snapInfo, snap.ComponentSideInfo{
 		Revision: snap.R(1),
 	})
 
@@ -5699,6 +5691,69 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnInstall(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceManagerSuite) TestUndoSetupProfilesOnComponentInstall(c *C) {
+	s.MockModel(c, nil)
+
+	snapInfo := s.mockSnap(c, sampleSnapWithComponentsYaml)
+	s.manager(c)
+
+	compInfo := snaptest.MockComponent(c, sampleComponentYaml, snapInfo, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
+
+	change := s.addSetupSnapSecurityChangeFromComponent(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	}, &snapstate.ComponentSetup{
+		CompSideInfo: &snap.ComponentSideInfo{
+			Component: compInfo.Component,
+			Revision:  snap.R(1),
+		},
+	})
+
+	s.state.Lock()
+
+	c.Assert(change.Tasks(), HasLen, 3)
+	errorTask := s.state.NewTask("error-trigger", "...")
+	errorTask.WaitFor(change.Tasks()[2])
+	change.AddTask(errorTask)
+
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Err(), ErrorMatches, "(?s).*error out.*")
+	c.Check(change.Status(), Equals, state.ErrorStatus)
+
+	// since we didn't remove the snap, we're just removing the component, the
+	// profiles should be there, but the setup call shouldn't include anything
+	// pertaining to the components
+	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
+	appSetAfterRemoval := s.secBackend.SetupCalls[1].AppSet
+	c.Check(appSetAfterRemoval.Runnables(), DeepEquals, []interfaces.Runnable{
+		{
+			CommandName: "app",
+			SecurityTag: "snap.snap.app",
+		},
+	})
+	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snap", &snapst)
+	c.Assert(err, IsNil)
+
+	comps, err := snapst.CurrentComponentInfos()
+	c.Assert(err, IsNil)
+
+	// make sure that the component was removed
+	c.Check(comps, HasLen, 0)
 }
 
 // Test that setup-snap-security gets undone correctly when a snap is refreshed

--- a/overlord/snapstate/handlers_components_test.go
+++ b/overlord/snapstate/handlers_components_test.go
@@ -136,14 +136,6 @@ func (s *handlersComponentsSuite) TestComponentSetupsForTaskComponentInstall(c *
 
 	c.Assert(setups, HasLen, 1)
 	c.Check(setups[0], DeepEquals, compsup)
-
-	// if the task isn't being done right now, then the component shouldn't be
-	// considered as being setup
-	t2.SetStatus(state.UndoStatus)
-	t.SetStatus(state.UndoStatus)
-	setups, err = snapstate.ComponentSetupsForTask(t)
-	c.Assert(err, IsNil)
-	c.Check(setups, HasLen, 0)
 }
 
 func (s *handlersComponentsSuite) TestComponentSetupsForTaskSnapWithoutComponents(c *C) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -234,13 +234,6 @@ func ComponentSetupsForTask(t *state.Task) ([]*ComponentSetup, error) {
 	case t.Has("component-setup") || t.Has("component-setup-task"):
 		// task comes from a singular component installation for an already
 		// installed snap
-		// if the task isn't being done right now (we may be undoing it), then
-		// we shouldn't consider the new component when setting up profiles.
-		if t.Status() != state.DoingStatus {
-			return nil, nil
-		}
-
-		// task comes from a component installation
 		compsup, _, err := TaskComponentSetup(t)
 		if err != nil {
 			return nil, err

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -234,6 +234,13 @@ func ComponentSetupsForTask(t *state.Task) ([]*ComponentSetup, error) {
 	case t.Has("component-setup") || t.Has("component-setup-task"):
 		// task comes from a singular component installation for an already
 		// installed snap
+		// if the task isn't being done right now (we may be undoing it), then
+		// we shouldn't consider the new component when setting up profiles.
+		if t.Status() != state.DoingStatus {
+			return nil, nil
+		}
+
+		// task comes from a component installation
 		compsup, _, err := TaskComponentSetup(t)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This corrects and tests the behavior of undoing a `setup-profiles` task that contains components. We change `setupProfilesForSnap` to be `setupProfilesForAppSet`, so we can pass in a `SnapAppSet` that doesn't contain the components being set up for the current task when undoing the task.