### PR TITLE
i/prompting/requestprompts: add package to manage outstanding request prompts

### DIFF
--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -25,6 +25,17 @@ import (
 	"time"
 )
 
+// Metadata stores information about the origin or applicability of a prompt or
+// rule.
+type Metadata struct {
+	// User is the UID of the subject (user) triggering the applicable requests.
+	User uint32
+	// Snap is the instance name of the snap for which the prompt or rule applies.
+	Snap string
+	// Interface is the interface for which the prompt or rule applies.
+	Interface string
+}
+
 // OutcomeType describes the outcome associated with a reply or rule.
 type OutcomeType string
 

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -64,9 +64,9 @@ func (outcome *OutcomeType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// IsAllow returns true if the outcome is OutcomeAllow, false if the outcome is
+// AsBool returns true if the outcome is OutcomeAllow, false if the outcome is
 // OutcomeDeny, or an error if it cannot be parsed.
-func (outcome OutcomeType) IsAllow() (bool, error) {
+func (outcome OutcomeType) AsBool() (bool, error) {
 	switch outcome {
 	case OutcomeAllow:
 		return true, nil

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -22,6 +22,7 @@ package prompting
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -34,6 +35,25 @@ type Metadata struct {
 	Snap string
 	// Interface is the interface for which the prompt or rule applies.
 	Interface string
+}
+
+type IDType uint64
+
+func (i *IDType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(fmt.Sprintf("%016X", *i))
+}
+
+func (i *IDType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("cannot read ID into string: %w", err)
+	}
+	value, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse ID as uint64: %w", err)
+	}
+	*i = IDType(value)
+	return nil
 }
 
 // OutcomeType describes the outcome associated with a reply or rule.

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -36,6 +36,27 @@ type promptingSuite struct{}
 
 var _ = Suite(&promptingSuite{})
 
+func (s *promptingSuite) TestIDTypeMarshalUnmarshalJSON(c *C) {
+	for _, testCase := range []struct {
+		id         prompting.IDType
+		marshalled []byte
+	}{
+		{0, []byte(`"0000000000000000"`)},
+		{1, []byte(`"0000000000000001"`)},
+		{0x1000000000000000, []byte(`"1000000000000000"`)},
+		{0xDEADBEEFDEADBEEF, []byte(`"DEADBEEFDEADBEEF"`)},
+		{0xFFFFFFFFFFFFFFFF, []byte(`"FFFFFFFFFFFFFFFF"`)},
+	} {
+		marshalled, err := testCase.id.MarshalJSON()
+		c.Check(err, IsNil)
+		c.Check(marshalled, DeepEquals, testCase.marshalled)
+		var id prompting.IDType
+		err = id.UnmarshalJSON(testCase.marshalled)
+		c.Check(err, IsNil)
+		c.Check(id, Equals, testCase.id)
+	}
+}
+
 func (s *promptingSuite) TestOutcomeAsBool(c *C) {
 	result, err := prompting.OutcomeAllow.AsBool()
 	c.Check(err, IsNil)

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -36,16 +36,16 @@ type promptingSuite struct{}
 
 var _ = Suite(&promptingSuite{})
 
-func (s *promptingSuite) TestOutcomeIsAllow(c *C) {
-	result, err := prompting.OutcomeAllow.IsAllow()
+func (s *promptingSuite) TestOutcomeAsBool(c *C) {
+	result, err := prompting.OutcomeAllow.AsBool()
 	c.Check(err, IsNil)
 	c.Check(result, Equals, true)
-	result, err = prompting.OutcomeDeny.IsAllow()
+	result, err = prompting.OutcomeDeny.AsBool()
 	c.Check(err, IsNil)
 	c.Check(result, Equals, false)
-	_, err = prompting.OutcomeUnset.IsAllow()
+	_, err = prompting.OutcomeUnset.AsBool()
 	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
-	_, err = prompting.OutcomeType("foo").IsAllow()
+	_, err = prompting.OutcomeType("foo").AsBool()
 	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
 }
 

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package requestprompts
+
+import (
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockSendReply(f func(listenerReq *listener.Request, reply interface{}) error) (restore func()) {
+	restore = testutil.Backup(&sendReply)
+	sendReply = f
+	return restore
+}
+
+func (pdb *PromptDB) MaxID() uint64 {
+	return pdb.maxID
+}

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+const MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
+
 func MockSendReply(f func(listenerReq *listener.Request, reply interface{}) error) (restore func()) {
 	restore = testutil.Backup(&sendReply)
 	sendReply = f

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -34,6 +34,6 @@ func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
 	return pdb.perUser
 }
 
-func (pdb *PromptDB) MaxID() uint64 {
-	return pdb.maxID
+func (pdb *PromptDB) NextID() string {
+	return pdb.nextID()
 }

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -36,6 +36,6 @@ func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
 	return pdb.perUser
 }
 
-func (pdb *PromptDB) NextID() string {
+func (pdb *PromptDB) NextID() (string, error) {
 	return pdb.nextID()
 }

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -30,6 +30,10 @@ func MockSendReply(f func(listenerReq *listener.Request, reply interface{}) erro
 	return restore
 }
 
+func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
+	return pdb.perUser
+}
+
 func (pdb *PromptDB) MaxID() uint64 {
 	return pdb.maxID
 }

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -20,6 +20,7 @@
 package requestprompts
 
 import (
+	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -36,6 +37,6 @@ func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
 	return pdb.perUser
 }
 
-func (pdb *PromptDB) NextID() (string, error) {
+func (pdb *PromptDB) NextID() (prompting.IDType, error) {
 	return pdb.nextID()
 }

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -112,7 +112,10 @@ type PromptDB struct {
 }
 
 const (
-	maxIDFileSize                int = 8
+	// maxIDFileSize should be enough bytes to encode the maximum prompt ID.
+	maxIDFileSize int = 8
+	// maxOutstandingPromptsPerUser is an arbitrary limit.
+	// TODO: review this limit after some usage.
 	maxOutstandingPromptsPerUser int = 1000
 )
 
@@ -329,6 +332,10 @@ func (pdb *PromptDB) Reply(user uint32, id string, outcome prompting.OutcomeType
 	}
 	for _, listenerReq := range prompt.listenerReqs {
 		if err := sendReply(listenerReq, allow); err != nil {
+			// Error should only occur if reply is malformed, and since these
+			// listener requests should be identical, if a reply is malformed
+			// for one, it should be malformed for all. Malformed replies should
+			// leave the listener request unchanged. Thus, return early.
 			return nil, err
 		}
 	}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -219,7 +219,7 @@ func (pdb *PromptDB) Prompts(user uint32) []*Prompt {
 	defer pdb.mutex.Unlock()
 	userEntry, exists := pdb.perUser[user]
 	if !exists {
-		return make([]*Prompt, 0)
+		return []*Prompt{}
 	}
 	prompts := make([]*Prompt, 0, len(userEntry.ByID))
 	for _, prompt := range userEntry.ByID {
@@ -300,7 +300,7 @@ func (pdb *PromptDB) HandleNewRule(user uint32, snap string, iface string, const
 	if err != nil {
 		return nil, err
 	}
-	var satisfiedPromptIDs []string
+	satisfiedPromptIDs := []string{}
 	userEntry, exists := pdb.perUser[user]
 	if !exists {
 		return satisfiedPromptIDs, nil

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -210,6 +210,12 @@ func (pdb *PromptDB) AddOrMerge(user uint32, snap string, iface string, path str
 	for _, prompt := range userEntry.ByID {
 		if prompt.Snap == snap && prompt.Interface == iface && prompt.Constraints.equals(constraints) {
 			prompt.listenerReqs = append(prompt.listenerReqs, listenerReq)
+			// Although the prompt itself has not changed, re-record a notice
+			// to re-notify clients to respond to this request. A client may
+			// have replied with a malformed response and not retried after
+			// receiving the error, so this notice encourages it to try again
+			// if the user retries the operation.
+			pdb.notifyPrompt(user, prompt.ID)
 			return prompt, true
 		}
 	}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -244,7 +244,7 @@ func (pdb *PromptDB) Prompts(user uint32) []*Prompt {
 	defer pdb.mutex.RUnlock()
 	userEntry, ok := pdb.perUser[user]
 	if !ok || len(userEntry.ByID) == 0 {
-		return []*Prompt{}
+		return nil
 	}
 	prompts := make([]*Prompt, 0, len(userEntry.ByID))
 	for _, prompt := range userEntry.ByID {
@@ -331,11 +331,11 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 	}
 	pdb.mutex.Lock()
 	defer pdb.mutex.Unlock()
-	satisfiedPromptIDs := []string{}
 	userEntry, ok := pdb.perUser[metadata.User]
 	if !ok {
-		return satisfiedPromptIDs, nil
+		return nil, nil
 	}
+	var satisfiedPromptIDs []string
 	for id, prompt := range userEntry.ByID {
 		if !(prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface) {
 			continue

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
@@ -117,10 +118,11 @@ func New(notifyPrompt func(userID uint32, promptID string, data map[string]strin
 		notifyPrompt: notifyPrompt,
 	}
 	// Importantly, set maxIDPath before attempting to load max ID
-	pdb.maxIDPath = filepath.Join(dirs.SnapRunDir, "/request-prompt-max-id")
+	pdb.maxIDPath = filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
 	err := pdb.loadMaxID()
 	if err != nil {
 		// If cannot read max existing prompt ID, start again from 0.
+		logger.Debugf("%v; restarting at ID 0", err)
 		pdb.maxID = 0
 	}
 	return &pdb

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -295,8 +295,7 @@ func (pdb *PromptDB) Reply(user uint32, id string, outcome prompting.OutcomeType
 		}
 	}
 	delete(userEntry.ByID, id)
-	data := make(map[string]string)
-	data["resolved"] = "replied"
+	data := map[string]string{"resolved": "replied"}
 	pdb.notifyPrompt(user, id, data)
 	return prompt, nil
 }
@@ -358,8 +357,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		}
 		delete(userEntry.ByID, id)
 		satisfiedPromptIDs = append(satisfiedPromptIDs, id)
-		data := make(map[string]string)
-		data["resolved"] = "satisfied"
+		data := map[string]string{"resolved": "satisfied"}
 		pdb.notifyPrompt(metadata.User, id, data)
 	}
 	return satisfiedPromptIDs, nil
@@ -370,8 +368,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 // This should be called when snapd is shutting down, to notify prompt clients
 // that the given prompts are no longer awaiting a reply.
 func (pdb *PromptDB) Close() {
-	data := make(map[string]string)
-	data["resolved"] = "cancelled"
+	data := map[string]string{"resolved": "cancelled"}
 	pdb.mutex.Lock()
 	defer pdb.mutex.Unlock()
 	for user, userEntry := range pdb.perUser {

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -279,7 +279,7 @@ func (pdb *PromptDB) promptWithID(user uint32, id string) (*userPromptDB, *Promp
 //
 // Records a notice for the prompt, and returns the prompt's former contents.
 func (pdb *PromptDB) Reply(user uint32, id string, outcome prompting.OutcomeType) (*Prompt, error) {
-	allow, err := outcome.IsAllow()
+	allow, err := outcome.AsBool()
 	if err != nil {
 		return nil, err
 	}
@@ -322,12 +322,12 @@ var sendReply = func(listenerReq *listener.Request, reply interface{}) error {
 // Returns the IDs of any prompts which were fully satisfied by the given rule
 // contents.
 func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *prompting.Constraints, outcome prompting.OutcomeType) ([]string, error) {
-	pdb.mutex.Lock()
-	defer pdb.mutex.Unlock()
-	allow, err := outcome.IsAllow()
+	allow, err := outcome.AsBool()
 	if err != nil {
 		return nil, err
 	}
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
 	satisfiedPromptIDs := []string{}
 	userEntry, ok := pdb.perUser[metadata.User]
 	if !ok {

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -1,0 +1,283 @@
+package requestprompts
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/strutil"
+)
+
+// Prompt contains information about a request for which a user should be
+// prompted.
+type Prompt struct {
+	ID           string              `json:"id"`
+	Timestamp    time.Time           `json:"timestamp"`
+	Snap         string              `json:"snap"`
+	Interface    string              `json:"interface"`
+	Constraints  *promptConstraints  `json:"constraints"`
+	listenerReqs []*listener.Request `json:"-"`
+}
+
+// promptConstraints are like prompting.Constraints, but have a "path" field
+// instead of a "path-pattern", and include the available permissions for the
+// interface corresponding to the prompt.
+type promptConstraints struct {
+	Path                 string   `json:"path"`
+	Permissions          []string `json:"permissions"`
+	AvailablePermissions []string `json:"available-permissions"`
+}
+
+func (pc *promptConstraints) equals(other *promptConstraints) bool {
+	if pc.Path != other.Path || len(pc.Permissions) != len(other.Permissions) {
+		return false
+	}
+	// Avoid using reflect.DeepEquals to compare []string contents
+	for i := range pc.Permissions {
+		if pc.Permissions[i] != other.Permissions[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// subtractPermissions removes all of the given permissions from the list of
+// permissions in the constraints.
+func (pc *promptConstraints) subtractPermissions(permissions []string) bool {
+	newPermissions := make([]string, 0, len(pc.Permissions))
+	for _, perm := range pc.Permissions {
+		if !strutil.ListContains(permissions, perm) {
+			newPermissions = append(newPermissions, perm)
+		}
+	}
+	if len(newPermissions) != len(pc.Permissions) {
+		pc.Permissions = newPermissions
+		return true
+	}
+	return false
+}
+
+type userPromptDB struct {
+	ByID map[string]*Prompt
+}
+
+// PromptDB stores outstanding prompts and ensures that new prompts are created
+// with a unique ID.
+type PromptDB struct {
+	perUser map[uint32]*userPromptDB
+	maxID   uint64
+	mutex   sync.Mutex
+	// Function to issue a notice for a change in a prompt
+	notifyPrompt func(userID uint32, promptID string) error
+}
+
+// New creates and returns a new prompt database.
+//
+// The given notifyPrompt closure should record a notice of type
+// "interfaces-requests-prompt" for the given user with the given
+// promptID as its key.
+func New(notifyPrompt func(userID uint32, promptID string) error) *PromptDB {
+	pdb := PromptDB{
+		perUser:      make(map[uint32]*userPromptDB),
+		notifyPrompt: notifyPrompt,
+	}
+	return &pdb
+}
+
+// nextID advances the internal monotonically-increasing maxID integer.
+//
+// The caller must ensure that the prompt DB mutex is held.
+func (pdb *PromptDB) nextID() string {
+	pdb.maxID += 1
+	padded := pdb.paddedMaxIDString()
+	return padded
+}
+
+// paddedMaxIDString returns a 16-character string corresponding to the current
+// maxID. The ID string is the max ID in hexadecimal, padded by leading zeroes.
+func (pdb *PromptDB) paddedMaxIDString() string {
+	maxIDStr := strconv.FormatUint(pdb.maxID, 16)
+	// pad with leading zeros
+	padded := "0000000000000000"[:16-len(maxIDStr)] + maxIDStr
+	return padded
+}
+
+// AddOrMerge checks if the given prompt contents are identical to an existing
+// prompt and, if so, merges with it by adding the given listenerReq to it.
+// Otherwise, adds a new prompt with the given contents to the prompt DB.
+//
+// If the prompt was merged with an identical existing prompt, returns the
+// existing prompt and true, indicating it was merged. If a new prompt was
+// added, returns the new prompt and false, indicating the prompt was not
+// merged.
+//
+// The caller must ensure that the given permissions are in the order in which
+// they appear in the available permissions list for the given interface.
+func (pdb *PromptDB) AddOrMerge(user uint32, snap string, iface string, path string, permissions []string, listenerReq *listener.Request) (*Prompt, bool) {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+	userEntry, exists := pdb.perUser[user]
+	if !exists {
+		pdb.perUser[user] = &userPromptDB{
+			ByID: make(map[string]*Prompt),
+		}
+		userEntry = pdb.perUser[user]
+	}
+
+	availablePermissions, _ := prompting.AvailablePermissions(iface)
+	// Error should be impossible, since caller has already validated that iface
+	// is valid, and tests check that all valid interfaces have valid available
+	// permissions returned by AvailablePermissions.
+
+	constraints := &promptConstraints{
+		Path:                 path,
+		Permissions:          permissions,
+		AvailablePermissions: availablePermissions,
+	}
+
+	// Search for an identical existing prompt, merge if found
+	for _, prompt := range userEntry.ByID {
+		if prompt.Snap == snap && prompt.Interface == iface && prompt.Constraints.equals(constraints) {
+			prompt.listenerReqs = append(prompt.listenerReqs, listenerReq)
+			return prompt, true
+		}
+	}
+
+	id := pdb.nextID()
+	timestamp := time.Now()
+	prompt := &Prompt{
+		ID:           id,
+		Timestamp:    timestamp,
+		Snap:         snap,
+		Interface:    iface,
+		Constraints:  constraints,
+		listenerReqs: []*listener.Request{listenerReq},
+	}
+	userEntry.ByID[id] = prompt
+	pdb.notifyPrompt(user, id)
+	return prompt, false
+}
+
+// Prompts returns a slice of all outstanding prompts.
+func (pdb *PromptDB) Prompts(user uint32) []*Prompt {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+	userEntry, exists := pdb.perUser[user]
+	if !exists {
+		return make([]*Prompt, 0)
+	}
+	prompts := make([]*Prompt, 0, len(userEntry.ByID))
+	for _, prompt := range userEntry.ByID {
+		prompts = append(prompts, prompt)
+	}
+	return prompts
+}
+
+// PromptWithID returns the prompt with the given ID for the given user.
+func (pdb *PromptDB) PromptWithID(user uint32, id string) (*Prompt, error) {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+	userEntry, exists := pdb.perUser[user]
+	if !exists {
+		return nil, fmt.Errorf("cannot find prompts for the given UID: %d", user)
+	}
+	prompt, exists := userEntry.ByID[id]
+	if !exists {
+		return nil, fmt.Errorf("cannot find prompt for UID %d with the given ID: %s", user, id)
+	}
+	return prompt, nil
+}
+
+// Reply resolves the prompt with the given ID using the given outcome by
+// sending a reply to all associated listener requests, then removing the
+// prompt from the prompt DB.
+//
+// Records a notice for the prompt, and returns the prompt's former contents.
+func (pdb *PromptDB) Reply(user uint32, id string, outcome prompting.OutcomeType) (*Prompt, error) {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+	userEntry, exists := pdb.perUser[user]
+	if !exists || len(userEntry.ByID) == 0 {
+		return nil, fmt.Errorf("cannot find prompts for the given UID: %d", user)
+	}
+	prompt, exists := userEntry.ByID[id]
+	if !exists {
+		return nil, fmt.Errorf("cannot find prompt for UID %d with the given ID: %s", user, id)
+	}
+	allow, err := outcome.IsAllow()
+	if err != nil {
+		return nil, err
+	}
+	for _, listenerReq := range prompt.listenerReqs {
+		if err := sendReply(listenerReq, allow); err != nil {
+			return nil, err
+		}
+	}
+	delete(userEntry.ByID, id)
+	pdb.notifyPrompt(user, id)
+	return prompt, nil
+}
+
+var sendReply = func(listenerReq *listener.Request, reply interface{}) error {
+	return listenerReq.Reply(reply)
+}
+
+// HandleNewRule checks if any existing prompts are satisfied by the given rule
+// contents and, if so, sends back a decision to their listener requests.
+//
+// A prompt is satisfied by the given rule contents if the user, snap,
+// interface, and path of the prompt match those of the rule, and if either the
+// outcome is "allow" and all of the prompt's permissions are matched by those
+// of the rule contents, or if the outcome is "deny" and any of the permissions
+// match.
+//
+// Records a notice for any prompt which was satisfied, or which had some of
+// its permissions satisfied by the rule contents. In the future, only the
+// remaining unsatisfied permissions of a partially-satisfied prompt must be
+// satisfied for the prompt as a whole to be satisfied.
+//
+// Returns the IDs of any prompts which were fully satisfied by the given rule
+// contents.
+func (pdb *PromptDB) HandleNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType) ([]string, error) {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+	allow, err := outcome.IsAllow()
+	if err != nil {
+		return nil, err
+	}
+	var satisfiedPromptIDs []string
+	userEntry, exists := pdb.perUser[user]
+	if !exists {
+		return satisfiedPromptIDs, nil
+	}
+	for id, prompt := range userEntry.ByID {
+		if !(prompt.Snap == snap && prompt.Interface == iface) {
+			continue
+		}
+		matched, err := constraints.Match(prompt.Constraints.Path)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			continue
+		}
+		modified := prompt.Constraints.subtractPermissions(constraints.Permissions)
+		if !modified {
+			continue
+		}
+		pdb.notifyPrompt(user, id)
+		if len(prompt.Constraints.Permissions) > 0 && allow == true {
+			continue
+		}
+		// All permissions of prompt satisfied, or any permission denied
+		for _, listenerReq := range prompt.listenerReqs {
+			sendReply(listenerReq, allow)
+		}
+		delete(userEntry.ByID, id)
+		satisfiedPromptIDs = append(satisfiedPromptIDs, id)
+	}
+	return satisfiedPromptIDs, nil
+}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -162,18 +162,15 @@ func (pdb *PromptDB) loadMaxID() error {
 // The caller must ensure that the prompt DB mutex is held.
 func (pdb *PromptDB) nextID() string {
 	pdb.maxID++
-	padded := pdb.paddedMaxIDString()
-	osutil.AtomicWriteFile(pdb.maxIDPath, []byte(padded), 0600, 0)
-	return padded
+	idStr := pdb.maxIDString()
+	osutil.AtomicWriteFile(pdb.maxIDPath, []byte(idStr), 0600, 0)
+	return idStr
 }
 
-// paddedMaxIDString returns a 16-character string corresponding to the current
-// maxID. The ID string is the max ID in hexadecimal, padded by leading zeroes.
-func (pdb *PromptDB) paddedMaxIDString() string {
-	maxIDStr := strconv.FormatUint(pdb.maxID, 16)
-	// pad with leading zeros
-	padded := "0000000000000000"[:16-len(maxIDStr)] + maxIDStr
-	return padded
+// maxIDString returns a 16-character string corresponding to the current maxID.
+// The ID string is the max ID in hexadecimal, padded by leading zeroes.
+func (pdb *PromptDB) maxIDString() string {
+	return fmt.Sprintf("%016X", pdb.maxID)
 }
 
 // AddOrMerge checks if the given prompt contents are identical to an existing

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"testing"
 	"time"
 
@@ -130,9 +129,8 @@ func (s *requestpromptsSuite) TestLoadMaxIDNextID(c *C) {
 	defer restore()
 
 	var prevMaxID uint64 = 42
-	maxIDStr := strconv.FormatUint(prevMaxID, 16)
-	padded := "0000000000000000"[:16-len(maxIDStr)] + maxIDStr
-	osutil.AtomicWriteFile(filepath.Join(s.tmpdir, "/tmp/snapd-request-prompt-max-id"), []byte(padded), 0600, 0)
+	maxIDStr := fmt.Sprintf("%016X", prevMaxID)
+	osutil.AtomicWriteFile(filepath.Join(s.tmpdir, "/tmp/snapd-request-prompt-max-id"), []byte(maxIDStr), 0600, 0)
 
 	pdb1 := requestprompts.New(s.defaultNotifyPrompt)
 	c.Check(pdb1.PerUser(), HasLen, 0)
@@ -150,9 +148,8 @@ func (s *requestpromptsSuite) TestLoadMaxIDNextID(c *C) {
 	s.checkWrittenMaxID(c, prompt.ID)
 
 	expectedID := prevMaxID + 1
-	expectedIDStr := strconv.FormatUint(expectedID, 16)
-	padded = "0000000000000000"[:16-len(expectedIDStr)] + expectedIDStr
-	s.checkWrittenMaxID(c, padded)
+	expectedIDStr := fmt.Sprintf("%016X", expectedID)
+	s.checkWrittenMaxID(c, expectedIDStr)
 
 	pdb2 := requestprompts.New(s.defaultNotifyPrompt)
 	// New prompt DB should not have existing prompts, but should start from previous max ID

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -218,7 +218,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	listenerReq3 := &listener.Request{}
 
 	stored := pdb.Prompts(metadata.User)
-	c.Assert(stored, HasLen, 0)
+	c.Assert(stored, IsNil)
 
 	before := time.Now()
 	prompt1, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
@@ -687,7 +687,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	satisfied, err := pdb.HandleNewRule(metadata, constraints, badOutcome)
 	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
-	c.Check(satisfied, HasLen, 0)
+	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []string{}, nil)
 
@@ -698,7 +698,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	}
 	satisfied, err = pdb.HandleNewRule(otherUserMetadata, constraints, outcome)
 	c.Check(err, IsNil)
-	c.Check(satisfied, HasLen, 0)
+	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []string{}, nil)
 
@@ -709,7 +709,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	}
 	satisfied, err = pdb.HandleNewRule(otherSnapMetadata, constraints, outcome)
 	c.Check(err, IsNil)
-	c.Check(satisfied, HasLen, 0)
+	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []string{}, nil)
 
@@ -720,13 +720,13 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	}
 	satisfied, err = pdb.HandleNewRule(otherInterfaceMetadata, constraints, outcome)
 	c.Check(err, IsNil)
-	c.Check(satisfied, HasLen, 0)
+	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome)
 	c.Check(err, IsNil)
-	c.Check(satisfied, HasLen, 0)
+	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []string{}, nil)
 
@@ -745,7 +745,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Check(allowed, Equals, true)
 
 	stored = pdb.Prompts(metadata.User)
-	c.Check(stored, HasLen, 0)
+	c.Check(stored, IsNil)
 }
 
 func (s *requestpromptsSuite) TestClose(c *C) {

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,10 +41,34 @@ import (
 
 func Test(t *testing.T) { TestingT(t) }
 
+type noticeInfo struct {
+	promptID string
+	data     map[string]string
+}
+
+type noticeList []*noticeInfo
+
+// Implements sort.Interface
+func (l noticeList) Len() int {
+	return len(l)
+}
+
+// Implements sort.Interface
+func (l noticeList) Less(i, j int) bool {
+	return strings.Compare(l[i].promptID, l[j].promptID) < 0
+}
+
+// Implements sort.Interface
+func (l noticeList) Swap(i, j int) {
+	atI := l[i]
+	l[i] = l[j]
+	l[j] = atI
+}
+
 type requestpromptsSuite struct {
-	defaultNotifyPrompt func(userID uint32, promptID string) error
+	defaultNotifyPrompt func(userID uint32, promptID string, data map[string]string) error
 	defaultUser         uint32
-	noticePromptIDs     []string
+	promptNotices       noticeList
 
 	tmpdir string
 }
@@ -52,19 +77,23 @@ var _ = Suite(&requestpromptsSuite{})
 
 func (s *requestpromptsSuite) SetUpTest(c *C) {
 	s.defaultUser = 1000
-	s.defaultNotifyPrompt = func(userID uint32, promptID string) error {
+	s.defaultNotifyPrompt = func(userID uint32, promptID string, data map[string]string) error {
 		c.Check(userID, Equals, s.defaultUser)
-		s.noticePromptIDs = append(s.noticePromptIDs, promptID)
+		info := &noticeInfo{
+			promptID: promptID,
+			data:     data,
+		}
+		s.promptNotices = append(s.promptNotices, info)
 		return nil
 	}
-	s.noticePromptIDs = make([]string, 0)
+	s.promptNotices = make([]*noticeInfo, 0)
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
 	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0700), IsNil)
 }
 
 func (s *requestpromptsSuite) TestNew(c *C) {
-	notifyPrompt := func(userID uint32, promptID string) error {
+	notifyPrompt := func(userID uint32, promptID string, data map[string]string) error {
 		c.Fatalf("unexpected notice with userID %d and ID %s", userID, promptID)
 		return nil
 	}
@@ -74,7 +103,7 @@ func (s *requestpromptsSuite) TestNew(c *C) {
 }
 
 func (s *requestpromptsSuite) TestLoadMaxID(c *C) {
-	notifyPrompt := func(userID uint32, promptID string) error {
+	notifyPrompt := func(userID uint32, promptID string, data map[string]string) error {
 		c.Fatalf("unexpected notice with userID %d and ID %s", userID, promptID)
 		return nil
 	}
@@ -195,7 +224,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	after := time.Now()
 	c.Assert(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt1.ID})
+	s.checkNewNoticesSimple(c, []string{prompt1.ID}, nil)
 	c.Check(pdb.MaxID(), Equals, uint64(1))
 	s.checkWrittenMaxID(c, prompt1.ID)
 
@@ -204,7 +233,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	c.Assert(prompt2, Equals, prompt1)
 
 	// Merged prompts should re-record notice
-	s.checkNewNotices(c, []string{prompt1.ID})
+	s.checkNewNoticesSimple(c, []string{prompt1.ID}, nil)
 	// Merged prompts should not advance the max ID
 	c.Check(pdb.MaxID(), Equals, uint64(1))
 	s.checkWrittenMaxID(c, prompt1.ID)
@@ -226,28 +255,48 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	c.Check(storedPrompt, Equals, prompt1)
 
 	// Looking up prompt should not record notice
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	prompt3, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq3)
 	c.Check(merged, Equals, true)
 	c.Check(prompt3, Equals, prompt1)
 
 	// Merged prompts should re-record notice
-	s.checkNewNotices(c, []string{prompt1.ID})
+	s.checkNewNoticesSimple(c, []string{prompt1.ID}, nil)
 	// Merged prompts should not advance the max ID
 	c.Check(pdb.MaxID(), Equals, uint64(1))
 	s.checkWrittenMaxID(c, prompt1.ID)
 }
 
-func (s *requestpromptsSuite) checkNewNotices(c *C, expectedPromptIDs []string) {
-	c.Check(s.noticePromptIDs, DeepEquals, expectedPromptIDs)
-	s.noticePromptIDs = s.noticePromptIDs[:0]
+func (s *requestpromptsSuite) checkNewNoticesSimple(c *C, expectedPromptIDs []string, expectedData map[string]string) {
+	s.checkNewNotices(c, applyNotices(expectedPromptIDs, expectedData))
 }
 
-func (s *requestpromptsSuite) checkNewNoticesUnordered(c *C, expectedPromptIDs []string) {
-	sort.Strings(s.noticePromptIDs)
-	sort.Strings(expectedPromptIDs)
-	s.checkNewNotices(c, expectedPromptIDs)
+func applyNotices(expectedPromptIDs []string, expectedData map[string]string) noticeList {
+	expectedNotices := make(noticeList, len(expectedPromptIDs))
+	for i, id := range expectedPromptIDs {
+		info := &noticeInfo{
+			promptID: id,
+			data:     expectedData,
+		}
+		expectedNotices[i] = info
+	}
+	return expectedNotices
+}
+
+func (s *requestpromptsSuite) checkNewNotices(c *C, expectedNotices noticeList) {
+	c.Check(s.promptNotices, DeepEquals, expectedNotices)
+	s.promptNotices = s.promptNotices[:0]
+}
+
+func (s *requestpromptsSuite) checkNewNoticesUnorderedSimple(c *C, expectedPromptIDs []string, expectedData map[string]string) {
+	s.checkNewNoticesUnordered(c, applyNotices(expectedPromptIDs, expectedData))
+}
+
+func (s *requestpromptsSuite) checkNewNoticesUnordered(c *C, expectedNotices noticeList) {
+	sort.Sort(s.promptNotices)
+	sort.Sort(expectedNotices)
+	s.checkNewNotices(c, expectedNotices)
 }
 
 func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
@@ -272,7 +321,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 	prompt, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt.ID})
+	s.checkNewNoticesSimple(c, []string{prompt.ID}, nil)
 
 	result, err := pdb.PromptWithID(metadata.User, prompt.ID)
 	c.Check(err, IsNil)
@@ -287,7 +336,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 	c.Check(result, IsNil)
 
 	// Looking up prompts (with or without errors) should not record notices
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 }
 
 func (s *requestpromptsSuite) TestReply(c *C) {
@@ -317,14 +366,14 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		prompt1, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
 		c.Check(merged, Equals, false)
 
-		s.checkNewNotices(c, []string{prompt1.ID})
+		s.checkNewNoticesSimple(c, []string{prompt1.ID}, nil)
 
 		prompt2, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq2)
 		c.Check(merged, Equals, true)
 		c.Check(prompt2, Equals, prompt1)
 
 		// Merged prompts should re-record notice
-		s.checkNewNotices(c, []string{prompt1.ID})
+		s.checkNewNoticesSimple(c, []string{prompt1.ID}, nil)
 
 		repliedPrompt, err := pdb.Reply(metadata.User, prompt1.ID, outcome)
 		c.Check(err, IsNil)
@@ -340,7 +389,8 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 			c.Check(allowed, Equals, expected)
 		}
 
-		s.checkNewNotices(c, []string{repliedPrompt.ID})
+		expectedData := map[string]string{"resolved": "replied"}
+		s.checkNewNoticesSimple(c, []string{repliedPrompt.ID}, expectedData)
 	}
 }
 
@@ -380,7 +430,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	prompt, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt.ID})
+	s.checkNewNoticesSimple(c, []string{prompt.ID}, nil)
 
 	outcome := prompting.OutcomeAllow
 
@@ -397,7 +447,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	c.Check(err, Equals, fakeError)
 
 	// Failed replies should not record notice
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 }
 
 func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
@@ -439,7 +489,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	prompt4, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID})
+	s.checkNewNoticesSimple(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID}, nil)
 
 	stored := pdb.Prompts(metadata.User)
 	c.Assert(stored, HasLen, 4)
@@ -461,7 +511,11 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 
 	// Read and write permissions of prompt1 satisfied, so notice re-issued,
 	// but it has one remaining permission. prompt2 and prompt3 fully satisfied.
-	s.checkNewNoticesUnordered(c, []string{prompt1.ID, prompt2.ID, prompt3.ID})
+	e1 := &noticeInfo{promptID: prompt1.ID, data: nil}
+	e2 := &noticeInfo{promptID: prompt2.ID, data: map[string]string{"resolved": "satisfied"}}
+	e3 := &noticeInfo{promptID: prompt3.ID, data: map[string]string{"resolved": "satisfied"}}
+	expectedNotices := noticeList{e1, e2, e3}
+	s.checkNewNoticesUnordered(c, expectedNotices)
 
 	for i := 0; i < 2; i++ {
 		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
@@ -489,7 +543,8 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	c.Check(satisfied, HasLen, 1)
 	c.Check(satisfied[0], Equals, prompt1.ID)
 
-	s.checkNewNotices(c, []string{prompt1.ID})
+	expectedData := map[string]string{"resolved": "satisfied"}
+	s.checkNewNoticesSimple(c, []string{prompt1.ID}, expectedData)
 
 	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 	c.Check(err, IsNil)
@@ -538,7 +593,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	prompt4, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID})
+	s.checkNewNoticesSimple(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID}, nil)
 
 	stored := pdb.Prompts(metadata.User)
 	c.Assert(stored, HasLen, 4)
@@ -560,7 +615,8 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	c.Check(strutil.ListContains(satisfied, prompt2.ID), Equals, true)
 	c.Check(strutil.ListContains(satisfied, prompt3.ID), Equals, true)
 
-	s.checkNewNoticesUnordered(c, []string{prompt1.ID, prompt2.ID, prompt3.ID})
+	expectedData := map[string]string{"resolved": "satisfied"}
+	s.checkNewNoticesUnorderedSimple(c, []string{prompt1.ID, prompt2.ID, prompt3.ID}, expectedData)
 
 	for i := 0; i < 3; i++ {
 		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
@@ -603,7 +659,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	prompt, merged := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
-	s.checkNewNotices(c, []string{prompt.ID})
+	s.checkNewNoticesSimple(c, []string{prompt.ID}, nil)
 
 	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
 	c.Assert(err, IsNil)
@@ -632,7 +688,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
 	c.Check(satisfied, HasLen, 0)
 
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	otherUserMetadata := &prompting.Metadata{
 		User:      otherUser,
@@ -643,7 +699,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	otherSnapMetadata := &prompting.Metadata{
 		User:      user,
@@ -654,7 +710,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	otherInterfaceMetadata := &prompting.Metadata{
 		User:      user,
@@ -665,19 +721,20 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
-	s.checkNewNotices(c, []string{})
+	s.checkNewNoticesSimple(c, []string{}, nil)
 
 	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Assert(satisfied, HasLen, 1)
 
-	s.checkNewNotices(c, []string{prompt.ID})
+	expectedData := map[string]string{"resolved": "satisfied"}
+	s.checkNewNoticesSimple(c, []string{prompt.ID}, expectedData)
 
 	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 	c.Check(err, IsNil)
@@ -727,12 +784,13 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 	c.Check(pdb.MaxID(), Equals, uint64(3))
 
 	// One notice for each prompt when created
-	s.checkNewNotices(c, expectedPromptIDs)
+	s.checkNewNoticesSimple(c, expectedPromptIDs, nil)
 
 	pdb.Close()
 
 	// Once notice for each prompt when cleaned up
-	s.checkNewNoticesUnordered(c, expectedPromptIDs)
+	expectedData := map[string]string{"resolved": "cancelled"}
+	s.checkNewNoticesUnorderedSimple(c, expectedPromptIDs, expectedData)
 
 	// All prompts have been cleared, and all per-user maps deleted
 	c.Check(pdb.PerUser(), HasLen, 0)

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -1,3 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package requestprompts_test
 
 import (
@@ -261,7 +280,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 	c.Check(result, IsNil)
 
 	result, err = pdb.PromptWithID(user+1, "foo")
-	c.Check(err, ErrorMatches, "cannot find prompts for the given UID:.*")
+	c.Check(err, ErrorMatches, "cannot find prompt for UID 1001 with the given ID:.*")
 	c.Check(result, IsNil)
 
 	// Looking up prompts (with or without errors) should not trigger notices
@@ -362,7 +381,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	c.Check(err, ErrorMatches, "cannot find prompt for UID 1000 with the given ID:.*")
 
 	_, err = pdb.Reply(user+1, "foo", outcome)
-	c.Check(err, ErrorMatches, "cannot find prompts for the given UID:.*")
+	c.Check(err, ErrorMatches, "cannot find prompt for UID 1001 with the given ID:.*")
 
 	_, err = pdb.Reply(user, prompt.ID, prompting.OutcomeUnset)
 	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -1,0 +1,536 @@
+package requestprompts_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/strutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type requestpromptsSuite struct {
+	defaultNotifyPrompt func(userID uint32, promptID string) error
+	defaultUser         uint32
+	noticePromptIDs     []string
+
+	tmpdir string
+}
+
+var _ = Suite(&requestpromptsSuite{})
+
+func (s *requestpromptsSuite) SetUpTest(c *C) {
+	s.defaultUser = 1000
+	s.defaultNotifyPrompt = func(userID uint32, promptID string) error {
+		c.Check(userID, Equals, s.defaultUser)
+		s.noticePromptIDs = append(s.noticePromptIDs, promptID)
+		return nil
+	}
+	s.noticePromptIDs = make([]string, 0)
+}
+
+func (s *requestpromptsSuite) TestNew(c *C) {
+	notifyPrompt := func(userID uint32, promptID string) error {
+		c.Fatalf("unexpected notice with userID %d and ID %s", userID, promptID)
+		return nil
+	}
+	pdb := requestprompts.New(notifyPrompt)
+	c.Check(pdb.MaxID(), Equals, uint64(0))
+}
+
+func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		c.Fatalf("should not have called sendReply")
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "home"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []string{"read", "write", "execute"}
+
+	listenerReq1 := &listener.Request{}
+	listenerReq2 := &listener.Request{}
+	listenerReq3 := &listener.Request{}
+
+	stored := pdb.Prompts(user)
+	c.Assert(stored, HasLen, 0)
+
+	before := time.Now()
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
+	after := time.Now()
+	c.Assert(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt1.ID})
+	c.Check(pdb.MaxID(), Equals, uint64(1))
+
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
+	c.Assert(merged, Equals, true)
+	c.Assert(prompt2, Equals, prompt1)
+
+	// Merged prompts should not trigger notice
+	s.checkNewNotices(c, []string{})
+	// Merged prompts should not advance the max ID
+	c.Check(pdb.MaxID(), Equals, uint64(1))
+
+	c.Check(prompt1.Timestamp.After(before), Equals, true)
+	c.Check(prompt1.Timestamp.Before(after), Equals, true)
+
+	c.Check(prompt1.Snap, Equals, snap)
+	c.Check(prompt1.Interface, Equals, iface)
+	c.Check(prompt1.Constraints.Path, Equals, path)
+	c.Check(prompt1.Constraints.Permissions, DeepEquals, permissions)
+
+	stored = pdb.Prompts(user)
+	c.Assert(stored, HasLen, 1)
+	c.Check(stored[0], Equals, prompt1)
+
+	storedPrompt, err := pdb.PromptWithID(user, prompt1.ID)
+	c.Check(err, IsNil)
+	c.Check(storedPrompt, Equals, prompt1)
+
+	// Looking up prompt should not trigger notice
+	s.checkNewNotices(c, []string{})
+
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
+	c.Check(merged, Equals, true)
+	c.Check(prompt3, Equals, prompt1)
+
+	// Merged prompts should not trigger notice
+	s.checkNewNotices(c, []string{})
+	// Merged prompts should not advance the max ID
+	c.Check(pdb.MaxID(), Equals, uint64(1))
+}
+
+func (s *requestpromptsSuite) checkNewNotices(c *C, expectedPromptIDs []string) {
+	c.Check(s.noticePromptIDs, DeepEquals, expectedPromptIDs)
+	s.noticePromptIDs = s.noticePromptIDs[:0]
+}
+
+func (s *requestpromptsSuite) checkNewNoticesUnordered(c *C, expectedPromptIDs []string) {
+	sort.Strings(s.noticePromptIDs)
+	sort.Strings(expectedPromptIDs)
+	s.checkNewNotices(c, expectedPromptIDs)
+}
+
+func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		c.Fatalf("should not have called sendReply")
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "system-files"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []string{"read", "write", "execute"}
+
+	listenerReq := &listener.Request{}
+
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
+	c.Check(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt.ID})
+
+	result, err := pdb.PromptWithID(user, prompt.ID)
+	c.Check(err, IsNil)
+	c.Check(result, Equals, prompt)
+
+	result, err = pdb.PromptWithID(user, "foo")
+	c.Check(err, ErrorMatches, "cannot find prompt for UID 1000 with the given ID:.*")
+	c.Check(result, IsNil)
+
+	result, err = pdb.PromptWithID(user+1, "foo")
+	c.Check(err, ErrorMatches, "cannot find prompts for the given UID:.*")
+	c.Check(result, IsNil)
+
+	// Looking up prompts (with or without errors) should not trigger notices
+	s.checkNewNotices(c, []string{})
+}
+
+func (s *requestpromptsSuite) TestReply(c *C) {
+	listenerReqChan := make(chan *listener.Request, 2)
+	replyChan := make(chan interface{}, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		listenerReqChan <- listenerReq
+		replyChan <- reply
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "personal-files"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []string{"read", "write", "execute"}
+
+	for _, outcome := range []prompting.OutcomeType{prompting.OutcomeAllow, prompting.OutcomeDeny} {
+		listenerReq1 := &listener.Request{}
+		listenerReq2 := &listener.Request{}
+
+		prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
+		c.Check(merged, Equals, false)
+
+		s.checkNewNotices(c, []string{prompt1.ID})
+
+		prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
+		c.Check(merged, Equals, true)
+		c.Check(prompt2, Equals, prompt1)
+
+		// Merged prompts should not trigger notice
+		s.checkNewNotices(c, []string{})
+
+		repliedPrompt, err := pdb.Reply(user, prompt1.ID, outcome)
+		c.Check(err, IsNil)
+		c.Check(repliedPrompt, Equals, prompt1)
+		for _, listenerReq := range []*listener.Request{listenerReq1, listenerReq2} {
+			receivedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+			c.Check(err, IsNil)
+			c.Check(receivedReq, Equals, listenerReq)
+			allowed, ok := result.(bool)
+			c.Check(ok, Equals, true)
+			expected, err := outcome.IsAllow()
+			c.Check(err, IsNil)
+			c.Check(allowed, Equals, expected)
+		}
+
+		s.checkNewNotices(c, []string{repliedPrompt.ID})
+	}
+}
+
+func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <-chan *listener.Request, replyChan <-chan interface{}) (req *listener.Request, reply interface{}, err error) {
+	select {
+	case req = <-listenerReqChan:
+	case <-time.NewTimer(10 * time.Second).C:
+		err = fmt.Errorf("failed to receive request over channel")
+	}
+	select {
+	case reply = <-replyChan:
+	case <-time.NewTimer(10 * time.Second).C:
+		err = fmt.Errorf("failed to receive reply over channel")
+	}
+	return req, reply, err
+}
+
+func (s *requestpromptsSuite) TestReplyErrors(c *C) {
+	fakeError := fmt.Errorf("fake reply error")
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		return fakeError
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "removable-media"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []string{"read", "write", "execute"}
+
+	listenerReq := &listener.Request{}
+
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
+	c.Check(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt.ID})
+
+	outcome := prompting.OutcomeAllow
+
+	_, err := pdb.Reply(user, "foo", outcome)
+	c.Check(err, ErrorMatches, "cannot find prompt for UID 1000 with the given ID:.*")
+
+	_, err = pdb.Reply(user+1, "foo", outcome)
+	c.Check(err, ErrorMatches, "cannot find prompts for the given UID:.*")
+
+	_, err = pdb.Reply(user, prompt.ID, prompting.OutcomeUnset)
+	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
+
+	_, err = pdb.Reply(user, prompt.ID, outcome)
+	c.Check(err, Equals, fakeError)
+
+	// Failed replies should not trigger notice
+	s.checkNewNotices(c, []string{})
+}
+
+func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
+	listenerReqChan := make(chan *listener.Request, 2)
+	replyChan := make(chan interface{}, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		listenerReqChan <- listenerReq
+		replyChan <- reply
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "home"
+	path := "/home/test/Documents/foo.txt"
+
+	permissions := []string{"read", "write", "execute"}
+	listenerReq1 := &listener.Request{}
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"read", "write"}
+	listenerReq2 := &listener.Request{}
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"read"}
+	listenerReq3 := &listener.Request{}
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"open"}
+	listenerReq4 := &listener.Request{}
+	prompt4, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq4)
+	c.Check(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID})
+
+	stored := pdb.Prompts(user)
+	c.Assert(stored, HasLen, 4)
+
+	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
+	c.Assert(err, IsNil)
+	permissions = []string{"read", "write", "append"}
+	constraints := &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	outcome := prompting.OutcomeAllow
+
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, outcome)
+	c.Assert(err, IsNil)
+	c.Check(satisfied, HasLen, 2)
+	c.Check(strutil.ListContains(satisfied, prompt2.ID), Equals, true)
+	c.Check(strutil.ListContains(satisfied, prompt3.ID), Equals, true)
+
+	// Read and write permissions of prompt1 satisfied, so notice re-issued,
+	// but it has one remaining permission. prompt2 and prompt3 fully satisfied.
+	s.checkNewNoticesUnordered(c, []string{prompt1.ID, prompt2.ID, prompt3.ID})
+
+	for i := 0; i < 2; i++ {
+		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+		c.Check(err, IsNil)
+		if satisfiedReq != listenerReq2 && satisfiedReq != listenerReq3 {
+			c.Errorf("unexpected request satisfied by new rule")
+		}
+		allowed, ok := result.(bool)
+		c.Check(ok, Equals, true)
+		c.Check(allowed, Equals, true)
+	}
+
+	stored = pdb.Prompts(user)
+	c.Assert(stored, HasLen, 2)
+
+	// Check that allowing the final missing permission allows the prompt.
+	permissions = []string{"execute"}
+	constraints = &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, constraints, outcome)
+
+	c.Assert(err, IsNil)
+	c.Check(satisfied, HasLen, 1)
+	c.Check(satisfied[0], Equals, prompt1.ID)
+
+	s.checkNewNotices(c, []string{prompt1.ID})
+
+	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+	c.Check(err, IsNil)
+	c.Check(satisfiedReq, Equals, listenerReq1)
+	allowed, ok := result.(bool)
+	c.Check(ok, Equals, true)
+	c.Check(allowed, Equals, true)
+}
+
+func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
+	listenerReqChan := make(chan *listener.Request, 3)
+	replyChan := make(chan interface{}, 3)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		listenerReqChan <- listenerReq
+		replyChan <- reply
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "home"
+	path := "/home/test/Documents/foo.txt"
+
+	permissions := []string{"read", "write", "execute"}
+	listenerReq1 := &listener.Request{}
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"read", "write"}
+	listenerReq2 := &listener.Request{}
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"read"}
+	listenerReq3 := &listener.Request{}
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
+	c.Check(merged, Equals, false)
+
+	permissions = []string{"open"}
+	listenerReq4 := &listener.Request{}
+	prompt4, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq4)
+	c.Check(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt1.ID, prompt2.ID, prompt3.ID, prompt4.ID})
+
+	stored := pdb.Prompts(user)
+	c.Assert(stored, HasLen, 4)
+
+	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
+	c.Assert(err, IsNil)
+	permissions = []string{"read", "write", "append"}
+	constraints := &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	outcome := prompting.OutcomeDeny
+
+	// If one or more permissions denied each for prompts 1-3, so each is denied
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, outcome)
+	c.Assert(err, IsNil)
+	c.Check(satisfied, HasLen, 3)
+	c.Check(strutil.ListContains(satisfied, prompt1.ID), Equals, true)
+	c.Check(strutil.ListContains(satisfied, prompt2.ID), Equals, true)
+	c.Check(strutil.ListContains(satisfied, prompt3.ID), Equals, true)
+
+	s.checkNewNoticesUnordered(c, []string{prompt1.ID, prompt2.ID, prompt3.ID})
+
+	for i := 0; i < 3; i++ {
+		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+		c.Check(err, IsNil)
+		if satisfiedReq != listenerReq1 && satisfiedReq != listenerReq2 && satisfiedReq != listenerReq3 {
+			c.Errorf("unexpected request satisfied by new rule")
+		}
+		allowed, ok := result.(bool)
+		c.Check(ok, Equals, true)
+		c.Check(allowed, Equals, false)
+	}
+
+	stored = pdb.Prompts(user)
+	c.Check(stored, HasLen, 1)
+}
+
+func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
+	listenerReqChan := make(chan *listener.Request, 1)
+	replyChan := make(chan interface{}, 1)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+		listenerReqChan <- listenerReq
+		replyChan <- reply
+		return nil
+	})
+	defer restore()
+
+	pdb := requestprompts.New(s.defaultNotifyPrompt)
+
+	user := s.defaultUser
+	snap := "nextcloud"
+	iface := "home"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []string{"read"}
+	listenerReq := &listener.Request{}
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
+	c.Check(merged, Equals, false)
+
+	s.checkNewNotices(c, []string{prompt.ID})
+
+	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
+	c.Assert(err, IsNil)
+	constraints := &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	outcome := prompting.OutcomeAllow
+
+	otherUser := user + 1
+	otherSnap := "ldx"
+	otherInterface := "system-files"
+	otherPattern, err := patterns.ParsePathPattern("/home/test/Pictures/**.png")
+	c.Assert(err, IsNil)
+	otherConstraints := &prompting.Constraints{
+		PathPattern: otherPattern,
+		Permissions: permissions,
+	}
+	badOutcome := prompting.OutcomeType("foo")
+
+	stored := pdb.Prompts(user)
+	c.Assert(stored, HasLen, 1)
+	c.Assert(stored[0], Equals, prompt)
+
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, badOutcome)
+	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
+	c.Check(satisfied, HasLen, 0)
+
+	s.checkNewNotices(c, []string{})
+
+	satisfied, err = pdb.HandleNewRule(otherUser, snap, iface, constraints, outcome)
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	s.checkNewNotices(c, []string{})
+
+	satisfied, err = pdb.HandleNewRule(user, otherSnap, iface, constraints, outcome)
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	s.checkNewNotices(c, []string{})
+
+	satisfied, err = pdb.HandleNewRule(user, snap, otherInterface, constraints, outcome)
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	s.checkNewNotices(c, []string{})
+
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, otherConstraints, outcome)
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	s.checkNewNotices(c, []string{})
+
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, constraints, outcome)
+	c.Check(err, IsNil)
+	c.Assert(satisfied, HasLen, 1)
+
+	s.checkNewNotices(c, []string{prompt.ID})
+
+	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+	c.Check(err, IsNil)
+	c.Check(satisfiedReq, Equals, listenerReq)
+	allowed, ok := result.(bool)
+	c.Check(ok, Equals, true)
+	c.Check(allowed, Equals, true)
+
+	stored = pdb.Prompts(user)
+	c.Check(stored, HasLen, 0)
+}

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -70,7 +70,8 @@ type requestpromptsSuite struct {
 	defaultUser         uint32
 	promptNotices       noticeList
 
-	tmpdir string
+	tmpdir    string
+	maxIDPath string
 }
 
 var _ = Suite(&requestpromptsSuite{})
