### PR TITLE
asserts: allow $PLUG_PUBLISHER_ID in plug attribute constraints

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -1049,7 +1049,7 @@ func (aks *accountKeySuite) TestDecodeConstraintsInvalid(c *C) {
 		{constr, "\n  -\n    headers:\n      t: x\n", "type header constraint mandatory in asserions constraints"},
 		{constr, "\n  -\n    headers:\n      type:\n        - foo\n", "type header constraint must be a string"},
 		{constr, "\n  -\n    headers:\n      type: preseed|model\n", "type header constraint must be a precise string and not a regexp"},
-		{constr, "\n  -\n    headers:\n      type: foo\n      model: $X\n", `cannot compile headers constraint: cannot compile "model" constraint "\$X": no \$OP\(\) constraints supported`},
+		{constr, "\n  -\n    headers:\n      type: foo\n      model: $X\n", `cannot compile headers constraint: cannot compile "model" constraint "\$X": no \$OP\(\) or \$REF constraints supported`},
 	}
 	for _, test := range invalidHeaderTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -207,7 +207,8 @@ func init() {
 	// 3: support for on-store/on-brand/on-model device scope constraints
 	// 4: support for plug-names/slot-names constraints
 	// 5: alt attr matcher usage (was unused before, has new behavior now)
-	maxSupportedFormat[SnapDeclarationType.Name] = 5
+	// 6: support for $PLUG_PUBLISHER_ID/$SLOT_PUBLISHER_ID in attr constraints
+	maxSupportedFormat[SnapDeclarationType.Name] = 6
 
 	// 1: support to limit to device serials
 	// 2: support for user-presence constraint

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -85,7 +85,7 @@ func (as *assertsSuite) TestMaxSupportedFormats(c *C) {
 	systemUserMaxFormat := asserts.SystemUserType.MaxSupportedFormat()
 	// validity
 	c.Check(accountKeyMaxFormat >= 1, Equals, true)
-	c.Check(snapDeclMaxFormat >= 4, Equals, true)
+	c.Check(snapDeclMaxFormat >= 6, Equals, true)
 	c.Check(systemUserMaxFormat >= 2, Equals, true)
 	c.Check(asserts.MaxSupportedFormats(1), DeepEquals, map[string]int{
 		"account-key":      accountKeyMaxFormat,

--- a/asserts/constraint_test.go
+++ b/asserts/constraint_test.go
@@ -62,7 +62,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
   bar: BAR`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -94,7 +94,7 @@ func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
   bar: BAR|BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -136,7 +136,7 @@ func (s *attrMatcherSuite) TestNested(c *C) {
     bar2: BAR2`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -188,7 +188,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
     bar: BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil, nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -226,7 +226,7 @@ func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
       - BAR22`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -264,7 +264,7 @@ write:
   write: /var/(tmp|lib/snapd/snapshots)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -276,7 +276,7 @@ write:
     - /var/lib/snapd/snapshots`))
 	c.Assert(err, IsNil)
 
-	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchLst(toMatch, nil)
@@ -296,7 +296,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
       options: rw|bind|nodev`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -318,7 +318,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensive(toMatch, nil)
@@ -340,7 +340,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensiveNoMatch(toMatch, nil)
@@ -353,7 +353,7 @@ func (s *attrMatcherSuite) TestOtherScalars(c *C) {
   bar: true`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -371,39 +371,39 @@ bar: true
 }
 
 func (s *attrMatcherSuite) TestCompileErrors(c *C) {
-	_, err := asserts.CompileAttrMatcher(1, nil)
+	_, err := asserts.CompileAttrMatcher(1, nil, nil)
 	c.Check(err, ErrorMatches, `top constraint must be a key-value map, regexp or a list of alternative constraints: 1`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": 1,
-	}, nil)
+	}, nil, nil)
 	c.Check(err, ErrorMatches, `constraint "foo" must be a key-value map, regexp or a list of alternative constraints: 1`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": "[",
-	}, nil)
+	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": []interface{}{"foo", "["},
-	}, nil)
+	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo/alt#2/" constraint "\[": error parsing regexp:.*`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": []interface{}{"foo", []interface{}{"bar", "baz"}},
-	}, nil)
+	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
 
