### PR TITLE
many: build drivers tree when current mount is not the target mount

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/mkfs"
+	"github.com/snapcore/snapd/snap"
 )
 
 var (
@@ -124,7 +125,14 @@ func writeFilesystemContent(laidOut *gadget.LaidOutStructure, kSnapInfo *KernelS
 		destDir := kernel.DriversTreeDir(destRoot, kSnapInfo.Name, kSnapInfo.Revision)
 		logger.Noticef("building drivers tree in %s", destDir)
 
-		if err := kernelEnsureKernelDriversTree(kSnapInfo.MountPoint, destDir, nil,
+		kTargetSysMntPt := snap.MinimalSnapContainerPlaceInfo(kSnapInfo.Name, kSnapInfo.Revision)
+		if err := kernelEnsureKernelDriversTree(
+			kernel.MountPoints{
+				Current: kSnapInfo.MountPoint,
+				Target:  kTargetSysMntPt.MountDir(),
+			},
+			nil,
+			destDir,
 			&kernel.KernelDriversTreeOptions{KernelInstall: true}); err != nil {
 			return err
 		}

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel"
-	"github.com/snapcore/snapd/snap"
 )
 
 type MkfsParams = mkfsParams
@@ -76,7 +75,7 @@ func MockMkfsMake(f func(typ, img, label string, devSize, sectorSize quantity.Si
 	}
 }
 
-func MockKernelEnsureKernelDriversTree(f func(kSnapRoot, destDir string, kmodsConts []snap.ContainerPlaceInfo, opts *kernel.KernelDriversTreeOptions) (err error)) (restore func()) {
+func MockKernelEnsureKernelDriversTree(f func(kMntPts kernel.MountPoints, compsMntPts []kernel.ModulesCompMountPoints, destDir string, opts *kernel.KernelDriversTreeOptions) (err error)) (restore func()) {
 	old := kernelEnsureKernelDriversTree
 	kernelEnsureKernelDriversTree = f
 	return func() {

--- a/gadget/install/kernel.go
+++ b/gadget/install/kernel.go
@@ -24,7 +24,7 @@ import (
 )
 
 // KernelSnapInfo includes information from the kernel snap that is
-// needed to build a drivers tree. Defin
+// needed to build a drivers tree.
 type KernelSnapInfo struct {
 	Name     string
 	Revision snap.Revision

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -96,7 +96,11 @@ func (s *kernelDriversTestSuite) TestKernelVersionFromModulesDirBadVersion(c *C)
 	c.Check(ver, Equals, "")
 }
 
-func createKernelSnapFiles(c *C, kversion, kdir string) {
+type createKernelSnapFilesOpts struct {
+	withFwUpdatesDir bool
+}
+
+func createKernelSnapFiles(c *C, kversion, kdir string, opts createKernelSnapFilesOpts) {
 	c.Assert(os.MkdirAll(kdir, 0755), IsNil)
 
 	// Create modinfo files
@@ -115,6 +119,9 @@ func createKernelSnapFiles(c *C, kversion, kdir string) {
 	for _, f := range []string{"blob1", "blob2"} {
 		c.Assert(os.WriteFile(filepath.Join(fwDir, f), []byte{}, 0644), IsNil)
 	}
+	if opts.withFwUpdatesDir {
+		c.Assert(os.MkdirAll(filepath.Join(fwDir, "updates"), 0755), IsNil)
+	}
 	// Directory, write file inside
 	fwSubDir := filepath.Join(fwDir, "subdir")
 	c.Assert(os.MkdirAll(fwSubDir, 0755), IsNil)
@@ -126,8 +133,17 @@ func createKernelSnapFiles(c *C, kversion, kdir string) {
 
 func (s *kernelDriversTestSuite) TestBuildKernelDriversTree(c *C) {
 	// Build twice to make sure the function is idempotent
-	testBuildKernelDriversTree(c)
-	testBuildKernelDriversTree(c)
+	testBuildKernelDriversTree(c, createKernelSnapFilesOpts{})
+	testBuildKernelDriversTree(c, createKernelSnapFilesOpts{})
+
+	// Now remove and check
+	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
+	kernel.RemoveKernelDriversTree(treeRoot)
+	c.Assert(osutil.FileExists(treeRoot), Equals, false)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeWithUpdates(c *C) {
+	testBuildKernelDriversTree(c, createKernelSnapFilesOpts{withFwUpdatesDir: true})
 
 	// Now remove and check
 	treeRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1")
@@ -156,14 +172,18 @@ func doDirChecks(c *C, dir string, expected []expectInode) {
 	}
 }
 
-func testBuildKernelDriversTree(c *C) {
+func testBuildKernelDriversTree(c *C, opts createKernelSnapFilesOpts) {
 	mountDir := filepath.Join(dirs.SnapMountDir, "pc-kernel/1")
 	kversion := "5.15.0-78-generic"
-	createKernelSnapFiles(c, kversion, mountDir)
+	createKernelSnapFiles(c, kversion, mountDir, opts)
 
 	// Now build the tree
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	c.Assert(kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	c.Assert(kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir},
+		nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true}), IsNil)
 
 	// Check content is as expected
@@ -216,7 +236,10 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversNoModsOrFw(c *C) {
 
 	// Build the tree should not fail
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
 
@@ -244,7 +267,10 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyMods(c *C) {
 
 	// Build the tree should not fail
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
 
@@ -254,6 +280,41 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyMods(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, true)
 	c.Check(isReg, Equals, true)
+
+	// but log should warn about this
+	c.Assert(buf.String(), testutil.Contains, `no firmware found in "`+mountDir+`/firmware"`)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyModsWithTargetDir(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
+	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  kTargetDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	// check created file
+	modPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion)
+	modDepBinPath := filepath.Join(modPath, "modules.dep.bin")
+	exists, isReg, err := osutil.RegularFileExists(modDepBinPath)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+	c.Check(isReg, Equals, true)
+	// Check symlinks points to final target
+	modsPath := filepath.Join(modPath, "kernel")
+	modsTarget, err := os.Readlink(modsPath)
+	c.Assert(err, IsNil)
+	c.Check(modsTarget, Equals, filepath.Join(kTargetDir, "modules", kversion, "kernel"))
 
 	// but log should warn about this
 	c.Assert(buf.String(), testutil.Contains, `no firmware found in "`+mountDir+`/firmware"`)
@@ -277,13 +338,43 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyFw(c *C) {
 
 	// Build the tree should not fail
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
 
 	// check link
 	fwPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "firmware", "wifi_fw.bin")
 	c.Assert(osutil.IsSymlink(fwPath), Equals, true)
+
+	// but log should warn about this
+	c.Assert(buf.String(), testutil.Contains, `no modules found in "`+mountDir+`"`)
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyFwWithTargetDir(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
+	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	createKernelSnapFilesOnlyFw(c, mountDir)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  kTargetDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	// check link
+	fwPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "firmware", "wifi_fw.bin")
+	fwPathTarget, err := os.Readlink(fwPath)
+	c.Assert(err, IsNil)
+	c.Check(fwPathTarget, Equals, filepath.Join(kTargetDir, "firmware", "wifi_fw.bin"))
 
 	// but log should warn about this
 	c.Assert(buf.String(), testutil.Contains, `no modules found in "`+mountDir+`"`)
@@ -300,7 +391,10 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversAbsFwSymlink(c *C) {
 
 	// Fails on the absolute path in the link
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, ErrorMatches, `symlink \".*lib/firmware/ln_to_abs\" points to absolute path \"/absdir/blob3\"`)
 
@@ -312,7 +406,7 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversAbsFwSymlink(c *C) {
 func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCleanup(c *C) {
 	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
 	kversion := "5.15.0-78-generic"
-	createKernelSnapFiles(c, kversion, mountDir)
+	createKernelSnapFiles(c, kversion, mountDir, createKernelSnapFilesOpts{})
 
 	restore := kernel.MockOsSymlink(func(string, string) error {
 		return errors.New("mocked symlink error")
@@ -321,7 +415,10 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCleanup(c *C) {
 
 	// Now build the tree
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, ErrorMatches, "mocked symlink error")
 
@@ -333,7 +430,7 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCleanup(c *C) {
 func (s *kernelDriversTestSuite) TestBuildKernelDriversBadFileType(c *C) {
 	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
 	kversion := "5.15.0-78-generic"
-	createKernelSnapFiles(c, kversion, mountDir)
+	createKernelSnapFiles(c, kversion, mountDir, createKernelSnapFilesOpts{})
 
 	// Additional file of not expected type in "firmware"
 	fwDir := filepath.Join(mountDir, "firmware")
@@ -341,7 +438,10 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversBadFileType(c *C) {
 
 	// Now build the tree
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, nil,
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, ErrorMatches, `"fifo" has unexpected file type: p---------`)
 
@@ -378,7 +478,7 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeWithKernelAndComps(c 
 
 func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCompsNoKernelInstall(c *C) {
 	// Kernel needs to have been installed first
-	testBuildKernelDriversTree(c)
+	testBuildKernelDriversTree(c, createKernelSnapFilesOpts{})
 	// Build twice to make sure the function is idempotent
 	opts := &kernel.KernelDriversTreeOptions{KernelInstall: false}
 	testBuildKernelDriversTreeWithComps(c, opts)
@@ -400,7 +500,7 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCompsNoKernel(c *C) {
 
 	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
 	kversion := "5.15.0-78-generic"
-	createKernelSnapFiles(c, kversion, mountDir)
+	createKernelSnapFiles(c, kversion, mountDir, createKernelSnapFilesOpts{})
 
 	compMntDir1 := filepath.Join(dirs.RunDir, "mnt/kernel-snaps/comp1")
 	compMntDir2 := filepath.Join(dirs.RunDir, "mnt/kernel-snaps/comp2")
@@ -410,10 +510,18 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCompsNoKernel(c *C) {
 		snap.MinimalComponentContainerPlaceInfo("comp1", snap.R(11), "pc-kernel"),
 		snap.MinimalComponentContainerPlaceInfo("comp2", snap.R(22), "pc-kernel"),
 	}
+	compsMntPts := []kernel.ModulesCompMountPoints{
+		{"comp1", kernel.MountPoints{kmodsConts[0].MountDir(), kmodsConts[0].MountDir()}},
+		{"comp2", kernel.MountPoints{kmodsConts[1].MountDir(), kmodsConts[1].MountDir()}},
+	}
 
 	// Now build the tree, will fail as no kernel was installed previously
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	err := kernel.EnsureKernelDriversTree(mountDir, destDir, kmodsConts, &kernel.KernelDriversTreeOptions{KernelInstall: false})
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir},
+		compsMntPts, destDir, &kernel.KernelDriversTreeOptions{KernelInstall: false})
 	c.Assert(err, ErrorMatches, `while swapping .*: no such file or directory`)
 }
 
@@ -423,7 +531,7 @@ func testBuildKernelDriversTreeWithComps(c *C, opts *kernel.KernelDriversTreeOpt
 
 	mountDir := filepath.Join(dirs.SnapMountDir, "pc-kernel/1")
 	kversion := "5.15.0-78-generic"
-	createKernelSnapFiles(c, kversion, mountDir)
+	createKernelSnapFiles(c, kversion, mountDir, createKernelSnapFilesOpts{})
 
 	compMntDir1 := filepath.Join(dirs.SnapMountDir, "pc-kernel/components/mnt/comp1/11")
 	compMntDir2 := filepath.Join(dirs.SnapMountDir, "pc-kernel/components/mnt/comp2/22")
@@ -432,6 +540,10 @@ func testBuildKernelDriversTreeWithComps(c *C, opts *kernel.KernelDriversTreeOpt
 	kmodsConts := []snap.ContainerPlaceInfo{
 		snap.MinimalComponentContainerPlaceInfo("comp1", snap.R(11), "pc-kernel"),
 		snap.MinimalComponentContainerPlaceInfo("comp2", snap.R(22), "pc-kernel"),
+	}
+	compsMntPts := []kernel.ModulesCompMountPoints{
+		{"comp1", kernel.MountPoints{kmodsConts[0].MountDir(), kmodsConts[0].MountDir()}},
+		{"comp2", kernel.MountPoints{kmodsConts[1].MountDir(), kmodsConts[1].MountDir()}},
 	}
 
 	workSubdir := "1_tmp"
@@ -446,7 +558,11 @@ func testBuildKernelDriversTreeWithComps(c *C, opts *kernel.KernelDriversTreeOpt
 
 	// Now build the tree
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
-	c.Assert(kernel.EnsureKernelDriversTree(mountDir, destDir, kmodsConts, opts), IsNil)
+	c.Assert(kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir},
+		compsMntPts, destDir, opts), IsNil)
 
 	if exists {
 		c.Assert(isDir, Equals, true)
@@ -523,4 +639,43 @@ func testBuildKernelDriversTreeWithComps(c *C, opts *kernel.KernelDriversTreeOpt
 		exists, _, _ = osutil.RegularFileExists(tmpDir)
 		c.Check(exists, Equals, false)
 	}
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCompsWithTargetDir(c *C) {
+	mockCmd := testutil.MockCommand(c, "depmod", "")
+	defer mockCmd.Restore()
+
+	// Kernel needs to have been installed first
+	testBuildKernelDriversTree(c, createKernelSnapFilesOpts{})
+
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFiles(c, kversion, mountDir, createKernelSnapFilesOpts{})
+
+	compMntDir1 := filepath.Join(dirs.RunDir, "mnt/kernel-snaps/comp1")
+	createKernelModulesCompFiles(c, kversion, compMntDir1, "comp1")
+	kmodCont := snap.MinimalComponentContainerPlaceInfo("comp1", snap.R(11), "pc-kernel")
+	// Current mount is different to the one in the final system
+	compsMntPts := []kernel.ModulesCompMountPoints{
+		{"comp1", kernel.MountPoints{
+			Current: compMntDir1,
+			Target:  kmodCont.MountDir()}},
+	}
+
+	// Now build the tree, will fail as no kernel was installed previously
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir},
+		compsMntPts, destDir, &kernel.KernelDriversTreeOptions{KernelInstall: false})
+	c.Assert(err, IsNil)
+
+	// Check firmware entries from components
+	fwRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "firmware")
+	fwUpdates := filepath.Join(fwRoot, "updates")
+	expected := []expectInode{
+		{"comp1.bin", fs.ModeSymlink, filepath.Join(kmodCont.MountDir(), "firmware/comp1.bin")},
+	}
+	doDirChecks(c, fwUpdates, expected)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -279,7 +279,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		Revision:   kernelInfo.Revision,
 		IsCore:     !deviceCtx.Classic(),
 	}
-	if snapstate.NeedsKernelSetup(deviceCtx) {
+	if snapstate.NeedsKernelSetup(deviceCtx.Model()) {
 		kSnapInfo.NeedsDriversTree = true
 	}
 	timings.Run(perfTimings, "install-run", "Install the run system", func(tm timings.Measurer) {
@@ -559,7 +559,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		Revision:   kernelInfo.Revision,
 		IsCore:     !deviceCtx.Classic(),
 	}
-	if snapstate.NeedsKernelSetup(deviceCtx) {
+	if snapstate.NeedsKernelSetup(deviceCtx.Model()) {
 		kSnapInfo.NeedsDriversTree = true
 	}
 	timings.Run(perfTimings, "factory-reset", "Factory reset", func(tm timings.Measurer) {
@@ -1038,13 +1038,11 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 	logger.Debugf("writing content to partitions")
 	kSnapInfo := &install.KernelSnapInfo{
-		Name:       kernInfo.SnapName(),
-		Revision:   kernInfo.Revision,
-		MountPoint: kernMntPoint,
-		IsCore:     !deviceCtx.Classic(),
-	}
-	if snapstate.NeedsKernelSetup(deviceCtx) {
-		kSnapInfo.NeedsDriversTree = true
+		Name:             kernInfo.SnapName(),
+		Revision:         kernInfo.Revision,
+		MountPoint:       kernMntPoint,
+		IsCore:           !deviceCtx.Classic(),
+		NeedsDriversTree: snapstate.NeedsKernelSetup(systemAndSnaps.Model),
 	}
 	timings.Run(perfTimings, "install-content", "Writing content to partitions", func(tm timings.Measurer) {
 		st.Unlock()

--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -17,7 +17,7 @@ prepare_classic_rootfs() {
         echo "internal error: prepare_classic_rootfs called without 'ROLE'"
         exit 1
     fi
-    
+
     # Create basic devices to be able to install packages
     [ -e "$DESTDIR"/dev/null ] || sudo mknod -m 666 "$DESTDIR"/dev/null c 1 3
     [ -e "$DESTDIR"/dev/zero ] || sudo mknod -m 666 "$DESTDIR"/dev/zero c 1 5
@@ -63,7 +63,7 @@ EOF
 		 "DEBIAN_FRONTEND=noninteractive apt install -y /var/cache/apt/archives/$(basename "$package")"
 	fi
     fi
-        
+
     # ensure we can login
     sudo chroot "$DESTDIR" /usr/sbin/adduser --disabled-password --gecos "" user1
     printf "ubuntu\nubuntu\n" | sudo chroot "$DESTDIR" /usr/bin/passwd user1
@@ -100,7 +100,13 @@ if [ -f /cdrom/casper/base.squashfs ]; then
 else
     BASETAR=ubuntu-base.tar.gz
     # important to use "-q" to avoid journalctl suppressing  log output
-    wget -q -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O "$BASETAR"
+    release=$(lsb_release -r -s)
+    if [ "$release" = 22.04 ]; then
+        pointrel=.4
+    else
+        pointrel=
+    fi
+    wget -q -c http://cdimage.ubuntu.com/ubuntu-base/releases/"$release"/release/ubuntu-base-"$release""$pointrel"-base-amd64.tar.gz -O "$BASETAR"
     sudo tar -C "$DST" -xf "$BASETAR"
     ROLE=spread
 fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -669,6 +669,16 @@ prepare_suite_each() {
 
     # Save all the installed packages
     if os.query is-classic; then
+        # lxd-installer is in cloud images starting from 24.04. This package
+        # installs lxd when any lxc command is run. This caused problems
+        # because if we install snapcraft & lxd, in the restore step lxd is
+        # removed, and after that snapcraft is removed. However, snapcraft's
+        # remove hook calls lxd and triggers a new installation of lxd, and in
+        # turn when we try to remove core22, it fails as lxd has been
+        # re-installed and depends on that base. Therefore, we remove it to
+        # prevent these issues, and we do that before we get the list of
+        # installed packages to make sure we do not re-install it again.
+        apt remove -y --purge lxd-installer || true
         tests.pkgs list-installed > installed-initial.pkgs
     fi
 

--- a/tests/lib/tools/lxd-state
+++ b/tests/lib/tools/lxd-state
@@ -5,7 +5,7 @@ show_help() {
     echo "       lxd-state prepare-snap"
 }
 
-prepare_snap(){    
+prepare_snap(){
     echo "lxd-state: installing lxd snap"
     snap install lxd --channel="$LXD_SNAP_CHANNEL"
 

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -156,7 +156,11 @@ run_muinstaller() {
     image_path="${NESTED_IMAGES_DIR}/${image_name}"
     kpartx -asv "${image_path}"
     fatlabel /dev/disk/by-label/ubuntu-seed UBUNTU-SEED
-    kpartx -d "${image_path}"
+    if ! kpartx -d "${image_path}"; then
+        # Some times there are random failures, let's wait and re-try
+        sleep 1
+        kpartx -d "${image_path}"
+    fi
 
     if [ -n "${store_dir}" ]; then
         # if we had a store setup, then we should bring it back up

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -157,7 +157,7 @@ run_muinstaller() {
     kpartx -asv "${image_path}"
     fatlabel /dev/disk/by-label/ubuntu-seed UBUNTU-SEED
     if ! kpartx -d "${image_path}"; then
-        # Some times there are random failures, let's wait and re-try
+        # Sometimes there are random failures, let's wait and re-try
         sleep 1
         kpartx -d "${image_path}"
     fi

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -129,6 +129,7 @@ run_muinstaller() {
     tests.nested create-vm core --extra-param "${NESTED_PARAM_EXTRA}"
 
     # bind mount new seed
+    remote.exec "sudo mkdir -p /var/lib/snapd/seed"
     remote.exec "sudo mount -o bind /var/lib/snapd/install-seed /var/lib/snapd/seed"
     # push and install muinstaller
     remote.push "${muinstaller_snap}"

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -75,7 +75,11 @@ execute: |
   # Retrieve kernel
   snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
   # Build kernel with initramfs with the compiled snap-bootstrap
-  uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  if os.query is-ubuntu-ge 24.04; then
+    uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  else
+    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  fi
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
   # prepare a core seed

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -119,10 +119,16 @@ execute: |
      --kernel-assertion pc-kernel.assert \
      --disk disk.img
 
-  # things look fine
+  # basic things look fine
   remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
   remote.exec "snap changes" | MATCH "Done.* Initialize system state"
   remote.exec "snap list" | MATCH pc-kernel
+  if os.query is-ubuntu-ge 24.04; then
+      # kernel drivers tree has been created
+      remote.exec test -d /var/lib/snapd/kernel/pc-kernel/x1
+      # TODO check the drivers tree has been mounted (depends on
+      # https://github.com/snapcore/core-initrd/pull/238 being present in initramfs)
+  fi
 
   # check encryption
   if [ "$NESTED_ENABLE_TPM" = true ]; then

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -99,7 +99,7 @@ execute: |
   gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-"$version"-classic-dangerous.json > classic.model
 
   # create new disk for the installer to work on and attach to VM
-  truncate --size=4G disk.img
+  truncate --size=6G disk.img
   if [ "$PARTIAL_GADGET" = true ]; then
       # create gpt volume and add a partition that should be ignored by snapd
       cat << 'EOF' | sfdisk disk.img

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -88,7 +88,11 @@ execute: |
   # keep original blob just so we can find the assertion later
   cp pc-kernel.snap pc-kernel.snap.orig
   # Build kernel with initramfs with the compiled snap-bootstrap
-  uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  if os.query is-ubuntu-ge 24.04; then
+    uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  else
+    uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  fi
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
   version="$(nested_get_version)"


### PR DESCRIPTION
In some cases (when using the snapd install API or when installing
from initramfs), the place where the kernel snap / components used for the
installation are mounted is different to the final location in the
installed system. This change considers this so the drivers tree is
generated with symlinks pointing to the final expected location.

Additionally, fix `muinstaller-{core,real}` tests for core24.