### PR TITLE
tests: skip the apparmor-batch-reload test in trusty

### DIFF
--- a/tests/main/apparmor-batch-reload/task.yaml
+++ b/tests/main/apparmor-batch-reload/task.yaml
@@ -10,7 +10,7 @@ details: |
     and then verifies apparmor cache to ensure expected profiles were created by fallback
     logic.
 
-systems: [ubuntu-1*]
+systems: [ubuntu-16*, ubuntu-18*]
 
 environment:
     VARIANT/changed: changed


### PR DESCRIPTION
This test is failing randomly and it is not required to keep it running in ubuntu 14.04.

Just livepatch is required in ubuntu 14.04
