### PR TITLE
cmd/snap-failure: do not attempt to run snapd on classic when reexec is disabled

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snapdtool"
 )
 
 func init() {
@@ -112,6 +114,16 @@ var (
 )
 
 func (c *cmdSnapd) Execute(args []string) error {
+	if release.OnClassic {
+		// snap failure was invoked in a classic system, while there are
+		// scenarios in which it may make sense, they are limited to a
+		// case when snapd is being reexec'd from the snapd snap
+		if !snapdtool.DistroSupportsReExec() || !snapdtool.IsReexecEnabled() {
+			logger.Noticef("re-exec unsupported or disabled")
+			return nil
+		}
+	}
+
 	var snapdPath string
 	// find previous the snapd snap
 	prevRev, err := prevRevision("snapd")

--- a/cmd/snap-failure/main_test.go
+++ b/cmd/snap-failure/main_test.go
@@ -42,6 +42,8 @@ type failureSuite struct {
 	stderr *bytes.Buffer
 	stdout *bytes.Buffer
 	log    *bytes.Buffer
+
+	systemctlCmd *testutil.MockCmd
 }
 
 func (r *failureSuite) SetUpTest(c *C) {
@@ -64,6 +66,9 @@ func (r *failureSuite) SetUpTest(c *C) {
 	log, restore := logger.MockLogger()
 	r.log = log
 	r.AddCleanup(restore)
+
+	r.systemctlCmd = testutil.MockCommand(c, "systemctl", "")
+	r.AddCleanup(r.systemctlCmd.Restore)
 }
 
 func (r *failureSuite) Stderr() string {

--- a/cmd/snap-failure/main_test.go
+++ b/cmd/snap-failure/main_test.go
@@ -28,6 +28,7 @@ import (
 	failure "github.com/snapcore/snapd/cmd/snap-failure"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -58,6 +59,8 @@ func (r *failureSuite) SetUpTest(c *C) {
 	})
 	failure.Stderr = r.stderr
 	failure.Stdout = r.stdout
+
+	r.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
 
 	r.rootdir = c.MkDir()
 	dirs.SetRootDir(r.rootdir)

--- a/snapdtool/export_test.go
+++ b/snapdtool/export_test.go
@@ -20,7 +20,6 @@
 package snapdtool
 
 var (
-	DistroSupportsReExec     = distroSupportsReExec
 	SystemSnapSupportsReExec = systemSnapSupportsReExec
 )
 

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -142,6 +142,20 @@ func InternalToolPath(tool string) (string, error) {
 	return distroTool, nil
 }
 
+// IsReexecEnabled checks the environment and configuration to assert whether
+// reexec has been explicitly enabled/disabled.
+func IsReexecEnabled() bool {
+	// XXX for now we are only checking environment variables
+
+	// If we are asked not to re-execute use distribution packages. This is
+	// "spiritual" re-exec so use the same environment variable to decide.
+	if !osutil.GetenvBool(reExecKey, true) {
+		// TODO
+		return false
+	}
+	return true
+}
+
 // mustUnsetenv will unset the given environment key or panic if it
 // cannot do that
 func mustUnsetenv(key string) {
@@ -170,9 +184,7 @@ func ExecInSnapdOrCoreSnap() {
 		return
 	}
 
-	// If we are asked not to re-execute use distribution packages. This is
-	// "spiritual" re-exec so use the same environment variable to decide.
-	if !osutil.GetenvBool(reExecKey, true) {
+	if !IsReexecEnabled() {
 		logger.Debugf("re-exec disabled by user")
 		return
 	}

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -55,12 +55,12 @@ var (
 	osReadlink  = os.Readlink
 )
 
-// distroSupportsReExec returns true if the distribution we are running on can use re-exec.
+// DistroSupportsReExec returns true if the distribution we are running on can use re-exec.
 //
 // This is true by default except for a "core/all" snap system where it makes
 // no sense and in certain distributions that we don't want to enable re-exec
 // yet because of missing validation or other issues.
-func distroSupportsReExec() bool {
+func DistroSupportsReExec() bool {
 	if !release.OnClassic {
 		return false
 	}
@@ -195,7 +195,7 @@ func ExecInSnapdOrCoreSnap() {
 	}
 
 	// If the distribution doesn't support re-exec or run-from-core then don't do it.
-	if !distroSupportsReExec() {
+	if !DistroSupportsReExec() {
 		return
 	}
 

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -483,3 +483,17 @@ func (s *toolSuite) TestIsReexecd(c *C) {
 	c.Assert(err, ErrorMatches, ".*/proc/self/exe: no such file or directory")
 	c.Assert(is, Equals, false)
 }
+
+func (s *toolSuite) TestInReexecEnabled(c *C) {
+	defer os.Unsetenv("SNAP_REEXEC")
+
+	// explicitly disabled
+	os.Setenv("SNAP_REEXEC", "0")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, false)
+	// default to true
+	os.Unsetenv("SNAP_REEXEC")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, true)
+	// explicitly enabled
+	os.Setenv("SNAP_REEXEC", "1")
+	c.Assert(snapdtool.IsReexecEnabled(), Equals, true)
+}


### PR DESCRIPTION
The snap-failure helper is used as a general failure handler for failures of the
snapd.service unit. Its purpose is to trigger a revert of snapd snap to the
previous revision whenever a failure occurs. The logic asserting whether a snapd
refresh was in progress is privy to the actual snapd binary, however any attempt
to execute snapd binary from the snapd snap makes no sense if the system does
not support running snapd directly from the snap in the first place.

Related issues: SNAPDENG-21263, SNAPDENG-21264

Based on top of #13996