### PR TITLE
cmd/libsnap-confine-private: add snap mount dir detection

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -68,6 +68,9 @@ new_format = \
 	 libsnap-confine-private/panic-test.h \
 	 libsnap-confine-private/panic.c \
 	 libsnap-confine-private/panic.h \
+	 libsnap-confine-private/snap-dir-test.c \
+	 libsnap-confine-private/snap-dir.c \
+	 libsnap-confine-private/snap-dir.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
 	 snap-confine/selinux-support.c \
@@ -152,6 +155,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/privs.h \
 	libsnap-confine-private/secure-getenv.c \
 	libsnap-confine-private/secure-getenv.h \
+	libsnap-confine-private/snap-dir.c \
+	libsnap-confine-private/snap-dir.h \
 	libsnap-confine-private/snap.c \
 	libsnap-confine-private/snap.h \
 	libsnap-confine-private/string-utils.c \
@@ -187,6 +192,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/panic-test.c \
 	libsnap-confine-private/privs-test.c \
 	libsnap-confine-private/secure-getenv-test.c \
+	libsnap-confine-private/snap-dir-test.c \
 	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/string-utils-test.c \
 	libsnap-confine-private/test-utils-test.c \

--- a/cmd/libsnap-confine-private/snap-dir-test.c
+++ b/cmd/libsnap-confine-private/snap-dir-test.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "snap-dir.h"
+#include "snap-dir.c"
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "test-utils.h"  // For rm_rf_tmp
+
+// For compatibility with g_test_queue_destroy.
+static void close_noerr(uintptr_t fd) { (void)close((int)fd); }
+
+static void test_sc_probe_snap_mount_dir__absent(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+
+    sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
+    const char *snap_mount_dir = sc_snap_mount_dir(NULL);
+    g_assert_nonnull(snap_mount_dir);
+    g_assert_cmpstr(snap_mount_dir, ==, "/var/lib/snapd/snap");
+}
+
+static void test_sc_probe_snap_mount_dir__preferred(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+
+    char *proc_snap_dir = g_build_filename(root_dir, "/proc/1/root/snap", NULL);
+    g_test_queue_free(proc_snap_dir);
+    int ret = g_mkdir_with_parents(proc_snap_dir, 0755);
+    g_assert_cmpint(ret, ==, 0);
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+
+    sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
+    const char *snap_mount_dir = sc_snap_mount_dir(NULL);
+    g_assert_nonnull(snap_mount_dir);
+    g_assert_cmpstr(snap_mount_dir, ==, "/snap");
+}
+
+static void test_sc_probe_snap_mount_dir__fallback(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+
+    char *proc_root_dir = g_build_filename(root_dir, "/proc/1/root/", NULL);
+    g_test_queue_free(proc_root_dir);
+    int ret = g_mkdir_with_parents(proc_root_dir, 0755);
+    g_assert_cmpint(ret, ==, 0);
+
+    char *proc_snap_symlink = g_build_filename(proc_root_dir, "snap", NULL);
+    g_test_queue_free(proc_snap_symlink);
+    ret = symlink("/var/lib/snapd/snap", proc_snap_symlink);
+    g_assert_cmpint(ret, ==, 0);
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+
+    sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
+    const char *snap_mount_dir = sc_snap_mount_dir(NULL);
+    g_assert_nonnull(snap_mount_dir);
+    g_assert_cmpstr(snap_mount_dir, ==, "/var/lib/snapd/snap");
+}
+
+static void test_sc_probe_snap_mount_dir__bad_symlink_target(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+
+    char *proc_root_dir = g_build_filename(root_dir, "/proc/1/root/", NULL);
+    g_test_queue_free(proc_root_dir);
+    int ret = g_mkdir_with_parents(proc_root_dir, 0755);
+    g_assert_cmpint(ret, ==, 0);
+
+    char *proc_snap_symlink = g_build_filename(proc_root_dir, "snap", NULL);
+    g_test_queue_free(proc_snap_symlink);
+    ret = symlink("/potato", proc_snap_symlink);
+    g_assert_cmpint(ret, ==, 0);
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+
+    struct sc_error *err = NULL;
+    (void)sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, &err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_SNAP_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, SC_SNAP_MOUNT_DIR_UNSUPPORTED);
+    g_assert_cmpstr(sc_error_msg(err), ==, "/snap must be a symbolic link to /var/lib/snapd/snap");
+}
+
+static void test_sc_snap_mount_dir__not_probed(void) {
+    _snap_mount_dir = NULL;
+
+    struct sc_error *err = NULL;
+    const char *snap_mount_dir = sc_snap_mount_dir(&err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
+    g_assert_null(snap_mount_dir);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
+    g_assert_cmpstr(sc_error_msg(err), ==, "sc_probe_snap_mount_dir_from_pid_1_mount_ns was not called yet");
+}
+
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/snap-dir/probe-absent", test_sc_probe_snap_mount_dir__absent);
+    g_test_add_func("/snap-dir/probe-preferred", test_sc_probe_snap_mount_dir__preferred);
+    g_test_add_func("/snap-dir/probe-fallback", test_sc_probe_snap_mount_dir__fallback);
+    g_test_add_func("/snap-dir/probe-bad-symlink-target", test_sc_probe_snap_mount_dir__bad_symlink_target);
+    g_test_add_func("/snap-dir/dir-not-probed", test_sc_snap_mount_dir__not_probed);
+}

