### PR TITLE
tests/main/interfaces-many-core-provided: connect 50% only of interfaces to save time

### DIFF
--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -63,11 +63,8 @@ execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     for plugcmd in "$SNAP_MOUNT_DIR"/bin/"$CONSUMER_SNAP".* ; do
 
-        # Just connect 20% of the interfaces on debian 10, Otherwise connect 50%
-        # Debian 10 has bad performance disconnecting interfaces
-        # and the test fails (kill-timeout) trying either to remove
-        # interfaces or removing the snap
-        if (os.query is-debian 10 && [ "$((RANDOM % 5))" != 0 ]) || [ "$((RANDOM % 2))" != 0 ]; then
+        # Just connect 50% of the interfaces since this is quite slow otherwise
+        if [ "$((RANDOM % 2))" != 0 ]; then
             echo "skipping plug: $plugcmd"
             continue
         fi

--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -63,11 +63,11 @@ execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     for plugcmd in "$SNAP_MOUNT_DIR"/bin/"$CONSUMER_SNAP".* ; do
 
-        # Just connect 20% of the interfaces on debian 10
+        # Just connect 20% of the interfaces on debian 10, Otherwise connect 50%
         # Debian 10 has bad performance disconnecting interfaces
         # and the test fails (kill-timeout) trying either to remove
         # interfaces or removing the snap
-        if os.query is-debian 10 && [ "$((RANDOM % 5))" != 0 ]; then
+        if (os.query is-debian 10 && [ "$((RANDOM % 5))" != 0 ]) || [ "$((RANDOM % 2))" != 0 ]; then
             echo "skipping plug: $plugcmd"
             continue
         fi


### PR DESCRIPTION
Only test 50% of interfaces chosen at random to save time because test was sometimes reaching kill-timeout. Since the test is run on many systems, it should (with high probability) cover all interfaces.