### PR TITLE
tests: new spread log utils

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -804,7 +804,7 @@ jobs:
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
             issues_metadata='{"source_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error-debug --output spread-results.json --cut 100
+            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 100
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Reporting spread error..."

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -85,8 +85,15 @@ jobs:
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           fi
+          CHANGE_ID="${{ github.event.number }}"
+          if [ -z "$PR_ID" ]; then
+            CHANGE_ID="main"
+          fi
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}"
+          # The log-filter tool is used to filter the spread logs to be stored
+          FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"
 
-          (set -o pipefail; spread $RUN_TESTS | tee spread.log)
+          (set -o pipefail; spread $RUN_TESTS | ./utils/log-filter $FILTER_PARAMS | tee spread.log)
 
     - name: Discard spread workers
       if: always()

--- a/tests/lib/external/snapd-testing-tools/CODE_OF_CONDUCT.md
+++ b/tests/lib/external/snapd-testing-tools/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/tests/lib/external/snapd-testing-tools/remote/remote.pull
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.pull
@@ -45,7 +45,7 @@ remote_pull() {
     SSH_CERT="$(_get_cert)"
 
     # shellcheck disable=SC2153,SC2086
-    $SSH_PASS scp $SSH_CERT -P "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST":"$REMOTE_PATH" "$LOCAL_PATH"
+    $SSH_PASS scp $SSH_CERT -O -P "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST":"$REMOTE_PATH" "$LOCAL_PATH"
 }
 
 main() {

--- a/tests/lib/external/snapd-testing-tools/remote/remote.pull
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.pull
@@ -44,8 +44,14 @@ remote_pull() {
     SSH_PASS="$(_get_pass)"
     SSH_CERT="$(_get_cert)"
 
+    LEGACY_PARAM=""
+    # We check if the scp version is greated than 9, then -O option is supported
+    if [ "$(ssh -V 2>&1 | awk -F'[_,]' '{print $2+0}')" -ge 9 ]; then
+        LEGACY_PARAM="-O"
+    fi
+
     # shellcheck disable=SC2153,SC2086
-    $SSH_PASS scp $SSH_CERT -O -P "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST":"$REMOTE_PATH" "$LOCAL_PATH"
+    $SSH_PASS scp $SSH_CERT $LEGACY_PARAM -P "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST":"$REMOTE_PATH" "$LOCAL_PATH"
 }
 
 main() {

--- a/tests/lib/external/snapd-testing-tools/remote/remote.pull
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.pull
@@ -45,7 +45,7 @@ remote_pull() {
     SSH_CERT="$(_get_cert)"
 
     LEGACY_PARAM=""
-    # We check if the scp version is greated than 9, then -O option is supported
+    # We check if the scp version is greater than 9, so -O option is supported
     if [ "$(ssh -V 2>&1 | awk -F'[_,]' '{print $2+0}')" -ge 9 ]; then
         LEGACY_PARAM="-O"
     fi

--- a/tests/lib/external/snapd-testing-tools/spread.yaml
+++ b/tests/lib/external/snapd-testing-tools/spread.yaml
@@ -28,9 +28,8 @@ backends:
                 storage: preserve-size
             - amazon-linux-2023-64:
                 storage: preserve-size
-            - centos-7-64:
                 storage: preserve-size
-            - centos-8-64:
+            - centos-7-64:
                 storage: preserve-size
             - centos-9-64:
                 storage: preserve-size

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/aborted-and-failed-execute-and-restore.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/aborted-and-failed-execute-and-restore.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:06",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:06",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:15",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242137-942824) to boot at 34.75.199.115..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:20",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242137-942720) to boot at 34.75.71.82..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:57",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242137-942720)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:57",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242137-942720)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:58",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242137-942720) at 34.75.71.82."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:37:58",
         "verb": "Sending",
@@ -64,14 +64,14 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242137-942720)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:02",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:02",
         "verb": "Allocated",
@@ -79,7 +79,7 @@
         "extra": "google:ubuntu-20.04-64 (may242137-942824)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:02",
         "verb": "Connecting",
@@ -87,21 +87,21 @@
         "extra": "to google:ubuntu-20.04-64 (may242137-942824)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:02",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:03",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:04",
         "verb": "Connected",
@@ -109,7 +109,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242137-942824) at 34.75.199.115."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:04",
         "verb": "Sending",
@@ -117,28 +117,28 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242137-942824)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:04",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:04",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:05",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:05",
         "verb": "Executing",
@@ -164,14 +164,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:06",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:06",
         "verb": "Preparing",
@@ -197,35 +197,35 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:06",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:07",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:07",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:07",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:07",
         "verb": "Discarding",
@@ -233,91 +233,91 @@
         "extra": "google:ubuntu-22.04-64 (may242137-942720)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:08",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:08",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:09",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:09",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:10",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:10",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:11",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:11",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:12",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:12",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:13",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:13",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:14",
         "verb": "Executing",
@@ -343,7 +343,7 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:14",
         "verb": "Restoring",
@@ -369,21 +369,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:15",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:38:15",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:38:16",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-aborted.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-aborted.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:06:40",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:06:40",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:06:49",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242106-435572) to boot at 34.148.101.55..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:06:50",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242106-435744) to boot at 34.148.4.171..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:30",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242106-435572)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:30",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242106-435572)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:32",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242106-435572) at 34.148.101.55."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:32",
         "verb": "Sending",
@@ -64,7 +64,7 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242106-435572)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:07:36",
         "verb": "Preparing",
@@ -90,14 +90,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:07:37",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:37",
         "verb": "Discarding",
@@ -105,7 +105,7 @@
         "extra": "google:ubuntu-22.04-64 (may242106-435572)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:41",
         "verb": "Allocated",
@@ -113,7 +113,7 @@
         "extra": "google:ubuntu-20.04-64 (may242106-435744)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:41",
         "verb": "Connecting",
@@ -121,7 +121,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242106-435744)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:42",
         "verb": "Connected",
@@ -129,7 +129,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242106-435744) at 34.148.4.171."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:42",
         "verb": "Sending",
@@ -137,7 +137,7 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242106-435744)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:07:46",
         "verb": "Preparing",
@@ -163,14 +163,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:07:47",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:07:47",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-failed.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-failed.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:52:29",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:52:29",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:52:39",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242052-202754) to boot at 34.139.205.254..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:52:43",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242052-202652) to boot at 104.196.209.131..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:24",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242052-202652)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:24",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242052-202652)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:25",
         "verb": "Allocated",
@@ -56,7 +56,7 @@
         "extra": "google:ubuntu-20.04-64 (may242052-202754)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:25",
         "verb": "Connecting",
@@ -64,7 +64,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242052-202754)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:26",
         "verb": "Connected",
@@ -72,7 +72,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242052-202652) at 104.196.209.131."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:26",
         "verb": "Sending",
@@ -80,7 +80,7 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242052-202652)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:26",
         "verb": "Connected",
@@ -88,7 +88,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242052-202754) at 34.139.205.254."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:26",
         "verb": "Sending",
@@ -96,49 +96,49 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242052-202754)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:28",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:29",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:29",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:29",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:30",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:30",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:30",
         "verb": "Preparing",
@@ -164,14 +164,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:31",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:31",
         "verb": "Executing",
@@ -197,35 +197,35 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:31",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:31",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:32",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:32",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:32",
         "verb": "Executing",
@@ -251,7 +251,7 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:33",
         "verb": "Restoring",
@@ -277,35 +277,35 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:33",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:33",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:33",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:34",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:34",
         "verb": "Executing",
@@ -331,7 +331,7 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:34",
         "verb": "Restoring",
@@ -357,28 +357,28 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:35",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:35",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:35",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:35",
         "verb": "Preparing",
@@ -404,21 +404,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:36",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:36",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:36",
         "verb": "Preparing",
@@ -444,21 +444,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:36",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:37",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:37",
         "verb": "Preparing",
@@ -484,28 +484,28 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:37",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:38",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:38",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:38",
         "verb": "Restoring",
@@ -531,14 +531,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:38",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:39",
         "verb": "Discarding",
@@ -546,21 +546,21 @@
         "extra": "google:ubuntu-20.04-64 (may242052-202754)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:39",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:53:40",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:53:41",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-success-failed-restore.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-success-failed-restore.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:42:58",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:42:58",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:07",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242043-312411) to boot at 34.148.59.204..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:07",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242043-312500) to boot at 34.138.215.109..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:43",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242043-312411)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:43",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:45",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242043-312411) at 34.148.59.204."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:45",
         "verb": "Sending",
@@ -64,133 +64,133 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:50",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:50",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:51",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:52",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:52",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:53",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:54",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:55",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:55",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:56",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:56",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:57",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:58",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:58",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:59",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:00",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:00",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:01",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:02",
         "verb": "Restoring",
@@ -216,7 +216,7 @@
         }
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:02",
         "verb": "Discarding",
@@ -224,7 +224,7 @@
         "extra": "google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:04",
         "verb": "Allocated",
@@ -232,7 +232,7 @@
         "extra": "google:ubuntu-20.04-64 (may242043-312500)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:04",
         "verb": "Connecting",
@@ -240,7 +240,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242043-312500)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:05",
         "verb": "Connected",
@@ -248,7 +248,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242043-312500) at 34.138.215.109."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:05",
         "verb": "Sending",
@@ -256,133 +256,133 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242043-312500)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:08",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:08",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:09",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:09",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:10",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:10",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:11",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:11",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:12",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:13",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:13",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:14",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:14",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:15",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:15",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:16",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:16",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:17",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:17",
         "verb": "Restoring",
@@ -408,7 +408,7 @@
         }
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:18",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-success.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/all-success.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:45:05",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:45:05",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:45:14",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242045-878680) to boot at 35.237.221.225..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:45:15",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242045-878764) to boot at 34.148.94.157..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:00",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242045-878680)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:00",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242045-878680)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:02",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242045-878680) at 35.237.221.225."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:02",
         "verb": "Sending",
@@ -64,77 +64,77 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242045-878680)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:06",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:06",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:07",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:08",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:08",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:09",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:09",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:10",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:10",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:11",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:11",
         "verb": "Allocated",
