### PR TITLE
snapdtool, cmd: switch to FIPS mode when needed

### DIFF
--- a/cmd/snap-repair/main.go
+++ b/cmd/snap-repair/main.go
@@ -59,6 +59,8 @@ func init() {
 var errOnClassic = fmt.Errorf("cannot use snap-repair on a classic system")
 
 func main() {
+	// TODO setup FIPS if needed?
+
 	if err := run(); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)
 		if err != errOnClassic {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -442,6 +442,11 @@ func exitCodeFromError(err error) int {
 func main() {
 	snapdtool.ExecInSnapdOrCoreSnap()
 
+	if err := snapdtool.MaybeSetupFIPS(); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot check or enable FIPS mode: %v", err)
+		os.Exit(1)
+	}
+
 	// check for magic symlink to /usr/bin/snap:
 	// 1. symlink from command-not-found to /usr/bin/snap: run c-n-f
 	if os.Args[0] == filepath.Join(dirs.GlobalRootDir, "/usr/lib/command-not-found") {

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -56,6 +56,11 @@ func main() {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
 
+	if err := snapdtool.MaybeSetupFIPS(); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot check or enable FIPS mode: %v", err)
+		os.Exit(1)
+	}
+
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	if err := run(ch); err != nil {

--- a/snapdtool/export_test.go
+++ b/snapdtool/export_test.go
@@ -21,6 +21,7 @@ package snapdtool
 
 var (
 	SystemSnapSupportsReExec = systemSnapSupportsReExec
+	ExeAndRoot               = exeAndRoot
 )
 
 func MockCoreSnapdPaths(newCoreSnap, newSnapdSnap string) func() {

--- a/snapdtool/fips_linux.go
+++ b/snapdtool/fips_linux.go
@@ -1,0 +1,145 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build linux
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapdtool
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/fips"
+	"github.com/snapcore/snapd/release"
+)
+
+func findFIPSLibsAndModules(snapRoot string) (opensslLib, module string) {
+	// with OpenSSL supported by 22.04 (the snapd snap build base), the FIPS
+	// module is available as an *.so library loaded by libcrypto.so.3 at
+	// runtime.
+	var fipsLibAndModulePathInSnapdSnap = []struct {
+		opensslLib, moduleFile string
+	}{
+		{"usr/lib/x86_64-linux-gnu/libcrypto.so.3", "usr/lib/x86_64-linux-gnu/ossl-modules-3/fips.so"},
+		{"usr/lib/aarch64-linux-gnu/libcrypto.so.3", "usr/lib/aarch64-linux-gnu/ossl-modules-3/fips.so"},
+		{"usr/lib/arm-linux-gnueabihf/libcrypto.so.3", "usr/lib/arm-linux-gnueabihf/ossl-modules-3/fips.so"},
+		{"usr/lib/i386-linux-gnu/libcrypto.so.3", "usr/lib/i386-linux-gnu/ossl-modules-3/fips.so"},
+		{"usr/lib/riscv64-linux-gnu/libcrypto.so.3", "usr/lib/riscv64-linux-gnu/ossl-modules-3/fips.so"},
+		{"usr/lib/s390x-linux-gnu/libcrypto.so.3", "usr/lib/s390x-linux-gnu/ossl-modules-3/fips.so"},
+	}
+
+	for _, bundle := range fipsLibAndModulePathInSnapdSnap {
+		lib := filepath.Join(snapRoot, bundle.opensslLib)
+		module := filepath.Join(snapRoot, bundle.moduleFile)
+		if osutil.FileExists(lib) && osutil.FileExists(module) {
+			return lib, module
+		}
+	}
+	return "", ""
+}
+
+// MaybeSetupFIPS checks whether a system-wide FIPS mode is enabled and if
+// so sets up an environment such that the current process is able to use
+// libraries that are required for FIPS compliance and reexecs.
+func MaybeSetupFIPS() error {
+	enabled, err := fips.IsEnabled()
+	if err != nil {
+		return fmt.Errorf("cannot obtain FIPS status: %w", err)
+	}
+
+	if !enabled {
+		// FIPS not enabled do nothing
+		return nil
+	}
+
+	logger.Debugf("FIPS mode enabled system wide")
+
+	if os.Getenv("SNAPD_FIPS_BOOTSTRAP_DONE") == "1" {
+		// we've already been reexeced into FIPS mode and bootstrap was
+		// performed
+		logger.Debugf("FIPS bootstrap complete")
+
+		// if we reached this place, then the initialization was
+		// completed successfully and we can drop the environment
+		// variables, other processes which may be invoked by snapd will
+		// perform the initialization cycle on their own when needed
+		os.Unsetenv("GOFIPS")
+		os.Unsetenv("SNAPD_FIPS_BOOTSTRAP_DONE")
+		os.Unsetenv("OPENSSL_MODULES")
+		os.Unsetenv("GO_OPENSSL_VERSION_OVERRIDE")
+		return nil
+	}
+
+	snapdRev, err := osReadlink(snapdSnap)
+	if err != nil {
+		return err
+	}
+
+	currentRevSnapdSnap := filepath.Join(dirs.SnapMountDir, "snapd", snapdRev)
+
+	logger.Debugf("snapd snap: %s", currentRevSnapdSnap)
+
+	exe, err := osReadlink(selfExe)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("self exe: %s", exe)
+
+	// on a classic system we need to be reexecuted from the snapd snap for
+	// the FIPS setup to be relevant, but on core we are not reexeced but
+	// running directly from the mount of the snapd snap under
+	// /usr/lib/snapd, yet we still want to set up the right environment
+	if release.OnClassic {
+		if !strings.HasPrefix(exe, currentRevSnapdSnap+"/") {
+			// this is only supported for reexecing from the snapd snap
+			return nil
+		}
+	}
+
+	lib, mod := findFIPSLibsAndModules(currentRevSnapdSnap)
+
+	env := append(os.Environ(), []string{
+		"SNAPD_FIPS_BOOTSTRAP_DONE=1",
+		// make FIPS mod required at runtime, if the module was not
+		// found or the setup is incorrect snapd will fail in a
+		// predictable way
+		"GOFIPS=1",
+	}...)
+
+	if mod != "" {
+		// version override uses the version suffix right after *.so.
+		libVer := strings.TrimPrefix(filepath.Ext(lib), ".")
+		logger.Debugf("found FIPS library and module at %s (ver %s) and %s", lib, libVer, mod)
+		env = append(env, []string{
+			// be specific about where the modules come from
+			fmt.Sprintf("OPENSSL_MODULES=%s", filepath.Dir(mod)),
+			// and the openssl lib version
+			fmt.Sprintf("GO_OPENSSL_VERSION_OVERRIDE=%s", libVer),
+		}...)
+	}
+
+	// TODO how to ensure that we only load the library from the snapd snap?
+
+	panic(syscallExec(exe, os.Args, env))
+}

--- a/snapdtool/fips_linux.go
+++ b/snapdtool/fips_linux.go
@@ -99,19 +99,20 @@ func MaybeSetupFIPS() error {
 
 	logger.Debugf("snapd snap: %s", currentRevSnapdSnap)
 
-	exe, err := osReadlink(selfExe)
+	rootDir, exe, err := exeAndRoot()
 	if err != nil {
 		return err
 	}
 
 	logger.Debugf("self exe: %s", exe)
+	logger.Debugf("exe root dir: %q", rootDir)
 
 	// on a classic system we need to be reexecuted from the snapd snap for
 	// the FIPS setup to be relevant, but on core we are not reexeced but
 	// running directly from the mount of the snapd snap under
 	// /usr/lib/snapd, yet we still want to set up the right environment
 	if release.OnClassic {
-		if !strings.HasPrefix(exe, currentRevSnapdSnap+"/") {
+		if !strings.HasPrefix(rootDir, dirs.SnapMountDir) {
 			// this is only supported for reexecing from the snapd snap
 			return nil
 		}
@@ -141,5 +142,5 @@ func MaybeSetupFIPS() error {
 
 	// TODO how to ensure that we only load the library from the snapd snap?
 
-	panic(syscallExec(exe, os.Args, env))
+	panic(syscallExec(filepath.Join(rootDir, exe), os.Args, env))
 }

--- a/snapdtool/fips_linux.go
+++ b/snapdtool/fips_linux.go
@@ -112,7 +112,7 @@ func MaybeSetupFIPS() error {
 	// running directly from the mount of the snapd snap under
 	// /usr/lib/snapd, yet we still want to set up the right environment
 	if release.OnClassic {
-		if !strings.HasPrefix(rootDir, dirs.SnapMountDir) {
+		if rootDir != currentRevSnapdSnap {
 			// this is only supported for reexecing from the snapd snap
 			return nil
 		}

--- a/snapdtool/fips_linux.go
+++ b/snapdtool/fips_linux.go
@@ -74,7 +74,7 @@ func MaybeSetupFIPS() error {
 
 	logger.Debugf("FIPS mode enabled system wide")
 
-	if os.Getenv("SNAPD_FIPS_BOOTSTRAP_DONE") == "1" {
+	if os.Getenv("SNAPD_FIPS_BOOTSTRAP") == "1" {
 		// we've already been reexeced into FIPS mode and bootstrap was
 		// performed
 		logger.Debugf("FIPS bootstrap complete")
@@ -84,7 +84,7 @@ func MaybeSetupFIPS() error {
 		// variables, other processes which may be invoked by snapd will
 		// perform the initialization cycle on their own when needed
 		os.Unsetenv("GOFIPS")
-		os.Unsetenv("SNAPD_FIPS_BOOTSTRAP_DONE")
+		os.Unsetenv("SNAPD_FIPS_BOOTSTRAP")
 		os.Unsetenv("OPENSSL_MODULES")
 		os.Unsetenv("GO_OPENSSL_VERSION_OVERRIDE")
 		return nil
@@ -120,7 +120,7 @@ func MaybeSetupFIPS() error {
 	lib, mod := findFIPSLibsAndModules(currentRevSnapdSnap)
 
 	env := append(os.Environ(), []string{
-		"SNAPD_FIPS_BOOTSTRAP_DONE=1",
+		"SNAPD_FIPS_BOOTSTRAP=1",
 		// make FIPS mod required at runtime, if the module was not
 		// found or the setup is incorrect snapd will fail in a
 		// predictable way

--- a/snapdtool/fips_linux_test.go
+++ b/snapdtool/fips_linux_test.go
@@ -139,7 +139,7 @@ func (s *fipsSuite) TestMaybeSetupFIPSFullWithReexecClassic(c *C) {
 		"OPENSSL_MODULES="+filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/x86_64-linux-gnu/ossl-modules-3"))
 	c.Check(observedEnv, testutil.Contains, "GO_OPENSSL_VERSION_OVERRIDE=3")
 	// bootstrap done
-	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP=1")
 }
 
 func (s *fipsSuite) TestMaybeSetupFIPSFullWithReexecCore(c *C) {
@@ -181,7 +181,7 @@ func (s *fipsSuite) TestMaybeSetupFIPSFullWithReexecCore(c *C) {
 		"OPENSSL_MODULES="+filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/x86_64-linux-gnu/ossl-modules-3"))
 	c.Check(observedEnv, testutil.Contains, "GO_OPENSSL_VERSION_OVERRIDE=3")
 	// bootstrap done
-	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP=1")
 }
 
 func (s *fipsSuite) TestMaybeSetupFIPSNoModulesButStillReexec(c *C) {
@@ -224,7 +224,7 @@ func (s *fipsSuite) TestMaybeSetupFIPSNoModulesButStillReexec(c *C) {
 		}
 	}
 	// bootstrap is done
-	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP=1")
 }
 
 func (s *fipsSuite) TestMaybeSetupFIPSBootstrapAlreadyDone(c *C) {
@@ -237,12 +237,12 @@ func (s *fipsSuite) TestMaybeSetupFIPSBootstrapAlreadyDone(c *C) {
 
 	defer func() {
 		os.Unsetenv("GOFIPS")
-		os.Unsetenv("SNAPD_FIPS_BOOSTRAP_DONE")
+		os.Unsetenv("SNAPD_FIPS_BOOSTRAP")
 		os.Unsetenv("OPENSSL_MODULES")
 		os.Unsetenv("GO_OPENSSL_VERSION_OVERRIDE")
 	}()
 
-	os.Setenv("SNAPD_FIPS_BOOTSTRAP_DONE", "1")
+	os.Setenv("SNAPD_FIPS_BOOTSTRAP", "1")
 	os.Setenv("GOFIPS", "1")
 	os.Setenv("OPENSSL_MODULES", "bogus-dir")
 	os.Setenv("GO_OPENSSL_VERSION_OVERRIDE", "123-xyz")
@@ -250,7 +250,7 @@ func (s *fipsSuite) TestMaybeSetupFIPSBootstrapAlreadyDone(c *C) {
 	err := snapdtool.MaybeSetupFIPS()
 	c.Assert(err, IsNil)
 
-	c.Check(os.Getenv("SNAPD_FIPS_BOOTSTRAP_DONE"), Equals, "")
+	c.Check(os.Getenv("SNAPD_FIPS_BOOTSTRAP"), Equals, "")
 	c.Check(os.Getenv("GOFIPS"), Equals, "")
 	c.Check(os.Getenv("OPENSSL_MODULES"), Equals, "")
 	c.Check(os.Getenv("GO_OPENSSL_VERSION_OVERRIDE"), Equals, "")

--- a/snapdtool/fips_linux_test.go
+++ b/snapdtool/fips_linux_test.go
@@ -1,0 +1,280 @@
+package snapdtool_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type fipsSuite struct {
+	testutil.BaseTest
+
+	logbuf *bytes.Buffer
+}
+
+var _ = Suite(&fipsSuite{})
+
+func (s *fipsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	os.Setenv("SNAPD_DEBUG", "1")
+	s.AddCleanup(func() { os.Unsetenv("SNAPD_DEBUG") })
+
+	buf, restore := logger.MockLogger()
+	s.AddCleanup(restore)
+	s.logbuf = buf
+
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	s.AddCleanup(snapdtool.MockSyscallExec(func(argv0 string, argv []string, envv []string) (err error) {
+		c.Fatal("exec not mocked")
+		return fmt.Errorf("exec not mocked")
+	}))
+}
+
+func (s *fipsSuite) TearDownTest(c *C) {
+	if c.Failed() {
+		c.Logf("logs:\n%s", s.logbuf.String())
+	}
+	s.BaseTest.TearDownTest(c)
+}
+
+func mockFipsEnabledWithContent(c *C, root, content string) {
+	f := filepath.Join(root, "/proc/sys/crypto/fips_enabled")
+	err := os.MkdirAll(filepath.Dir(f), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(f, []byte(content), 0444)
+	c.Assert(err, IsNil)
+}
+
+type fipsConf struct {
+	fipsEnabledPresent bool
+	fipsEnabledYes     bool
+	moduleAvaialble    bool
+	onCore             bool
+}
+
+func (s *fipsSuite) mockFIPSState(c *C, conf fipsConf) (selfExe string) {
+	if conf.fipsEnabledPresent {
+		content := "0\n"
+		if conf.fipsEnabledYes {
+			content = "1\n"
+		}
+		mockFipsEnabledWithContent(c, dirs.GlobalRootDir, content)
+	}
+
+	mockSelfExe := filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/snapd/snapd")
+	if conf.onCore {
+		mockSelfExe = filepath.Join(dirs.DistroLibExecDir, "snapd")
+	}
+	restore := snapdtool.MockOsReadlink(func(p string) (string, error) {
+		switch {
+		case p == "/snap/snapd/current":
+			return "123", nil
+		case strings.HasSuffix(p, "/proc/self/exe"):
+			return mockSelfExe, nil
+		}
+		return "", fmt.Errorf("unexpected path %q", p)
+	})
+	s.AddCleanup(restore)
+
+	if conf.moduleAvaialble {
+		// even on Core modules are still part of the snapd snap
+		snaptest.PopulateDir(filepath.Join(dirs.SnapMountDir, "snapd/123"), [][]string{
+			{"usr/lib/x86_64-linux-gnu/libcrypto.so.3", ""},
+			{"usr/lib/x86_64-linux-gnu/ossl-modules-3/fips.so", ""},
+		})
+	}
+
+	return mockSelfExe
+}
+
+func (s *fipsSuite) TestMaybeSetupFIPSFullWithReexecClassic(c *C) {
+	// everything is set up correctly
+
+	mockSelfExe := s.mockFIPSState(c, fipsConf{
+		fipsEnabledPresent: true,
+		fipsEnabledYes:     true,
+		moduleAvaialble:    true,
+		onCore:             false,
+	})
+	osArgs := os.Args
+	s.AddCleanup(func() { os.Args = osArgs })
+	os.Args = []string{"--arg"}
+
+	var observedEnv []string
+	var observedArgv []string
+	var observedArg0 string
+
+	restore := snapdtool.MockSyscallExec(func(argv0 string, argv []string, envv []string) (err error) {
+		observedArg0 = argv0
+		observedArgv = argv
+		observedEnv = envv
+		return fmt.Errorf("exec in tests on classic")
+	})
+	s.AddCleanup(restore)
+
+	c.Check(snapdtool.MaybeSetupFIPS, PanicMatches, "exec in tests on classic")
+
+	c.Check(observedArg0, Equals, mockSelfExe)
+	c.Check(observedArgv, DeepEquals, []string{"--arg"})
+	// FIPS mode is required
+	c.Check(observedEnv, testutil.Contains, "GOFIPS=1")
+	// module was found, and relevant env was added
+	c.Check(observedEnv, testutil.Contains,
+		"OPENSSL_MODULES="+filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/x86_64-linux-gnu/ossl-modules-3"))
+	c.Check(observedEnv, testutil.Contains, "GO_OPENSSL_VERSION_OVERRIDE=3")
+	// bootstrap done
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+}
+
+func (s *fipsSuite) TestMaybeSetupFIPSFullWithReexecCore(c *C) {
+	// everything is set up correctly
+
+	s.AddCleanup(release.MockOnClassic(false))
+
+	mockSelfExe := s.mockFIPSState(c, fipsConf{
+		fipsEnabledPresent: true,
+		fipsEnabledYes:     true,
+		moduleAvaialble:    true,
+		onCore:             true,
+	})
+	osArgs := os.Args
+	s.AddCleanup(func() { os.Args = osArgs })
+	os.Args = []string{"--arg"}
+
+	var observedEnv []string
+	var observedArgv []string
+	var observedArg0 string
+
+	restore := snapdtool.MockSyscallExec(func(argv0 string, argv []string, envv []string) (err error) {
+		observedArg0 = argv0
+		observedArgv = argv
+		observedEnv = envv
+		return fmt.Errorf("exec in tests on core")
+	})
+	s.AddCleanup(restore)
+
+	c.Check(snapdtool.MaybeSetupFIPS, PanicMatches, "exec in tests on core")
+
+	c.Check(observedArg0, Equals, mockSelfExe)
+	c.Check(observedArgv, DeepEquals, []string{"--arg"})
+	// FIPS mode is required
+	c.Check(observedEnv, testutil.Contains, "GOFIPS=1")
+	// module was found, and relevant env was added, and still points to the
+	// snapd snap mount directory
+	c.Check(observedEnv, testutil.Contains,
+		"OPENSSL_MODULES="+filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/x86_64-linux-gnu/ossl-modules-3"))
+	c.Check(observedEnv, testutil.Contains, "GO_OPENSSL_VERSION_OVERRIDE=3")
+	// bootstrap done
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+}
+
+func (s *fipsSuite) TestMaybeSetupFIPSNoModulesButStillReexec(c *C) {
+	// FIPS is enabled, we do not find the module, but still reexec into
+	// mandatory FIPS mode to obtain an predictable error from FIPS
+	// initialization
+
+	mockSelfExe := s.mockFIPSState(c, fipsConf{
+		fipsEnabledPresent: true,
+		fipsEnabledYes:     true,
+		moduleAvaialble:    false,
+	})
+
+	var observedEnv []string
+	var observedArgv []string
+	var observedArg0 string
+
+	osArgs := os.Args
+	s.AddCleanup(func() { os.Args = osArgs })
+	os.Args = []string{"--arg"}
+
+	restore := snapdtool.MockSyscallExec(func(argv0 string, argv []string, envv []string) (err error) {
+		observedArg0 = argv0
+		observedArgv = argv
+		observedEnv = envv
+		return fmt.Errorf("exec in tests")
+	})
+	s.AddCleanup(restore)
+
+	c.Check(snapdtool.MaybeSetupFIPS, PanicMatches, "exec in tests")
+
+	c.Check(observedArg0, Equals, mockSelfExe)
+	c.Check(observedArgv, DeepEquals, []string{"--arg"})
+	// FIPS mode is erquired
+	c.Check(observedEnv, testutil.Contains, "GOFIPS=1")
+	// module was not found, so paths are not set
+	for _, env := range observedEnv {
+		if strings.HasPrefix(env, "OPENSSL_MODULES=") || strings.HasPrefix(env, "GO_OPENSSL_VERSION_OVERRIDE=") {
+			c.Fatalf("found unexpected env %q", env)
+		}
+	}
+	// bootstrap is done
+	c.Check(observedEnv, testutil.Contains, "SNAPD_FIPS_BOOTSTRAP_DONE=1")
+}
+
+func (s *fipsSuite) TestMaybeSetupFIPSBootstrapAlreadyDone(c *C) {
+	// bootstrap was already completed
+
+	s.mockFIPSState(c, fipsConf{
+		fipsEnabledPresent: true,
+		fipsEnabledYes:     true,
+	})
+
+	defer func() {
+		os.Unsetenv("GOFIPS")
+		os.Unsetenv("SNAPD_FIPS_BOOSTRAP_DONE")
+		os.Unsetenv("OPENSSL_MODULES")
+		os.Unsetenv("GO_OPENSSL_VERSION_OVERRIDE")
+	}()
+
+	os.Setenv("SNAPD_FIPS_BOOTSTRAP_DONE", "1")
+	os.Setenv("GOFIPS", "1")
+	os.Setenv("OPENSSL_MODULES", "bogus-dir")
+	os.Setenv("GO_OPENSSL_VERSION_OVERRIDE", "123-xyz")
+
+	err := snapdtool.MaybeSetupFIPS()
+	c.Assert(err, IsNil)
+
+	c.Check(os.Getenv("SNAPD_FIPS_BOOTSTRAP_DONE"), Equals, "")
+	c.Check(os.Getenv("GOFIPS"), Equals, "")
+	c.Check(os.Getenv("OPENSSL_MODULES"), Equals, "")
+	c.Check(os.Getenv("GO_OPENSSL_VERSION_OVERRIDE"), Equals, "")
+}
+
+func (s *fipsSuite) TestMaybeSetupFIPSSnapdNotFromSnapOnClassic(c *C) {
+	// FIPS is enabled, but snapd is not running from the snapd snap
+
+	restore := snapdtool.MockOsReadlink(func(p string) (string, error) {
+		switch {
+		case p == "/snap/snapd/current":
+			return "123", nil
+		case strings.HasSuffix(p, "/proc/self/exe"):
+			return filepath.Join(dirs.DistroLibExecDir, "snapd"), nil
+		}
+		return "", fmt.Errorf("unexpected path %q", p)
+	})
+	s.AddCleanup(restore)
+
+	restore = snapdtool.MockSyscallExec(func(argv0 string, argv []string, envv []string) (err error) {
+		return fmt.Errorf("exec in tests")
+	})
+	s.AddCleanup(restore)
+
+	err := snapdtool.MaybeSetupFIPS()
+	c.Assert(err, IsNil)
+}

--- a/snapdtool/fips_other.go
+++ b/snapdtool/fips_other.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !linux
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapdtool
+
+// MaybeSetupFIPS does nothing but also returns no error on unsupported systems.
+func MaybeSetupFIPS() error {
+	return nil
+}

--- a/snapdtool/tool_linux_test.go
+++ b/snapdtool/tool_linux_test.go
@@ -1,3 +1,23 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build linux
+
+/*
+ * Copyright (C) 2020-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package snapdtool_test
 
 import (

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -521,7 +521,10 @@ func (s *toolSuite) TestExeAndRoot(c *C) {
 	root, exe, err = snapdtool.ExeAndRoot()
 	c.Assert(err, IsNil)
 	c.Assert(root, Equals, dirs.GlobalRootDir)
-	c.Assert(exe, Equals, "usr/lib/snapd/snapd")
+	// distro libexecdir without the root part
+	noRootPrefix, err := filepath.Rel(dirs.GlobalRootDir, dirs.DistroLibExecDir)
+	c.Assert(err, IsNil)
+	c.Assert(exe, Equals, filepath.Join(noRootPrefix, "snapd"))
 
 	// trouble reading the symlink
 	err = os.Remove(mockedSelfExe)


### PR DESCRIPTION
Switch to FIPS compliance mode when the system has booted with FIPS enabled. Specifically, set GOFIPS=1 to enforce FIPS mode at runtime, and set up environment such that the relevant openssl modules can be located.