### PR TITLE
o/configstate/configcore: guard against classic systems for kernel commandline params

### DIFF
--- a/overlord/configstate/configcore/kernel.go
+++ b/overlord/configstate/configcore/kernel.go
@@ -68,7 +68,6 @@ func validateCmdlineParamsAreAllowed(st *state.State, devCtx snapstate.DeviceCon
 	if err != nil {
 		return err
 	}
-
 	logger.Debugf("gadget data read from %s", gd.RootDir)
 
 	if _, forbidden := gadget.FilterKernelCmdline(cmdline, gd.Info.KernelCmdline.Allow); forbidden != "" {

--- a/overlord/configstate/configcore/kernel.go
+++ b/overlord/configstate/configcore/kernel.go
@@ -64,6 +64,12 @@ func validateCmdlineParamsAreAllowed(st *state.State, devCtx snapstate.DeviceCon
 	if err != nil {
 		return err
 	}
+	if gd == nil {
+		// no gadget data currently, so we cannot check against the allow-list
+		// this can happen on classic systems
+		return fmt.Errorf("changing the kernel command line is not supported on a classic system")
+	}
+
 	logger.Debugf("gadget data read from %s", gd.RootDir)
 
 	if _, forbidden := gadget.FilterKernelCmdline(cmdline, gd.Info.KernelCmdline.Allow); forbidden != "" {

--- a/overlord/configstate/configcore/kernel.go
+++ b/overlord/configstate/configcore/kernel.go
@@ -60,14 +60,13 @@ func changedKernelConfigs(c RunTransaction) []string {
 }
 
 func validateCmdlineParamsAreAllowed(st *state.State, devCtx snapstate.DeviceContext, cmdline string) error {
+	if devCtx.IsClassicBoot() {
+		return fmt.Errorf("changing the kernel command line is not supported on a classic system")
+	}
+
 	gd, err := devicestate.CurrentGadgetData(st, devCtx)
 	if err != nil {
 		return err
-	}
-	if gd == nil {
-		// no gadget data currently, so we cannot check against the allow-list
-		// this can happen on classic systems
-		return fmt.Errorf("changing the kernel command line is not supported on a classic system")
 	}
 
 	logger.Debugf("gadget data read from %s", gd.RootDir)

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -159,6 +159,24 @@ func (s *kernelSuite) mockEarlyConfig() {
 	s.AddCleanup(func() { devicestate.EarlyConfig = nil })
 }
 
+func (s *kernelSuite) mockClassicBasicModelWithoutSnaps() {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	extras := map[string]interface{}{
+		"architecture": "amd64",
+		"classic":      "true",
+	}
+	model := s.Brands.Model("my-brand", "pc", extras)
+
+	assertstatetest.AddMany(s.state, model)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  model.BrandID(),
+		Model:  model.Model(),
+		Serial: "serialserial",
+	})
+}
+
 func (s *kernelSuite) mockModelWithModeenv(grade string, isClassic bool) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -473,4 +491,27 @@ func (s *kernelSuite) TestConfigureKernelCmdlineSignedGradeNotAllowed(c *C) {
 	} {
 		s.testConfigureKernelCmdlineSignedGradeNotAllowed(c, cmdline)
 	}
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineOnClassicFails(c *C) {
+	s.mockClassicBasicModelWithoutSnaps()
+
+	cmdline := "param1=val1"
+	s.state.Lock()
+
+	tugc := s.state.NewTask("update-gadget-cmdline", "update gadget cmdline")
+	chgUpd := s.state.NewChange("optional-kernel-cmdline", "optional kernel cmdline")
+	chgUpd.AddTask(tugc)
+
+	ts := s.state.NewTask("hook-task", "system hook task")
+	chg := s.state.NewChange("system-option", "...")
+	chg.AddTask(ts)
+	rt := configcore.NewRunTransaction(config.NewTransaction(s.state), ts)
+
+	s.state.Unlock()
+
+	rt.Set("core", "system.kernel.cmdline-append", cmdline)
+
+	err := configcore.Run(core20Dev, rt)
+	c.Assert(err, ErrorMatches, "changing the kernel command line is not supported on a classic system")
 }

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -159,7 +159,7 @@ func (s *kernelSuite) mockEarlyConfig() {
 	s.AddCleanup(func() { devicestate.EarlyConfig = nil })
 }
 
-func (s *kernelSuite) mockClassicBasicModelWithoutSnaps() {
+func (s *kernelSuite) mockClassicBootModelWithoutSnaps() {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -493,8 +493,8 @@ func (s *kernelSuite) TestConfigureKernelCmdlineSignedGradeNotAllowed(c *C) {
 	}
 }
 
-func (s *kernelSuite) TestConfigureKernelCmdlineOnClassicFails(c *C) {
-	s.mockClassicBasicModelWithoutSnaps()
+func (s *kernelSuite) TestConfigureKernelCmdlineOnClassicBootFails(c *C) {
+	s.mockClassicBootModelWithoutSnaps()
 
 	cmdline := "param1=val1"
 	s.state.Lock()


### PR DESCRIPTION
A bug was reported here (https://bugs.launchpad.net/snapd/+bug/2068874) relating to a derefencing of a nil structure. The real issue is that this code was invoked from a classic system, and the code clearly expects a gadget to be present on the system.

If we inspect the task handler for the resulting task, it would have errored out anyway:

overlord/devicestate/handlers_gadget.go:366.
```
	if devCtx.IsClassicBoot() {
		return fmt.Errorf("internal error: cannot run update gadget kernel command line task on a classic system")
	}
``` 