### PR TITLE
systemd: strip pre-release suffixes when comparing versions

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -230,6 +230,12 @@ func getVersion() (int, error) {
 		}
 	}
 
+	// ignore the pre-release suffixes, since we otherwise we can't convert to an
+	// int and we only compare versions coarsely to check systemd is not too old
+	if i := strings.IndexRune(verstr, '~'); i != -1 {
+		verstr = verstr[:i]
+	}
+
 	ver, err := strconv.Atoi(verstr)
 	if err != nil {
 		return 0, fmt.Errorf("cannot convert systemd version to number: %s", verstr)

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -790,6 +790,8 @@ func (s *SystemdTestSuite) TestVersion(c *C) {
 	s.outs = [][]byte{
 		[]byte("systemd 223\n+PAM\n"),
 		[]byte("systemd 245 (245.4-4ubuntu3)\n+PAM +AUDIT +SELINUX +IMA\n"),
+		[]byte("systemd 255~rc3\n+PAM"),
+		[]byte("systemd 256~rc3-foo\n+PAM"),
 		// error cases
 		[]byte("foo 223\n+PAM\n"),
 		[]byte(""),
@@ -804,6 +806,14 @@ func (s *SystemdTestSuite) TestVersion(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(v, Equals, 245)
 
+	v, err = Version()
+	c.Assert(err, IsNil)
+	c.Check(v, Equals, 255)
+
+	v, err = Version()
+	c.Assert(err, IsNil)
+	c.Check(v, Equals, 256)
+
 	_, err = Version()
 	c.Assert(err, ErrorMatches, `cannot parse systemd version: expected "systemd", got "foo"`)
 
@@ -814,6 +824,8 @@ func (s *SystemdTestSuite) TestVersion(c *C) {
 	c.Assert(err, ErrorMatches, `cannot convert systemd version to number: abc`)
 
 	c.Check(s.argses, DeepEquals, [][]string{
+		{"--version"},
+		{"--version"},
 		{"--version"},
 		{"--version"},
 		{"--version"},


### PR DESCRIPTION
Some tests were failing on debian-sid because we weren't coping with systemd versions that contained a release candidate suffix. This deals with it simply by ignoring which should be enough given that we only compare them roughly to check if systemd is not too old.
```
error: cannot get logs: cannot get systemd version: cannot convert systemd
       version to number: 256~rc3
```

Seen here: https://github.com/snapcore/snapd/actions/runs/9267748316/job/25501253602#step:8:14581