### PR TITLE
tests: moving out google machines from us-east1-b

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -592,25 +592,25 @@ jobs:
       matrix:
         include:
           - group: amazon-linux
-            backend: google-central
+            backend: google-distro-1
             systems: 'amazon-linux-2-64 amazon-linux-2023-64'
           - group: arch-linux
-            backend: google-central
+            backend: google-distro-2
             systems: 'arch-linux-64'
           - group: centos
-            backend: google-central
+            backend: google-distro-2
             systems: 'centos-7-64 centos-8-64 centos-9-64'
           - group: debian-req
-            backend: google-central
+            backend: google-distro-1
             systems: 'debian-11-64'
           - group: debian-no-req
-            backend: google-central
+            backend: google-distro-1
             systems: 'debian-12-64 debian-sid-64'
           - group: fedora
-            backend: google-central
+            backend: google-distro-1
             systems: 'fedora-38-64 fedora-39-64'
           - group: opensuse
-            backend: google-central
+            backend: google-distro-2
             systems: 'opensuse-15.5-64 opensuse-tumbleweed-64'
           - group: ubuntu-trusty-xenial
             backend: google
@@ -628,19 +628,19 @@ jobs:
             backend: google
             systems: 'ubuntu-24.04-64'
           - group: ubuntu-core-16
-            backend: google
+            backend: google-core
             systems: 'ubuntu-core-16-64'
           - group: ubuntu-core-18
-            backend: google
+            backend: google-core
             systems: 'ubuntu-core-18-64'
           - group: ubuntu-core-20
-            backend: google
+            backend: google-core
             systems: 'ubuntu-core-20-64'
           - group: ubuntu-core-22
-            backend: google
+            backend: google-core
             systems: 'ubuntu-core-22-64'
           - group: ubuntu-core-24
-            backend: google
+            backend: google-core
             systems: 'ubuntu-core-24-64'
           - group: ubuntu-arm
             backend: google-arm

--- a/spread.yaml
+++ b/spread.yaml
@@ -110,7 +110,7 @@ environment:
 backends:
     google:
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/europe-west2-b
         halt-timeout: 2h
         systems:
             - ubuntu-14.04-64:
@@ -126,6 +126,26 @@ backends:
             - ubuntu-20.04-64:
                   storage: 12G
                   workers: 8
+            - ubuntu-secboot-20.04-64:
+                  image: ubuntu-20.04-64
+                  workers: 1
+                  secure-boot: true
+            - ubuntu-22.04-64:
+                  storage: 12G
+                  workers: 8
+            - ubuntu-23.10-64:
+                  storage: 12G
+                  workers: 8
+            - ubuntu-24.04-64:
+                  storage: 12G
+                  workers: 8
+
+    google-core:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: snapd-spread/europe-west1-b
+        halt-timeout: 2h
+        systems:
             - ubuntu-core-16-64:
                   image: ubuntu-16.04-64
                   workers: 6
@@ -144,24 +164,11 @@ backends:
                   image: ubuntu-24.04-64
                   workers: 8
                   storage: 20G
-            - ubuntu-secboot-20.04-64:
-                  image: ubuntu-20.04-64
-                  workers: 1
-                  secure-boot: true
-            - ubuntu-22.04-64:
-                  storage: 12G
-                  workers: 8
-            - ubuntu-23.10-64:
-                  storage: 12G
-                  workers: 8
-            - ubuntu-24.04-64:
-                  storage: 12G
-                  workers: 8
 
-    google-central:
+    google-distro-1:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-central1-b
+        location: snapd-spread/europe-west3-b
         halt-timeout: 2h
         systems:
             - debian-11-64:
@@ -177,15 +184,22 @@ backends:
             - fedora-39-64:
                   workers: 6
 
-            - arch-linux-64:
-                  workers: 6
-                  storage: 12G
             - amazon-linux-2-64:
                   workers: 6
                   storage: preserve-size
             - amazon-linux-2023-64:
                   workers: 6
                   storage: preserve-size
