### PR TITLE
boot: do not import go-efilib on nosecboot

### DIFF
--- a/boot/export_sb_test.go
+++ b/boot/export_sb_test.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"github.com/canonical/go-efilib"
+	"github.com/canonical/go-efilib/linux"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+var (
+	ConstructLoadOption      = constructLoadOption
+	SetEfiBootOptionVariable = setEfiBootOptionVariable
+	SetEfiBootOrderVariable  = setEfiBootOrderVariable
+)
+
+func MockEfiListVariables(f func() ([]efi.VariableDescriptor, error)) (restore func()) {
+	restore = testutil.Backup(&efiListVariables)
+	efiListVariables = f
+	return restore
+}
+
+func MockEfiReadVariable(f func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error)) (restore func()) {
+	restore = testutil.Backup(&efiReadVariable)
+	efiReadVariable = f
+	return restore
+}
+
+func MockEfiWriteVariable(f func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error) (restore func()) {
+	restore = testutil.Backup(&efiWriteVariable)
+	efiWriteVariable = f
+	return restore
+}
+
+func MockLinuxFilePathToDevicePath(f func(path string, mode linux.FilePathToDevicePathMode) (out efi.DevicePath, err error)) (restore func()) {
+	restore = testutil.Backup(&linuxFilePathToDevicePath)
+	linuxFilePathToDevicePath = f
+	return restore
+}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -23,9 +23,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/canonical/go-efilib"
-	"github.com/canonical/go-efilib/linux"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/kernel/fde"
@@ -289,34 +286,4 @@ func MockWriteModelToUbuntuBoot(mock func(*asserts.Model) error) (restore func()
 func EnableTestingRebootFunction() (restore func()) {
 	testingRebootItself = true
 	return func() { testingRebootItself = false }
-}
-
-var (
-	ConstructLoadOption      = constructLoadOption
-	SetEfiBootOptionVariable = setEfiBootOptionVariable
-	SetEfiBootOrderVariable  = setEfiBootOrderVariable
-)
-
-func MockEfiListVariables(f func() ([]efi.VariableDescriptor, error)) (restore func()) {
-	restore = testutil.Backup(&efiListVariables)
-	efiListVariables = f
-	return restore
-}
-
-func MockEfiReadVariable(f func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error)) (restore func()) {
-	restore = testutil.Backup(&efiReadVariable)
-	efiReadVariable = f
-	return restore
-}
-
-func MockEfiWriteVariable(f func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error) (restore func()) {
-	restore = testutil.Backup(&efiWriteVariable)
-	efiWriteVariable = f
-	return restore
-}
-
-func MockLinuxFilePathToDevicePath(f func(path string, mode linux.FilePathToDevicePathMode) (out efi.DevicePath, err error)) (restore func()) {
-	restore = testutil.Backup(&linuxFilePathToDevicePath)
-	linuxFilePathToDevicePath = f
-	return restore
 }

--- a/boot/setefibootvars.go
+++ b/boot/setefibootvars.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2023-2024 Canonical Ltd
+ * Copyright (C) 2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,8 +19,20 @@
 
 package boot
 
-import "github.com/snapcore/snapd/osutil"
+import (
+	"errors"
+)
 
-func SetEfiBootVariables(description string, assetPath string, optionalData []byte) error {
-	return osutil.ErrDarwin
+func setEfiBootVariablesNotImpl(description string, assetPath string, optionalData []byte) error {
+	return errors.New("not implemented without secboot")
+}
+
+var SetEfiBootVariables = setEfiBootVariablesNotImpl
+
+func MockSetEfiBootVariables(f func(description string, assetPath string, optionalData []byte) error) func() {
+	old := SetEfiBootVariables
+	SetEfiBootVariables = f
+	return func() {
+		SetEfiBootVariables = old
+	}
 }

--- a/boot/setefibootvars_sb.go
+++ b/boot/setefibootvars_sb.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 
 /*
  * Copyright (C) 2023-2024 Canonical Ltd
@@ -199,12 +200,6 @@ func setEfiBootVariablesImpl(description string, assetPath string, optionalData 
 	return setEfiBootOrderVariable(bootNum)
 }
 
-var SetEfiBootVariables = setEfiBootVariablesImpl
-
-func MockSetEfiBootVariables(f func(description string, assetPath string, optionalData []byte) error) func() {
-	old := SetEfiBootVariables
-	SetEfiBootVariables = f
-	return func() {
-		SetEfiBootVariables = old
-	}
+func init() {
+	SetEfiBootVariables = setEfiBootVariablesImpl
 }

--- a/boot/setefibootvars_sb_test.go
+++ b/boot/setefibootvars_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 
 /*
  * Copyright (C) 2023-2024 Canonical Ltd


### PR DESCRIPTION
go-efilib always queries for efivarfs on initialization, which is not needed for most use of snapd. We can remove import of go-efilib when nosecboot tag is used.

See https://github.com/canonical/go-efilib/blob/ac83d67997a21bdf37b7a697425d505649a862fa/vars_linux.go#L287

Also this simplify packaging on some distributions.