### PR TITLE
tests/nested: use None as single datasource in the tests

### DIFF
--- a/tests/nested/manual/cmdline-option/cloud.conf
+++ b/tests/nested/manual/cmdline-option/cloud.conf
@@ -1,5 +1,5 @@
 #cloud-config
-datasource_list: [NoCloud,None]
+datasource_list: [None]
 users:
   - name: user1
     sudo: "ALL=(ALL) NOPASSWD:ALL"

--- a/tests/nested/manual/core20-gadget-cloud-conf/cloud.conf
+++ b/tests/nested/manual/core20-gadget-cloud-conf/cloud.conf
@@ -1,5 +1,5 @@
 # cloud-config
-datasource_list: [NoCloud,None]
+datasource_list: [None]
 users:
   - name: normal-user
     sudo: "ALL=(ALL) NOPASSWD:ALL"

--- a/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
+++ b/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
@@ -137,6 +137,3 @@ execute: |
   remote.exec "test -f /etc/cloud/cloud-init.disabled"
   remote.exec "test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
   remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
-
-  # TODO: if we ever decide to leave NoCloud datasources enabled if the source
-  # is the gadget, check that here too

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -53,7 +53,7 @@ execute: |
   echo 'console=ttyS0' > pc-gadget/cmdline.extra
   cat <<EOF > pc-gadget/cloud.conf
   #cloud-config
-  datasource_list: [NoCloud,None]
+  datasource_list: [None]
   ssh_pwauth: True
   users:
    - name: user1


### PR DESCRIPTION
We are not actually using the NoCloud datasource, so just use None which is the one really used by cloud-init if not specified by external means.