+
+    google-distro-2:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: snapd-spread/europe-west4-b
+        halt-timeout: 2h
+        systems:
+            - arch-linux-64:
+                  workers: 6
+                  storage: 12G
 
             - centos-7-64:
                   workers: 6
@@ -228,7 +242,7 @@ backends:
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/us-central1-a
         halt-timeout: 2h
         systems:
             - ubuntu-20.04-64:
@@ -243,7 +257,7 @@ backends:
     google-nested:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/us-east1-b
+        location: snapd-spread/us-central1-a
         plan: n2-standard-2
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"

--- a/spread.yaml
+++ b/spread.yaml
@@ -834,7 +834,7 @@ prepare: |
 
     # Make sure ssh service is restarted after it is killed by spread (pkill -o -HUP sshd)
     # during the machine setup in google systems. For more details see lp:2011458
-    if [ "$SPREAD_BACKEND" = "google" ] && [[ "$SPREAD_SYSTEM" == ubuntu-2* ]] && ! systemctl is-active ssh; then
+    if [[ "$SPREAD_BACKEND" =~ google ]] && [[ "$SPREAD_SYSTEM" == ubuntu-2* ]] && ! systemctl is-active ssh; then
         systemctl restart ssh
     fi
 

--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -32,7 +32,7 @@ prepare: |
     chown -R test:12345 /tmp/cross-build
 
     UBUNTU_ARCHIVE="http://archive.ubuntu.com/ubuntu/"
-    if [ "$SPREAD_BACKEND" = "google" ]; then
+    if [[ "$SPREAD_BACKEND" =~ google ]]; then
         UBUNTU_ARCHIVE="http://$(cloud-id -l | cut -f2).gce.archive.ubuntu.com/ubuntu/"
     fi
 

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -115,7 +115,7 @@ get_ubuntu_image_url_for_vm() {
 
 # shellcheck disable=SC2120
 get_image_url_for_vm() {
-    if [[ "$SPREAD_BACKEND" == google* ]]; then
+    if [[ "$SPREAD_BACKEND" =~ google ]]; then
         get_google_image_url_for_vm "$@"
     else
         get_ubuntu_image_url_for_vm "$@"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1171,7 +1171,7 @@ EOF
         # so for now, don't include snapd.debug=1, but eventually it would be
         # nice to have this on
 
-        if [ "$SPREAD_BACKEND" = "google" ]; then
+        if [[ "$SPREAD_BACKEND" =~ google ]]; then
             # the default console settings for snapd aren't super useful in GCE,
             # instead it's more useful to have all console go to ttyS0 which we 
             # can read more easily than tty1 for example

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -35,12 +35,12 @@ execute: |
     NOTES=core
 
     #shellcheck disable=SC2166
-    if [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && os.query is-core16; then
+    if [[ "$SPREAD_BACKEND" =~ google ]] || [ "$SPREAD_BACKEND" == "qemu" ] && os.query is-core16; then
         echo "With customized images the core snap is sideloaded"
         REV=$SIDELOAD_REV
         PUBLISHER=-
 
-    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" = "google-arm" -o "$SPREAD_BACKEND" == "qemu" ] && os.query is-core-ge 18; then
+    elif [[ "$SPREAD_BACKEND" =~ google ]] || [ "$SPREAD_BACKEND" == "qemu" ] && os.query is-core-ge 18; then
         echo "With customized images the snapd snap is sideloaded"
         NAME=snapd
         VERSION=$SNAPD_GIT_VERSION


### PR DESCRIPTION
The region us-east1 is shared among project. In order to avoid reaching the instances quota we are moving out to europe regions. The idea of moving to europe is because the CI is in the UK.

From now, we will have 5 regions for snapd (4 in europe and 1 in the USA for sru and nested)

In all cases I tried to keep regions balanced in terms of number of instances.

In a following pr I'll create a tool to check the current spread backend in order to make simpler checks in the tests. 