### PR TITLE
snapcraft.yaml: add missing etelpmoc.sh for shell completion

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -302,7 +302,7 @@ parts:
       install -Dm644 data/info "${CRAFT_PART_INSTALL}/usr/lib/snapd/info"
       install -Dm644 data/preseed.json "${CRAFT_PART_INSTALL}/usr/lib/snapd/preseed.json"
 
-      install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" data/completion/bash/complete.sh
+      install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" data/completion/bash/complete.sh data/completion/bash/etelpmoc.sh
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions" ./data/completion/bash/snap
 
       # copy helper for collecting debug output


### PR DESCRIPTION
This is needed by Ubuntu Core to have completion to work. It should be tested by `ubuntu-core-22-64:tests/core/bash-completion`. But because we still repack older snaps, it does not get caught.