### PR TITLE
tests: increase `kill-timeout` for auto-refresh-pre-download

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -7,7 +7,7 @@ details: |
 # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
 systems: [-ubuntu-14.04-*]
 
-kill-timeout: 5m
+kill-timeout: 10m
 
 environment:
   # trigger the auto-refresh continuation by closing the snap


### PR DESCRIPTION
Timeout was noticed to [happen occasionally](https://github.com/snapcore/snapd/actions/runs/9300283020/job/25596467751?pr=13953#step:8:4102), increasing the `kill-timeout` should decrease the likelihood of failing.