### PR TITLE
snapdtool: explicit opt-in for reexec

### DIFF
--- a/tests/main/command-chain/command-chain/meta/snap.yaml
+++ b/tests/main/command-chain/command-chain/meta/snap.yaml
@@ -2,6 +2,7 @@ name: command-chain
 version: 1.0
 summary: Command chain snap
 description: A buildable snap that uses command chain
+base: core20
 
 apps:
   hello:

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -7,6 +7,11 @@ details: |
     that the command-chain is executed when running a snap with `snap run
     --shell`.
 
+systems:
+  # uubuntu 32bit: test uses snap with base core20 which there is no 32bit
+  # variant of
+  - -ubuntu-*-32
+
 environment:
     # Ensure that running purely from the deb (without re-exec) works
     # correctly
@@ -19,12 +24,35 @@ prepare: |
     echo "Build command chain snap"
     snap pack command-chain
     snap install --dangerous command-chain_1.0_all.snap
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
+        # reexec expects to find the snapd snap under /snap, enable it to do so
+        # on distros using /var/lib/snapd/snap
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     echo "Test that command-chain runs for hooks"
     [ "$(cat "$BREADCRUMB")" = "chain1 chain2 configure" ]
     MATCH '^CHAIN_1_RAN=1$' < "$ENVDUMP"
     MATCH '^CHAIN_2_RAN=1$' < "$ENVDUMP"
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+        # with snap mount dir different than /snap, internal s-c checks will fail
+        if command-chain.hello > err.out 2>&1 ; then
+            echo "unexpected success"
+            cat err.out || true
+            exit 1
+        fi
+
+        # with no AA support, we fail on a simple check for s-c being executed
+        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
+        # confinement
+        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
+        exit 0
+    fi
 
     echo "Test that command-chain runs for apps"
     [ "$(command-chain.hello)" = "chain1 chain2 hello" ]

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -17,6 +17,13 @@ prepare: |
     for snap in basic test-snapd-tools basic-desktop test-snapd-devmode snap-hooks-bad-install; do
         snap pack "$TESTSLIB"/snaps/$snap
     done
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
+        # reexec expects to find the snapd snap under /snap, enable it to do so
+        # on distros using /var/lib/snapd/snap
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     echo "Sideloaded snap shows status"
@@ -29,6 +36,23 @@ execute: |
 
     echo "Sideloaded snap executes commands"
     snap install --dangerous ./test-snapd-tools_1.0_all.snap
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+        # with snap mount dir different than /snap, internal s-c checks will fail
+        if test-snapd-tools.success > err.out 2>&1 ; then
+            echo "unexpected success"
+            cat err.out || true
+            exit 1
+        fi
+
+        # with no AA support, we fail on a simple check for s-c being executed
+        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
+        # confinement
+        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
+        exit 0
+    fi
+
     test-snapd-tools.success
     [ "$(test-snapd-tools.echo Hello World)" = "Hello World" ]
 

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -13,12 +13,35 @@ environment:
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-hooks
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
+        # reexec expects to find the snapd snap under /snap, enable it to do so
+        # on distros using /var/lib/snapd/snap
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     # Note that `snap run` doesn't exit non-zero if the hook is missing, so we
     # check the output instead.
 
     echo "Test that snap run can call valid hooks"
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+        # with snap mount dir different than /snap, internal s-c checks will fail
+        if snap run --hook=configure basic-hooks > err.out 2>&1 ; then
+            echo "unexpected success"
+            cat err.out || true
+            exit 1
+        fi
+
+        # with no AA support, we fail on a simple check for s-c being executed
+        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
+        # confinement
+        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
+        exit 0
+    fi
 
     if ! output="$(snap run --hook=configure basic-hooks)"; then
         echo "Failed to run configure hook"

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -14,11 +14,35 @@ environment:
 
 prepare: |
     snap pack data-writer
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
+        # reexec expects to find the snapd snap under /snap, enable it to do so
+        # on distros using /var/lib/snapd/snap
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     snap install --dangerous data-writer_1.0_all.snap
 
     echo "Apps can write to writable areas"
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+        # with snap mount dir different than /snap, internal s-c checks will fail
+        if data-writer.app > err.out 2>&1 ; then
+            echo "unexpected success"
+            cat err.out || true
+            exit 1
+        fi
+
+        # with no AA support, we fail on a simple check for s-c being executed
+        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
+        # confinement
+        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
+        exit 0
+    fi
+
     data-writer.app
     [ -f /var/snap/data-writer/x1/from-app ]
     [ -f /var/snap/data-writer/common/from-app ]


### PR DESCRIPTION
Snapd normally stops trying to reexec when the current host distribution is not
in the list of supported ones. However, allow reexec to be attempt if
SNAP_REEXEC is explicitly set to a truthy value in the environment. This enables
testing of the reexec functionality on a wider range of distributions.

Based on #13370 