### PR TITLE
snapdtool: export helpers for asserting whether reeexec is enabled

### DIFF
--- a/snapdtool/export_test.go
+++ b/snapdtool/export_test.go
@@ -20,7 +20,6 @@
 package snapdtool
 
 var (
-	DistroSupportsReExec     = distroSupportsReExec
 	SystemSnapSupportsReExec = systemSnapSupportsReExec
 )
 

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -142,6 +142,20 @@ func InternalToolPath(tool string) (string, error) {
 	return distroTool, nil
 }
 
+// IsReexecEnabled checks the environment and configuration to assert whether
+// reexec has been explicitly enabled/disabled.
+func IsReexecEnabled() bool {
+	// XXX for now we are only checking environment variables
+
+	// If we are asked not to re-execute use distribution packages. This is
+	// "spiritual" re-exec so use the same environment variable to decide.
+	if !osutil.GetenvBool(reExecKey, true) {
+		// TODO
+		return false
+	}
+	return true
+}
+
 // mustUnsetenv will unset the given environment key or panic if it
 // cannot do that
 func mustUnsetenv(key string) {
@@ -170,9 +184,7 @@ func ExecInSnapdOrCoreSnap() {
 		return
 	}
 
-	// If we are asked not to re-execute use distribution packages. This is
-	// "spiritual" re-exec so use the same environment variable to decide.
-	if !osutil.GetenvBool(reExecKey, true) {
+	if !IsReexecEnabled() {
 		logger.Debugf("re-exec disabled by user")
 		return
 	}

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -55,12 +55,12 @@ var (
 	osReadlink  = os.Readlink
 )
 
-// distroSupportsReExec returns true if the distribution we are running on can use re-exec.
+// DistroSupportsReExec returns true if the distribution we are running on can use re-exec.
 //
 // This is true by default except for a "core/all" snap system where it makes
 // no sense and in certain distributions that we don't want to enable re-exec
 // yet because of missing validation or other issues.
-func distroSupportsReExec() bool {
+func DistroSupportsReExec() bool {
 	if !release.OnClassic {
 		return false
 	}
@@ -195,7 +195,7 @@ func ExecInSnapdOrCoreSnap() {
 	}
 
 	// If the distribution doesn't support re-exec or run-from-core then don't do it.
-	if !distroSupportsReExec() {
+	if !DistroSupportsReExec() {
 		return
 	}
 

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -483,3 +483,17 @@ func (s *toolSuite) TestIsReexecd(c *C) {
 	c.Assert(err, ErrorMatches, ".*/proc/self/exe: no such file or directory")
 	c.Assert(is, Equals, false)
 }
+
+func (s *toolSuite) TestInReexecEnabled(c *C) {
+	defer os.Unsetenv("SNAP_REEXEC")
+
+	// explicitly disabled
+	os.Setenv("SNAP_REEXEC", "0")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, false)
+	// default to true
+	os.Unsetenv("SNAP_REEXEC")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, true)
+	// explicitly enabled
+	os.Setenv("SNAP_REEXEC", "1")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, true)
+}


### PR DESCRIPTION
Export 2 helpers for checking whether reexec is enabled at runtime.

Related issues: SNAPDENG-21263
