### PR TITLE
tests: remove leftover mounts made by snapctl mount

### DIFF
--- a/tests/regression/lp-2065077/task.yaml
+++ b/tests/regression/lp-2065077/task.yaml
@@ -14,7 +14,7 @@ prepare: |
     snap connect test-snapd-sh:mount-control
 
     mkdir -p /var/snap/test-snapd-sh/common/base-files
-    echo 'snapctl mount -o ro,bind,noatime,noexec /usr/share/base-files /var/snap/test-snapd-sh/common/base-files' | snap run --shell test-snapd-sh.sh
+    snap run --shell test-snapd-sh.sh -c 'snapctl mount -o ro,bind,noatime,noexec /usr/share/base-files /var/snap/test-snapd-sh/common/base-files'
     mountpoint /var/snap/test-snapd-sh/common/base-files
     tests.cleanup defer snap run --shell test-snapd-sh.sh -c \'snapctl umount /var/snap/test-snapd-sh/common/base-files\'
 

--- a/tests/regression/lp-2065077/task.yaml
+++ b/tests/regression/lp-2065077/task.yaml
@@ -16,7 +16,7 @@ prepare: |
     mkdir -p /var/snap/test-snapd-sh/common/base-files
     echo 'snapctl mount -o ro,bind,noatime,noexec /usr/share/base-files /var/snap/test-snapd-sh/common/base-files' | snap run --shell test-snapd-sh.sh
     mountpoint /var/snap/test-snapd-sh/common/base-files
-    tests.cleanup defer umount /var/snap/test-snapd-sh/common/base-files
+    tests.cleanup defer snap run --shell test-snapd-sh.sh -c \'snapctl umount /var/snap/test-snapd-sh/common/base-files\'
 
     tests.session prepare -u test
     tests.cleanup defer tests.session restore -u test

--- a/tests/regression/lp-2065077/task.yaml
+++ b/tests/regression/lp-2065077/task.yaml
@@ -14,6 +14,8 @@ prepare: |
     snap connect test-snapd-sh:mount-control
 
     mkdir -p /var/snap/test-snapd-sh/common/base-files
+    tests.cleanup defer rmdir /var/snap/test-snapd-sh/common/base-files
+
     snap run --shell test-snapd-sh.sh -c 'snapctl mount -o ro,bind,noatime,noexec /usr/share/base-files /var/snap/test-snapd-sh/common/base-files'
     mountpoint /var/snap/test-snapd-sh/common/base-files
     tests.cleanup defer snap run --shell test-snapd-sh.sh -c \'snapctl umount /var/snap/test-snapd-sh/common/base-files\'


### PR DESCRIPTION
We used to unmount the directory, but the unit left behind by snapctl mount could be re-activated and cause problems to other tests.