### PR TITLE
o/snapstate: refactor/optimise dependency setup in split refresh

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -250,7 +250,7 @@ func isInstalled(st *state.State, snapName string) (bool, error) {
 }
 
 // timeout for tasks to check if the prerequisites are ready
-var prerequisitesRetryTimeout = 30 * time.Second
+var prerequisitesRetryTimeout = 10 * time.Second
 
 func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -116,6 +116,7 @@ func (s *snapmgrBaseTest) logTasks(c *C) {
 
 		for _, t := range chg.Tasks() {
 			c.Logf("  %s - %s", t.Summary(), t.Status())
+
 			if t.Status() == state.ErrorStatus {
 				c.Logf("    %s", strings.Join(t.Log(), "    \n"))
 			}


### PR DESCRIPTION
Since the prerequisites code can deal with app that depend on the model base, we can remove the code that sets up explicit dependencies between them. This also enables the app refresh to finish faster because the prereq code will only wait for the base to link and not to fully refresh (which requires the gadget/kernel to refresh, reboot,etc). Also, since this means all non-essential snaps are guaranteed to finish before the reboot, the rerefresh check can also always run before the reboot and we can simplify some of the associated logic.
Also lowers the prerequisites timeout since this makes split refreshes rely on it and 30 seconds is high.