### PR TITLE
tests/core/system-settings: handle missing /etc/timezone on uc24

### DIFF
--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -6,7 +6,7 @@ details: |
 
 prepare: |
     hostname > hostname.bak
-    cp /etc/timezone timezone.bak
+    readlink -f /etc/localtime | sed "s/\/usr\/share\/zoneinfo\///" > timezone.bak
 
 restore: |
     hostnamectl set-hostname "$(cat hostname.bak)" || true
@@ -22,5 +22,8 @@ execute: |
     timedatectl set-timezone "America/Lima"
     date +"%Z" | MATCH '\-05'
     timedatectl | MATCH "Time zone: America/Lima"
-    MATCH "America/Lima" < /etc/timezone
+    # /etc/timezone is missing on core24, skip check
+    if ! os.query is-core24; then
+        MATCH "America/Lima" < /etc/timezone
+    fi
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Lima"

--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -22,8 +22,4 @@ execute: |
     timedatectl set-timezone "America/Lima"
     date +"%Z" | MATCH '\-05'
     timedatectl | MATCH "Time zone: America/Lima"
-    # /etc/timezone is missing on core24, skip check
-    if ! os.query is-core24; then
-        MATCH "America/Lima" < /etc/timezone
-    fi
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Lima"


### PR DESCRIPTION
`/etc/timezone` is missing on uc24 which caused `tests/core/system-settings` to fail on prepare step while backing up "the non-existing" /etc/timezone file