### PR TITLE
tests: create test user with useradd in uc24

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -167,8 +167,8 @@ nested_uc20_transition_to_system_mode() {
 
 nested_prepare_ssh() {
     if nested_is_core_ge 24; then
-        remote.exec "sudo useradd --uid 12345 --extrausers test"
-        remote.exec "sudo useradd --extrausers external"
+        remote.exec "sudo useradd --uid 12345 -m --extrausers test"
+        remote.exec "sudo useradd -m --extrausers external"
     else 
         remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
         remote.exec "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -167,11 +167,11 @@ nested_uc20_transition_to_system_mode() {
 
 nested_prepare_ssh() {
     if nested_is_core_ge 24; then
-        remote.exec "sudo useradd --uid 12345 -m --extrausers test"
-        remote.exec "sudo useradd -m --extrausers external"
+        remote.exec "sudo useradd --uid 12345 --create-home --extrausers test"
+        remote.exec "sudo useradd --create-home --extrausers external"
     else 
-        remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
-        remote.exec "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"
+        remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --comment '' test"
+        remote.exec "sudo adduser --extrausers --quiet --disabled-password --comment '' external"
     fi
     
     remote.exec "echo test:ubuntu123 | sudo chpasswd"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -294,9 +294,9 @@ prepare_project() {
 
     if [ "$SPREAD_BACKEND" = "testflinger" ]; then
         if os.query is-core-ge 24; then
-            useradd --uid 12345 -m --extrausers test
+            useradd --uid 12345 --create-home --extrausers test
         else
-            adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
+            adduser --uid 12345 --extrausers --quiet --disabled-password --comment '' test
         fi
         echo test:ubuntu | sudo chpasswd
         echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -293,7 +293,11 @@ prepare_project() {
     fi
 
     if [ "$SPREAD_BACKEND" = "testflinger" ]; then
-        adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
+        if os.query is-core-ge 24; then
+            useradd --uid 12345 -m --extrausers test
+        else
+            adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
+        fi
         echo test:ubuntu | sudo chpasswd
         echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test
         chown test.test -R "$PROJECT_PATH"


### PR DESCRIPTION
This change is needed to create the test user in uc24 with home directory.

This is needed to fix tests in uc24 (edge validation)
