### PR TITLE
snapcraft.yaml: statically link snapd-preseed

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -244,7 +244,7 @@ parts:
            # FIXME: some binaries need to be run confined in apps. But
            # instead we should allow apps to access dynamic linkers
            # and libraries from snapd.
-           lib/snapd/snap-exec|lib/snapd/snapctl)
+           lib/snapd/snap-exec|lib/snapd/snapctl|lib/snapd/snap-preseed)
              export CGO_ENABLED=0
              GO_LD_FLAGS=()
              CHECK_STATIC=1


### PR DESCRIPTION
This is a commit from #13517. But I do not remember if it was useful. So I save it as draft here, and will test #13517 without it.