-	_, err = asserts.CompileAttrMatcher("FOO", nil)
+	_, err = asserts.CompileAttrMatcher("FOO", nil, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
-	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil)
+	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": "$FOO()",
-	}, nil)
-	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) constraints supported`)
+	}, nil, nil)
+	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) or \$REF constraints supported`)
 
 	wrongDollarConstraints := []string{
 		"$",
@@ -417,9 +417,9 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	for _, wrong := range wrongDollarConstraints {
 		_, err := asserts.CompileAttrMatcher(map[string]interface{}{
 			"foo": wrong,
-		}, []string{"SLOT", "OP"})
+		}, []string{"SLOT", "OP"}, []string{"PLUG_PUBLISHER_ID"})
 		if wrong != "$SLOT(x,y)" {
-			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$OP\(\) constraint`, regexp.QuoteMeta(wrong)))
+			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$OP\(\)/\$PLUG_PUBLISHER_ID constraint`, regexp.QuoteMeta(wrong)))
 		} else {
 			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": \$SLOT\(\) constraint expects 1 argument`, regexp.QuoteMeta(wrong)))
 		}
@@ -432,7 +432,7 @@ func (s *attrMatcherSuite) TestMatchingListsSimple(c *C) {
   foo: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -451,7 +451,7 @@ func (s *attrMatcherSuite) TestMissingCheck(c *C) {
   foo: $MISSING`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -472,7 +472,7 @@ func (s *attrMatcherSuite) TestEvalCheck(c *C) {
   bar: $PLUG(bar.baz)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"})
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"}, []string{"PLUG_PUBLISHER_ID"})
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -490,7 +490,7 @@ bar: bar
 	err = domatch(vals(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp1})
+`), testEvalAttr{comp: comp1})
 	c.Check(err, IsNil)
 
 	c.Check(calls, DeepEquals, map[[2]string]bool{
@@ -508,7 +508,7 @@ bar: bar.baz
 	err = domatch(vals(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp2})
+`), testEvalAttr{comp: comp2})
 	c.Check(err, ErrorMatches, `field "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
 	comp3 := func(op string, arg string) (interface{}, error) {
@@ -521,7 +521,7 @@ bar: bar.baz
 	err = domatch(vals(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp3})
+`), testEvalAttr{comp: comp3})
 	c.Check(err, ErrorMatches, `field "foo" does not match \$SLOT\(foo\): foo != other-value`)
 }
 
@@ -531,7 +531,7 @@ func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
     p: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -310,11 +310,12 @@ func (gkm *GPGKeypairManager) ParametersForGenerate(passphrase string, name stri
 
 // constraint tests
 
-func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
+func CompileAttrMatcher(constraints interface{}, allowedOperations, allowedRefs []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
 	// XXX adjust
 	cc := compileContext{
 		opts: &compileAttrMatcherOptions{
 			allowedOperations: allowedOperations,
+			allowedRefs:       allowedRefs,
 		},
 	}
 	matcher, err := compileAttrMatcher(cc, constraints)

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -33,6 +33,8 @@ import (
 type AttrMatchContext interface {
 	PlugAttr(arg string) (interface{}, error)
 	SlotAttr(arg string) (interface{}, error)
+	PlugPublisherID() string
+	SlotPublisherID() string
 }
 
 const (
@@ -57,6 +59,7 @@ func compileAttributeConstraints(constraints interface{}) (*AttributeConstraints
 	cc := compileContext{
 		opts: &compileAttrMatcherOptions{
 			allowedOperations: []string{"SLOT", "PLUG"},
+			allowedRefs:       []string{"PLUG_PUBLISHER_ID", "SLOT_PUBLISHER_ID"},
 		},
 	}
 	matcher, err := compileAttrMatcher(cc, constraints)

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -281,13 +281,15 @@ func (s *attrConstraintsSuite) TestCompileErrors(c *C) {
 		_, err := asserts.CompileAttributeConstraints(map[string]interface{}{
 			"foo": wrong,
 		})
-		c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$PLUG\(\) constraint`, regexp.QuoteMeta(wrong)))
+		c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$PLUG\(\)/\$PLUG_PUBLISHER_ID/\$SLOT_PUBLISHER_ID constraint`, regexp.QuoteMeta(wrong)))
 
 	}
 }
 
 type testEvalAttr struct {
-	comp func(side string, arg string) (interface{}, error)
+	comp            func(side string, arg string) (interface{}, error)
+	plugPublisherID string
+	slotPublisherID string
 }
 
 func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
@@ -296,6 +298,14 @@ func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
 
 func (ca testEvalAttr) PlugAttr(arg string) (interface{}, error) {
 	return ca.comp("plug", arg)
+}
+
+func (ca testEvalAttr) PlugPublisherID() string {
+	return ca.plugPublisherID
+}
+
+func (ca testEvalAttr) SlotPublisherID() string {
+	return ca.slotPublisherID
 }
 
 func (s *attrConstraintsSuite) TestEvalCheck(c *C) {
@@ -323,7 +333,7 @@ bar: bar
 	err = cstrs.Check(attrs(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp1})
+`), testEvalAttr{comp: comp1})
 	c.Check(err, IsNil)
 
 	c.Check(calls, DeepEquals, map[[2]string]bool{
@@ -341,7 +351,7 @@ bar: bar.baz
 	err = cstrs.Check(attrs(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp2})
+`), testEvalAttr{comp: comp2})
 	c.Check(err, ErrorMatches, `attribute "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
 	comp3 := func(op string, arg string) (interface{}, error) {
@@ -354,8 +364,72 @@ bar: bar.baz
 	err = cstrs.Check(attrs(`
 foo: foo
 bar: bar.baz
-`), testEvalAttr{comp3})
+`), testEvalAttr{comp: comp3})
 	c.Check(err, ErrorMatches, `attribute "foo" does not match \$SLOT\(foo\): foo != other-value`)
+}
+
+func (s *attrConstraintsSuite) TestCheckWithAttrPlugPublisherID(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  my-attr: $PLUG_PUBLISHER_ID`))
+	c.Assert(err, IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, IsNil)
+	c.Check(asserts.RuleFeature(cstrs, "publisher-id-constraints"), Equals, true)
+
+	helper := testEvalAttr{plugPublisherID: "my-account"}
+
+	err = cstrs.Check(attrs(`
+my-attr: my-account
+`), nil)
+	c.Check(err, ErrorMatches, `attribute "my-attr" cannot be matched without context`)
+
+	err = cstrs.Check(attrs(`
+my-attr: my-account
+`), helper)
+	c.Check(err, IsNil)
+
+	err = cstrs.Check(attrs(`
+my-attr: other-account
+`), helper)
+	c.Check(err, ErrorMatches, `.*attribute "my-attr" does not match \$PLUG_PUBLISHER_ID\: other-account != my-account`)
+
+	err = cstrs.Check(attrs(`
+my-attr: 1
+`), helper)
+	c.Check(err, ErrorMatches, `.*attribute "my-attr" is not expected string type: int64`)
+}
+
+func (s *attrConstraintsSuite) TestCheckWithAttrSlotPublisherID(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  my-attr: $SLOT_PUBLISHER_ID`))
+	c.Assert(err, IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, IsNil)
+	c.Check(asserts.RuleFeature(cstrs, "publisher-id-constraints"), Equals, true)
+
+	helper := testEvalAttr{slotPublisherID: "my-account"}
+
+	err = cstrs.Check(attrs(`
+my-attr: my-account
+`), nil)
+	c.Check(err, ErrorMatches, `attribute "my-attr" cannot be matched without context`)
+
+	err = cstrs.Check(attrs(`
+my-attr: my-account
+`), helper)
+	c.Check(err, IsNil)
+
+	err = cstrs.Check(attrs(`
+my-attr: other-account
+`), helper)
+	c.Check(err, ErrorMatches, `.*attribute "my-attr" does not match \$SLOT_PUBLISHER_ID\: other-account != my-account`)
+
+	err = cstrs.Check(attrs(`
+my-attr: 1
+`), helper)
+	c.Check(err, ErrorMatches, `.*attribute "my-attr" is not expected string type: int64`)
 }
 
 func (s *attrConstraintsSuite) TestNeverMatchAttributeConstraints(c *C) {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -196,6 +196,9 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 		if rule.feature(altAttrMatcherFeature) {
 			setFormatNum(5)
 		}
+		if rule.feature(publisherIDConstraintsFeature) {
+			setFormatNum(6)
+		}
 	})
 	if err != nil {
 		return 0, err
@@ -217,6 +220,9 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 		}
 		if rule.feature(altAttrMatcherFeature) {
 			setFormatNum(5)
+		}
+		if rule.feature(publisherIDConstraintsFeature) {
+			setFormatNum(6)
 		}
 	})
 	if err != nil {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -714,6 +714,26 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(fmtnum, Equals, 5)
 	}
+
+	for _, cstr := range []string{"$PLUG_PUBLISHER_ID", "$SLOT_PUBLISHER_ID"} {
+		for _, sidePrefix := range []string{"plug", "slot"} {
+			headers = map[string]interface{}{
+				sidePrefix + "s": map[string]interface{}{
+					"interface6": map[string]interface{}{
+						"allow-auto-connection": map[string]interface{}{
+							sidePrefix + "-attributes": map[string]interface{}{
+								"x": cstr,
+							},
+						},
+					},
+				},
+			}
+
+			fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+			c.Assert(err, IsNil)
+			c.Check(fmtnum, Equals, 6)
+		}
+	}
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -123,8 +123,8 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := checkID("snap id", connc.slotSnapID(), constraints.SlotSnapIDs, nil); err != nil {
 		return err
 	}
-	err := checkID("publisher id", connc.slotPublisherID(), constraints.SlotPublisherIDs, map[string]string{
-		"$PLUG_PUBLISHER_ID": connc.plugPublisherID(),
+	err := checkID("publisher id", connc.SlotPublisherID(), constraints.SlotPublisherIDs, map[string]string{
+		"$PLUG_PUBLISHER_ID": connc.PlugPublisherID(),
 	})
 	if err != nil {
 		return err
@@ -176,8 +176,8 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := checkID("snap id", connc.plugSnapID(), constraints.PlugSnapIDs, nil); err != nil {
 		return err
 	}
-	err := checkID("publisher id", connc.plugPublisherID(), constraints.PlugPublisherIDs, map[string]string{
-		"$SLOT_PUBLISHER_ID": connc.slotPublisherID(),
+	err := checkID("publisher id", connc.PlugPublisherID(), constraints.PlugPublisherIDs, map[string]string{
+		"$SLOT_PUBLISHER_ID": connc.SlotPublisherID(),
 	})
 	if err != nil {
 		return err

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -169,14 +169,14 @@ func (connc *ConnectCandidate) slotSnapID() string {
 	return "" // never a valid snap-id
 }
 
-func (connc *ConnectCandidate) plugPublisherID() string {
+func (connc *ConnectCandidate) PlugPublisherID() string {
 	if connc.PlugSnapDeclaration != nil {
 		return connc.PlugSnapDeclaration.PublisherID()
 	}
 	return "" // never a valid publisher-id
 }
 
-func (connc *ConnectCandidate) slotPublisherID() string {
+func (connc *ConnectCandidate) SlotPublisherID() string {
 	if connc.SlotSnapDeclaration != nil {
 		return connc.SlotSnapDeclaration.PublisherID()
 	}


### PR DESCRIPTION
Allow plugs to specify the $PLUG_PUBLISHER_ID reference in attribute constraints such that interfaces can restrict auto-connection to when certain attributes match their publisher IDs.