### PR TITLE
o/snapstate: implement download-component handler

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -181,7 +181,7 @@ type fakeStore struct {
 	state           *state.State
 	seenPrivacyKeys map[string]bool
 
-	// snapResources is called for each snap that gets returned by SnapAction,
+	// snapResourcesFn is called for each snap that gets returned by SnapAction,
 	// it should return the resources that the snap should have.
 	snapResourcesFn func(*snap.Info) []store.SnapResourceResult
 

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -153,12 +153,9 @@ func (m *SnapManager) doDownloadComponent(t *state.Task, tomb *tomb.Tomb) error 
 		return err
 	}
 
-	// TODO: actually get the user ID here, like in doDownloadSnap, and do
-	// something with it. this will require some plumbing
-	const userID = 0
-	user, err := userFromUserID(st, userID)
+	user, err := userFromUserID(st, snapsup.UserID)
 	if err != nil {
-		return fmt.Errorf("cannot get user for user ID %d: %w", userID, err)
+		return fmt.Errorf("cannot get user for user ID %d: %w", snapsup.UserID, err)
 	}
 
 	var rate int64

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -179,18 +179,13 @@ func (m *SnapManager) doDownloadComponent(t *state.Task, tomb *tomb.Tomb) error 
 
 	st.Unlock()
 	timings.Run(perf, "download", fmt.Sprintf("download component %q", compsup.ComponentName()), func(timings.Measurer) {
-		err = sto.Download(
-			tomb.Context(nil),
-			compsup.CompSideInfo.Component.String(),
-			target,
-			compsup.DownloadInfo,
-			meter,
-			user,
-			&store.DownloadOptions{
-				Scheduled: snapsup.IsAutoRefresh,
-				RateLimit: rate,
-			},
-		)
+		compRef := compsup.CompSideInfo.Component.String()
+		opts := &store.DownloadOptions{
+			Scheduled: snapsup.IsAutoRefresh,
+			RateLimit: rate,
+		}
+
+		err = sto.Download(tomb.Context(nil), compRef, target, compsup.DownloadInfo, meter, user, opts)
 	})
 	st.Lock()
 	if err != nil {

--- a/overlord/snapstate/handlers_components_download_test.go
+++ b/overlord/snapstate/handlers_components_download_test.go
@@ -1,15 +1,21 @@
 package snapstate_test
 
 import (
+	"context"
+	"errors"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
 
 	. "gopkg.in/check.v1"
 )
@@ -91,7 +97,8 @@ func (s *downloadComponentSuite) TestDoDownloadComponentNormal(c *C) {
 	expectedPath := filepath.Join(dirs.SnapBlobDir, "snap_key+comp_11.comp")
 
 	var compsup snapstate.ComponentSetup
-	t.Get("component-setup", &compsup)
+	err := t.Get("component-setup", &compsup)
+	c.Assert(err, IsNil)
 	c.Check(compsup.CompPath, Equals, expectedPath)
 	c.Check(t.Status(), Equals, state.DoneStatus)
 
@@ -101,4 +108,65 @@ func (s *downloadComponentSuite) TestDoDownloadComponentNormal(c *C) {
 			target: expectedPath,
 		},
 	})
