### PR TITLE
interfaces: Fixup raw_usb AppArmor path for the Thinkpad x13s

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -44,7 +44,7 @@ const rawusbConnectedPlugAppArmor = `
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,
-/sys/devices/platform/soc/*.usb/usb[0-9]** r,
+/sys/devices/platform/soc**/*.usb**/usb[0-9]** r,
 /sys/devices/platform/scb/*.pcie/pci**/usb[0-9]** r,
 
 /run/udev/data/c16[67]:[0-9] r, # ACM USB modems


### PR DESCRIPTION
The Thinkpad x13s exposes USB device busnum files at a slightly different path:

apparmor="DENIED" operation="open" class="file" profile="snap.android-platform-tools.adb"
  name="/sys/devices/platform/soc@0/a6f8800.usb/a600000.usb/xhci-hcd.1.auto/usb1/1-1/busnum"
  pid=78132 comm="libusb_event" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0

Accommodate for that by adjusting the path in the generated AppArmor profile.