### PR TITLE
o/snapstate: test for specific errors returned by Install and InstallMany

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -562,7 +562,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 	}
 
 	if len(currentSnaps) == 0 && len(actions) == 0 {
-		return nil, nil, nil
+		return nil, nil, &store.SnapActionError{NoResults: true}
 	}
 	if len(actions) > 7 {
 		panic("fake SnapAction unexpectedly called with more than 7 actions")


### PR DESCRIPTION
`Install` and `InstallMany` have subtle differences in how they handle the case where the store provides an empty response.

`Install` -> returns a `snapstate.ErrMissingExpectedResult`
`InstallMany` -> returns a `store.SnapActionError`

Add tests to define this behavior, and thus requiring #13949 to conform to this behavior.