### PR TITLE
snapcraft, github: build a FIPS variant of the snap in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,12 +22,35 @@ concurrency:
 jobs:
   snap-builds:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        toolchain:
+          - default
+          - FIPS
     # only build the snap for pull requests, it's not needed on release branches
     # or on master since we have launchpad build recipes which do this already
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+
+    - name: Select Go toolchain
+      run: |
+        case "${{ matrix.toolchain }}" in
+            default)
+                ;;
+            FIPS)
+                sed -i -e \
+                's|- go/\(.*\)/stable # XXX Go toolchain|- go/\1-fips/stable # toolchain channel patched|' \
+                build-aux/snap/snapcraft.yaml
+                # this should be true now
+                grep '# toolchain channel patched' build-aux/snap/snapcraft.yaml
+                ;;
+            *)
+                echo "unknown toolchain ${{ matrix.toolchain }}"
+                exit 1
+                ;;
+        esac
 
     - name: Build snapd snap
       uses: snapcore/action-build@v1
@@ -51,7 +74,7 @@ jobs:
     - name: Uploading snapd snap artifact
       uses: actions/upload-artifact@v3
       with:
-        name: snap-files
+        name: snap-files-${{ matrix.toolchain }}
         path: "*.snap"
 
   cache-build-deps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,13 +38,10 @@ jobs:
       run: |
         case "${{ matrix.toolchain }}" in
             default)
+                rm -f fips-build
                 ;;
             FIPS)
-                sed -i -e \
-                's|- go/\(.*\)/stable # XXX Go toolchain|- go/\1-fips/stable # toolchain channel patched|' \
-                build-aux/snap/snapcraft.yaml
-                # this should be true now
-                grep '# toolchain channel patched' build-aux/snap/snapcraft.yaml
+                touch fips-build
                 ;;
             *)
                 echo "unknown toolchain ${{ matrix.toolchain }}"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -189,7 +189,7 @@ parts:
     plugin: nil
     source: .
     build-snaps:
-      - go/1.18/stable
+      - go/1.18/stable # the default Go toolchain
     after:
       - apparmor
     build-packages:
@@ -206,12 +206,31 @@ parts:
     override-pull: |
       craftctl default
       # set version, this needs dpkg-parsechangelog (from dpkg-dev) and git
-      craftctl set version="$(./mkversion.sh --output-only)"
+      VERSION="$(./mkversion.sh --output-only)"
+      if [ -f fips-build ] ; then
+          echo "-- appending FIPS tag to version $VERSION"
+          VERSION="$VERSION-fips"
+      fi
+      craftctl set version="$VERSION"
+
       ./get-deps.sh --skip-unused-check
     override-build: |
-      echo "--- go is at $(which go)"
+      # this should be passed through build environment, but we're already
+      # anchoring dynamic linker env variables
+      GO_TOOLCHAIN_FIPS_CHANNEL="1.18-fips/stable"
+
+      VERSION="$(craftctl get version)"
+      if [ -f fips-build ] ; then
+          # use the fips channel of Go
+          snap refresh --channel "$GO_TOOLCHAIN_FIPS_CHANNEL" go
+      fi
+      # make sure to set the version we declared in pull
+      ./mkversion.sh "$VERSION"
+
+      # double check the toolchain
       echo "--- go version $(go version)"
-      ./mkversion.sh
+      echo "--- go is at $(which go)"
+
       cd "${CRAFT_PART_BUILD}/cmd"
 
       autoreconf -fvi
@@ -226,8 +245,6 @@ parts:
       #  * When building in a git worktree, snapcraft does not share
       #    the main directory, and it fails.
       EXTRA_GO_FLAGS="-buildvcs=false"
-
-      VERSION="$(craftctl get version)"
 
       CMDS=(bin/snap
             lib/snapd/snapd
@@ -263,9 +280,14 @@ parts:
              ;;
         esac
 
+        TAGS=()
+
+        # general build tags, note that version 1337 is used only in CI and
+        # triggers testing specific build tags which produce binaries that are
+        # insecure for use in production systems
         case "${cmd}" in
           bin/snap)
-            TAGS=(nomanagers)
+            TAGS+=(nomanagers)
             case "${VERSION}" in
               1337.*)
                 TAGS+=(withtestkeys faultinject)
@@ -273,7 +295,6 @@ parts:
             esac
             ;;
           *)
-            TAGS=()
             case "${VERSION}" in
               1337.*)
                 TAGS+=(withtestkeys withbootassetstesting faultinject)
@@ -281,6 +302,18 @@ parts:
             esac
             ;;
         esac
+
+        # FIPS specific build tags
+        if [ -f fips-build ]; then
+          case "${cmd}" in
+            # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
+            # snap, snap-repair and snap-bootstrap (where snap-bootstrap isn't
+            # part of the snapd snap)
+            bin/snap|lib/snapd/snapd|lib/snapd/snap-repair)
+              TAGS+=(goexperiment.opensslcrypto requirefips)
+              ;;
+          esac
+        fi
 
         output="${CRAFT_PART_INSTALL}/usr/${cmd}"
         go build -mod=vendor -tags "${TAGS[*]}" "${GO_LD_FLAGS[@]}" ${EXTRA_GO_FLAGS-} -o "${output}" "github.com/snapcore/snapd/cmd/$(basename ${cmd})"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -209,6 +209,8 @@ parts:
       craftctl set version="$(./mkversion.sh --output-only)"
       ./get-deps.sh --skip-unused-check
     override-build: |
+      echo "--- go is at $(which go)"
+      echo "--- go version $(go version)"
       ./mkversion.sh
       cd "${CRAFT_PART_BUILD}/cmd"
 

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -86,6 +86,7 @@ parts:
       - libbrotli1
       - libc6
       - libcap2
+      - libssl3
       - libexpat1
       - libfreetype6
       - libgcc-s1


### PR DESCRIPTION
The branch adds support for building a FIPS variant of the snapd snap for the purpose of simply exercising that code in the github CI. The relevant patches were extracted from #13978. Note that we do not currently run any tests with that snap, nor use it for any other purpose than just having the build run and have the built snap available for download as artifact.