### PR TITLE
packaging/debian-sid: gadget/install: fix build on debian sid

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -32,27 +32,12 @@ import (
 	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/mkfs"
-	"github.com/snapcore/snapd/snap"
 )
 
 var (
 	mkfsImpl                      = mkfs.Make
 	kernelEnsureKernelDriversTree = kernel.EnsureKernelDriversTree
 )
-
-// KernelSnapInfo includes information from the kernel snap that is
-// needed to build a drivers tree. Defin
-type KernelSnapInfo struct {
-	Name     string
-	Revision snap.Revision
-	// MountPoint is the root of the files from the kernel snap
-	MountPoint string
-	// NeedsDriversTree will be set if a drivers tree needs to be
-	// build on installation
-	NeedsDriversTree bool
-	// IsCore is set if this is UC
-	IsCore bool
-}
 
 type mkfsParams struct {
 	Type       string

--- a/gadget/install/kernel.go
+++ b/gadget/install/kernel.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package install
+
+import (
+	"github.com/snapcore/snapd/snap"
+)
+
+// KernelSnapInfo includes information from the kernel snap that is
+// needed to build a drivers tree. Defin
+type KernelSnapInfo struct {
+	Name     string
+	Revision snap.Revision
+	// MountPoint is the root of the files from the kernel snap
+	MountPoint string
+	// NeedsDriversTree will be set if a drivers tree needs to be
+	// build on installation
+	NeedsDriversTree bool
+	// IsCore is set if this is UC
+	IsCore bool
+}

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -140,7 +140,7 @@ override_dh_auto_build:
 	# exclude certain parts that won't be used by debian
 	find _build/src/$(DH_GOPKG)/cmd/snap-bootstrap -name "*.go" | xargs rm -f
 	find _build/src/$(DH_GOPKG)/cmd/snap-fde-keymgr -name "*.go" | xargs rm -f
-	find _build/src/$(DH_GOPKG)/gadget/install -name "*.go" | grep -vE '(params\.go|install_dummy\.go)'| xargs rm -f
+	find _build/src/$(DH_GOPKG)/gadget/install -name "*.go" | grep -vE '(params\.go|install_dummy\.go|kernel\.go)'| xargs rm -f
 	# XXX: once dh-golang understands go build tags this would not be needed
 	find _build/src/$(DH_GOPKG)/secboot/ -name "*.go" | grep -E '(.*_sb(_test)?\.go|.*_tpm(_test)?\.go|secboot_hooks.go|keymgr/)' | xargs rm -f
 	# and build, we cannot use modules as packaging on Debian requires us to use

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -143,6 +143,7 @@ override_dh_auto_build:
 	find _build/src/$(DH_GOPKG)/gadget/install -name "*.go" | grep -vE '(params\.go|install_dummy\.go|kernel\.go)'| xargs rm -f
 	# XXX: once dh-golang understands go build tags this would not be needed
 	find _build/src/$(DH_GOPKG)/secboot/ -name "*.go" | grep -E '(.*_sb(_test)?\.go|.*_tpm(_test)?\.go|secboot_hooks.go|keymgr/)' | xargs rm -f
+	find _build/src/$(DH_GOPKG)/boot/ -name "*.go" | grep -E '(.*_sb(_test)?\.go)' | xargs rm -f
 	# and build, we cannot use modules as packaging on Debian requires us to use
 	# dependencies from the distro, and this would require further updates to the
 	# go.mod file


### PR DESCRIPTION
We use debhelpers when building on Sid, but dh_golang is very 'automatic' and does not work well if the repository is complicated or makes use of build tags. Because of this we tend to 'modify' the code imperatively at build time (such that there's no need to maintain a bunch of additional patches for pieces which change often).

The branch addresses the build problem observed on Sid:
```
 # github.com/snapcore/snapd/gadget/install
src/github.com/snapcore/snapd/gadget/install/install_dummy.go:33:65: undefined: KernelSnapInfo
src/github.com/snapcore/snapd/gadget/install/install_dummy.go:37:74: undefined: KernelSnapInfo
src/github.com/snapcore/snapd/gadget/install/install_dummy.go:41:151: undefined: KernelSnapInfo
```