### PR TITLE
o/devicestate: create pending users after receiving a serial

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2023 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1066,7 +1066,11 @@ func (m *DeviceManager) ensureAutoImportAssertions() error {
 	return nil
 }
 
-func (m *DeviceManager) ensureSerialBoundAssertionsProcessed() error {
+func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
+	if release.OnClassic {
+		return nil
+	}
+
 	m.state.Lock()
 	defer m.state.Unlock()
 
@@ -1075,10 +1079,6 @@ func (m *DeviceManager) ensureSerialBoundAssertionsProcessed() error {
 		return err
 	}
 	if !seeded {
-		return nil
-	}
-
-	if release.OnClassic {
 		return nil
 	}
 
@@ -1825,7 +1825,7 @@ func (m *DeviceManager) Ensure() error {
 			errs = append(errs, err)
 		}
 
-		if err := m.ensureSerialBoundAssertionsProcessed(); err != nil {
+		if err := m.ensureSerialBoundSystemUserAssertionsProcessed(); err != nil {
 			errs = append(errs, err)
 		}
 

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -199,6 +199,10 @@ func EnsureCloudInitRestricted(m *DeviceManager) error {
 	return m.ensureCloudInitRestricted()
 }
 
+func EnsureSerialBoundSystemUserAssertionsProcessed(m *DeviceManager) error {
+	return m.ensureSerialBoundSystemUserAssertionsProcessed()
+}
+
 func ImportAssertionsFromSeed(m *DeviceManager, isCoreBoot bool) (seed.Seed, error) {
 	return m.importAssertionsFromSeed(isCoreBoot)
 }

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2022-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -185,8 +185,10 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	// the assertion against the current brand/model/time
 	username, expiration, addUserOpts, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
 	if err != nil {
-		if err == errSystemUserBoundToSerialButTooEarly {
-			// TODO retry later once we have acquired a device serial
+		if errors.Is(err, errSystemUserBoundToSerialButTooEarly) {
+			state.Set("system-user-waiting-on-serial", true)
+			logger.Noticef("waiting for serial to add user %q: %s", email, err)
+			return nil, nil
 		}
 		logger.Noticef("ignoring system-user assertion for %q: %s", email, err)
 		return nil, nil

--- a/overlord/devicestate/users_test.go
+++ b/overlord/devicestate/users_test.go
@@ -787,6 +787,12 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 	// make sure that no users were created
 	c.Check(userErr, check.IsNil)
 	c.Assert(createdUsers, check.IsNil)
+	var waitingOnSerial bool
+	s.state.Lock()
+	err = s.state.Get("system-user-waiting-on-serial", &waitingOnSerial)
+	s.state.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(waitingOnSerial, check.Equals, true)
 
 	// restore seed, and mark as seeded
 	s.state.Lock()
@@ -803,7 +809,6 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 	s.mgr.Ensure()
 
 	// make sure that system-user-waiting-on-serial has been set to false
-	var waitingOnSerial bool
 	s.state.Lock()
 	err = s.state.Get("system-user-waiting-on-serial", &waitingOnSerial)
 	s.state.Unlock()


### PR DESCRIPTION
Currently, if you attempt to create a user using a serial-bound assertion before the serial is available, the request will simply fail. This commit makes it so that attempts to create a system-user with a serial-bound assertion fail, but a flag is set within the device manager's state. Once the serial assertion is acquired, any serial-bound users will be created by the device manager's Ensure() function.

This is a reprise of #12852 applying my own feedback there