### PR TITLE
tests: skip tics tool installation in self-hosted runners

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,4 +11,3 @@ jobs:
         with:
           projectName: snapd
           ticsConfiguration: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          installTics: true


### PR DESCRIPTION
This step is not required because the tool was already installed in the self-hosted runners. This is needed to avoid requesting the secret with the tics token.
