### PR TITLE
spread.yaml: revert "spread.yaml: disable centos-9"

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -199,7 +199,6 @@ backends:
                   workers: 6
                   storage: preserve-size
                   image: centos-9-64
-                  manual: true
 
             - opensuse-15.5-64:
                   workers: 6


### PR DESCRIPTION
This reverts commit f58de9076d8286b8a07faaccbd237f068805baf6.

Centos 9 is not blocking merges. I was confused by GitHub user interface.