### PR TITLE
tests: add rpm-build as dependency for opensuse systems

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -794,11 +794,12 @@ pkg_dependencies_opensuse(){
         man-pages
         nfs-kernel-server
         nss-mdns
+        osc
         PackageKit
         python3-yaml
         strace
         netcat-openbsd
-        osc
+        rpm-build
         udisks2
         upower
         uuidd


### PR DESCRIPTION
To make opensuse tests work in openstack, it is needed to install rpm-build.
