### PR TITLE
data/selinux: allow statfs() on efi filesystem

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -468,6 +468,11 @@ gen_require(`
 ')
 allow snappy_t devicekit_power_exec_t:file { getattr };
 
+# go-efilib probes for efivars
+gen_require(`
+    type efivarfs_t;
+')
+allow snappy_t efivarfs_t:filesystem { getattr };
 
 
 ########################################
@@ -880,6 +885,12 @@ systemd_exec_systemctl(snappy_cli_t)
 
 # allow snap to read SSL certs
 miscfiles_read_all_certs(snappy_cli_t)
+
+# go-efilib which is included through snap debug command probes for efivars
+gen_require(`
+    type efivarfs_t;
+')
+allow snappy_cli_t efivarfs_t:filesystem { getattr };
 
 ########################################
 #


### PR DESCRIPTION
The snapd and snap binaries trigger an AVC denial due to go-efilib probing for efivars:

2024-06-03T08:45:31.5157177Z type=AVC msg=audit(06/03/24 08:45:28.241:2091) : avc:  denied  *** getattr *** for  pid=8599 comm=snapd name=/ dev="efivarfs" ino=7120 scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:object_r:efivarfs_t:s0
tclass=filesystem permissive=1

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
