### PR TITLE
interfaces/network-control: Allow systemd resolved cache flushing via D-Bus

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -90,7 +90,21 @@ dbus (send)
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
      member="SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
-     peer=(label=unconfined),
+     peer=(name="org.freedesktop.resolve1", label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="FlushCaches"
+     peer=(name="org.freedesktop.resolve1", label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.DBus.Peer"
+     member="Ping"
+     peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 # required by resolvectl command
 dbus (send)


### PR DESCRIPTION
Add the `FlushCaches` method to the already existing rules that allow resolved management. The existing access is for safe members of the systemd-resolved D-Bus API, and FlushCache should also be a safe operation.

Some utilities that configure systemd resolved via D-Bus use flush caches as part of their setup flow.

One such use case is Tailscale, which this changes enables use of in a strictly confined snap. Discussed here: https://github.com/tailscale/tailscale/issues/267