### PR TITLE
packaging: add missing dependencies, disable centos-9

### DIFF
--- a/packaging/debian-sid/control
+++ b/packaging/debian-sid/control
@@ -55,6 +55,7 @@ Build-Depends: autoconf,
                python3-docutils,
                python3-markdown,
                squashfs-tools,
+               systemd-dev,
                tzdata,
                udev,
                xfslibs-dev

--- a/spread.yaml
+++ b/spread.yaml
@@ -199,6 +199,7 @@ backends:
                   workers: 6
                   storage: preserve-size
                   image: centos-9-64
+                  manual: true
 
             - opensuse-15.5-64:
                   workers: 6


### PR DESCRIPTION
We need to be able to iterate and at present master is broken, requiring a force-merge that only few people can use. Let's agressively fix master so that we can iterate and make things better bit-by-bit.