### PR TITLE
tests: revert change to used --comment in adduser

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -170,8 +170,8 @@ nested_prepare_ssh() {
         remote.exec "sudo useradd --uid 12345 --create-home --extrausers test"
         remote.exec "sudo useradd --create-home --extrausers external"
     else 
-        remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --comment '' test"
-        remote.exec "sudo adduser --extrausers --quiet --disabled-password --comment '' external"
+        remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
+        remote.exec "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"
     fi
     
     remote.exec "echo test:ubuntu123 | sudo chpasswd"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -296,7 +296,7 @@ prepare_project() {
         if os.query is-core-ge 24; then
             useradd --uid 12345 --create-home --extrausers test
         else
-            adduser --uid 12345 --extrausers --quiet --disabled-password --comment '' test
+            adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test
         fi
         echo test:ubuntu | sudo chpasswd
         echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test


### PR DESCRIPTION
The nested tests are failing bucause of this problem

--comment is not supported by all the adduser versions (Unknown option: comment)

