### PR TITLE
bootloader: allow building without bootloader support

### DIFF
--- a/bootloader/bootloader_supported.go
+++ b/bootloader/bootloader_supported.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nobootloader
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootloader
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+var (
+	//  bootloaders list all possible bootloaders by their constructor
+	//  function.
+	bootloaders = []bootloaderNewFunc{
+		newUboot,
+		newGrub,
+		newAndroidBoot,
+		newLk,
+		newPiboot,
+	}
+)
+
+// Find returns the bootloader for the system
+// or an error if no bootloader is found.
+//
+// The rootdir option is useful for image creation operations. It
+// can also be used to find the recovery bootloader, e.g. on uc20:
+//
+//	bootloader.Find("/run/mnt/ubuntu-seed")
+func Find(rootdir string, opts *Options) (Bootloader, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	if forcedBootloader != nil || forcedError != nil {
+		return forcedBootloader, forcedError
+	}
+
+	if rootdir == "" {
+		rootdir = dirs.GlobalRootDir
+	}
+	if opts == nil {
+		opts = &Options{}
+	}
+
+	// note that the order of this is not deterministic
+	for _, blNew := range bootloaders {
+		bl := blNew(rootdir, opts)
+		present, err := bl.Present()
+		if err != nil {
+			return nil, fmt.Errorf("bootloader %q found but not usable: %v", bl.Name(), err)
+		}
+		if present {
+			return bl, nil
+		}
+	}
+	// no, weeeee
+	return nil, ErrBootloader
+}
+
+// ForGadget returns a bootloader matching a given gadget by inspecting the
+// contents of gadget directory or an error if no matching bootloader is found.
+func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	if forcedBootloader != nil || forcedError != nil {
+		return forcedBootloader, forcedError
+	}
+	for _, blNew := range bootloaders {
+		bl := blNew(rootDir, opts)
+		markerConf := filepath.Join(gadgetDir, bl.Name()+".conf")
+		// do we have a marker file?
+		if osutil.FileExists(markerConf) {
+			return bl, nil
+		}
+	}
+	return nil, ErrBootloader
+}

--- a/bootloader/bootloader_unsupported.go
+++ b/bootloader/bootloader_unsupported.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nobootloader
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootloader
+
+import (
+	"errors"
+)
+
+var errBootloaderSupportDisabled = errors.New("no bootloader support")
+
+var (
+	// no bootloader supported with this build configuration
+	bootloaders = []bootloaderNewFunc{}
+)
+
+// Find returns the bootloader for the system
+// or an error if no bootloader is found.
+//
+// The rootdir option is useful for image creation operations. It
+// can also be used to find the recovery bootloader, e.g. on uc20:
+//
+//	bootloader.Find("/run/mnt/ubuntu-seed")
+func Find(rootdir string, opts *Options) (Bootloader, error) {
+	return nil, errBootloaderSupportDisabled
+}
+
+// ForGadget returns a bootloader matching a given gadget by inspecting the
+// contents of gadget directory or an error if no matching bootloader is found.
+func ForGadget(gadgetDir, rootDir string, opts *Options) (Bootloader, error) {
+	return nil, errBootloaderSupportDisabled
+}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -52,11 +52,11 @@ build() {
   # GOFLAGS may be modified by CI tools
   # GOFLAGS are the go build flags for all binaries, GOFLAGS_SNAP are for snap
   # build only.
-  GOFLAGS=""
-  GOFLAGS_SNAP="-tags nomanagers"
+  GOFLAGS="-tags nosecboot,nobootloader"
+  GOFLAGS_SNAP="-tags nomanagers,nosecboot,nobootloader"
   if [[ "$WITH_TEST_KEYS" == 1 ]]; then
-      GOFLAGS="$GOFLAGS -tags withtestkeys"
-      GOFLAGS_SNAP="-tags nomanagers,withtestkeys"
+      GOFLAGS="$GOFLAGS -tags nosecboot,nobootloader,withtestkeys"
+      GOFLAGS_SNAP="-tags nomanagers,nosecboot,nobootloader,withtestkeys"
   fi
 
   export CGO_ENABLED="1"

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -545,9 +545,9 @@ export GO111MODULE=off
 # see https://github.com/gofed/go-macros/blob/master/rpm/macros.d/macros.go-compilers-golang
 BUILDTAGS=
 %if 0%{?with_test_keys}
-BUILDTAGS="withtestkeys nosecboot"
+BUILDTAGS="withtestkeys nosecboot nobootloader"
 %else
-BUILDTAGS="nosecboot"
+BUILDTAGS="nosecboot nobootloader"
 %endif
 
 %if ! 0%{?with_bundled}

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -55,7 +55,7 @@ endif
 # The list of go binaries we are expected to build.
 go_binaries = $(addprefix $(builddir)/, snap snapctl snap-seccomp snap-update-ns snap-exec snapd snapd-apparmor)
 
-GO_TAGS = nosecboot
+GO_TAGS = nosecboot nobootloader
 ifeq ($(with_testkeys),1)
 GO_TAGS += withtestkeys
 endif


### PR DESCRIPTION
Some platforms we build snapd for have no use for boot or bootloader support,
since snapd is not playing any role in the management of those platform, nor it
participates in the boot process. This is a first step to enable building of a
slightly leaner version of snapd package.