+}
+
+type downloadErrorStore struct {
+	storetest.Store
+}
+
+func (*downloadErrorStore) Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, *store.DownloadOptions) error {
+	return errors.New("download failed")
+}
+
+func (s *downloadComponentSuite) TestDoDownloadComponentFailure(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.ReplaceStore(s.state, &downloadErrorStore{})
+
+	si := &snap.SideInfo{
+		RealName: "snap",
+		SnapID:   snaptest.AssertedSnapID("snap"),
+		Revision: snap.R(11),
+		Channel:  "latest/stable",
+	}
+
+	t := s.state.NewTask("download-component", "...")
+
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo:    si,
+		InstanceKey: "key",
+	})
+
+	t.Set("component-setup", &snapstate.ComponentSetup{
+		CompSideInfo: snap.NewComponentSideInfo(
+			naming.NewComponentRef("snap", "comp"),
+			snap.R(11),
+		),
+		CompType: snap.TestComponent,
+		DownloadInfo: &snap.DownloadInfo{
+			DownloadURL: "http://some-url.com/comp",
+		},
+	})
+
+	chg := s.state.NewChange("download", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot download component "comp": download failed.*`)
+
+	// only the download endpoint of the store was hit
+	c.Check(s.fakeBackend.ops, HasLen, 0)
+
+	// make sure we didn't set a path on the component setup
+	var compsup snapstate.ComponentSetup
+	err := t.Get("component-setup", &compsup)
+	c.Assert(err, IsNil)
+	c.Check(compsup.CompPath, Equals, "")
 }

--- a/overlord/snapstate/handlers_components_download_test.go
+++ b/overlord/snapstate/handlers_components_download_test.go
@@ -1,0 +1,104 @@
+package snapstate_test
+
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snaptest"
+
+	. "gopkg.in/check.v1"
+)
+
+type downloadComponentSuite struct {
+	baseHandlerSuite
+
+	fakeStore *fakeStore
+}
+
+var _ = Suite(&downloadComponentSuite{})
+
+func (s *downloadComponentSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+
+	s.fakeStore = &fakeStore{
+		state:       s.state,
+		fakeBackend: s.fakeBackend,
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.AddCleanup(snapstatetest.UseFallbackDeviceModel())
+
+	snapstate.ReplaceStore(s.state, s.fakeStore)
+	s.state.Set("refresh-privacy-key", "privacy-key")
+}
+
+func (s *downloadComponentSuite) TestDoDownloadComponentNormal(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{
+		RealName: "snap",
+		SnapID:   snaptest.AssertedSnapID("snap"),
+		Revision: snap.R(11),
+		Channel:  "latest/stable",
+	}
+
+	t := s.state.NewTask("download-component", "...")
+
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo:    si,
+		InstanceKey: "key",
+	})
+
+	t.Set("component-setup", &snapstate.ComponentSetup{
+		CompSideInfo: snap.NewComponentSideInfo(
+			naming.NewComponentRef("snap", "comp"),
+			snap.R(11),
+		),
+		CompType: snap.TestComponent,
+		DownloadInfo: &snap.DownloadInfo{
+			DownloadURL: "http://some-url.com/comp",
+		},
+	})
+
+	chg := s.state.NewChange("download", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+
+	c.Assert(chg.Err(), IsNil)
+
+	// only the download endpoint of the store was hit
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op:   "storesvc-download",
+			name: "snap+comp",
+		},
+	})
+
+	expectedPath := filepath.Join(dirs.SnapBlobDir, "snap_key+comp_11.comp")
+
+	var compsup snapstate.ComponentSetup
+	t.Get("component-setup", &compsup)
+	c.Check(compsup.CompPath, Equals, expectedPath)
+	c.Check(t.Status(), Equals, state.DoneStatus)
+
+	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
+		{
+			name:   "snap+comp",
+			target: expectedPath,
+		},
+	})
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -194,9 +194,10 @@ type ComponentSetup struct {
 	// CompSideInfo for metadata not coming from the component
 	CompSideInfo *snap.ComponentSideInfo `json:"comp-side-info,omitempty"`
 	// CompType is needed as some types need special handling
-	CompType snap.ComponentType
-	// CompPath is the path to the file. Will be an empty string if the
-	// component should be downloaded from the store.
+	CompType snap.ComponentType `json:"comp-type,omitempty"`
+	// CompPath is the path to the component that will be mounted on the system.
+	// It may be empty if the component is not yet present on the system (i.e.,
+	// needs to be downloaded).
 	CompPath string `json:"comp-path,omitempty"`
 	// DownloadInfo contains information about how to download this component.
 	// Will be nil if the component should be sourced from a local file.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -769,8 +769,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("pre-download-snap", m.doPreDownloadSnap, nil)
 
 	// component tasks
-	runner.AddHandler("prepare-component", m.doPrepareComponent, nil)   // TODO: add undo?
-	runner.AddHandler("download-component", m.doDownloadComponent, nil) // TODO: add undo?
+	runner.AddHandler("prepare-component", m.doPrepareComponent, nil)
+	runner.AddHandler("download-component", m.doDownloadComponent, nil)
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)
 	runner.AddHandler("link-component", m.doLinkComponent, m.undoLinkComponent)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -195,8 +195,12 @@ type ComponentSetup struct {
 	CompSideInfo *snap.ComponentSideInfo `json:"comp-side-info,omitempty"`
 	// CompType is needed as some types need special handling
 	CompType snap.ComponentType
-	// CompPath is the path to the file
+	// CompPath is the path to the file. Will be an empty string if the
+	// component should be downloaded from the store.
 	CompPath string `json:"comp-path,omitempty"`
+	// DownloadInfo contains information about how to download this component.
+	// Will be nil if the component should be sourced from a local file.
+	DownloadInfo *snap.DownloadInfo `json:"download-info,omitempty"`
 }
 
 func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType, compPath string) *ComponentSetup {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -768,7 +768,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("pre-download-snap", m.doPreDownloadSnap, nil)
 
 	// component tasks
-	runner.AddHandler("prepare-component", m.doPrepareComponent, nil)
+	runner.AddHandler("prepare-component", m.doPrepareComponent, nil)   // TODO: add undo?
+	runner.AddHandler("download-component", m.doDownloadComponent, nil) // TODO: add undo?
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)
 	runner.AddHandler("link-component", m.doLinkComponent, m.undoLinkComponent)


### PR DESCRIPTION
Implement a task handler for downloading components from the store. Will be used in subsequent PRs for installing components and snaps from the store at the same time.