--- a/cmd/libsnap-confine-private/snap-dir.c
+++ b/cmd/libsnap-confine-private/snap-dir.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "snap-dir.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "snap.h"  // For SC_SNAP_MOUNT_DIR_UNSUPPORTED
+
+static const char *_snap_mount_dir = NULL;
+
+const char *sc_snap_mount_dir(sc_error **errorp) {
+    sc_error *err = NULL;
+
+    if (_snap_mount_dir == NULL) {
+        err = sc_error_init_api_misuse("sc_probe_snap_mount_dir_from_pid_1_mount_ns was not called yet");
+    }
+
+    sc_error_forward(errorp, err);
+    return _snap_mount_dir;
+}
+
+void sc_probe_snap_mount_dir_from_pid_1_mount_ns(int root_fd, sc_error **errorp) {
+    char target[PATH_MAX] = {0};
+    struct stat sb;
+    ssize_t n = 0;
+    sc_error *err = NULL;
+
+    const char *const probe_dir =
+        /* Depending on the value of the root_fd descriptor, the probe path is either absolute or relative.*/
+        root_fd == AT_FDCWD
+            /* If we are given the special AT_FDCWD descriptor then probe the path "/proc/1/root/snap". */
+            ? "/proc/1/root" SC_CANONICAL_SNAP_MOUNT_DIR
+            /* If we are given any other descriptor the probe a relative path "proc/1/root/snap",
+             * which is relative to root_fd. */
+            : "proc/1/root" SC_CANONICAL_SNAP_MOUNT_DIR;
+
+    // If /snap does not exist, then we assume the fallback directory is used.
+    if (fstatat(root_fd, probe_dir, &sb, AT_SYMLINK_NOFOLLOW) != 0) {
+        if (errno != ENOENT) {
+            err = sc_error_init_from_errno(errno, "cannot fstatat canonical snap directory");
+            goto out;
+        }
+
+        _snap_mount_dir = SC_ALTERNATE_SNAP_MOUNT_DIR;
+        return;
+    }
+
+    // If /snap exists it must be either a directory or a symbolic link.
+    switch (sb.st_mode & S_IFMT) {
+        case S_IFDIR:
+            _snap_mount_dir = SC_CANONICAL_SNAP_MOUNT_DIR;
+            break;
+
+        case S_IFLNK:
+            // If /snap exits and is a symbolic link it must point to the fallback directory.
+            n = readlinkat(root_fd, probe_dir, target, sizeof target);
+            if (n < 0 || n == sizeof(target)) {
+                err = sc_error_init_from_errno(errno, "cannot readlinkat canonical snap directory");
+                goto out;
+            }
+
+            if (strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR, n) != 0) {
+                err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_MOUNT_DIR_UNSUPPORTED,
+                                    SC_CANONICAL_SNAP_MOUNT_DIR
+                                    " must be a symbolic link to " SC_ALTERNATE_SNAP_MOUNT_DIR);
+                goto out;
+            }
+
+            _snap_mount_dir = SC_ALTERNATE_SNAP_MOUNT_DIR;
+            break;
+
+        default:
+            err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_MOUNT_DIR_UNSUPPORTED,
+                                SC_CANONICAL_SNAP_MOUNT_DIR
+                                " must be a directory or a symbolic link to " SC_ALTERNATE_SNAP_MOUNT_DIR);
+            goto out;
+            break;
+    }
+
+out:
+    sc_error_forward(errorp, err);
+}

--- a/cmd/libsnap-confine-private/snap-dir.h
+++ b/cmd/libsnap-confine-private/snap-dir.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_SNAP_DIR_H
+#define SNAP_CONFINE_SNAP_DIR_H
+
+#include "error.h"
+
+/**
+ * Canonical location of the mount tree where snaps are visible on the system or
+ * the location of the symbolic link to the fallback location.
+ **/
+#define SC_CANONICAL_SNAP_MOUNT_DIR "/snap"
+
+/**
+ * Alternate location of the mount tree where snaps are visible on the system.
+ * Used if distribution policy disallows the use of the preferred location.
+ **/
+#define SC_ALTERNATE_SNAP_MOUNT_DIR "/var/lib/snapd/snap"
+
+/**
+ * Return the value probed by sc_probe_snap_mount_dir_from_pid_1_mount_ns.
+ *
+ * The function fails if the directory was not probed yet.
+ *
+ * The error protocol is observed so if the caller doesn't provide an outgoing
+ * error pointer the function will die on any error.
+ **/
+const char *sc_snap_mount_dir(sc_error **errorp);
+
+/**
+ * Probe the system to decide which of the two possible mount locations to use.
+ *
+ * The function is safe to call from the any mount namespace. The function
+ * internally stores the value later returned by sc_snap_mount_dir(), making the
+ * result stable during each execution.
+ *
+ * The root_fd argument is either an AT_FDCWD or a descriptor to a O_PATH
+ * representing an alternative root directory during tests.
+ *
+ * The error protocol is observed so if the caller doesn't provide an outgoing
+ * error pointer the function will die on any error.
+ **/
+void sc_probe_snap_mount_dir_from_pid_1_mount_ns(int root_fd, sc_error **errorp);
+
+#endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -35,6 +35,8 @@ enum {
 	SC_SNAP_INVALID_INSTANCE_KEY = 2,
 	/** The instance of the snap is not valid. */
 	SC_SNAP_INVALID_INSTANCE_NAME = 3,
+	/** System configuration is not supported. */
+	SC_SNAP_MOUNT_DIR_UNSUPPORTED = 4,
 };
 
 /* SNAP_NAME_LEN is the maximum length of a snap name, enforced by snapd and the


### PR DESCRIPTION
Add a pair of functions to probe, memoize and return the value of snap mount directory. The premise is to look at /snap in the initial mount namespace and depending on its absence or presence and type, and if it is a symbolic link, link target, either pick /snap, /var/lib/snapd/snap or die.

Jira: SNAPDENG-22335
Spec: SD-179
