### PR TITLE
.github/workflows: enable test workflow to retrieve pr labels for any repo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -870,7 +870,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-          LABELS="$(gh api -H 'Accept: application/vnd.github+json' /repos/snapcore/snapd/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name] | join(",")')"
+          LABELS="$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name] | join(",")')"
           echo "labels=$LABELS" >> $GITHUB_OUTPUT
           echo "Collected labels: $LABELS"
       shell: bash


### PR DESCRIPTION
Modified the test workflow to enable running nested tests on the private snapd repo snapcore/snapd-security-release by specifying "Run nested" label.