@@ -89,6 +90,7 @@ func (s *requestpromptsSuite) SetUpTest(c *C) {
 	s.promptNotices = make([]*noticeInfo, 0)
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
+	s.maxIDPath = filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
 	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0700), IsNil)
 }
 
@@ -144,7 +146,7 @@ func (s *requestpromptsSuite) TestLoadMaxID(c *C) {
 			0,
 		},
 	} {
-		osutil.AtomicWriteFile(filepath.Join(dirs.SnapRunDir, "/request-prompt-max-id"), testCase.fileContents, 0600, 0)
+		osutil.AtomicWriteFile(s.maxIDPath, testCase.fileContents, 0600, 0)
 		pdb := requestprompts.New(notifyPrompt)
 		c.Check(pdb.MaxID(), Equals, testCase.initialMaxID)
 	}
@@ -159,7 +161,7 @@ func (s *requestpromptsSuite) TestLoadMaxIDNextID(c *C) {
 
 	var prevMaxID uint64 = 42
 	maxIDStr := fmt.Sprintf("%016X", prevMaxID)
-	osutil.AtomicWriteFile(filepath.Join(dirs.SnapRunDir, "/request-prompt-max-id"), []byte(maxIDStr), 0600, 0)
+	osutil.AtomicWriteFile(s.maxIDPath, []byte(maxIDStr), 0600, 0)
 
 	pdb1 := requestprompts.New(s.defaultNotifyPrompt)
 	c.Check(pdb1.PerUser(), HasLen, 0)
@@ -189,8 +191,7 @@ func (s *requestpromptsSuite) TestLoadMaxIDNextID(c *C) {
 }
 
 func (s *requestpromptsSuite) checkWrittenMaxID(c *C, id string) {
-	maxIDPath := filepath.Join(dirs.SnapRunDir, "/request-prompt-max-id")
-	data, err := os.ReadFile(maxIDPath)
+	data, err := os.ReadFile(s.maxIDPath)
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, id)
 }

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -199,8 +199,8 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	c.Assert(merged, Equals, true)
 	c.Assert(prompt2, Equals, prompt1)
 
