### PR TITLE
snapcraft.yaml: use expected path for snap-confine apparmor profile

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -305,6 +305,11 @@ parts:
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" data/completion/bash/complete.sh
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions" ./data/completion/bash/snap
 
+      # TODO: For now snapd expects a renamed apparmor profile to
+      # work-around LP#1673247. We should fix that since the snapd
+      # should not need that work-around.
+      mv "${CRAFT_PART_INSTALL}/etc/apparmor.d/usr.lib.snapd.snap-confine" "${CRAFT_PART_INSTALL}/etc/apparmor.d/usr.lib.snapd.snap-confine.real"
+
       # copy helper for collecting debug output
       cp -av debug-tools/snap-debug-info.sh ${CRAFT_PART_INSTALL}/usr/lib/snapd/
 


### PR DESCRIPTION
This is a work-around for [LP#1673247](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1673247), which in theory should not affect the snap. But for now, since the code and tests depend on that path we should use that name, and then fix the code later.