### PR TITLE
tests: add more storage for sru google instances

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -232,12 +232,16 @@ backends:
         halt-timeout: 2h
         systems:
             - ubuntu-20.04-64:
+                  storage: 12G
                   workers: 8
             - ubuntu-22.04-64:
+                  storage: 12G
                   workers: 8
             - ubuntu-23.10-64:
+                  storage: 12G
                   workers: 8
             - ubuntu-24.04-64:
+                  storage: 12G
                   workers: 8
 
     google-nested:


### PR DESCRIPTION
This is required to avoid errors related to space in the sru instances