-	// Merged prompts should not trigger notice
-	s.checkNewNotices(c, []string{})
+	// Merged prompts should re-record notice
+	s.checkNewNotices(c, []string{prompt1.ID})
 	// Merged prompts should not advance the max ID
 	c.Check(pdb.MaxID(), Equals, uint64(1))
 	s.checkWrittenMaxID(c, prompt1.ID)
@@ -221,15 +221,15 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	c.Check(err, IsNil)
 	c.Check(storedPrompt, Equals, prompt1)
 
-	// Looking up prompt should not trigger notice
+	// Looking up prompt should not record notice
 	s.checkNewNotices(c, []string{})
 
 	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, true)
 	c.Check(prompt3, Equals, prompt1)
 
-	// Merged prompts should not trigger notice
-	s.checkNewNotices(c, []string{})
+	// Merged prompts should re-record notice
+	s.checkNewNotices(c, []string{prompt1.ID})
 	// Merged prompts should not advance the max ID
 	c.Check(pdb.MaxID(), Equals, uint64(1))
 	s.checkWrittenMaxID(c, prompt1.ID)
@@ -280,7 +280,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 	c.Check(err, ErrorMatches, "cannot find prompt for UID 1001 with the given ID:.*")
 	c.Check(result, IsNil)
 
-	// Looking up prompts (with or without errors) should not trigger notices
+	// Looking up prompts (with or without errors) should not record notices
 	s.checkNewNotices(c, []string{})
 }
 
