### PR TITLE
store: interface with the store to request snap resources

### DIFF
--- a/snap/types.go
+++ b/snap/types.go
@@ -195,6 +195,16 @@ const (
 
 var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesComponent}
 
+// ComponentTypeFromString returns true if the given component type is valid.
+func ComponentTypeFromString(t string) (ComponentType, error) {
+	for _, valid := range validComponentTypes {
+		if t == string(valid) {
+			return valid, nil
+		}
+	}
+	return "", fmt.Errorf("invalid component type %q", t)
+}
+
 // Component represents a snap component.
 type Component struct {
 	Type          ComponentType

--- a/snap/types.go
+++ b/snap/types.go
@@ -195,7 +195,8 @@ const (
 
 var validComponentTypes = [...]ComponentType{TestComponent, KernelModulesComponent}
 
-// ComponentTypeFromString returns true if the given component type is valid.
+// ComponentTypeFromString converts a string to a ComponentType. An error is
+// returned if the string is not a valid ComponentType.
 func ComponentTypeFromString(t string) (ComponentType, error) {
 	for _, valid := range validComponentTypes {
 		if t == string(valid) {

--- a/snap/types_test.go
+++ b/snap/types_test.go
@@ -290,3 +290,16 @@ func (s *typeSuite) TestJsonUnmarshalInvalidDaemonScopes(c *C) {
 		c.Assert(err, NotNil, Commentf("Expected '%s' to be an invalid daemon scope", thisDaemonScope))
 	}
 }
+
+func (s *typeSuite) TestComponentTypeFromString(c *C) {
+	t, err := ComponentTypeFromString("test")
+	c.Assert(err, IsNil)
+	c.Check(t, Equals, TestComponent)
+
+	t, err = ComponentTypeFromString("kernel-modules")
+	c.Assert(err, IsNil)
+	c.Check(t, Equals, KernelModulesComponent)
+
+	_, err = ComponentTypeFromString("invalid")
+	c.Assert(err, ErrorMatches, "invalid component type \"invalid\"")
+}

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -401,6 +401,8 @@ func downloadInfoFromStoreDownload(d storeDownload) snap.DownloadInfo {
 		Sha3_384:    d.Sha3_384,
 	}
 
+	// resources don't have deltas right now, so this slice will always be empty
+	// for them
 	if len(d.Deltas) > 0 {
 		downloadInfo.Deltas = make([]snap.DeltaInfo, 0, len(d.Deltas))
 		for _, d := range d.Deltas {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -355,8 +355,10 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 }
 
 func componentFromStoreResource(r storeResource) (*snap.Component, error) {
-	typeString, ok := strings.CutPrefix(r.Type, "component/")
-	if !ok {
+	typeString := strings.TrimPrefix(r.Type, "component/")
+
+	// nothing was trimmed, so the type must not be a component
+	if typeString == r.Type {
 		return nil, fmt.Errorf("resource is not a component: %s", r.Type)
 	}
 

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -369,7 +369,6 @@ func componentFromStoreResource(r storeResource) (*snap.Component, error) {
 
 	comp := &snap.Component{
 		Name:        r.Name,
-		Summary:     r.Description.Clean(),
 		Description: r.Description.Clean(),
 		Type:        compType,
 

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -40,7 +40,7 @@ type storeSnap struct {
 	Contact       string              `json:"contact"`
 	CreatedAt     string              `json:"created-at"` // revision timestamp
 	Description   safejson.Paragraph  `json:"description"`
-	Download      storeSnapDownload   `json:"download"`
+	Download      storeDownload       `json:"download"`
 	Epoch         snap.Epoch          `json:"epoch"`
 	License       string              `json:"license"`
 	Name          string              `json:"name"`
@@ -56,6 +56,7 @@ type storeSnap struct {
 	Version       string              `json:"version"`
 	Website       string              `json:"website"`
 	StoreURL      string              `json:"store-url"`
+	Resources     []storeResource     `json:"resources"`
 
 	// TODO: not yet defined: channel map
 
@@ -67,11 +68,21 @@ type storeSnap struct {
 	Categories []storeSnapCategory `json:"categories"`
 }
 
-type storeSnapDownload struct {
+type storeDownload struct {
 	Sha3_384 string           `json:"sha3-384"`
 	Size     int64            `json:"size"`
 	URL      string           `json:"url"`
 	Deltas   []storeSnapDelta `json:"deltas"`
+}
+
+type storeResource struct {
+	Download    storeDownload      `json:"download"`
+	Type        string             `json:"type"`
+	Name        string             `json:"name"`
+	Revision    int                `json:"revision"`
+	Version     string             `json:"version"`
+	CreatedAt   string             `json:"created-at"`
+	Description safejson.Paragraph `json:"description"`
 }
 
 type storeSnapDelta struct {
@@ -265,6 +276,9 @@ func copyNonZeroFrom(src, dst *storeSnap) {
 	if len(src.Website) > 0 {
 		dst.Website = src.Website
 	}
+	if len(src.Resources) > 0 {
+		dst.Resources = src.Resources
+	}
 }
 
 func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
@@ -302,23 +316,9 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.Base = d.Base
 	info.License = d.License
 	info.Publisher = d.Publisher
-	info.DownloadURL = d.Download.URL
-	info.Size = d.Download.Size
-	info.Sha3_384 = d.Download.Sha3_384
-	if len(d.Download.Deltas) > 0 {
-		deltas := make([]snap.DeltaInfo, len(d.Download.Deltas))
-		for i, d := range d.Download.Deltas {
-			deltas[i] = snap.DeltaInfo{
-				FromRevision: d.Source,
-				ToRevision:   d.Target,
-				Format:       d.Format,
-				DownloadURL:  d.URL,
-				Size:         d.Size,
-				Sha3_384:     d.Sha3_384,
-			}
-		}
-		info.Deltas = deltas
-	}
+
+	info.DownloadInfo = downloadInfoFromStoreDownload(d.Download)
+
 	info.CommonIDs = d.CommonIDs
 	if len(info.EditedLinks) == 0 {
 		// if non empty links was provided, no need to set this
@@ -347,6 +347,30 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	addCategories(info, d.Categories)
 
 	return info, nil
+}
+
+func downloadInfoFromStoreDownload(d storeDownload) snap.DownloadInfo {
+	downloadInfo := snap.DownloadInfo{
+		DownloadURL: d.URL,
+		Size:        d.Size,
+		Sha3_384:    d.Sha3_384,
+	}
+
+	if len(d.Deltas) > 0 {
+		downloadInfo.Deltas = make([]snap.DeltaInfo, 0, len(d.Deltas))
+		for _, d := range d.Deltas {
+			downloadInfo.Deltas = append(downloadInfo.Deltas, snap.DeltaInfo{
+				FromRevision: d.Source,
+				ToRevision:   d.Target,
+				Format:       d.Format,
+				DownloadURL:  d.URL,
+				Size:         d.Size,
+				Sha3_384:     d.Sha3_384,
+			})
+		}
+	}
+
+	return downloadInfo
 }
 
 func addMedia(info *snap.Info, media []storeSnapMedia) {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -171,7 +171,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: kernel-modules\n    name: some-component\n    description: Some component\n    hooks:\n      install:",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: kernel-modules\n    name: some-component\n    description: Some component\n    summary: Component summary\n    hooks:\n      install:",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -271,7 +271,6 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 				Name:        "some-component",
 				Type:        snap.KernelModulesComponent,
 				Description: "Some component",
-				Summary:     "Some component",
 			},
 		},
 	})
@@ -388,9 +387,19 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	c.Check(info.Apps["user-svc"].DaemonScope, Equals, snap.UserDaemon)
 
 	// validate components
-	c.Check(info.Components["some-component"].Name, Equals, "some-component")
-	c.Check(info.Components["some-component"].Type, Equals, snap.KernelModulesComponent)
-	c.Check(info.Components["some-component"].ExplicitHooks["install"].Explicit, Equals, true)
+	someComponent := *info.Components["some-component"]
+	c.Assert(someComponent, NotNil)
+
+	c.Check(someComponent.ExplicitHooks["install"].Explicit, Equals, true)
+	// clear recursive bits
+	someComponent.ExplicitHooks = nil
+
+	c.Check(someComponent, DeepEquals, snap.Component{
+		Name:        "some-component",
+		Type:        snap.KernelModulesComponent,
+		Description: "Some component",
+		Summary:     "Component summary",
+	})
 
 	// private
 	err = json.Unmarshal([]byte(strings.Replace(thingyStoreJSON, `"private": false`, `"private": true`, 1)), &snp)

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -93,6 +93,19 @@ const (
     },
     {
       "download": {
+        "sha3-384": "6d001da919b965dc3a4672b9d7ddce374d165452a2285f2753988842092ea6b9946645375cff3ede89a991c9698bfcea",
+        "size": 20000021,
+        "url": "https://api.snapcraft.io/api/v1/snaps/download/ABCEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
+      },
+      "type": "component/unknown-type",
+      "name": "unknown-component",
+      "revision": 1,
+      "version": "1.0",
+      "created-at": "2018-01-26T11:38:35.536410+00:00",
+      "description": "Unknown component"
+    },
+    {
+      "download": {
         "sha3-384": "e6da7b15f767111ce34f22fa2059d23b43cb756e73256279e1d7f98a2eaab0d93725c2bfb25dd1deb1261223d961ee61",
         "size": 20000023,
         "url": "https://api.snapcraft.io/api/v1/snaps/download/123Efjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
@@ -251,7 +264,8 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 		StoreURL:      "https://snapcraft.io/core",
 
 		// components are derived from resources in this case, rather than
-		// snap-yaml
+		// snap-yaml. note that non-component resources are ignored and unknown
+		// components types are ignored
 		Components: map[string]*snap.Component{
 			"some-component": {
 				Name:        "some-component",

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -386,8 +386,8 @@ func fillStruct(a interface{}, c *C) {
 			var p safejson.Paragraph
 			c.Assert(json.Unmarshal([]byte(`"foo"`), &p), IsNil)
 			x = p
-		case storeSnapDownload:
-			x = storeSnapDownload{
+		case storeDownload:
+			x = storeDownload{
 				URL:      "http://example.com/foo",
 				Size:     42,
 				Sha3_384: "foo",
@@ -423,6 +423,17 @@ func fillStruct(a interface{}, c *C) {
 			x = map[string][]string{
 				"contact": {"mailto:foo", "mailto:bar"},
 			}
+		case []storeResource:
+			x = []storeResource{{
+				Type: "component/kernel-modules",
+				Download: storeDownload{
+					URL:      "http://example.com/resource",
+					Size:     42,
+					Sha3_384: "sha",
+				},
+				Name:     "some-component",
+				Revision: 1,
+			}}
 		default:
 			c.Fatalf("unhandled field type %T", field.Interface())
 		}

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -76,7 +76,35 @@ const (
   "type": "os",
   "version": "16-2.30",
   "website": "http://example.com/core",
-  "media": []
+  "media": [],
+  "resources": [
+    {
+      "download": {
+        "sha3-384": "6d001da919b965dc3a4672b9d7ddce374d165452a2285f2753988842092ea6b9946645375cff3ede89a991c9698bfcea",
+        "size": 20000021,
+        "url": "https://api.snapcraft.io/api/v1/snaps/download/ABCEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
+      },
+      "type": "component/kernel-modules",
+      "name": "some-component",
+      "revision": 1,
+      "version": "1.0",
+      "created-at": "2018-01-26T11:38:35.536410+00:00",
+      "description": "Some component"
+    },
+    {
+      "download": {
+        "sha3-384": "e6da7b15f767111ce34f22fa2059d23b43cb756e73256279e1d7f98a2eaab0d93725c2bfb25dd1deb1261223d961ee61",
+        "size": 20000023,
+        "url": "https://api.snapcraft.io/api/v1/snaps/download/123Efjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
+      },
+      "type": "not-a-component/thing",
+      "name": "some-not-component",
+      "revision": 1,
+      "version": "1.0",
+      "created-at": "2018-01-26T11:38:35.536410+00:00",
+      "description": "Something that is not a component"
+    }
+  ]
 }`
 
 	thingyStoreJSON = `{
@@ -130,7 +158,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\n",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: kernel-modules\n    name: some-component\n    description: Some component\n    hooks:\n      install:",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -141,6 +169,34 @@ const (
      {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png"},
      {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
      {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", "width": 600, "height": 200}
+  ],
+  "resources": [
+    {
+      "download": {
+          "sha3-384": "6d001da919b965dc3a4672b9d7ddce374d165452a2285f2753988842092ea6b9946645375cff3ede89a991c9698bfcea",
+          "size": 20000021,
+          "url": "https://api.snapcraft.io/api/v1/snaps/download/ABCEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
+      },
+      "type": "component/kernel-modules",
+      "name": "some-component",
+      "revision": 1,
+      "version": "1.0",
+      "created-at": "2018-01-26T11:38:35.536410+00:00",
+      "description": "Some component"
+    },
+    {
+      "download": {
+          "sha3-384": "e6da7b15f767111ce34f22fa2059d23b43cb756e73256279e1d7f98a2eaab0d93725c2bfb25dd1deb1261223d961ee61",
+          "size": 20000023,
+          "url": "https://api.snapcraft.io/api/v1/snaps/download/123Efjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
+      },
+      "type": "not-a-component/thing",
+      "name": "some-not-component",
+      "revision": 1,
+      "version": "1.0",
+      "created-at": "2018-01-26T11:38:35.536410+00:00",
+      "description": "Something that is not a component"
+    }
   ]
 }`
 )
@@ -193,6 +249,17 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 		},
 		LegacyWebsite: "http://example.com/core",
 		StoreURL:      "https://snapcraft.io/core",
+
+		// components are derived from resources in this case, rather than
+		// snap-yaml
+		Components: map[string]*snap.Component{
+			"some-component": {
+				Name:        "some-component",
+				Type:        snap.KernelModulesComponent,
+				Description: "Some component",
+				Summary:     "Some component",
+			},
+		},
 	})
 }
 
@@ -213,6 +280,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	info2.Slots = nil
 	info2.Apps = nil
 	info2.Hooks = nil
+	info2.Components = nil
 	c.Check(&info2, DeepEquals, &snap.Info{
 		SuggestedName: "test-snapd-content-plug",
 		Architectures: []string{"amd64"},
@@ -305,6 +373,11 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	c.Check(info.Apps["user-svc"].Daemon, Equals, "simple")
 	c.Check(info.Apps["user-svc"].DaemonScope, Equals, snap.UserDaemon)
 
+	// validate components
+	c.Check(info.Components["some-component"].Name, Equals, "some-component")
+	c.Check(info.Components["some-component"].Type, Equals, snap.KernelModulesComponent)
+	c.Check(info.Components["some-component"].ExplicitHooks["install"].Explicit, Equals, true)
+
 	// private
 	err = json.Unmarshal([]byte(strings.Replace(thingyStoreJSON, `"private": false`, `"private": true`, 1)), &snp)
 	c.Assert(err, IsNil)
@@ -331,7 +404,6 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"Layout",
 		"SideInfo.Channel",
 		"LegacyWebsite",
-		"Components",
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {

--- a/store/store.go
+++ b/store/store.go
@@ -323,7 +323,7 @@ func init() {
 	defaultConfig.DetailFields = jsonutil.StructFields((*snapDetails)(nil), "snap_yaml_raw")
 	defaultConfig.InfoFields = jsonutil.StructFields((*storeSnap)(nil), "snap-yaml")
 	defaultConfig.FindFields = append(jsonutil.StructFields((*storeSnap)(nil),
-		"architectures", "created-at", "epoch", "name", "snap-id", "snap-yaml"),
+		"architectures", "created-at", "epoch", "name", "snap-id", "snap-yaml", "resources"),
 		"channel")
 }
 
@@ -1560,7 +1560,7 @@ func (s *Store) ReadyToBuy(user *auth.UserState) error {
 
 // abbreviated info structs just for the download info
 type storeInfoChannelAbbrev struct {
-	Download storeSnapDownload `json:"download"`
+	Download storeDownload `json:"download"`
 }
 
 type storeInfoAbbrev struct {

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -305,13 +305,12 @@ type SnapActionResult struct {
 }
 
 type SnapResourceResult struct {
-	DownloadInfo    snap.DownloadInfo
-	Type            snap.ComponentType
-	Name            string
-	Revision        int
-	Version         string
-	CreatedAt       string
-	RedirectChannel string
+	DownloadInfo snap.DownloadInfo
+	Type         string
+	Name         string
+	Revision     int
+	Version      string
+	CreatedAt    string
 }
 
 // AssertionResult encapsulates the non-error result for one assertion
@@ -687,13 +686,12 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		resources := make([]SnapResourceResult, 0, len(res.Snap.Resources))
 		for _, r := range res.Snap.Resources {
 			resources = append(resources, SnapResourceResult{
-				DownloadInfo:    downloadInfoFromStoreDownload(r.Download),
-				Type:            "",
-				Name:            instanceName,
-				Revision:        0,
-				Version:         "",
-				CreatedAt:       "",
-				RedirectChannel: "",
+				DownloadInfo: downloadInfoFromStoreDownload(r.Download),
+				Type:         r.Type,
+				Name:         r.Name,
+				Version:      r.Version,
+				CreatedAt:    r.CreatedAt,
+				Revision:     r.Revision,
 			})
 		}
 

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -300,6 +300,17 @@ func genInstanceKey(curSnap *CurrentSnap, salt string) (string, error) {
 // action of the SnapAction call.
 type SnapActionResult struct {
 	*snap.Info
+	Resources       []SnapResourceResult
+	RedirectChannel string
+}
+
+type SnapResourceResult struct {
+	DownloadInfo    snap.DownloadInfo
+	Type            snap.ComponentType
+	Name            string
+	Revision        int
+	Version         string
+	CreatedAt       string
 	RedirectChannel string
 }
 
@@ -673,7 +684,24 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		_, instanceKey := snap.SplitInstanceName(instanceName)
 		snapInfo.InstanceKey = instanceKey
 
-		sars = append(sars, SnapActionResult{Info: snapInfo, RedirectChannel: res.RedirectChannel})
+		resources := make([]SnapResourceResult, 0, len(res.Snap.Resources))
+		for _, r := range res.Snap.Resources {
+			resources = append(resources, SnapResourceResult{
+				DownloadInfo:    downloadInfoFromStoreDownload(r.Download),
+				Type:            "",
+				Name:            instanceName,
+				Revision:        0,
+				Version:         "",
+				CreatedAt:       "",
+				RedirectChannel: "",
+			})
+		}
+
+		sars = append(sars, SnapActionResult{
+			Info:            snapInfo,
+			RedirectChannel: res.RedirectChannel,
+			Resources:       resources,
+		})
 	}
 
 	for _, errObj := range results.ErrorList {

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -74,6 +74,14 @@ func init() {
 const helloCohortKey = "this is a very short cohort key, as cohort keys go, because those are *long*"
 
 func (s *storeActionSuite) TestSnapAction(c *C) {
+	s.testSnapAction(c, nil)
+}
+
+func (s *storeActionSuite) TestSnapActionResources(c *C) {
+	s.testSnapAction(c, []string{"component"})
+}
+
+func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -105,8 +113,6 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
-		c.Check(req.Fields, DeepEquals, store.SnapActionFields)
-
 		c.Assert(req.Context, HasLen, 1)
 		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
@@ -124,26 +130,56 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 			"cohort-key":   helloCohortKey,
 		})
 
-		io.WriteString(w, `{
-  "results": [{
-     "result": "refresh",
-     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-     "name": "hello-world",
-     "snap": {
-       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-       "name": "hello-world",
-       "revision": 26,
-       "version": "6.1",
-       "epoch": {"read": [0], "write": [0]},
-       "publisher": {
-          "id": "canonical",
-          "username": "canonical",
-          "display-name": "Canonical"
-       }
-     }
-  }]
-}`)
+		expectedFields := make([]string, len(store.SnapActionFields))
+		copy(expectedFields, store.SnapActionFields)
+		if len(resources) > 0 {
+			expectedFields = append(expectedFields, "resources")
+		}
+
+		c.Check(req.Fields, DeepEquals, expectedFields)
+
+		res := map[string]interface{}{
+			"results": []map[string]interface{}{
+				{
+					"result":       "refresh",
+					"instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+					"snap-id":      "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+					"name":         "hello-world",
+					"snap": map[string]interface{}{
+						"snap-id":  "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+						"name":     "hello-world",
+						"revision": 26,
+						"version":  "6.1",
+						"epoch":    map[string]interface{}{"read": []int{0}, "write": []int{0}},
+						"publisher": map[string]interface{}{
+							"id":           "canonical",
+							"username":     "canonical",
+							"display-name": "Canonical",
+						},
+					},
+				},
+			},
+		}
+
+		if len(resources) > 0 {
+			res["results"].([]map[string]interface{})[0]["snap"].(map[string]interface{})["resources"] = []map[string]interface{}{
+				{
+					"download": map[string]interface{}{
+						"sha3-384": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+						"size":     1024,
+						"url":      "https://example.com/comp.comp",
+					},
+					"type":        "component/test-component",
+					"name":        "comp",
+					"revision":    3,
+					"version":     "1",
+					"created-at":  "2023-06-02T19:34:30.179208",
+					"description": "A test component",
+				},
+			}
+		}
+
+		json.NewEncoder(w).Encode(res)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -170,6 +206,7 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 			CohortKey:    helloCohortKey,
+			Resources:    resources,
 		},
 	}, nil, nil, nil)
 	c.Assert(err, IsNil)
@@ -182,6 +219,13 @@ func (s *storeActionSuite) TestSnapAction(c *C) {
 	c.Assert(results[0].Publisher.ID, Equals, helloWorldDeveloperID)
 	c.Assert(results[0].Deltas, HasLen, 0)
 	c.Assert(results[0].Epoch, DeepEquals, snap.E("0"))
+	if len(resources) > 0 {
+		c.Assert(results[0].Resources, HasLen, 1)
+		c.Assert(results[0].Resources[0].Name, Equals, "comp")
+		c.Assert(results[0].Resources[0].Type, Equals, "component/test-component")
+		c.Assert(results[0].Resources[0].Revision, Equals, 3)
+		c.Assert(results[0].Resources[0].Version, Equals, "1")
+	}
 }
 
 func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {


### PR DESCRIPTION
This enables us to request resources for a snap during a call to `SnapAction`. We only add the "resources" to the request "fields" query param if one of the actions includes resources.