### PR TITLE
tests: add check that removal of snaps works with user data

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -205,6 +205,10 @@ execute: |
     su -c 'sudo snap list' test 2>&1 |MATCH EOF
     su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
 
+    # Ensure snap remove/install with user-data works when `root_squash` is enabled with NFSv3.
+    snap remove test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home
     restart_snapd
@@ -260,6 +264,10 @@ execute: |
     su -c 'snap list' test 2>&1 |MATCH EOF
     su -c 'sudo snap list' test 2>&1 |MATCH EOF
     su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
+
+    # Ensure snap remove/install with user-data works when `root_squash` is enabled with NFSv4.
+    snap remove test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home


### PR DESCRIPTION
Test adds check to see if https://bugs.launchpad.net/snapd/+bug/2002697 is easily reproducible when using home directories exported via NFSv3 or NFSv4.

This issue is easily reproducible on HPC deployments where NFS is used as the shared filesystem for exporting data across the cluster. Snaps can be installed and used by "remote users" - defined in LDAP and not in _/etc/passwd_ - but they cannot be refreshed an/or removed when `root_squash` is enabled as snapshotting `SNAP_USER_DATA` and `SNAP_USER_COMMON` is disallowed by the filesystem.
