### PR TITLE
o/snapstate: handling of unexpected runtime restart

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -66,7 +66,7 @@ func main() {
 			// the exit code must be in sync with
 			// data/systemd/snapd.service.in:SuccessExitStatus=
 			os.Exit(42)
-		} else if errors.Is(err, daemon.ErrNoRuntimeRecoveryNeeded) {
+		} else if errors.Is(err, daemon.ErrNoFailureRecoveryNeeded) {
 			// Similar consideration as above.
 			fmt.Fprintf(os.Stdout, "%v\n", err)
 			// We were invoked from a failure handler, but there is

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -62,13 +62,13 @@ func main() {
 		if errors.Is(err, daemon.ErrRestartSocket) {
 			// Note that we don't prepend: "error: " here because
 			// ErrRestartSocket is not an error as such.
-			fmt.Fprintf(os.Stdout, "%v\n", err)
+			fmt.Fprintln(os.Stdout, err)
 			// the exit code must be in sync with
 			// data/systemd/snapd.service.in:SuccessExitStatus=
 			os.Exit(42)
 		} else if errors.Is(err, daemon.ErrNoFailureRecoveryNeeded) {
 			// Similar consideration as above.
-			fmt.Fprintf(os.Stdout, "%v\n", err)
+			fmt.Fprintln(os.Stdout, err)
 			// We were invoked from a failure handler, but there is
 			// nothing to recover from in the state, as such the
 			// failure handling was successful.

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -58,13 +59,20 @@ func main() {
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	if err := run(ch); err != nil {
-		if err == daemon.ErrRestartSocket {
+		if errors.Is(err, daemon.ErrRestartSocket) {
 			// Note that we don't prepend: "error: " here because
 			// ErrRestartSocket is not an error as such.
 			fmt.Fprintf(os.Stdout, "%v\n", err)
 			// the exit code must be in sync with
 			// data/systemd/snapd.service.in:SuccessExitStatus=
 			os.Exit(42)
+		} else if errors.Is(err, daemon.ErrNoRuntimeRecoveryNeeded) {
+			// Similar consideration as above.
+			fmt.Fprintf(os.Stdout, "%v\n", err)
+			// We were invoked from a failure handler, but there is
+			// nothing to recover from in the state, as such the
+			// failure handling was successful.
+			return
 		}
 		fmt.Fprintf(os.Stderr, "cannot run daemon: %v\n", err)
 		os.Exit(1)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -53,7 +53,7 @@ import (
 )
 
 var ErrRestartSocket = fmt.Errorf("daemon stop requested to wait for socket activation")
-var ErrNoRuntimeRecoveryNeeded = fmt.Errorf("recovery not needed")
+var ErrNoFailureRecoveryNeeded = fmt.Errorf("no failure recovery needed")
 
 var systemdSdNotify = systemd.SdNotify
 
@@ -344,9 +344,9 @@ func (d *Daemon) Start() error {
 	}
 	// now perform expensive overlord/manages initialization
 	if err := d.overlord.StartUp(); err != nil {
-		if errors.Is(err, snapstate.ErrUnexpectedRuntimeFailure) {
-			logger.Noticef("detected recovery context, but no recovery needed, aborting startup")
-			return ErrNoRuntimeRecoveryNeeded
+		if errors.Is(err, snapstate.ErrUnexpectedRuntimeRestart) {
+			logger.Noticef("detected failure recovery context, but no recovery needed")
+			return ErrNoFailureRecoveryNeeded
 		}
 		return err
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1465,3 +1465,15 @@ func (s *daemonSuite) TestDegradedModeReply(c *check.C) {
 	rec = doTestReq(c, cmd, "POST")
 	c.Check(rec.Code, check.Equals, 200)
 }
+
+func (s *daemonSuite) TestHandleUnexpectedRestart(c *check.C) {
+	os.Setenv("SNAPD_REVERT_TO_REV", "999")
+	defer os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+	d := s.newTestDaemon(c)
+
+	// mark as already seeded
+	s.markSeeded(d)
+
+	c.Assert(d.Start(), check.Equals, ErrNoRuntimeRecoveryNeeded)
+}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1475,5 +1475,5 @@ func (s *daemonSuite) TestHandleUnexpectedRestart(c *check.C) {
 	// mark as already seeded
 	s.markSeeded(d)
 
-	c.Assert(d.Start(), check.Equals, ErrNoRuntimeRecoveryNeeded)
+	c.Assert(d.Start(), check.Equals, ErrNoFailureRecoveryNeeded)
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -14272,18 +14272,7 @@ type: snapd`
 		Model:  "my-model",
 		Serial: "serialserialserial",
 	})
-	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
-	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
-		"type":         "model",
-		"authority-id": "my-brand",
-		"series":       "16",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"gadget":       "pc",
-		"kernel":       "kernel",
-		"architecture": "amd64",
-		"base":         "core18",
-	})
+	model := s.brands.Model("my-brand", "my-model", modelDefaults)
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
@@ -14305,16 +14294,17 @@ type: snapd`
 	c.Check(restarting, Equals, true)
 	c.Assert(kind, Equals, restart.RestartDaemon)
 
-	// now verify whether the state would be correctly asserted, note that
-	// this isn't 100% realistic, as the check happens in overlord.StartUp()
-	// which we cannot fake here
+	// now verify whether the state would be correctly asserted as to
+	// whether the failure recovery is needed, note that this isn't 100%
+	// realistic, as the check happens in overlord.StartUp() which we cannot
+	// fake here
 
 	func() {
 		// simple case, the environment variable from snap-failure is
 		// unset
 		os.Unsetenv("SNAPD_REVERT_TO_REV")
 
-		err := snapstate.AssertRuntimeFailureRestart(st)
+		err := snapstate.CheckExpectedRestart(st)
 		c.Assert(err, IsNil)
 	}()
 
@@ -14323,7 +14313,7 @@ type: snapd`
 		os.Setenv("SNAPD_REVERT_TO_REV", "999")
 		defer os.Unsetenv("SNAPD_REVERT_TO_REV")
 
-		err := snapstate.AssertRuntimeFailureRestart(st)
+		err := snapstate.CheckExpectedRestart(st)
 		c.Assert(err, IsNil)
 	}()
 
@@ -14343,7 +14333,7 @@ type: snapd`
 		// systemd handled it
 		os.Unsetenv("SNAPD_REVERT_TO_REV")
 
-		err := snapstate.AssertRuntimeFailureRestart(st)
+		err := snapstate.CheckExpectedRestart(st)
 		c.Assert(err, Equals, nil)
 	}()
 
@@ -14353,7 +14343,7 @@ type: snapd`
 		os.Setenv("SNAPD_REVERT_TO_REV", "999")
 		defer os.Unsetenv("SNAPD_REVERT_TO_REV")
 
-		err := snapstate.AssertRuntimeFailureRestart(st)
-		c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+		err := snapstate.CheckExpectedRestart(st)
+		c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 	}()
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -14212,3 +14212,148 @@ waitLoop:
 	c.Assert(chg, NotNil, Commentf("cannot find a ready change of kind %s", kind))
 	return chg
 }
+
+func (s *mgrsSuite) TestSnapdRefreshAssertRuntimeFailure(c *C) {
+	// set up a refresh of snapd snap, such that we get the right set of
+	// tasks that actually reflect what would happen in reality and next
+	// check whether the detection of unexpected runtime failure is behaving
+	// as expected
+
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer restore()
+	// reload directories
+	dirs.SetRootDir(dirs.GlobalRootDir)
+	restore = release.MockOnClassic(false)
+	defer restore()
+	bl := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bl)
+	defer bootloader.Force(nil)
+	const snapdSnap = `
+name: snapd
+version: 1.0
+type: snapd`
+	snapPath := snaptest.MakeTestSnapWithFiles(c, snapdSnap, nil)
+	si := &snap.SideInfo{RealName: "snapd"}
+
+	st := s.o.State()
+	st.Lock()
+
+	// we must be seeded
+	st.Set("seeded", true)
+
+	// we also need to setup the usr-lib-snapd.mount file too
+	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
+	err := os.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	c.Assert(err, IsNil)
+
+	systemctlCalls := 0
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		systemctlCalls++
+		return []byte("ActiveState=inactive"), nil
+	})
+	s.AddCleanup(r)
+	// make sure that we get the expected number of systemctl calls
+	s.AddCleanup(func() { c.Assert(systemctlCalls, Equals, 8) })
+
+	// also add the snapd snap to state which we will refresh
+	si1 := &snap.SideInfo{RealName: "snapd", Revision: snap.R(1)}
+	snapstate.Set(st, "snapd", &snapstate.SnapState{
+		SnapType: "snapd",
+		Active:   true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
+		Current:  si1.Revision,
+	})
+	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
+
+	// setup model assertion
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"base":         "core18",
+	})
+	err = assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	c.Assert(err, IsNil)
+
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	// run, this will trigger wait for restart
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// check the snapd task state
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+	restarting, kind := restart.Pending(st)
+	c.Check(restarting, Equals, true)
+	c.Assert(kind, Equals, restart.RestartDaemon)
+
+	// now verify whether the state would be correctly asserted, note that
+	// this isn't 100% realistic, as the check happens in overlord.StartUp()
+	// which we cannot fake here
+
+	func() {
+		// simple case, the environment variable from snap-failure is
+		// unset
+		os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+		err := snapstate.AssertRuntimeFailureRestart(st)
+		c.Assert(err, IsNil)
+	}()
+
+	func() {
+		// environment variable from snap-failure is set
+		os.Setenv("SNAPD_REVERT_TO_REV", "999")
+		defer os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+		err := snapstate.AssertRuntimeFailureRestart(st)
+		c.Assert(err, IsNil)
+	}()
+
+	// pretend auto connect is done
+	for _, tsk := range chg.Tasks() {
+		if tsk.Kind() == "auto-connect" {
+			tsk.SetStatus(state.DoneStatus)
+			break
+		}
+	}
+
+	dumpTasks(c, "after manipulation", chg.Tasks())
+
+	func() {
+		// the environment variable from snap-failure is unset, snapd
+		// could have restated at runtime for whatever reason and
+		// systemd handled it
+		os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+		err := snapstate.AssertRuntimeFailureRestart(st)
+		c.Assert(err, Equals, nil)
+	}()
+
+	func() {
+		// environment variable from snap-failure is set, but we did not
+		// expect a restart
+		os.Setenv("SNAPD_REVERT_TO_REV", "999")
+		defer os.Unsetenv("SNAPD_REVERT_TO_REV")
+
+		err := snapstate.AssertRuntimeFailureRestart(st)
+		c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	}()
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/state"
@@ -796,6 +797,12 @@ func (m *SnapManager) StartUp() error {
 	// register handler that records a refresh-inhibit notice when
 	// the set of inhibited snaps is changed.
 	m.changeCallbackID = m.state.AddChangeStatusChangedHandler(processInhibitedAutoRefresh)
+
+	if AssertRuntimeFailureRestart(m.state) == ErrUnexpectedRuntimeFailure {
+		logger.Noticef("detected a runtime failure without a corresponding snapd change")
+		// restart manager is added before snap manager
+		restart.Request(m.state, restart.StopDaemon, nil)
+	}
 
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -35,7 +35,6 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/state"
@@ -800,8 +799,7 @@ func (m *SnapManager) StartUp() error {
 
 	if AssertRuntimeFailureRestart(m.state) == ErrUnexpectedRuntimeFailure {
 		logger.Noticef("detected a runtime failure without a corresponding snapd change")
-		// restart manager is added before snap manager
-		restart.Request(m.state, restart.StopDaemon, nil)
+		return ErrUnexpectedRuntimeFailure
 	}
 
 	return nil

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -797,9 +797,9 @@ func (m *SnapManager) StartUp() error {
 	// the set of inhibited snaps is changed.
 	m.changeCallbackID = m.state.AddChangeStatusChangedHandler(processInhibitedAutoRefresh)
 
-	if AssertRuntimeFailureRestart(m.state) == ErrUnexpectedRuntimeFailure {
-		logger.Noticef("detected a runtime failure without a corresponding snapd change")
-		return ErrUnexpectedRuntimeFailure
+	if CheckExpectedRestart(m.state) == ErrUnexpectedRuntimeRestart {
+		logger.Noticef("detected a restart at runtime without a corresponding snapd change")
+		return ErrUnexpectedRuntimeRestart
 	}
 
 	return nil

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1091,7 +1091,7 @@ func isChangeRequestingSnapdRestart(chg *state.Change) bool {
 			continue
 		}
 
-		tss, err := TaskSnapSetup(tsk)
+		snapsup, err := TaskSnapSetup(tsk)
 		if err != nil {
 			// we're invoked in rollback scenario, things can be
 			// wrong in a way we cannot anticipate, so let's only
@@ -1100,7 +1100,7 @@ func isChangeRequestingSnapdRestart(chg *state.Change) bool {
 			continue
 		}
 
-		if tss.SnapName() != "snapd" {
+		if snapsup.SnapName() != "snapd" {
 			// not the snap we are looking for
 			continue
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1080,9 +1080,9 @@ var ErrUnexpectedRuntimeFailure = errors.New("unexpected restart at runtime")
 
 // AssertRuntimeFailureRestart asserts whether the current process state
 // indicates a failure at runtime and depending on the current changes state
-// either returns ErrUnexpectedRuntimeFailure to indicate that the failure
-// handling was invoked due to an earlier unexpected process failure at runtime,
-// or nil indicating that snapd should proceed with execution.
+// either returns ErrRecoveryFromUnexpectedRuntimeFailure to indicate that the
+// failure handling was invoked due to an earlier unexpected process failure at
+// runtime, or nil indicating that snapd should proceed with execution.
 func AssertRuntimeFailureRestart(st *state.State) error {
 	if !isInvokedWithRevert() {
 		return nil

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10087,7 +10087,7 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 	return n
 }
 
-func (s *snapmgrTestSuite) TestAssertRuntimeFailureNoEnv(c *C) {
+func (s *snapmgrTestSuite) TestCheckExpectedRestartNoEnv(c *C) {
 	os.Unsetenv("SNAPD_REVERT_TO_REV")
 
 	st := s.state
@@ -10132,7 +10132,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureNoEnv(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
+func (s *snapmgrTestSuite) TestCheckExpectedRestartFromSnapFailure(c *C) {
 	os.Setenv("SNAPD_REVERT_TO_REV", "1")
 	defer os.Unsetenv("SNAPD_REVERT_TO_REV")
 
@@ -10193,7 +10193,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
 	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 }
 
-func (s *snapmgrTestSuite) TestRuntimeFailureStartUpRequestsStop(c *C) {
+func (s *snapmgrTestSuite) TestCheckExpectedRestartFromStartUpRequestsStop(c *C) {
 	os.Setenv("SNAPD_REVERT_TO_REV", "1")
 	defer os.Unsetenv("SNAPD_REVERT_TO_REV")
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10095,7 +10095,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureNoEnv(c *C) {
 	defer st.Unlock()
 
 	// no snapd related change in the state
-	err := snapstate.AssertRuntimeFailureRestart(st)
+	err := snapstate.CheckExpectedRestart(st)
 	c.Assert(err, IsNil)
 
 	// procure a non-ready change for the snapd snap in the state
@@ -10115,7 +10115,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureNoEnv(c *C) {
 	chg.AddAll(ts)
 
 	// but since the env variable is still unset, we just proceed with execution
-	err = snapstate.AssertRuntimeFailureRestart(st)
+	err = snapstate.CheckExpectedRestart(st)
 	c.Assert(err, IsNil)
 
 	// pretend everything up to auto-connect is done, as if daemon restart
@@ -10128,7 +10128,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureNoEnv(c *C) {
 	}
 
 	// but even then we just proceed with execution
-	err = snapstate.AssertRuntimeFailureRestart(st)
+	err = snapstate.CheckExpectedRestart(st)
 	c.Assert(err, IsNil)
 }
 
@@ -10141,9 +10141,9 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
 	defer st.Unlock()
 
 	// no snapd related change in the state
-	err := snapstate.AssertRuntimeFailureRestart(st)
+	err := snapstate.CheckExpectedRestart(st)
 	// indicating we should exit
-	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 
 	// procure a non-ready change for the snapd snap in the state
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
@@ -10161,9 +10161,9 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
 	chg.Set("snap-names", []string{"snapd"})
 	chg.AddAll(tss)
 
-	err = snapstate.AssertRuntimeFailureRestart(st)
+	err = snapstate.CheckExpectedRestart(st)
 	// snapd should proceed with execution (possibly rolling back)
-	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 
 	// pretend everything up to auto-connect is done
 	for _, tsk := range chg.Tasks() {
@@ -10175,7 +10175,7 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
 
 	// if snap-failure was to call snapd now, the restart would not be
 	// unexpected
-	err = snapstate.AssertRuntimeFailureRestart(st)
+	err = snapstate.CheckExpectedRestart(st)
 	// now a restart is not unexpected
 	c.Assert(err, IsNil)
 
@@ -10188,9 +10188,9 @@ func (s *snapmgrTestSuite) TestAssertRuntimeFailureFromSnapFailure(c *C) {
 	// now there are no non-ready changes related to the snapd snap, which
 	// means restart with the env varialbe set would indicate a failure at
 	// runtime
-	err = snapstate.AssertRuntimeFailureRestart(st)
+	err = snapstate.CheckExpectedRestart(st)
 	// snapd should proceed with execution (possibly rolling back)
-	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 }
 
 func (s *snapmgrTestSuite) TestRuntimeFailureStartUpRequestsStop(c *C) {
@@ -10199,11 +10199,11 @@ func (s *snapmgrTestSuite) TestRuntimeFailureStartUpRequestsStop(c *C) {
 
 	s.state.Lock()
 	// make sure we have an expected state
-	err := snapstate.AssertRuntimeFailureRestart(s.state)
-	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	err := snapstate.CheckExpectedRestart(s.state)
+	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 	s.state.Unlock()
 
 	// startup asserts the runtime failure state
 	err = s.snapmgr.StartUp()
-	c.Check(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
+	c.Check(err, Equals, snapstate.ErrUnexpectedRuntimeRestart)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10174,17 +10174,9 @@ func (s *snapmgrTestSuite) TestRuntimeFailureStartUpRequestsStop(c *C) {
 	// make sure we have an expected state
 	err := snapstate.AssertRuntimeFailureRestart(s.state)
 	c.Assert(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
-
-	var restartRequests []restart.RestartType
-	_, err = restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
-		restartRequests = append(restartRequests, t)
-	}))
-	c.Assert(err, IsNil)
 	s.state.Unlock()
 
 	// startup asserts the runtime failure state
 	err = s.snapmgr.StartUp()
-	c.Check(err, IsNil)
-
-	c.Assert(restartRequests, DeepEquals, []restart.RestartType{restart.StopDaemon})
+	c.Check(err, Equals, snapstate.ErrUnexpectedRuntimeFailure)
 }

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -20,6 +20,7 @@
 package overlord
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -92,6 +93,17 @@ type startupError struct {
 
 func (e *startupError) Error() string {
 	return fmt.Sprintf("state startup errors: %v", e.errs)
+}
+
+// Is returns true if errors.Is(target) evaluates to true for any of the
+// underlying startup errors.
+func (e *startupError) Is(target error) bool {
+	for _, err := range e.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
 }
 
 // StartUp asks all managers to perform any expensive initialization. It is a noop after the first invocation.

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -105,6 +105,11 @@ func (ses *stateEngineSuite) TestStartUpError(c *C) {
 	err := se.StartUp()
 	c.Check(err.Error(), DeepEquals, "state startup errors: [boom1 boom2]")
 	c.Check(calls, DeepEquals, []string{"startup:mgr1", "startup:mgr2"})
+
+	err3 := errors.New("other error")
+	c.Check(errors.Is(err, err1), Equals, true)
+	c.Check(errors.Is(err, err2), Equals, true)
+	c.Check(errors.Is(err, err3), Equals, false)
 }
 
 func (ses *stateEngineSuite) TestEnsure(c *C) {

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -95,9 +95,11 @@ execute: |
             fi
 
             # make sure that snapd is being executed within the cgroup assigned to snapd.service
-            echo "Verify behavior on UC16, where snapd process runs under snapd.failure.service unit"
-            # shellcheck disable=SC2046,SC2002
-            cat /proc/$(pidof snapd)/cgroup | MATCH /snapd.failure.service
+            echo "Verify behavior on UC16, where snapd process eventually becomes"
+            # snap-failure only starts the socket unit, but we want to verify
+            # that the snapd runs
+            # shellcheck disable=SC2046,SC2002,SC2016
+            retry -n 60 --wait 1 sh -e -c 'snap list ; cat /proc/$(pidof snapd)/cgroup | MATCH /snapd.service'
         else
             # TODO this check is incorrect and is essentially racing with systemd
             # which could try to active the failure service, as we're essentially


### PR DESCRIPTION
When the snapd.service unit fails to be activated, an OnFailure handler will
execute snap-failure which in turn starts the snapd process from the previous
revision of the snap with SNAPD_REVERT_TO_REV set in its environment. It may
happen that the snapd unit fails at runtime without an associated change to the
snapd snap, however snap-failure is not able to detect such case, and so the
snapd process started in its context would continue to run. Avoid this by
extending the logic within snapd to check it if has been started by snap-failure
with the intention of handling a rollback, and so whether there is a change
related to snapd snap in the state. When the conditions have not been met, snapd
exits and snap-failure continues to restart the snapd service.

Related issues: SNAPDENG-21605

Based on #13998 