### PR TITLE
packaging: remove stale workaround from snap-seccomp RHEL build

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -578,10 +578,6 @@ BUILDTAGS="${BUILDTAGS} nomanagers"
     %gobuild_static -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
 )
 
-%if 0%{?rhel}
-# There's no static link library for libseccomp in RHEL/CentOS...
-sed -e "s/-Bstatic -lseccomp/-Bstatic/g" -i cmd/snap-seccomp/*.go
-%endif
 %gobuild -o bin/snap-seccomp $GOFLAGS %{import_path}/cmd/snap-seccomp
 
 %if 0%{?with_selinux}


### PR DESCRIPTION
There's no need to use sed to remove -lseccomp, the code uses pkg-config to interrogate for the right build flags.

This was tested with mock (fedora build tool) for EPEL-{7,8,9} and FC-{39,40,41}.

For context see commit 536f30bebcbaca8b391919afbda8dd67b360d45d