@@ -142,7 +142,7 @@
         "extra": "google:ubuntu-20.04-64 (may242045-878764)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:11",
         "verb": "Connecting",
@@ -150,21 +150,21 @@
         "extra": "to google:ubuntu-20.04-64 (may242045-878764)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:11",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:12",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:12",
         "verb": "Connected",
@@ -172,7 +172,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242045-878764) at 34.148.94.157."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:12",
         "verb": "Sending",
@@ -180,63 +180,63 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242045-878764)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:12",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:13",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:13",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:14",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:14",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:15",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:15",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:15",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:16",
         "verb": "Discarding",
@@ -244,133 +244,133 @@
         "extra": "google:ubuntu-22.04-64 (may242045-878680)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:16",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:17",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:17",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:18",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:19",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:19",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:20",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:20",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:21",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:22",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:22",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:23",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:24",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:24",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:25",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:25",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:26",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:46:27",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:46:27",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-and-restore.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-and-restore.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:26",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:26",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:26",
         "verb": "Allocating",
@@ -24,7 +24,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:36",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242056-644336) to boot at 35.185.37.159..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:41",
         "verb": "Waiting",
@@ -40,7 +40,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242056-644230) to boot at 34.75.94.174..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:56:42",
         "verb": "Waiting",
@@ -48,7 +48,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242056-644428) to boot at 34.138.43.204..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:17",
         "verb": "Allocated",
@@ -56,7 +56,7 @@
         "extra": "google:ubuntu-22.04-64 (may242056-644230)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:17",
         "verb": "Connecting",
@@ -64,7 +64,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242056-644230)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:19",
         "verb": "Connected",
@@ -72,7 +72,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242056-644230) at 34.75.94.174."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:19",
         "verb": "Sending",
@@ -80,7 +80,7 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242056-644230)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:22",
         "verb": "Allocated",
@@ -88,7 +88,7 @@
         "extra": "google:ubuntu-20.04-64 (may242056-644336)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:22",
         "verb": "Connecting",
@@ -96,14 +96,14 @@
         "extra": "to google:ubuntu-20.04-64 (may242056-644336)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:23",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:24",
         "verb": "Allocated",
@@ -111,7 +111,7 @@
         "extra": "google:ubuntu-20.04-64 (may242056-644428)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:24",
         "verb": "Connecting",
@@ -119,7 +119,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242056-644428)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:24",
         "verb": "Connected",
@@ -127,7 +127,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242056-644336) at 35.185.37.159."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:24",
         "verb": "Sending",
@@ -135,21 +135,21 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242056-644336)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:24",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:25",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:25",
         "verb": "Connected",
@@ -157,7 +157,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242056-644428) at 34.138.43.204."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:25",
         "verb": "Sending",
@@ -165,42 +165,42 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242056-644428)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:26",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:26",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:27",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:27",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:27",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:28",
         "verb": "Preparing",
@@ -226,21 +226,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:28",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:28",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:28",
         "verb": "Preparing",
@@ -266,49 +266,49 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:28",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:29",
         "verb": "Discarding",
@@ -316,42 +316,42 @@
         "extra": "google:ubuntu-22.04-64 (may242056-644230)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:30",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:30",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:30",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:30",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:31",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:31",
         "verb": "Preparing",
@@ -377,14 +377,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:31",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:32",
         "verb": "Executing",
@@ -410,42 +410,42 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:32",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:32",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:33",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:33",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:57:33",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:34",
         "verb": "Discarding",
@@ -453,7 +453,7 @@
         "extra": "google:ubuntu-20.04-64 (may242056-644336)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:57:34",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-project.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-project.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:04:51",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:04:51",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:00",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242104-523536) to boot at 34.148.146.189..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:05",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242104-523644) to boot at 35.185.103.64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:42",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242104-523536)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:42",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242104-523536)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:43",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242104-523536) at 34.148.146.189."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:43",
         "verb": "Sending",
@@ -64,140 +64,140 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242104-523536)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:47",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:48",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:48",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:49",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:49",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:50",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:50",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:50",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:51",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:52",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:52",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:53",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:53",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:54",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:54",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:55",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:55",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:56",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:05:56",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:57",
         "verb": "Allocated",
@@ -205,7 +205,7 @@
         "extra": "google:ubuntu-20.04-64 (may242104-523644)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:57",
         "verb": "Connecting",
@@ -213,7 +213,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242104-523644)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:57",
         "verb": "Discarding",
@@ -221,7 +221,7 @@
         "extra": "google:ubuntu-22.04-64 (may242104-523536)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:58",
         "verb": "Connected",
@@ -229,7 +229,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242104-523644) at 35.185.103.64."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:05:58",
         "verb": "Sending",
@@ -237,7 +237,7 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242104-523644)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:06:01",
         "verb": "Preparing",
@@ -264,14 +264,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:06:01",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:06:02",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-suite.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-suite.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:02:09",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:02:09",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:02:17",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242102-500954) to boot at 34.138.163.49..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:02:18",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242102-501054) to boot at 35.227.118.17..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:04",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242102-500954)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:04",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242102-500954)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:05",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242102-500954) at 34.138.163.49."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:05",
         "verb": "Sending",
@@ -64,7 +64,7 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242102-500954)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:09",
         "verb": "Allocated",
@@ -72,7 +72,7 @@
         "extra": "google:ubuntu-20.04-64 (may242102-501054)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:09",
         "verb": "Connecting",
@@ -80,14 +80,14 @@
         "extra": "to google:ubuntu-20.04-64 (may242102-501054)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:09",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:11",
         "verb": "Connected",
@@ -95,7 +95,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242102-501054) at 35.227.118.17."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:11",
         "verb": "Sending",
@@ -103,63 +103,63 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242102-501054)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:11",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:11",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:12",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:12",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:13",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:13",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:14",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:14",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:14",
         "verb": "Restoring",
@@ -184,28 +184,28 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:14",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:15",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:15",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:15",
         "verb": "Discarding",
@@ -213,77 +213,77 @@
         "extra": "google:ubuntu-20.04-64 (may242102-501054)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:15",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:16",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:17",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:17",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:18",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:19",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:20",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:20",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:21",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "18:03:22",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "18:03:22",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-task.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/failed-prepare-task.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:47",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:47",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:47",
         "verb": "Allocating",
@@ -24,7 +24,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:47",
         "verb": "Allocating",
@@ -32,7 +32,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:56",
         "verb": "Waiting",
@@ -40,7 +40,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242058-071834) to boot at 34.75.85.33..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:56",
         "verb": "Waiting",
@@ -48,7 +48,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242058-071935) to boot at 104.196.44.113..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:58:57",
         "verb": "Waiting",
@@ -56,7 +56,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242058-072004) to boot at 35.196.115.140..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:02",
         "verb": "Waiting",
@@ -64,7 +64,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242058-072021) to boot at 34.139.4.50..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:32",
         "verb": "Allocated",
@@ -72,7 +72,7 @@
         "extra": "google:ubuntu-22.04-64 (may242058-071834)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:32",
         "verb": "Connecting",
@@ -80,7 +80,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242058-071834)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:33",
         "verb": "Connected",
@@ -88,7 +88,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242058-071834) at 34.75.85.33."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:33",
         "verb": "Sending",
@@ -96,28 +96,28 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242058-071834)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:37",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:38",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:38",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:38",
         "verb": "Allocated",
@@ -125,7 +125,7 @@
         "extra": "google:ubuntu-22.04-64 (may242058-072021)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:38",
         "verb": "Connecting",
@@ -152,21 +152,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:39",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:39",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:40",
         "verb": "Connected",
@@ -174,7 +174,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242058-072021) at 34.139.4.50."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:40",
         "verb": "Sending",
@@ -182,49 +182,49 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242058-072021)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:40",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:40",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:41",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:41",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:42",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:42",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:43",
         "verb": "Allocated",
@@ -232,7 +232,7 @@
         "extra": "google:ubuntu-20.04-64 (may242058-072004)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:43",
         "verb": "Connecting",
@@ -240,42 +240,42 @@
         "extra": "to google:ubuntu-20.04-64 (may242058-072004)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:43",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:43",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:43",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Connected",
@@ -283,7 +283,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242058-072004) at 35.196.115.140."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Sending",
@@ -291,28 +291,28 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242058-072004)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:44",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:45",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:45",
         "verb": "Discarding",
@@ -320,28 +320,28 @@
         "extra": "google:ubuntu-22.04-64 (may242058-071834)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:45",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:46",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:46",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:47",
         "verb": "Discarding",
@@ -349,7 +349,7 @@
         "extra": "google:ubuntu-22.04-64 (may242058-072021)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:47",
         "verb": "Allocated",
@@ -357,7 +357,7 @@
         "extra": "google:ubuntu-20.04-64 (may242058-071935)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:47",
         "verb": "Connecting",
@@ -365,7 +365,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242058-071935)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:49",
         "verb": "Connected",
@@ -373,7 +373,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242058-071935) at 104.196.44.113."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:49",
         "verb": "Sending",
@@ -381,126 +381,126 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242058-071935)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:50",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:50",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:51",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:51",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:52",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:52",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:52",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:53",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:53",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:53",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:53",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:54",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:54",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:55",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:55",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:55",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:56",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:56",
         "verb": "Restoring",
@@ -526,21 +526,28 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:56",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:56",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
+        "date": "2022-05-24",
+        "time": "17:59:57",
+        "verb": "Restoring",
+        "task": "google:ubuntu-20.04-64"
+    },
+    {
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:59:57",
         "verb": "Restoring",
@@ -548,13 +555,6 @@
     },
     {
         "type": "action",
-        "date": "2022-05-24",
-        "time": "17:59:57",
-        "verb": "Restoring",
-        "task": "google:ubuntu-20.04-64"
-    },
-    {
-        "type": "operation",
         "date": "2022-05-24",
         "time": "17:59:57",
         "verb": "Discarding",
@@ -562,7 +562,7 @@
         "extra": "google:ubuntu-20.04-64 (may242058-072004)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:59:58",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/with-aborted-and-failed-restore.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/with-aborted-and-failed-restore.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:47:36",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:47:36",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:47:46",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242047-566476) to boot at 104.196.212.243..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:47:46",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242047-566626) to boot at 34.75.76.3..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:32",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242047-566626)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:32",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242047-566626)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:34",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242047-566626) at 34.75.76.3."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:34",
         "verb": "Sending",
