### PR TITLE
snapdtool: simplify check for reexec being enabled

### DIFF
--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -149,11 +149,7 @@ func IsReexecEnabled() bool {
 
 	// If we are asked not to re-execute use distribution packages. This is
 	// "spiritual" re-exec so use the same environment variable to decide.
-	if !osutil.GetenvBool(reExecKey, true) {
-		// TODO
-		return false
-	}
-	return true
+	return osutil.GetenvBool(reExecKey, true)
 }
 
 // mustUnsetenv will unset the given environment key or panic if it


### PR DESCRIPTION
Simplify the check for reexec being enabled in the system.

