### PR TITLE
tests: update check-pr-title script to use it in forked projects

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,6 +102,7 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
+      GITHUB_PROJECT_URL: ${{ github.server_url }}/${{ github.repository }}
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
 
     strategy:

--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -29,7 +29,7 @@ class GithubTitleParser(HTMLParser):
             self.title = data
 
 
-def check_pr_title(pr_number: int):
+def check_pr_title(project_url: str, pr_number: int):
     # ideally we would use the github API - however we can't because:
     # a) its rate limiting and travis IPs hit the API a lot so we regularly
     #    get errors
@@ -39,7 +39,7 @@ def check_pr_title(pr_number: int):
     # radically
     parser = GithubTitleParser()
     with urllib.request.urlopen(
-        "https://github.com/snapcore/snapd/pull/{}".format(pr_number)
+        "{}/pull/{}".format(project_url, pr_number)
     ) as f:
         parser.feed(f.read().decode("utf-8"))
     # the title has the format:
@@ -60,11 +60,14 @@ def check_pr_title(pr_number: int):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "project_url", metavar="Project url", help="the github project url to check"
+    )
+    parser.add_argument(
         "pr_number", metavar="PR number", help="the github PR number to check"
     )
     args = parser.parse_args()
     try:
-        check_pr_title(args.pr_number)
+        check_pr_title(args.project_url, args.pr_number)
     except InvalidPRTitle as e:
         print('Invalid PR title: "{}"\n'.format(e.invalid_title))
         print("Please provide a title in the following format:")

--- a/run-checks
+++ b/run-checks
@@ -148,7 +148,7 @@ if [ "$STATIC" = 1 ]; then
     #      details why we still use this script
     if [ -n "${GITHUB_PULL_REQUEST:-}" ] && [ "${GITHUB_PULL_REQUEST:-}" != "false" ]; then
         echo Checking pull request summary
-        ./check-pr-title.py "$GITHUB_PULL_REQUEST"
+        ./check-pr-title.py "${GITHUB_PROJECT_URL:-https://github.com/snapcore/snapd}" "$GITHUB_PULL_REQUEST"
     fi
 
     # check commit author/committer name for unicode


### PR DESCRIPTION
This is needed to be able to check pr titles in forked projects.