@@ -315,8 +315,8 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		c.Check(merged, Equals, true)
 		c.Check(prompt2, Equals, prompt1)
 
-		// Merged prompts should not trigger notice
-		s.checkNewNotices(c, []string{})
+		// Merged prompts should re-record notice
+		s.checkNewNotices(c, []string{prompt1.ID})
 
 		repliedPrompt, err := pdb.Reply(user, prompt1.ID, outcome)
 		c.Check(err, IsNil)
@@ -386,7 +386,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	_, err = pdb.Reply(user, prompt.ID, outcome)
 	c.Check(err, Equals, fakeError)
 
-	// Failed replies should not trigger notice
+	// Failed replies should not record notice
 	s.checkNewNotices(c, []string{})
 }
 

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -421,7 +421,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	metadata := &prompting.Metadata{
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
-		Interface: "removable-media",
+		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read", "write", "execute"}

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -385,7 +385,7 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 			c.Check(receivedReq, Equals, listenerReq)
 			allowed, ok := result.(bool)
 			c.Check(ok, Equals, true)
-			expected, err := outcome.IsAllow()
+			expected, err := outcome.AsBool()
 			c.Check(err, IsNil)
 			c.Check(allowed, Equals, expected)
 		}


### PR DESCRIPTION
This is part of ongoing work to support AppArmor Prompting. When a request is received from the listener, a prompt is created with information which is provided to the user so that they may decide whether to allow or deny the requested action. This package manages the prompt database and individual request prompts.

This task is tracked internally by SNAPDENG-8329