### PR TITLE
tests: simplify the pr-title check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,8 +102,7 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PROJECT_URL: ${{ github.server_url }}/${{ github.repository }}
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+      GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
 
     strategy:
       # we cache successful runs so it's fine to keep going
@@ -269,7 +268,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false      
@@ -364,7 +362,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false
@@ -489,7 +486,6 @@ jobs:
       # snap in a step below. Without this we get the GitHub-controlled latest
       # version of go.
       PATH: /usr/sbin:/usr/bin:/sbin:/bin
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
 
     strategy:
       fail-fast: false
@@ -556,7 +552,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     steps:
     - name: Download the coverage files
       uses: actions/download-artifact@v3

--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -2,9 +2,6 @@
 
 import argparse
 import re
-import urllib.request
-
-from html.parser import HTMLParser
 
 
 class InvalidPRTitle(Exception):
@@ -12,62 +9,25 @@ class InvalidPRTitle(Exception):
         self.invalid_title = invalid_title
 
 
-class GithubTitleParser(HTMLParser):
-    def __init__(self):
-        HTMLParser.__init__(self)
-        self._cur_tag = ""
-        self.title = ""
-
-    def handle_starttag(self, tag, attributes):
-        self._cur_tag = tag
-
-    def handle_endtag(self, tag):
-        self._cur_tag = ""
-
-    def handle_data(self, data):
-        if self._cur_tag == "title":
-            self.title = data
-
-
-def check_pr_title(project_url: str, pr_number: int):
-    # ideally we would use the github API - however we can't because:
-    # a) its rate limiting and travis IPs hit the API a lot so we regularly
-    #    get errors
-    # b) using a API token is tricky because travis will not allow the secure
-    #    vars for forks
-    # so instead we just scrape the html title which is unlikely to change
-    # radically
-    parser = GithubTitleParser()
-    with urllib.request.urlopen(
-        "{}/pull/{}".format(project_url, pr_number)
-    ) as f:
-        parser.feed(f.read().decode("utf-8"))
-    # the title has the format:
-    #  "Added api endpoint for downloading snaps by glower · Pull Request #6958 · snapcore/snapd · GitHub"
-    # so we rsplit() once to get the title (rsplit to not get confused by
-    # possible "by" words in the real title)
-    title = parser.title.rsplit(" by ", maxsplit=1)[0]
-    print(title)
+def check_pr_title(pr_title: str):
+    print(pr_title)
     # cover most common cases:
     # package: foo
     # package, otherpackage/subpackage: this is a title
     # tests/regression/lp-12341234: foo
     # [RFC] foo: bar
-    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\](){}]+: .*", title):
-        raise InvalidPRTitle(title)
+    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\](){}]+: .*", pr_title):
+        raise InvalidPRTitle(pr_title)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "project_url", metavar="Project url", help="the github project url to check"
-    )
-    parser.add_argument(
-        "pr_number", metavar="PR number", help="the github PR number to check"
+        "pr_title", metavar="PR title", help="the github title to check"
     )
     args = parser.parse_args()
     try:
-        check_pr_title(args.project_url, args.pr_number)
+        check_pr_title(args.pr_title)
     except InvalidPRTitle as e:
         print('Invalid PR title: "{}"\n'.format(e.invalid_title))
         print("Please provide a title in the following format:")

--- a/run-checks
+++ b/run-checks
@@ -146,9 +146,11 @@ if [ "$STATIC" = 1 ]; then
 
     # XXX: remove once we can use an action, see workflows/test.yaml for
     #      details why we still use this script
-    if [ -n "${GITHUB_PULL_REQUEST:-}" ] && [ "${GITHUB_PULL_REQUEST:-}" != "false" ]; then
+    if [ -n "${GITHUB_PULL_REQUEST_TITLE:-}" ]; then
         echo Checking pull request summary
-        ./check-pr-title.py "${GITHUB_PROJECT_URL:-https://github.com/snapcore/snapd}" "$GITHUB_PULL_REQUEST"
+        ./check-pr-title.py "${GITHUB_PULL_REQUEST_TITLE}"
+    else
+	echo Skipping pull request summary check: not a pull request
     fi
 
     # check commit author/committer name for unicode


### PR DESCRIPTION
The check-pr-title.py was created when we used travis (a long time ago).

Now, in github actions we can access to the pr title from ${{ github.event.pull_request.title }}

The idea of this change is to avoid checking in the github api and simplify the check-pr-title.py tool.

This also is required to be able to use this check in private projects where a unauthenticated api call is not allowed.

Also, I am removing from the actions workflow the pr number variables which are not used anymore.
