### PR TITLE
interfaces: add desktop-file-prefix plug attr to desktop interface

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -39,9 +39,6 @@ const desktopSummary = `allows access to basic graphical desktop resources`
 // intended to prevent app snaps from the store that provide this slot
 // from installing without an override, while allowing an unpublished
 // snap to still be installed.
-//
-// The deny-connection and deny-auto-connection rules should ideally
-// use a slot-snap-type constraint when that is supported.
 const desktopBaseDeclarationSlots = `
   desktop:
     allow-installation:
@@ -51,6 +48,13 @@ const desktopBaseDeclarationSlots = `
     deny-installation:
       slot-snap-type:
         - app
+`
+
+const desktopBaseDeclarationPlugs = `
+  desktop:
+    allow-installation:
+      plug-attributes:
+        desktop-file-prefix: $MISSING
     deny-auto-connection:
       slot-snap-type:
         - app
@@ -597,6 +601,7 @@ func init() {
 			summary:              desktopSummary,
 			implicitOnClassic:    true,
 			baseDeclarationSlots: desktopBaseDeclarationSlots,
+			baseDeclarationPlugs: desktopBaseDeclarationPlugs,
 			// affects the plug snap because of mount backend
 			affectsPlugOnRefresh: true,
 		},

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1079,6 +1079,27 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 			}
 		}
 	}
+
+	// test desktop specially
+	ic := s.installPlugCand(c, "desktop", snap.TypeApp, `name: desktop
+version: 0
+type: app
+plugs:
+  desktop:
+`)
+	err := ic.Check()
+	c.Assert(err, IsNil)
+	// desktop-file-prefix can only be set by the store
+	ic = s.installPlugCand(c, "desktop", snap.TypeApp, `name: desktop
+version: 0
+type: app
+plugs:
+  desktop:
+    desktop-file-prefix: org.example
+`)
+	err = ic.Check()
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "installation not allowed by \"desktop\" plug rule of interface \"desktop\"")
 }
 
 func (s *baseDeclSuite) TestConnection(c *C) {
@@ -1343,6 +1364,7 @@ func (s *baseDeclSuite) TestValidity(c *C) {
 		"userns":                  true,
 		"wayland":                 true,
 		"xilinx-dma":              true,
+		"desktop":                 true,
 	}
 
 	for _, iface := range all {


### PR DESCRIPTION
This plug attribute is needed to allow snaps to have custom desktop file names.

Previously, snapd installed desktop files as `$snap_$app.desktop`. This causes problems in a number of cases where desktop files are expected to follow a particular format, or have a specific name. This PR is the first step in allowing custom desktop file names.

The new plug attribute allows snaps to have custom desktop file names (prefixed with the `desktop-file-prefix` attribute value).

Naming cannot be left uncontrolled, so the `$MISSING` constraint is added to only allow overriding `desktop-file-prefix` through the store. The process of requesting the snap declaration on the store will help ensure that the prefixes are sensible.

More details can be found in the spec: [SD170](https://docs.google.com/document/d/1j4flP303OJKrSxSCjkeZkh-9COuahVmo_EK_ye09RxQ/edit)

**Note: `deny-auto-connection` and `deny-connection` had to be moved to the plug base declaration because it takes precedence as mentioned in [interfaces/builtin/README.md](https://github.com/snapcore/snapd/blob/master/interfaces/builtin/README.md#base-declaration-policy-patterns)**
