### PR TITLE
spread.yaml: remove Fedora 38 (EOL)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -179,8 +179,6 @@ backends:
                   storage: 12G
                   workers: 6
 
-            - fedora-38-64:
-                  workers: 6
             - fedora-39-64:
                   workers: 6
 


### PR DESCRIPTION
I'll propose enabling Fedora 40 separately, as we need to have a special image prepared and uploaded to our Google repository.
