### PR TITLE
tests: deal with pre-release suffix in systemd versions

### DIFF
--- a/tests/core/watchdog/task.yaml
+++ b/tests/core/watchdog/task.yaml
@@ -19,7 +19,7 @@ restore: |
     rm -f "$WATCHDOG_FILE"
 
 execute: |
-    systemd_ver="$(systemctl --version|head -1|cut -d ' ' -f2)"
+    systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
     REBOOT_WATCHDOG_PROP=RebootWatchdogUSec
     if [ "${systemd_ver}" -lt 243 ]; then
         REBOOT_WATCHDOG_PROP=ShutdownWatchdogUSec

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -481,7 +481,7 @@ prepare_project() {
     restart_logind=
     local systemd_ver
     systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
-    if [ "$(systemd_ver)" -lt 246 ]; then
+    if [ "$systemd_ver" -lt 246 ]; then
         restart_logind=maybe
     fi
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -479,14 +479,16 @@ prepare_project() {
     esac
 
     restart_logind=
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -lt 246 ]; then
+    local systemd_ver
+    systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+    if [ "$(systemd_ver)" -lt 246 ]; then
         restart_logind=maybe
     fi
 
     install_pkg_dependencies
 
     if [ "$restart_logind" = maybe ]; then
-        if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 246 ]; then
+        if [ "$systemd_ver" -ge 246 ]; then
             restart_logind=yes
         else
             restart_logind=

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -249,7 +249,7 @@ main() {
 
 	# When systemd version is higher than 252 we use systemd-run to execute
 	# In other scenarios we use the older approach: bustctl with the dbus monitor
-	if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -gt 252 ]; then
+	if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")" -gt 252 ]; then
 		local selinux_context_arg=""
 		if os.query is-fedora || os.query is-centos; then
 			selinux_context_arg="--property SELinuxContext=unconfined_u:unconfined_r:unconfined_t:s0"
@@ -354,7 +354,9 @@ BEGIN {
 	selinux_context_arg=
 	case $SPREAD_SYSTEM in
 		fedora-*|centos-*)
-			if [ "$(systemctl --version | head -n 1 | awk '{ print $2 }')" -gt 219 ]; then
+			local systemd_ver
+			systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+			if [ "$systemd_ver" -gt 219 ]; then
 				selinux_context_arg="SELinuxContext s unconfined_u:unconfined_r:unconfined_t:s0"
 			fi
 			;;

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -70,7 +70,8 @@ execute: |
     echo "$service_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.nap\.service'
 
     # The application tracking is tested below.
-    if [ "$USER" = test ] && "$TESTSTOOLS"/version-compare --strict "$(systemctl --version | head -n 1 | cut -d ' ' -f 2)" -lt 238; then
+    systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+    if [ "$USER" = test ] && "$TESTSTOOLS"/version-compare --strict "$systemd_ver" -lt 238; then
         echo "Systemd running as user session manager cannot start transient units"
         echo "that cross ownership boundary. This test effectively runs through root"
         echo "that is using ssh to connect to a test machine. Crossing the boundary"
@@ -168,7 +169,7 @@ execute: |
 
     wait "$session3_pid" || true  # same as above
     # When tests.session is used with systemd-run
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -gt 252 ]; then
+    if [ "$systemd_ver" -gt 252 ]; then
         pid3_sleep="$(cat "$cgroup_procs_path")"
         test -e "${base_cg_path}${pid3_tracking_cg_path}"
         kill "$pid3_sleep"

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -54,7 +54,8 @@ execute: |
     echo "Then the device is shown as assigned to the snap"
     udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
     # CURRENT_TAGS just available on systemd 247+
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+    systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+    if [ "$systemd_ver" -ge 247 ]; then
         udevadm info /dev/ttyS4 | MATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
     fi
 
@@ -69,7 +70,7 @@ execute: |
     udevadm info /dev/ttyS4 | NOMATCH "E: CURRENT_TAGS=.*snap_test-snapd-sh_sh"
     test ! -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
 
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+    if [ "$systemd_ver" -ge 247 ]; then
         # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS has
         # been updated updated and checked
         udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -87,7 +87,8 @@ execute: |
     fi
 
     tags_are_sticky=0
-    if [ "$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }')" -ge 247 ]; then
+    systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+    if [ "$systemd_ver" -ge 247 ]; then
         # with systemd versions 247+, the TAGS are sticky, but CURRENT_TAGS is
         # updated to reflect the latest state of DB
         tags_are_sticky=1


### PR DESCRIPTION
Debian sid is using an rc version of systemd which tests.session and various other tests weren't dealing with. This change cuts the pre-release suffix from all of them although some were only used by distros in which this isn't a problem. This is more consistent and robust IMO.

`/home/gopath/src/github.com/snapcore/snapd/tests/bin/tests.session: line 252: [: 256~rc3: integer expression expected`