### PR TITLE
tests: run test workflow on security release PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 name: Tests
 on:
   pull_request:
-    branches: [ "master", "release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
   push:
     # we trigger runs on master branch, but we do not run spread on master 
     # branch, the master branch runs are just for unit tests + codecov.io
-    branches: [ "master","release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
 
   # XXX we suspect that the whenever the labeler workflow executes successfully
   # it will trigger another workflow of tests on master, temporarily disable to
@@ -880,9 +880,9 @@ jobs:
       shell: bash
 
     - name: Run spread tests
-      # run if the commit is pushed to the release/* branch or there is a 'Run
-      # nested' label set on the PR
-      if: "contains(steps.collect-pr-labels.outputs.labels, 'Run nested') || contains(github.ref, 'refs/heads/release/')"
+      # run if there is a 'Run nested' label set on the PR or the commit is pushed to one of the recognised release branches
+      # "release/**", "core-snap-security-release/**" or "security-release/**"
+      if: "contains(steps.collect-pr-labels.outputs.labels, 'Run nested') || contains(github.ref, 'refs/heads/release/') || contains(github.ref, 'refs/heads/core-snap-security-release/') || contains(github.ref, 'refs/heads/security-release/')"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |


### PR DESCRIPTION
Modified test workflow to enable tests on security release PRs.

As part of work to put in place a new security release process that includes security release for core maintenance the following to branches is required within a new private snapd fork https://github.com/snapcore/snapd-security-release.
 - core-snap-security-release/2.61: single branch based off release/2.61 (tag 2.61.3) for security maintenance for "core" snaps (counterpart for release/2.61 that will be merged back after disclosure)
 - security-release/: branches for general security releases for snapd (counterparts for release/ that will be merged back after disclosure)

I propose we keep branch matching fairly exact provide certainty about which branches we expect to exist. This is arguable ok since we do not foresee this changing again in the near future and its simple enough to evolve when more flexibility makes sense.