@@ -64,42 +64,42 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242047-566626)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:39",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:40",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:40",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:41",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:42",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:42",
         "verb": "Allocated",
@@ -107,7 +107,7 @@
         "extra": "google:ubuntu-20.04-64 (may242047-566476)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:42",
         "verb": "Connecting",
@@ -134,14 +134,14 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:43",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:43",
         "verb": "Connected",
@@ -149,7 +149,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242047-566476) at 104.196.212.243."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:43",
         "verb": "Sending",
@@ -157,14 +157,14 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242047-566476)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:44",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:45",
         "verb": "Discarding",
@@ -172,35 +172,35 @@
         "extra": "google:ubuntu-22.04-64 (may242047-566626)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:46",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:47",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:47",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:48",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:48",
         "verb": "Restoring",
@@ -226,21 +226,21 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:49",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:48:49",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:48:50",
         "verb": "Discarding",

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/with-failed-and-failed-restore-suite.json
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/data/with-failed-and-failed-restore-suite.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:42:58",
         "verb": "Allocating",
@@ -8,7 +8,7 @@
         "extra": "google:ubuntu-22.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:42:58",
         "verb": "Allocating",
@@ -16,7 +16,7 @@
         "extra": "google:ubuntu-20.04-64..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:07",
         "verb": "Waiting",
@@ -24,7 +24,7 @@
         "extra": "for google:ubuntu-22.04-64 (may242043-312411) to boot at 34.148.59.204..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:07",
         "verb": "Waiting",
@@ -32,7 +32,7 @@
         "extra": "for google:ubuntu-20.04-64 (may242043-312500) to boot at 34.138.215.109..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:43",
         "verb": "Allocated",
@@ -40,7 +40,7 @@
         "extra": "google:ubuntu-22.04-64 (may242043-312411)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:43",
         "verb": "Connecting",
@@ -48,7 +48,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:45",
         "verb": "Connected",
@@ -56,7 +56,7 @@
         "extra": "to google:ubuntu-22.04-64 (may242043-312411) at 34.148.59.204."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:43:45",
         "verb": "Sending",
@@ -64,49 +64,49 @@
         "extra": "project content to google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:50",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:50",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:51",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:52",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:52",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:53",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:54",
         "verb": "Executing",
@@ -132,84 +132,84 @@
         }
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:55",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:55",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:56",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:56",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:57",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:58",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:58",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:43:59",
         "verb": "Preparing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:00",
         "verb": "Executing",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:00",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:01",
         "verb": "Restoring",
         "task": "google:ubuntu-22.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:02",
         "verb": "Restoring",
@@ -235,7 +235,7 @@
         }
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:02",
         "verb": "Discarding",
@@ -243,7 +243,7 @@
         "extra": "google:ubuntu-22.04-64 (may242043-312411)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:04",
         "verb": "Allocated",
@@ -251,7 +251,7 @@
         "extra": "google:ubuntu-20.04-64 (may242043-312500)."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:04",
         "verb": "Connecting",
@@ -259,7 +259,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242043-312500)..."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:05",
         "verb": "Connected",
