### PR TITLE
cmd/snap: fix port usage after release

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -26,7 +26,6 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -135,6 +134,7 @@ func (s *SnapOpSuite) TestWait(c *check.C) {
 	// should always result in a connection refused error, since port zero isn't
 	// valid
 	snap.ClientConfig.BaseURL = "http://localhost:0"
+	s.BaseTest.AddCleanup(func() { snap.ClientConfig.BaseURL = "" })
 
 	cli := snap.Client()
 	chg, err := snap.Wait(cli, "x")
@@ -211,10 +211,9 @@ func (s *SnapOpSuite) TestWaitDaemonUnavailableWithMaintenance(c *check.C) {
 	// write the maintenance json
 	os.WriteFile(dirs.SnapdMaintenanceFile, b, 0666)
 
-	// lazy way of getting a URL that won't work nor break stuff
-	server := httptest.NewServer(nil)
-	snap.ClientConfig.BaseURL = server.URL
-	server.Close()
+	// use a port that we can't connect to anyway
+	snap.ClientConfig.BaseURL = "http://localhost:0"
+	s.BaseTest.AddCleanup(func() { snap.ClientConfig.BaseURL = "" })
 
 	cli := snap.Client()
 	chg, err := snap.Wait(cli, "x")


### PR DESCRIPTION
Similarly to the issue fixed in https://github.com/snapcore/snapd/pull/13783, the test was opening a socket just to get a valid port number and then immediately closing it. Unfortunately, the port was being reused by another test which then received the request from this test. Fixed by sending the request to port 0 which cannot be connected to.

```
2024-05-21T12:49:22.2057178Z FAIL: runner_test.go:1276: runnerSuite.TestNextVerifySelfSigned
2024-05-21T12:49:22.2070788Z 
2024-05-21T12:49:22.2072017Z runner_test.go:870:
2024-05-21T12:49:22.2072735Z     c.Check(ua, testutil.Contains, "snap-repair")
2024-05-21T12:49:22.2074096Z ... container string = "snapd/2.63+git168.g8ee86bf (series 16; classic) snap ubuntu/22.04 (amd64) linux/6.5.0-1021-azure"
2024-05-21T12:49:22.2075254Z ... elem string = "snap-repair"
2024-05-21T12:49:22.2075601Z 
2024-05-21T12:49:22.2075747Z runner_test.go:884:
2024-05-21T12:49:22.2076458Z     c.Check(strings.HasPrefix(urlPath, "/repairs/canonical/"), Equals, true)
2024-05-21T12:49:22.2077597Z ... obtained bool = false
2024-05-21T12:49:22.2078048Z ... expected bool = true
2024-05-21T12:49:22.2078336Z 
2024-05-21T12:49:22.2078487Z runner_test.go:887:
2024-05-21T12:49:22.2078879Z     c.Assert(err, IsNil)
2024-05-21T12:49:22.2080311Z ... value *strconv.NumError = &strconv.NumError{Func:"Atoi", Num:"/v2/changes/x", Err:(*errors.errorString)(0xc000074210)} ("strconv.Atoi: parsing \"/v2/changes/x\": invalid syntax")
2024-05-21T12:49:22.2081638Z 
2024-05-21T12:49:22.2081806Z OOPS: 68 passed, 1 FAILED
2024-05-21T12:49:22.2082300Z --- FAIL: Test (0.75s)
```