### PR TITLE
tests: increase the StartLimitBurst default value to 10

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -124,6 +124,8 @@ setup_systemd_snapd_overrides() {
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_REBOOT_DELAY=10m SNAPD_CONFIGURE_HOOK_TIMEOUT=30s SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE
 ExecStartPre=/bin/touch /dev/iio:device0
+StartLimitBurst=10
+StartLimitIntervalSec=10s
 EOF
 
     # We change the service configuration so reload and restart

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -124,6 +124,8 @@ setup_systemd_snapd_overrides() {
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_REBOOT_DELAY=10m SNAPD_CONFIGURE_HOOK_TIMEOUT=30s SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE
 ExecStartPre=/bin/touch /dev/iio:device0
+# The default limit is usually 5, which can be easily hit in 
+# a fast system with few systemd units
 StartLimitBurst=10
 StartLimitIntervalSec=10s
 EOF


### PR DESCRIPTION
As when we to prepare the main suite we restart snapd service at least 4 times (5 when we don't do re-exec), in fast vms it is easy to reach the starts limit and make the tests fail.

The error in the logs is:
snapd.service: Start request repeated too quickly.
snapd.service: Failed with result 'start-limit-hit'.
