### PR TITLE
tests: use no-debug-output for spread

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -708,10 +708,6 @@ jobs:
           set -x
 
           SPREAD=spread
-          if [[ "${{ matrix.systems }}" =~ -arm- ]]; then
-              SPREAD=spread-arm
-          fi
-
           if [[ "${{ matrix.systems }}" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable
               # xdelta on a per-target basis as it's used in the repack section

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -706,7 +706,6 @@ jobs:
           echo "::add-matcher::.github/spread-problem-matcher.json"
 
           set -x
-
           SPREAD=spread
           if [[ "${{ matrix.systems }}" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable
@@ -733,7 +732,8 @@ jobs:
           echo "Running command: $SPREAD $RUN_TESTS"
           (set -o pipefail; $SPREAD -no-debug-output -logs .logs $RUN_TESTS | tee spread.log)
 
-   - name: Uploading spread logs
+
+    - name: Uploading spread logs
       if: always()
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -735,7 +735,14 @@ jobs:
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
           echo "Running command: $SPREAD $RUN_TESTS"
-          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log)
+          (set -o pipefail; $SPREAD -no-debug-output -logs .logs $RUN_TESTS | tee spread.log)
+
+   - name: Uploading spread logs
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: spread-logs-${{ matrix.systems }}
+        path: ".logs/*.log"
 
     - name: Discard spread workers
       if: always()


### PR DESCRIPTION
-no-debug-output indicates to spread that debug output is not included in the log
-logs is used to store the logs generated (similar as artifacts is used)

When the log is saved, the debug line shows something like:	
2024-06-05 15:58:09 Debug output for google:ubuntu-20.04-64:tests/tests.backup (jun051856-832773) : saved to file .logs/google_ubuntu-20.04-64_tests_tests.backup.debug.log