@@ -267,7 +267,7 @@
         "extra": "to google:ubuntu-20.04-64 (may242043-312500) at 34.138.215.109."
     },
     {
-        "type": "operation",
+        "type": "action",
         "date": "2022-05-24",
         "time": "17:44:05",
         "verb": "Sending",
@@ -275,133 +275,133 @@
         "extra": "project content to google:ubuntu-20.04-64 (may242043-312500)..."
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:08",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:08",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:09",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:09",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:10",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-3"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:10",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:11",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:11",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-1"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:12",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:13",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:13",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-4"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:14",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:14",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:15",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-2"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:15",
         "verb": "Preparing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:16",
         "verb": "Executing",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:16",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/test-5"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:17",
         "verb": "Restoring",
         "task": "google:ubuntu-20.04-64:tests/"
     },
     {
-        "type": "action",
+        "type": "phase",
         "date": "2022-05-24",
         "time": "17:44:17",
         "verb": "Restoring",

--- a/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-filter/task.yaml
@@ -1,0 +1,51 @@
+summary: test for the log filter tool
+
+details: |
+    This test checks the log-filter tool is able to read the spread output
+    and filter the log following a set of rules. It is also checked that the
+    output of the log-filter tool is the same than spread.
+
+backends: [google]
+
+# Github actions agents are just running ubuntu jammy
+systems: [ubuntu-22.04-64]
+
+prepare: |
+    wget https://storage.googleapis.com/snapd-spread-tests/dependencies/spread-log-filter.tar.xz
+    tar -xf spread-log-filter.tar.xz
+
+restore: |
+    rm -rf spread-log-filter.tar.xz ./*.log
+
+execute: |
+    log-filter --help | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+    log-filter -h | MATCH 'usage: log-filter \[-h\] \[-o PATH\]'
+
+    # Run the tool for a real log    
+    # The output should:
+    # 1. the output should go to test.filtered.log file
+    # 2. exclude: Preparing, Restoring, Error, Warning
+    # 3. show: debug lines with ###DEBUG
+    # 4. show: failed tests for google-nested
+    log-filter -o test.filtered.log -e Error -e Restoring -e Preparing -f "Debug=###DEBUG" -f "Failed=google-nested:" < spread-log-filter.log > output.log
+
+    # Check the stdout is the same than the stdin
+    diff -Z spread-log-filter.log output.log
+
+    # Check exclude
+    test "$(grep -c Restoring test.filtered.log)" -eq 0
+    test "$(grep -c Preparing test.filtered.log)" -eq 0
+    test "$(grep -c Error test.filtered.log)" -eq 0
+
+    # Check the non excluded
+    test "$(grep -c 'Debug output' test.filtered.log)" -eq "$(grep -c 'Debug output' spread-log-filter.log)"
+
+    # Check the filters
+    test "$(grep -c '###DEBUG' test.filtered.log)" -eq "$(grep -c '###DEBUG' spread-log-filter.log)"
+    grep -A 1 'Failed suite prepare: 4' test.filtered.log | MATCH 'Failed suite restore: 1'
+
+    # Check no repeated
+    test "$(grep -c 'Failed suite prepare: 4' test.filtered.log)" -eq 1
+    test "$(grep -c 'Executing' test.filtered.log)" -eq "$(grep -c 'Executing' spread-log-filter.log)"
+    test "$(grep -c 'Aborted tasks' test.filtered.log)" -eq 1
+

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
@@ -111,10 +111,10 @@ execute: |
 
     # Check filtering the debug output
     log-parser with-debug-output.log.spread -c 1 -dr "executed_tests=EXECUTED_TESTS=(.*)" -dr "apparmor_version=AppArmor parser version .*"
-    test "$(jq -r '.[0].detail.executed_tests' spread-results.json | wc -w)" -eq 44
-    test "$(jq -r '.[0].detail.apparmor_version' spread-results.json)" = "AppArmor parser version 2.13.3"
+    test "$(jq -r '.[0].detail.executed_tests[0]' spread-results.json | wc -w)" -eq 44
+    test "$(jq -r '.[0].detail.apparmor_version[0]' spread-results.json)" = "AppArmor parser version 2.13.3"
 
     # Check filtering the error output
     log-parser with-error-output.log.spread -c 1 -er "executed_tests=EXECUTED_TESTS=(.*)" -er "apparmor_version=AppArmor parser version .*"
-    test "$(jq -r '.[0].detail.executed_tests' spread-results.json | wc -w)" -eq 44
-    test "$(jq -r '.[0].detail.apparmor_version' spread-results.json)" = "AppArmor parser version 2.13.3"
+    test "$(jq -r '.[0].detail.executed_tests[0]' spread-results.json | wc -w)" -eq 44
+    test "$(jq -r '.[0].detail.apparmor_version[0]' spread-results.json)" = "AppArmor parser version 2.13.3"

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
@@ -87,27 +87,27 @@ execute: |
     jq -r '.[] | select( .type == "result") | select( .result_type == "Failed")  | select(.level == "tasks") | .detail' spread-results.json | MATCH "degraded"
 
     # Check the filter
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error | grep -c "Error preparing")" -eq 5
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error | grep -c "command -v restorecon")" -eq 4
+    test "$(log-parser with-failed-and-aborted.log.spread | grep -c "Error preparing")" -eq 5
+    test "$(log-parser with-failed-and-aborted.log.spread | grep -c "command -v restorecon")" -eq 4
     
-    # Check the filter cuting the logs
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error | wc -l)" -eq 184
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 0 | wc -l)" -eq 14
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 0 | grep -c "Error preparing")" -eq 5
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 0 | grep -c "<kill-timeout reached>")" -eq 0
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 2 | wc -l)" -eq 26
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 2 | grep -c "Error preparing")" -eq 5
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 2 | grep -c "<kill-timeout reached>")" -eq 5
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 3 | wc -l)" -eq 32
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 3 | grep -c "Error preparing")" -eq 5
-    test "$(log-parser with-failed-and-aborted.log.spread -pd error -c 3 | grep -c "<kill-timeout reached>")" -eq 5
+    # Check the filter cutting the logs
+    test "$(log-parser with-failed-and-aborted.log.spread | wc -l)" -eq 261
+    test "$(log-parser with-failed-and-aborted.log.spread -c 0 | wc -l)" -eq 77
+    test "$(log-parser with-failed-and-aborted.log.spread -c 0 | grep -c "Error preparing")" -eq 5
+    test "$(log-parser with-failed-and-aborted.log.spread -c 0 | grep -c "<kill-timeout reached>")" -eq 0
+    test "$(log-parser with-failed-and-aborted.log.spread -c 2 | wc -l)" -eq 91
+    test "$(log-parser with-failed-and-aborted.log.spread -c 2 | grep -c "Error preparing")" -eq 5
+    test "$(log-parser with-failed-and-aborted.log.spread -c 2 | grep -c "<kill-timeout reached>")" -eq 5
+    test "$(log-parser with-failed-and-aborted.log.spread -c 3 | wc -l)" -eq 98
+    test "$(log-parser with-failed-and-aborted.log.spread -c 3 | grep -c "Error preparing")" -eq 5
+    test "$(log-parser with-failed-and-aborted.log.spread -c 3 | grep -c "<kill-timeout reached>")" -eq 5
     
     # Check the results can be filtered
-    log-parser with-failed-and-aborted.log.spread -pr failed | grep -q "Failed tasks: 1"
-    log-parser with-failed-and-aborted.log.spread -pr failed | grep -c "Failed project prepare: 4"
-    log-parser with-failed-and-aborted.log.spread -pr aborted | grep -c "Aborted tasks: 24"
-    log-parser all-successful.log.spread -pr successful | grep -q "Successful tasks: 434"
-    log-parser all-successful.log.spread -pr failed | grep -v "Aborted tasks"
+    log-parser with-failed-and-aborted.log.spread | grep -q "Failed tasks: 1"
+    log-parser with-failed-and-aborted.log.spread | grep -c "Failed project prepare: 4"
+    log-parser with-failed-and-aborted.log.spread | grep -c "Aborted tasks: 24"
+    log-parser all-successful.log.spread | grep -q "Successful tasks: 434"
+    log-parser all-successful.log.spread | grep -v "Aborted tasks"
 
     # Check filtering the debug output
     log-parser with-debug-output.log.spread -c 1 -dr "executed_tests=EXECUTED_TESTS=(.*)" -dr "apparmor_version=AppArmor parser version .*"

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
@@ -93,7 +93,7 @@ created 0 fifos
 2022-05-18 18:07:57 Restoring google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-never-used-not-vuln:firstboot (may181749-433163)...
 2022-05-18 18:08:00 Preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163)...
 2022-05-18 18:08:40 Executing google-nested:ubuntu-16.04-64:tests/nested/core/image-build (may181749-432987) (2/13)...
-Error: 2022-05-18 18:09:34 Error preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163) : 
+2022-05-18 18:09:34 Error preparing google-nested:ubuntu-16.04-64:tests/nested/manual/cloud-init-nocloud-not-vuln:firstboot (may181749-433163) : 
 -----
 + /home/gopath/src/github.com/snapcore/snapd/tests/lib/prepare-restore.sh --prepare-project-each
 + set -e
@@ -160,4 +160,3 @@ google-nested:ubuntu-16.04-64:tests/nested/classic/hotplug google-nested:ubuntu-
 2022-05-18 16:45:15 Failed project restore: 2
     - google:ubuntu-core-22-64:project
     - google:ubuntu-core-22-64:project
-error: unsuccessful run

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -149,11 +149,6 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
-        centos-8-64)            
-            os.query is-centos
-            os.query is-centos 8
-            ! os.query is-core
-            ;;
         centos-9-64)            
             os.query is-centos 9
             os.query is-centos

--- a/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
@@ -2,7 +2,7 @@ summary: smoke test for the remote.retry tool
 
 details: |
     This test checks the remote.retry tool properly handles retrying
-    a command in the remote instance. Also Verifies that on failure
+    a command in the remote instance. Also verifies that on failure
     the exit code from the final attempt is returned.   
 
 backends: [google]

--- a/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
@@ -2,7 +2,7 @@ summary: smoke test for the remote.retry tool
 
 details: |
     This test checks the remote.retry tool properly handles retrying
-    a command in the remote instance. Also verifies that on failure
+    a command in the remote instance. Also Verifies that on failure
     the exit code from the final attempt is returned.   
 
 backends: [google]

--- a/tests/lib/external/snapd-testing-tools/utils/log-analyzer
+++ b/tests/lib/external/snapd-testing-tools/utils/log-analyzer
@@ -258,7 +258,7 @@ list_executed_tasks() {
 
     local all_tasks executed_tasks
     all_tasks="$(list_all_tasks "$exec_exp")"
-    executed_tasks="$(jq -r '.[] | select( .type == "action") | select( .verb == "Executing") | .task' "$log")"
+    executed_tasks="$(jq -r '.[] | select( .type == "phase") | select( .verb == "Executing") | .task' "$log")"
     _intersection_tasks_lists "$executed_tasks" "$all_tasks"
 }
 

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+import argparse
+import io
+import re
+import sys
+
+import log_helper as helper
+
+# Rules are applied to filter content in the following operation details:
+# ERROR: The error shoes the bash output when a task fails
+# DEBUG: The debug includes the output of the debug script for task/suite errors
+# WARNING: The last lines from the task execution output
+# FAILED: Include a list of failed tests in the results section
+SUPPORTED_RULES = [helper.Result.FAILED.value] + helper.ExecutionInfo.list()
+
+
+def print_line(line: str):
+    if not line:
+        print()
+    else:
+        print(line.strip())
+
+
+def write_line(line: str, to_stream: io.TextIOWrapper):
+    if not line:
+        print('\n', file=to_stream)
+    else:
+        print(line.strip(), file=to_stream, end='\n')
+
+
+def compile_rules(rules, operation):
+    patterns = []
+    regex_list = []
+
+    for rule in rules:
+        parts = rule.split("=", 1)
+        if len(parts) != 2:
+            raise ValueError(
+                "Error: Rule '{}' does not follow the OPERATION=PATTERN format".format(
+                    rule
+                )
+            )
+
+        rule_operation = parts[0]
+        rule_pattern = parts[1]
+
+        if rule_operation not in SUPPORTED_RULES:
+            raise ValueError(
+                "Error: Rule operation '{}' not in supported list: {}".format(
+                    rule_operation, SUPPORTED_RULES
+                )
+            )
+
+        if operation == rule_operation:
+            patterns.append(rule_pattern)
+
+    for pattern in patterns:
+        regex_list.append(re.compile(pattern))
+    return regex_list
+
+
+def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
+    if not regex_list:
+        write_line(line, to_stream)
+    else:
+        for regex in regex_list:
+            matches = regex.findall(line)
+            for match in matches:
+                write_line(match, to_stream)
+
+
+def process_detail(
+    from_stream: io.TextIOWrapper,
+    start_line: str,
+    regex_list: list,
+    to_stream: io.TextIOWrapper,
+) -> str:
+    """Process lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    write_line(start_line, to_stream)
+    for line in sys.stdin:
+        print_line(line)
+
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if helper.is_detail_finished(line):
+            return line
+
+        # Print all the lines
+        process_detail_line(line, regex_list, to_stream)
+
+
+def skip_detail(from_stream: io.TextIOWrapper) -> str:
+    """Skip lines from the start of the details section until the last line,
+    returns the first line right after the details section
+    """
+    for line in sys.stdin:
+        print_line(line)
+        if not line:
+            continue
+
+        # Check if the detail is finished
+        if helper.is_detail_finished(line):
+            return line
+
+
+def process_spread_output(output_file, exclude_lines, filter_rules):
+    error_regex = compile_rules(filter_rules, helper.ExecutionInfo.ERROR.value)
+    debug_regex = compile_rules(filter_rules, helper.ExecutionInfo.DEBUG.value)
+    failed_regex = compile_rules(filter_rules, helper.Result.FAILED.value)
+    warning_regex = compile_rules(filter_rules, helper.ExecutionInfo.WARNING.value)
+
+    with open(output_file, "w") as myfile:
+        for line in sys.stdin:
+            print_line(line)
+
+            while helper.is_detail_start(line):
+                regex_list = []
+                if helper.is_operation(line, helper.ExecutionInfo.DEBUG):
+                    if helper.ExecutionInfo.DEBUG.value in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = debug_regex
+
+                if helper.is_operation(line, helper.ExecutionInfo.ERROR):
+                    if helper.ExecutionInfo.ERROR.value in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = error_regex
+
+                if helper.is_operation(line, helper.ExecutionInfo.WARNING):
+                    if helper.ExecutionInfo.WARNING.value in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = warning_regex
+
+                if helper.is_operation(line, helper.Result.FAILED):
+                    if helper.Result.FAILED.value in exclude_lines:
+                        line = skip_detail(sys.stdin)
+                        continue
+                    else:
+                        regex_list = failed_regex
+
+                line = process_detail(sys.stdin, line, regex_list, myfile)
+
+            if (
+                not exclude_lines
+                or not helper.is_any_operation(line)
+                or not helper.get_operation(line) in exclude_lines
+            ):
+                write_line(line, myfile)
+
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+This tool is used to save a filtered version of the spread output. It parses the spread output and filters
+sections and debug/error details to the file passed as parameter (all the lines are printed).
+When a output file is not provided the debug output is sent to spread_filtered.log
+"""
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        metavar="PATH",
+        default="spread.filtered.log",
+        help="path to the filtered output file",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        action="append",
+        default=[],
+        choices=helper.OPERATIONS,
+        help="A line section to exclude from the output",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action="append",
+        metavar="OPERATION=PATTERN",
+        default=[],
+        help="It is used to extract specific data from errors. Allowed operations are Error, Debug, Failed and WARNING:",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = _make_parser()
+    args = parser.parse_args()
+    process_spread_output(args.output_file, args.exclude, args.filter)

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -4,6 +4,7 @@ import argparse
 import io
 import re
 import sys
+import typing
 
 import log_helper as helper
 
@@ -15,21 +16,21 @@ import log_helper as helper
 SUPPORTED_RULES = [helper.Result.FAILED.value] + helper.ExecutionInfo.list()
 
 
-def print_line(line: str):
+def print_line(line: str) -> None:
     if not line:
         print()
     else:
         print(line.strip())
 
 
-def write_line(line: str, to_stream: io.TextIOWrapper):
+def write_line(line: str, to_stream: typing.TextIO) -> None:
     if not line:
         print('\n', file=to_stream)
     else:
         print(line.strip(), file=to_stream, end='\n')
 
 
-def compile_rules(rules, operation):
+def compile_rules(rules: list[str], operation: str) -> list[re.Pattern[str]]:
     patterns = []
     regex_list = []
 
@@ -60,7 +61,7 @@ def compile_rules(rules, operation):
     return regex_list
 
 
-def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper):
+def process_detail_line(line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> None:
     if not regex_list:
         write_line(line, to_stream)
     else:
@@ -70,12 +71,7 @@ def process_detail_line(line: str, regex_list: list, to_stream: io.TextIOWrapper
                 write_line(match, to_stream)
 
 
-def process_detail(
-    from_stream: io.TextIOWrapper,
-    start_line: str,
-    regex_list: list,
-    to_stream: io.TextIOWrapper,
-) -> str:
+def process_detail(from_stream: typing.TextIO, start_line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> str:
     """Process lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -94,7 +90,7 @@ def process_detail(
         process_detail_line(line, regex_list, to_stream)
 
 
-def skip_detail(from_stream: io.TextIOWrapper) -> str:
+def skip_detail(from_stream: typing.TextIO) -> str:
     """Skip lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -108,7 +104,7 @@ def skip_detail(from_stream: io.TextIOWrapper) -> str:
             return line
 
 
-def process_spread_output(output_file, exclude_lines, filter_rules):
+def process_spread_output(output_file: str, exclude_lines: set[str], filter_rules: list[str]) -> None:
     error_regex = compile_rules(filter_rules, helper.ExecutionInfo.ERROR.value)
     debug_regex = compile_rules(filter_rules, helper.ExecutionInfo.DEBUG.value)
     failed_regex = compile_rules(filter_rules, helper.Result.FAILED.value)
@@ -158,8 +154,7 @@ def process_spread_output(output_file, exclude_lines, filter_rules):
                 write_line(line, myfile)
 
 
-def _make_parser():
-    # type: () -> argparse.ArgumentParser
+def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="""
 This tool is used to save a filtered version of the spread output. It parses the spread output and filters

--- a/tests/lib/external/snapd-testing-tools/utils/log-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/log-filter
@@ -25,9 +25,9 @@ def print_line(line: str) -> None:
 
 def write_line(line: str, to_stream: typing.TextIO) -> None:
     if not line:
-        print('\n', file=to_stream)
+        print("\n", file=to_stream)
     else:
-        print(line.strip(), file=to_stream, end='\n')
+        print(line.strip(), file=to_stream, end="\n")
 
 
 def compile_rules(rules: list[str], operation: str) -> list[re.Pattern[str]]:
@@ -61,7 +61,9 @@ def compile_rules(rules: list[str], operation: str) -> list[re.Pattern[str]]:
     return regex_list
 
 
-def process_detail_line(line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> None:
+def process_detail_line(
+    line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO
+) -> None:
     if not regex_list:
         write_line(line, to_stream)
     else:
@@ -71,7 +73,12 @@ def process_detail_line(line: str, regex_list: list[re.Pattern[str]], to_stream:
                 write_line(match, to_stream)
 
 
-def process_detail(from_stream: typing.TextIO, start_line: str, regex_list: list[re.Pattern[str]], to_stream: typing.TextIO) -> str:
+def process_detail(
+    from_stream: typing.TextIO,
+    start_line: str,
+    regex_list: list[re.Pattern[str]],
+    to_stream: typing.TextIO,
+) -> str:
     """Process lines from the start of the details section until the last line,
     returns the first line right after the details section
     """
@@ -89,6 +96,8 @@ def process_detail(from_stream: typing.TextIO, start_line: str, regex_list: list
         # Print all the lines
         process_detail_line(line, regex_list, to_stream)
 
+    return ""
+
 
 def skip_detail(from_stream: typing.TextIO) -> str:
     """Skip lines from the start of the details section until the last line,
@@ -103,8 +112,12 @@ def skip_detail(from_stream: typing.TextIO) -> str:
         if helper.is_detail_finished(line):
             return line
 
+    return ""
 
-def process_spread_output(output_file: str, exclude_lines: set[str], filter_rules: list[str]) -> None:
+
+def process_spread_output(
+    output_file: str, exclude_lines: set[str], filter_rules: list[str]
+) -> None:
     error_regex = compile_rules(filter_rules, helper.ExecutionInfo.ERROR.value)
     debug_regex = compile_rules(filter_rules, helper.ExecutionInfo.DEBUG.value)
     failed_regex = compile_rules(filter_rules, helper.Result.FAILED.value)

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -32,7 +32,7 @@ class Phase:
     def __repr__(self):
         return self.source_line
 
-    def __dict__(self):
+    def to_dict(self):
         return {
             "type": self.type,
             "date": self.date,
@@ -66,10 +66,10 @@ class Result:
             return "{}{}".format(self.source_line, str(self.detail))
         return self.source_line
 
-    def __dict__(self):
+    def to_dict(self):
         prepared_detail = None
         if self.detail:
-            prepared_detail = self.detail.__dict__()
+            prepared_detail = self.detail.to_dict()
         return {
             "type": self.type,
             "date": self.date,
@@ -104,10 +104,10 @@ class Info:
             return "{}{}".format(self.source_line, self.detail)
         return self.source_line
 
-    def __dict__(self):
+    def to_dict(self):
         prepared_detail = None
         if self.detail:
-            prepared_detail = self.detail.__dict__()
+            prepared_detail = self.detail.to_dict()
         return {
             "type": self.type,
             "date": self.date,
@@ -159,13 +159,13 @@ class Detail:
     Detail represents the extra lines which are displayed after the info
     """
 
-    def __init__(self, lines_limit, lines, rules):
+    def __init__(self, lines_limit: int, lines: list[str], rules: list[str]) -> None:
         self.lines_limit = lines_limit
         self.lines = lines
         self.data = {}
         self._process_rules(rules)
 
-    def _get_lines(self):
+    def _get_lines(self) -> list[str]:
         if self.lines_limit < 0 or self.lines_limit > len(self.lines):
             return self.lines
 
@@ -173,7 +173,7 @@ class Detail:
         # want to count it as a line in the log details
         return self.lines[-self.lines_limit - 1 :]
 
-    def _process_rules(self, rules):
+    def _process_rules(self, rules) -> None:
         for rule in rules:
             key = rule.key
             matches = rule.filter(self.lines)
@@ -182,7 +182,7 @@ class Detail:
     def __repr__(self):
         return "".join(self._get_lines())
 
-    def __dict__(self):
+    def to_dict(self) -> dict :
         details_dict = {"lines": self.lines[-self.lines_limit - 1 :]}
         for key in self.data.keys():
             details_dict[key] = self.data[key]
@@ -197,7 +197,7 @@ class Action:
     Allocated, Connecting, Connected, Sending
     """
 
-    def __init__(self, verb, task, extra, date, time, source_line):
+    def __init__(self, verb: str, task: str, extra: str, date: str, time: str, source_line: str) -> None: 
         self.type = "action"
         self.verb = verb
         self.time = time
@@ -209,7 +209,7 @@ class Action:
     def __repr__(self):
         return self.source_line
 
-    def __dict__(self):
+    def to_dict(self) -> dict:
         return {
             "type": self.type,
             "date": self.date,
@@ -225,7 +225,7 @@ class LogReader:
     LogReader manages the spread log, it allows to read, export and print
     """
 
-    def __init__(self, filepath, output_type, lines_limit, error_rules, debug_rules):
+    def __init__(self, filepath: str, output_type: str, lines_limit: str, error_rules: str, debug_rules: str) -> None:
         self.filepath = filepath
         self.output_type = output_type
         self.lines_limit = lines_limit
@@ -236,35 +236,35 @@ class LogReader:
         self.debug_rules = [Rule(rule) for rule in debug_rules]
 
     def __repr__(self):
-        return str(self.__dict__())
+        return str(self.to_dict())
 
-    def __dict__(self):
+    def to_dict(self) -> dict:
         return {"full_log": self.full_log}
 
-    def print_log(self):
+    def print_log(self) -> None:
         if not self.full_log:
             return
 
         print("".join(str(x) for x in self.full_log))
 
-    def export_log(self, filepath):
+    def export_log(self, filepath: str) -> None:
         prepared_log = []
         for item in self.full_log:
             if isinstance(item, str):
                 prepared_log.append(item)
             else:
-                prepared_log.append(item.__dict__())
+                prepared_log.append(item.to_dict())
         with open(filepath, "w") as json_file:
             json.dump(prepared_log, json_file, indent=4)
 
-    def _next_line(self):
+    def _next_line(self) -> str:
         self.iter = self.iter + 1
         return self.lines[self.iter - 1]
 
-    def check_log_exists(self):
+    def check_log_exists(self) -> bool:
         return os.path.exists(self.filepath)
 
-    def read_spread_log(self):
+    def read_spread_log(self) -> None:
         try:
             with open(self.filepath, "r", encoding="utf-8") as filepath:
                 self.lines = filepath.readlines()
@@ -310,16 +310,19 @@ class LogReader:
                     self.full_log.append(result)
                 continue
 
-    def _match_info(self, line):
+    def _match_info(self, line: str) -> bool:
         return helper.get_operation(line) in helper.ExecutionInfo.list()
 
-    def _match_phase(self, line):
+    def _match_phase(self, line: str) -> bool:
         return helper.get_operation(line) in helper.ExecutionPhase.list()
 
-    def _match_action(self, line):
-        return helper.get_operation(line) in helper.GeneralAction.list() + helper.GeneralActionStatus.list()
+    def _match_action(self, line: str) -> bool:
+        return (
+            helper.get_operation(line)
+            in helper.GeneralAction.list() + helper.GeneralActionStatus.list()
+        )
 
-    def _match_result(self, line):
+    def _match_result(self, line: str) -> bool:
         return helper.get_operation(line) in helper.Result.list()
 
     def _get_detail(self, rules, results=False, other_limit=None):

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -12,51 +12,17 @@ import os
 import re
 import sys
 
-# Info types
-ERROR_TYPE = 'Error'
-DEBUG_TYPE = 'Debug'
-WARN_TYPE = 'WARNING:'
-
-# Results
-FAILED_TYPE = 'Failed'
-ABORTED_TYPE = 'Aborted'
-SUCCESSFUL_TYPE = 'Successful'
-
-# Printable names
-ALL = 'all'
-NONE = 'none'
-ACTION = 'action'
-OPERATION = 'operation'
-INFO = 'info'
-ERROR = 'error'
-ERROR_DEBUG = 'error-debug'
-FAILED = 'failed'
-ABORTED = 'aborted'
-SUCCESSFUL = 'successful'
-
-RESULT = 'result'
-START = 'Found'
-SPREAD_FILE = 'spread.yaml'
-
-EXEC_VERBS = ['Preparing', 'Executing', 'Restoring']
-INFO_TYPES = [ERROR_TYPE, DEBUG_TYPE, WARN_TYPE]
-OPERATIONS = [
-    'Rebooting', 'Discarding', 'Allocating', 'Waiting',
-    'Allocated', 'Connecting', 'Connected', 'Sending'
-    ]
-RESULTS = ['Successful', 'Aborted', 'Failed']
-FAILED_LEVELS = ['task', 'suite', 'project']
-FAILED_STAGES = ['prepare', 'restore']
+import log_helper as helper
 
 
-class Action:
+class Phase:
     """
-    Action represents the main spread tasks actions
-    The actions can be: Preparing, Executing and Restoring
+    Phase represents the task/suite/project action in terms of:
+    Preparing, Executing and Restoring
     """
 
     def __init__(self, verb, task, date, time, source_line):
-        self.type = ACTION
+        self.type = "phase"
         self.verb = verb
         self.time = time
         self.date = date
@@ -68,12 +34,12 @@ class Action:
 
     def __dict__(self):
         return {
-            'type': 'action',
-            'date': self.date,
-            'time': self.time,
-            'verb': self.verb,
-            'task': self.task
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "verb": self.verb,
+            "task": self.task,
+        }
 
 
 class Result:
@@ -82,9 +48,10 @@ class Result:
     The results can be: Successful, failed and aborted
     """
 
-    def __init__(self, result_type, level, stage, number, date, time,
-                 detail, source_line):
-        self.type = RESULT
+    def __init__(
+        self, result_type, level, stage, number, date, time, detail, source_line
+    ):
+        self.type = "result"
         self.result_type = result_type
         self.level = level
         self.stage = stage
@@ -96,7 +63,7 @@ class Result:
 
     def __repr__(self):
         if self.detail:
-            return '{}{}'.format(self.source_line, str(self.detail))
+            return "{}{}".format(self.source_line, str(self.detail))
         return self.source_line
 
     def __dict__(self):
@@ -104,26 +71,25 @@ class Result:
         if self.detail:
             prepared_detail = self.detail.__dict__()
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'result_type': self.result_type,
-            'level': self.level,
-            'stage': self.stage,
-            'number': self.number,
-            'detail': prepared_detail
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "result_type": self.result_type,
+            "level": self.level,
+            "stage": self.stage,
+            "number": self.number,
+            "detail": prepared_detail,
+        }
 
 
 class Info:
     """
-    Info represents the extra tasks information which is included in the
-    spread log. The info can be: Error, Debug and Warning
+    Info represents the tasks status information which is included
+    in the spread log. The info can be: Error, Debug and Warning.
     """
 
-    def __init__(self, info_type, verb, task, extra, date, time,
-                 detail, source_line):
-        self.type = INFO
+    def __init__(self, info_type, verb, task, extra, date, time, detail, source_line):
+        self.type = "info"
         self.info_type = info_type
         self.verb = verb
         self.time = time
@@ -135,7 +101,7 @@ class Info:
 
     def __repr__(self):
         if self.detail:
-            return '{}{}'.format(self.source_line, self.detail)
+            return "{}{}".format(self.source_line, self.detail)
         return self.source_line
 
     def __dict__(self):
@@ -143,15 +109,15 @@ class Info:
         if self.detail:
             prepared_detail = self.detail.__dict__()
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'info_type': self.info_type,
-            'verb': self.verb,
-            'task': self.task,
-            'extra': self.extra,
-            'detail': prepared_detail
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "info_type": self.info_type,
+            "verb": self.verb,
+            "task": self.task,
+            "extra": self.extra,
+            "detail": prepared_detail,
+        }
 
 
 class Rule:
@@ -160,9 +126,11 @@ class Rule:
     """
 
     def __init__(self, rule):
-        parts = rule.split('=',1)
+        parts = rule.split("=", 1)
         if len(parts) != 2:
-            raise ValueError("Error: Rule '{}' does not follow the KEY=PATTERN format".format(rule))
+            raise ValueError(
+                "Error: Rule '{}' does not follow the KEY=PATTERN format".format(rule)
+            )
 
         self.key = parts[0]
         self.pattern = parts[1]
@@ -170,7 +138,9 @@ class Rule:
         try:
             re.compile(self.pattern)
         except re.error as err:
-            raise ValueError("Error: pattern '{}' cannot be compiled: {}".format(pattern, err))
+            raise ValueError(
+                "Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err)
+            )
 
     def filter(self, lines):
         regex = re.compile(self.pattern)
@@ -182,6 +152,7 @@ class Rule:
                     all_matches.append(match)
 
         return all_matches
+
 
 class Detail:
     """
@@ -200,34 +171,34 @@ class Detail:
 
         # Use self.lines_limit-1 because the last line is a '.' and we don't
         # want to count it as a line in the log details
-        return self.lines[-self.lines_limit-1:]
+        return self.lines[-self.lines_limit - 1 :]
 
     def _process_rules(self, rules):
         for rule in rules:
             key = rule.key
             matches = rule.filter(self.lines)
-            self.data[key] = '\n'.join(matches)
+            self.data[key] = "\n".join(matches)
 
     def __repr__(self):
-        return ''.join(self._get_lines())
+        return "".join(self._get_lines())
 
     def __dict__(self):
-        details_dict = {'lines': self.lines[-self.lines_limit-1:]}
+        details_dict = {"lines": self.lines[-self.lines_limit - 1 :]}
         for key in self.data.keys():
             details_dict[key] = self.data[key]
 
         return details_dict
 
 
-class Operation:
+class Action:
     """
-    Operation represents other actions that the spread running can do while
+    The actions are general operations that the spread can do while
     executing tests like: Rebooting, Discarding, Allocating, Waiting,
     Allocated, Connecting, Connected, Sending
     """
 
     def __init__(self, verb, task, extra, date, time, source_line):
-        self.type = OPERATION
+        self.type = "action"
         self.verb = verb
         self.time = time
         self.extra = extra
@@ -240,24 +211,24 @@ class Operation:
 
     def __dict__(self):
         return {
-            'type': self.type,
-            'date': self.date,
-            'time': self.time,
-            'verb': self.verb,
-            'task': self.task,
-            'extra': self.extra
-            }
+            "type": self.type,
+            "date": self.date,
+            "time": self.time,
+            "verb": self.verb,
+            "task": self.task,
+            "extra": self.extra,
+        }
 
 
 class LogReader:
     """
     LogReader manages the spread log, it allows to read, export and print
     """
-    def __init__(self, filepath, output_type, lines_limit, store_setup, error_rules, debug_rules):
+
+    def __init__(self, filepath, output_type, lines_limit, error_rules, debug_rules):
         self.filepath = filepath
         self.output_type = output_type
         self.lines_limit = lines_limit
-        self.store_setup = store_setup
         self.lines = []
         self.iter = 0
         self.full_log = []
@@ -268,40 +239,13 @@ class LogReader:
         return str(self.__dict__())
 
     def __dict__(self):
-        return {'full_log': self.full_log}
+        return {"full_log": self.full_log}
 
-    def print_log(self, details, results):
+    def print_log(self):
         if not self.full_log:
             return
 
-        # Print the details
-        if details == ALL:
-            print(''.join(str(x) for x in self.full_log))
-        elif details == NONE:
-            pass
-        elif details == ERROR:
-            print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  x.info_type == ERROR_TYPE))
-        elif details == ERROR_DEBUG:
-            print(''.join(str(x) for x in self.full_log if x.type == INFO and
-                  (x.info_type == ERROR_TYPE or x.info_type == DEBUG_TYPE)))
-        else:
-            print(''.join(str(x) for x in self.full_log if x.type == details))
-
-        # Print the results
-        if results == ALL:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT))
-        elif results == NONE:
-            pass
-        elif results == FAILED:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == FAILED_TYPE))
-        elif results == ABORTED:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == ABORTED_TYPE))
-        else:
-            print(''.join(str(x) for x in self.full_log if x.type == RESULT and
-                  x.result_type == SUCCESSFUL_TYPE))
+        print("".join(str(x) for x in self.full_log))
 
     def export_log(self, filepath):
         prepared_log = []
@@ -310,47 +254,38 @@ class LogReader:
                 prepared_log.append(item)
             else:
                 prepared_log.append(item.__dict__())
-        with open(filepath, 'w') as json_file:
+        with open(filepath, "w") as json_file:
             json.dump(prepared_log, json_file, indent=4)
 
     def _next_line(self):
         self.iter = self.iter + 1
-        return self.lines[self.iter-1]
+        return self.lines[self.iter - 1]
 
     def check_log_exists(self):
         return os.path.exists(self.filepath)
 
     def read_spread_log(self):
         try:
-            with open(self.filepath, 'r', encoding='utf-8') as filepath:
+            with open(self.filepath, "r", encoding="utf-8") as filepath:
                 self.lines = filepath.readlines()
         except UnicodeDecodeError:
-            with open(self.filepath, 'r', encoding='latin-1') as filepath:
+            with open(self.filepath, "r", encoding="latin-1") as filepath:
                 self.lines = filepath.readlines()
 
-        # Find the start of the log, the log file could include
-        # initial lines which are not part of the spread log itself
         self.iter = 0
-        if self.store_setup:
-            while self.iter < len(self.lines):
-                line = self._next_line()
-                if self._match_start(line):
-                    break
-                self.full_log.append(line)
-
-            if self.iter >= len(self.lines):
-                # Start not found, the log is either empty, corrupted or cut
-                self.iter = 0
 
         # Then iterate line by line analyzing the log
         while self.iter < len(self.lines):
             line = self._next_line()
 
+            if not helper.is_any_operation(line):
+                continue
+
             # The line is a task execution; preparing, executing, restoring
-            if self._match_task(line):
-                action = self._get_action(line)
-                if action:
-                    self.full_log.append(action)
+            if self._match_phase(line):
+                phase = self._get_phase(line)
+                if phase:
+                    self.full_log.append(phase)
                 continue
 
             # The line shows info: error, debug, warning
@@ -362,10 +297,10 @@ class LogReader:
 
             # The line is another operation: Rebooting, Discarding, Allocating
             # Waiting, Allocated, Connecting, Connected, Sending'
-            if self._match_operation(line):
-                operation = self._get_operation(line)
-                if operation:
-                    self.full_log.append(operation)
+            if self._match_action(line):
+                action = self._get_action(line)
+                if action:
+                    self.full_log.append(action)
                 continue
 
             # The line is a result: Successful, Aborted, Failed
@@ -375,47 +310,17 @@ class LogReader:
                     self.full_log.append(result)
                 continue
 
-    def _match_date(self, date):
-        return re.findall(r'\d{4}-\d{2}-\d{2}', date)
-
-    def _match_time(self, time):
-        return re.findall(r'\d{2}:\d{2}:\d{2}', time)
-
     def _match_info(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 3 and \
-            parts[2] in INFO_TYPES and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+        return helper.get_operation(line) in helper.ExecutionInfo.list()
 
-    def _match_task(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in EXEC_VERBS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+    def _match_phase(self, line):
+        return helper.get_operation(line) in helper.ExecutionPhase.list()
 
-    def _match_start(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] == START and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1]) and \
-            SPREAD_FILE in parts[3]
-
-    def _match_operation(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in OPERATIONS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+    def _match_action(self, line):
+        return helper.get_operation(line) in helper.GeneralAction.list() + helper.GeneralActionStatus.list()
 
     def _match_result(self, line):
-        parts = line.strip().split(' ')
-        return len(parts) > 2 and \
-            parts[2] in RESULTS and \
-            self._match_date(parts[0]) and \
-            self._match_time(parts[1])
+        return helper.get_operation(line) in helper.Result.list()
 
     def _get_detail(self, rules, results=False, other_limit=None):
         """
@@ -424,44 +329,20 @@ class LogReader:
         a limit of lines to tail the log and show the last lines.
         It returns a Detail object included all the lines.
         """
-
-        # If the first line matches with a regular line, this means the detail
-        # has no output and has to be discarded
-        line = self.lines[self.iter]
-        if self._match_task(line) or self._match_info(line) or \
-            self._match_operation(line) or self._match_result(line):
-            return None
-
-        detail=[]
-        initial_iter = self.iter
+        detail = []
         while self.iter < len(self.lines):
+            previous_line = self.lines[self.iter - 1]
             line = self._next_line()
-            if self._match_task(line) or self._match_info(line) or \
-            self._match_operation(line) or self._match_result(line):
-                # When the details is for results, then any match is ok to break
-                if results:
-                    break
-                # When the details is no for results, then we need to check also
-                # the the last time was just a '.'
-                # The details for info (Error, Debug and Warning) always finish with
-                # ----
-                # .
-                #
-                # As the iter is already pointing to the next line since 'line = self._next_line()'
-                # to access the previous line of the current one it is needed to do 'self.iter-2'
-                elif self.lines[self.iter-2].strip() == '.':
+            if helper.is_detail_finished(line):
+                # This is needed because it could happen that in the details there is a spread log
+                # because sometimes we run nested spread
+                # The is not valid when the details are for failed tests in results section
+                if results or previous_line.strip() == ".":
                     break
 
-                detail.append(line)
+            detail.append(line)
 
-            # When the details is for results, if the detail line does not start
-            # with "    - ", then it is time to break
-            if results and not line.startswith("    - "):
-                break
-            else:
-                detail.append(line)
-        
-        # We leave the iter in the last time in case the log has finished
+        # We leave the iter in the last line in case the log has finished
         if not self.iter == len(self.lines):
             self.iter = self.iter - 1
         if not other_limit:
@@ -474,32 +355,40 @@ class LogReader:
         Get the Info object for the error, debug and warning lines including
         the details for this
         """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        info_type = parts[2]
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        info_type = helper.get_operation(line)
+        info_extra = helper.get_operation_info(line)
 
         verb = None
         task = None
-        if info_type == WARN_TYPE:
-            info_type = info_type.split(':')[0]
+        if info_type == helper.ExecutionInfo.WARNING.value:
+            # Removing the : from WARNING:
+            info_type = info_type.split(":")[0]
             verb = None
             task = None
-            extra = ' '.join(parts[3:])
-        elif info_type == ERROR_TYPE:
-            verb = parts[3]
-            task = parts[4]
+            extra = info_extra
+        elif info_type == helper.ExecutionInfo.ERROR.value:
+            verb = info_extra.split(" ")[0]
+            task = info_extra.split(" ")[1]
             extra = None
-        elif info_type == DEBUG_TYPE:
+        elif info_type == helper.ExecutionInfo.DEBUG.value:
             verb = None
-            task = parts[5]
+            task = info_extra.split(" ")[2]
             extra = None
         else:
-            print('log-parser: detail type not recognized: {}'.format(info_type))
+            print("log-parser: detail type not recognized: {}".format(info_type))
+            return
 
         # Pass the rules according to the info type
+        rules = self.debug_rules
+        if info_type == helper.ExecutionInfo.ERROR.value:
+            rules = self.error_rules
+
+        detail = None
+        if helper.is_detail(line):
+            detail = self._get_detail(rules)
+
         rules = self.debug_rules
         if info_type == ERROR_TYPE:
             rules = self.error_rules
@@ -508,50 +397,42 @@ class LogReader:
         return Info(info_type, verb, task, extra, date, time, detail, line)
 
     def _get_result(self, line):
-        """ Get the Result object including the details for the result """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        result_type = parts[2]
-        level = parts[3].split(':')[0]
-        number = parts[-1]
+        """Get the Result object including the details for the result"""
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        result_type = helper.get_operation(line)
+        result_extra = helper.get_operation_info(line)
+        level = result_extra.split(" ")[0].split(":")[0]
+        number = result_extra.split(" ")[-1]
 
         stage = None
         detail = None
-        if result_type == FAILED_TYPE:
-            if level in FAILED_LEVELS:
-                stage = parts[4].split(':')[0]
+        if result_type == helper.Result.FAILED.value:
+            if level in helper.ExecutionLevel.list():
+                stage = result_extra.split(" ")[1].split(":")[0]
             detail = self._get_detail([], results=True, other_limit=-1)
 
-        return Result(result_type, level, stage, number.strip(), date, time, detail,
-                      line)
+        return Result(result_type, level, stage, number, date, time, detail, line)
+
+    def _get_phase(self, line):
+        """
+        Get the phase object for lines preparing, executing and restoring
+        """
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
+        task = helper.get_operation_info(line).split(" ")[0]
+        return Phase(verb, task.split("...")[0], date, time, line)
 
     def _get_action(self, line):
-        """
-        Get the Action object for lines preparing, executing and restoring
-        """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        verb = parts[2]
-        task = parts[3]
-        return Action(verb, task.split('...')[0], date, time, line)
+        """Get the general actions object for lines rebooting, allocating, etc"""
 
-    def _get_operation(self, line):
-        """ Get the Operation object for lines rebooting, allocating, etc """
-        parts = line.strip().split(' ')
-        if len(parts) < 3:
-            return None
-        date = parts[0]
-        time = parts[1]
-        verb = parts[2]
+        date = helper.get_date(line)
+        time = helper.get_time(line)
+        verb = helper.get_operation(line)
         task = None
-        extra = ' '.join(parts[3:])
-        return Operation(verb, task, extra, date, time, line)
+        extra = helper.get_operation_info(line)
+        return Action(verb, task, extra, date, time, line)
 
 
 def _make_parser():
@@ -575,24 +456,8 @@ for the error/debug/warning output.
         "--format",
         type=str,
         default="json",
-        choices=['json'],
+        choices=["json"],
         help="format for the output",
-    )
-    parser.add_argument(
-        "-pd",
-        "--print-details",
-        type=str,
-        default=NONE,
-        choices=[ALL, ERROR, ERROR_DEBUG, OPERATION, ACTION, INFO, NONE],
-        help="Filter which info to print",
-    )
-    parser.add_argument(
-        "-pr",
-        "--print-results",
-        type=str,
-        default=NONE,
-        choices=[ALL, FAILED, ABORTED, SUCCESSFUL, NONE],
-        help="Filter which results to print",
     )
     parser.add_argument(
         "-o",
@@ -602,26 +467,27 @@ for the error/debug/warning output.
         help="output file to save the result",
     )
     parser.add_argument(
-        "--store-setup",
-        action="store_true",
-        help="will save all the text before the spread run is started",
-    )
-    parser.add_argument(
         "-er",
-        "--error-rule", 
+        "--error-rule",
         action="append",
         default=[],
-        help="A KEY=PATTERN used to extract and store specific data from errors"
+        help="A KEY=PATTERN used to extract and store specific data from errors",
     )
     parser.add_argument(
         "-dr",
+        "--debug-rule",
+        action="append",
+        default=[],
+        help="A KEY=PATTERN used to extract and store specific data from debug output",
+    )
+    parser.add_argument(
+        "log_path", metavar="PATH", help="path to the log to be analyzed"
         "--debug-rule", 
         action="append",
         default=[],
         help="A KEY=PATTERN used to extract and store specific data from debug output"
     )
     parser.add_argument(
-        "logpath", metavar="PATH", help="path to the log to be analyzed"
     )
     return parser
 
@@ -631,11 +497,17 @@ def main():
     parser = _make_parser()
     args = parser.parse_args()
 
-    if len(args.logpath) == 0:
+    if len(args.log_path) == 0:
         parser.print_usage()
         parser.exit(0)
 
-    reader = LogReader(args.logpath, args.format, args.cut, args.store_setup, args.error_rule, args.debug_rule)
+    reader = LogReader(
+        args.log_path,
+        args.format,
+        args.cut,
+        args.error_rule,
+        args.debug_rule,
+    )
     if not reader.check_log_exists():
         print("log-parser: log not found")
         sys.exit(1)
@@ -645,7 +517,7 @@ def main():
     if args.output:
         reader.export_log(args.output)
 
-    reader.print_log(args.print_details, args.print_results)
+    reader.print_log()
 
 
 if __name__ == "__main__":

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -142,7 +142,7 @@ class Rule:
                 "Error: pattern '{}' cannot be compiled: {}".format(self.pattern, err)
             )
 
-    def filter(self, lines):
+    def filter(self, lines) -> list[str]:
         regex = re.compile(self.pattern)
         all_matches = []
         for line in lines:
@@ -162,7 +162,7 @@ class Detail:
     def __init__(self, lines_limit: int, lines: list[str], rules: list[str]) -> None:
         self.lines_limit = lines_limit
         self.lines = lines
-        self.data = {}
+        self.data = dict[str, list[str]]()
         self._process_rules(rules)
 
     def _get_lines(self) -> list[str]:
@@ -177,12 +177,12 @@ class Detail:
         for rule in rules:
             key = rule.key
             matches = rule.filter(self.lines)
-            self.data[key] = "\n".join(matches)
+            self.data[key] = matches
 
     def __repr__(self):
         return "".join(self._get_lines())
 
-    def to_dict(self) -> dict :
+    def to_dict(self) -> dict[str, list[str]]:
         details_dict = {"lines": self.lines[-self.lines_limit - 1 :]}
         for key in self.data.keys():
             details_dict[key] = self.data[key]
@@ -197,7 +197,9 @@ class Action:
     Allocated, Connecting, Connected, Sending
     """
 
-    def __init__(self, verb: str, task: str, extra: str, date: str, time: str, source_line: str) -> None: 
+    def __init__(
+        self, verb: str, task: str, extra: str, date: str, time: str, source_line: str
+    ) -> None:
         self.type = "action"
         self.verb = verb
         self.time = time
@@ -209,7 +211,7 @@ class Action:
     def __repr__(self):
         return self.source_line
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str]:
         return {
             "type": self.type,
             "date": self.date,
@@ -225,13 +227,20 @@ class LogReader:
     LogReader manages the spread log, it allows to read, export and print
     """
 
-    def __init__(self, filepath: str, output_type: str, lines_limit: str, error_rules: str, debug_rules: str) -> None:
+    def __init__(
+        self,
+        filepath: str,
+        output_type: str,
+        lines_limit: str,
+        error_rules: str,
+        debug_rules: str,
+    ) -> None:
         self.filepath = filepath
         self.output_type = output_type
         self.lines_limit = lines_limit
-        self.lines = []
+        self.lines = list[str]()
         self.iter = 0
-        self.full_log = []
+        self.full_log = list[str]()
         self.error_rules = [Rule(rule) for rule in error_rules]
         self.debug_rules = [Rule(rule) for rule in debug_rules]
 

--- a/tests/lib/external/snapd-testing-tools/utils/log-parser
+++ b/tests/lib/external/snapd-testing-tools/utils/log-parser
@@ -392,11 +392,6 @@ class LogReader:
         if helper.is_detail(line):
             detail = self._get_detail(rules)
 
-        rules = self.debug_rules
-        if info_type == ERROR_TYPE:
-            rules = self.error_rules
-
-        detail = self._get_detail(rules, results=False)
         return Info(info_type, verb, task, extra, date, time, detail, line)
 
     def _get_result(self, line):
@@ -485,12 +480,6 @@ for the error/debug/warning output.
     )
     parser.add_argument(
         "log_path", metavar="PATH", help="path to the log to be analyzed"
-        "--debug-rule", 
-        action="append",
-        default=[],
-        help="A KEY=PATTERN used to extract and store specific data from debug output"
-    )
-    parser.add_argument(
     )
     return parser
 

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -1,0 +1,194 @@
+"""
+This library provides a set of functions that can be used to
+process the spread output.
+"""
+
+import re
+
+from enum import Enum
+
+
+class ListedEnum(Enum):
+    @classmethod
+    def list(cls):
+        return list(map(lambda c: c.value, cls))
+
+
+class ExecutionPhase(ListedEnum):
+    PREPARING = "Preparing"
+    EXECUTING = "Executing"
+    RESTORING = "Restoring"
+
+
+class ExecutionInfo(ListedEnum):
+    DEBUG = "Debug"
+    ERROR = "Error"
+    WARNING = "WARNING:"
+
+
+class ExecutionLevel(ListedEnum):
+    TASK = "task"
+    SUITE = "suite"
+    PROJECT = "project"
+
+
+class GeneralAction(ListedEnum):
+    REBOOTING = "Rebooting"
+    DISCARDING = "Discarding"
+    ALLOCATING = "Allocating"
+    WAITING = "Waiting"
+    CONNECTING = "Connecting"
+    SENDING = "Sending"
+
+
+class GeneralActionStatus(ListedEnum):
+    ALLOCATED = "Allocated"
+    CONNECTED = "Connected"
+
+
+class Result(ListedEnum):
+    FAILED = "Failed"
+    SUCCESSFUL = "Successful"
+    ABORTED = "Aborted"
+
+
+OPERATIONS = (
+    ExecutionPhase.list()
+    + GeneralAction.list()
+    + GeneralActionStatus.list()
+    + ExecutionInfo.list()
+    + Result.list()
+)
+
+
+# Start line
+START_LINE = ".*Project content is packed for delivery.*"
+
+
+def _match_date(date):
+    return re.match(r"\d{4}-\d{2}-\d{2}", date)
+
+
+def _match_time(time):
+    return re.match(r"\d{2}:\d{2}:\d{2}", time)
+
+
+def is_initial_line(line: str) -> bool:
+    if not line:
+        return False
+
+    pattern = re.compile(START_LINE)
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and re.match(pattern, line)
+    )
+
+
+# Debug line starts with the operation
+def is_operation(line: str, operation: Enum) -> bool:
+    if not line:
+        return False
+
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] == operation.value
+    )
+
+
+# Check if the line contains any operation
+def is_any_operation(line: str) -> bool:
+    if not line:
+        return False
+
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 2
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] in OPERATIONS
+    )
+
+
+# Return the date in the line
+def get_date(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+
+    return parts[0]
+
+
+# Return the time in the line
+def get_time(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]) or not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+
+    return parts[1]
+
+
+# Return the operation in the line
+def get_operation(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(" ")
+    if len(parts) <= 2 or not _match_date(parts[0]) or not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+
+    return parts[2]
+
+
+# Return the information that comes after the operation
+def get_operation_info(line: str) -> str:
+    if not line:
+        raise RuntimeError("Empty line provided")
+
+    parts = line.strip().split(" ")
+    if len(parts) <= 3 or not _match_date(parts[0]) or not _match_time(parts[1]):
+        raise ValueError("Incorrect format for line provided: {}".format(line))
+
+    return " ".join(parts[3:])
+
+
+# Details are displayed after Error/Debug/Failed/Warning operations
+def is_detail_start(line: str) -> bool:
+    return (
+        is_operation(line, ExecutionInfo.DEBUG)
+        or is_operation(line, ExecutionInfo.ERROR)
+        or is_operation(line, ExecutionInfo.WARNING)
+        or is_operation(line, Result.FAILED)
+    )
+
+
+# Error/Debug/Failed output sometimes finish with either EOF error or a log file
+# and no detail displayed
+def is_detail(line: str) -> bool:
+    return (
+        is_operation(line, ExecutionInfo.DEBUG)
+        or is_operation(line, ExecutionInfo.ERROR)
+        or is_operation(line, ExecutionInfo.WARNING)
+    ) and line.strip()[-1:] == ":"
+
+
+# Error/Debug/Failed output finishes when a new other line starts
+def is_detail_finished(line: str) -> bool:
+    parts = line.strip().split(" ")
+    return (
+        len(parts) > 3
+        and _match_date(parts[0])
+        and _match_time(parts[1])
+        and parts[2] in OPERATIONS
+    )

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -11,8 +11,7 @@ from enum import Enum
 class ListedEnum(Enum):
     @classmethod
     def list(cls) -> list[str]:
-        return [str(x) for x in cls.__members__.values()]
-
+        return list(map(lambda c: c.value, cls))
 
 class ExecutionPhase(ListedEnum):
     PREPARING = "Preparing"

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -65,12 +65,12 @@ OPERATIONS = (
 START_LINE = ".*Project content is packed for delivery.*"
 
 
-def _match_date(date):
-    return re.match(r"\d{4}-\d{2}-\d{2}", date)
+def _match_date(date) -> bool:
+    return re.match(r"\d{4}-\d{2}-\d{2}", date) is not None
 
 
-def _match_time(time):
-    return re.match(r"\d{2}:\d{2}:\d{2}", time)
+def _match_time(time) -> bool:
+    return re.match(r"\d{2}:\d{2}:\d{2}", time) is not None
 
 
 def is_initial_line(line: str) -> bool:
@@ -83,7 +83,7 @@ def is_initial_line(line: str) -> bool:
         len(parts) > 2
         and _match_date(parts[0])
         and _match_time(parts[1])
-        and re.match(pattern, line)
+        and re.match(pattern, line) is not None
     )
 
 

--- a/tests/lib/external/snapd-testing-tools/utils/log_helper.py
+++ b/tests/lib/external/snapd-testing-tools/utils/log_helper.py
@@ -10,8 +10,8 @@ from enum import Enum
 
 class ListedEnum(Enum):
     @classmethod
-    def list(cls):
-        return list(map(lambda c: c.value, cls))
+    def list(cls) -> list[str]:
+        return [str(x) for x in cls.__members__.values()]
 
 
 class ExecutionPhase(ListedEnum):
@@ -65,11 +65,11 @@ OPERATIONS = (
 START_LINE = ".*Project content is packed for delivery.*"
 
 
-def _match_date(date) -> bool:
+def _match_date(date: str) -> bool:
     return re.match(r"\d{4}-\d{2}-\d{2}", date) is not None
 
 
-def _match_time(time) -> bool:
+def _match_time(time: str) -> bool:
     return re.match(r"\d{2}:\d{2}:\d{2}", time) is not None
 
 


### PR DESCRIPTION
The log utilities from snapd-testing-tools have been updated
1. log-helper: has enums instead of constants
2. log-parser: does not offer --print-details functions anymore, and the complexity was reduced. Also many other minor improvements have been implemented. 
3. log-analyzer: minor changes
4. minor fix in remote.pull to make it work in ubuntu noble with nested tests
