### PR TITLE
 many: add Provenance field to ComponentInfo

### DIFF
--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -444,7 +444,7 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 		return snap.NewComponentInfo(
 			expectedCompSideInfo.Component,
 			snap.TestComponent,
-			"1.0", "", "", nil,
+			"1.0", "", "", "", nil,
 		), nil
 	})()
 

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -315,7 +315,7 @@ func (s *snapAppSetSuite) TestInstanceName(c *C) {
 func (s *snapAppSetSuite) TestNewAppSetWithWrongComponent(c *C) {
 	info := snaptest.MockInfo(c, yaml, nil)
 	_, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{
-		snap.NewComponentInfo(naming.NewComponentRef("other-name", "comp"), snap.TestComponent, "", "", "", nil),
+		snap.NewComponentInfo(naming.NewComponentRef("other-name", "comp"), snap.TestComponent, "", "", "", "", nil),
 	})
 	c.Assert(err, ErrorMatches, `internal error: snap "test-snap" does not own component "other-name\+comp"`)
 }

--- a/snap/component.go
+++ b/snap/component.go
@@ -29,11 +29,12 @@ import (
 
 // ComponentInfo contains information about a snap component.
 type ComponentInfo struct {
-	Component   naming.ComponentRef `yaml:"component"`
-	Type        ComponentType       `yaml:"type"`
-	Version     string              `yaml:"version"`
-	Summary     string              `yaml:"summary"`
-	Description string              `yaml:"description"`
+	Component           naming.ComponentRef `yaml:"component"`
+	Type                ComponentType       `yaml:"type"`
+	Version             string              `yaml:"version"`
+	Summary             string              `yaml:"summary"`
+	Description         string              `yaml:"description"`
+	ComponentProvenance string              `yaml:"provenance,omitempty"`
 
 	// Hooks contains information about implicit and explicit hooks that this
 	// component has. This information is derived from a combination of the
@@ -47,19 +48,30 @@ type ComponentInfo struct {
 	ComponentSideInfo
 }
 
+// Provenance returns the provenance of the component. This returns
+// naming.DefaultProvenance if no value is set explicitly in the component
+// metadata.
+func (ci *ComponentInfo) Provenance() string {
+	if ci.ComponentProvenance == "" {
+		return naming.DefaultProvenance
+	}
+	return ci.ComponentProvenance
+}
+
 // NewComponentInfo creates a new ComponentInfo.
-func NewComponentInfo(cref naming.ComponentRef, ctype ComponentType, version, summary, description string, csi *ComponentSideInfo) *ComponentInfo {
+func NewComponentInfo(cref naming.ComponentRef, ctype ComponentType, version, summary, description, provenance string, csi *ComponentSideInfo) *ComponentInfo {
 	if csi == nil {
 		csi = &ComponentSideInfo{}
 	}
 
 	return &ComponentInfo{
-		Component:         cref,
-		Type:              ctype,
-		Version:           version,
-		Summary:           summary,
-		Description:       description,
-		ComponentSideInfo: *csi,
+		Component:           cref,
+		Type:                ctype,
+		Version:             version,
+		Summary:             summary,
+		Description:         description,
+		ComponentProvenance: provenance,
+		ComponentSideInfo:   *csi,
 	}
 }
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -309,5 +309,8 @@ func (ci *ComponentInfo) validate() error {
 	if err := ValidateDescription(ci.Description); err != nil {
 		return err
 	}
+	if err := validateProvenance(ci.ComponentProvenance); err != nil {
+		return err
+	}
 	return nil
 }

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -195,6 +195,21 @@ version: 1.0
 	c.Assert(ci, IsNil)
 }
 
+func (s *componentSuite) TestReadComponentBadProvenance(c *C) {
+	const componentYaml = `component: mysnap+extra
+type: test
+version: 1.0
+provenance: invalid-prov-
+`
+	testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap+extra.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadComponentInfoFromContainer(compf, nil, nil)
+	c.Assert(err.Error(), Equals, `invalid provenance: "invalid-prov-"`)
+}
+
 func (s *componentSuite) TestReadComponentVersion(c *C) {
 	const componentYamlTmpl = `component: snap+comp
 type: test

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -55,6 +55,7 @@ type: test
 version: 1.0
 summary: short description
 description: long description
+provenance: prov
 `
 	compName := "mysnap+test-info"
 	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
@@ -70,9 +71,11 @@ description: long description
 		"1.0",
 		"short description",
 		"long description",
+		"prov",
 		nil,
 	))
 	c.Assert(ci.FullName(), Equals, compName)
+	c.Assert(ci.Provenance(), Equals, "prov")
 
 	// since we didn't pass a side info, then ComponentSideInfo should be empty
 	c.Assert(ci.ComponentSideInfo, Equals, snap.ComponentSideInfo{})
@@ -98,9 +101,10 @@ version: 1.0.2
 		naming.NewComponentRef("mysnap", "test-info"),
 		snap.ComponentType("test"),
 		"1.0.2",
-		"", "", nil,
+		"", "", "", nil,
 	))
 	c.Assert(ci.FullName(), Equals, compName)
+	c.Assert(ci.Provenance(), Equals, naming.DefaultProvenance)
 }
 
 func (s *componentSuite) TestReadComponentInfoFromFileBadName(c *C) {


### PR DESCRIPTION
Add a `Provenance` to `snap.ComponentInfo`. This allows `snap pack` to work with components that define a provenance in their `component.yaml` file.