### PR TITLE
cmd/snap-confine: switch to dynamic SNAP_MOUNT_DIR

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -3,3 +3,4 @@ ignore_files:
   - packaging/ubuntu-16.04/changelog
   - packaging/debian-sid/changelog
   - packaging/fedora/snapd.spec
+  - cmd/snap-confine/snap-confine.apparmor.in

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -454,6 +454,7 @@ snap_device_helper_unit_tests_SOURCES = \
 	libsnap-confine-private/cleanup-funcs.c \
 	libsnap-confine-private/panic.c \
 	libsnap-confine-private/snap.c \
+	libsnap-confine-private/snap-dir.c \
 	libsnap-confine-private/error.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -384,7 +384,7 @@ if HAVE_RST2MAN
 endif
 
 snap-confine/snap-confine.apparmor: snap-confine/snap-confine.apparmor.in Makefile
-	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),g' <$< >$@
+	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' <$< >$@
 
 # Install the apparmor profile
 #

--- a/cmd/libsnap-confine-private/snap-dir-test.c
+++ b/cmd/libsnap-confine-private/snap-dir-test.c
@@ -42,7 +42,7 @@ static void test_sc_probe_snap_mount_dir__absent(void) {
     g_assert_cmpstr(snap_mount_dir, ==, "/var/lib/snapd/snap");
 }
 
-static void test_sc_probe_snap_mount_dir__preferred(void) {
+static void test_sc_probe_snap_mount_dir__canonical(void) {
     char *root_dir = g_dir_make_tmp(NULL, NULL);
     g_assert_nonnull(root_dir);
     g_test_queue_free(root_dir);
@@ -63,7 +63,7 @@ static void test_sc_probe_snap_mount_dir__preferred(void) {
     g_assert_cmpstr(snap_mount_dir, ==, "/snap");
 }
 
-static void test_sc_probe_snap_mount_dir__fallback(void) {
+static void test_sc_probe_snap_mount_dir__alternate_absolute(void) {
     char *root_dir = g_dir_make_tmp(NULL, NULL);
     g_assert_nonnull(root_dir);
     g_test_queue_free(root_dir);
@@ -77,6 +77,32 @@ static void test_sc_probe_snap_mount_dir__fallback(void) {
     char *proc_snap_symlink = g_build_filename(proc_root_dir, "snap", NULL);
     g_test_queue_free(proc_snap_symlink);
     ret = symlink("/var/lib/snapd/snap", proc_snap_symlink);
+    g_assert_cmpint(ret, ==, 0);
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+
+    sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
+    const char *snap_mount_dir = sc_snap_mount_dir(NULL);
+    g_assert_nonnull(snap_mount_dir);
+    g_assert_cmpstr(snap_mount_dir, ==, "/var/lib/snapd/snap");
+}
+
+static void test_sc_probe_snap_mount_dir__alternate_relative(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+
+    char *proc_root_dir = g_build_filename(root_dir, "/proc/1/root/", NULL);
+    g_test_queue_free(proc_root_dir);
+    int ret = g_mkdir_with_parents(proc_root_dir, 0755);
+    g_assert_cmpint(ret, ==, 0);
+
+    char *proc_snap_symlink = g_build_filename(proc_root_dir, "snap", NULL);
+    g_test_queue_free(proc_snap_symlink);
+    ret = symlink("var/lib/snapd/snap", proc_snap_symlink);
     g_assert_cmpint(ret, ==, 0);
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
@@ -131,8 +157,9 @@ static void test_sc_snap_mount_dir__not_probed(void) {
 
 static void __attribute__((constructor)) init(void) {
     g_test_add_func("/snap-dir/probe-absent", test_sc_probe_snap_mount_dir__absent);
-    g_test_add_func("/snap-dir/probe-preferred", test_sc_probe_snap_mount_dir__preferred);
-    g_test_add_func("/snap-dir/probe-fallback", test_sc_probe_snap_mount_dir__fallback);
+    g_test_add_func("/snap-dir/probe-canonical", test_sc_probe_snap_mount_dir__canonical);
+    g_test_add_func("/snap-dir/probe-alternate-absolute", test_sc_probe_snap_mount_dir__alternate_absolute);
+    g_test_add_func("/snap-dir/probe-alternate-relative", test_sc_probe_snap_mount_dir__alternate_relative);
     g_test_add_func("/snap-dir/probe-bad-symlink-target", test_sc_probe_snap_mount_dir__bad_symlink_target);
     g_test_add_func("/snap-dir/dir-not-probed", test_sc_snap_mount_dir__not_probed);
 }

--- a/cmd/libsnap-confine-private/snap-dir.c
+++ b/cmd/libsnap-confine-private/snap-dir.c
@@ -87,7 +87,8 @@ void sc_probe_snap_mount_dir_from_pid_1_mount_ns(int root_fd, sc_error **errorp)
                 goto out;
             }
 
-            if (strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR, n) != 0) {
+            if (strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR, n) != 0 &&
+                strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR + 1, n) != 0) {
                 err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_MOUNT_DIR_UNSUPPORTED,
                                     SC_CANONICAL_SNAP_MOUNT_DIR
                                     " must be a symbolic link to " SC_ALTERNATE_SNAP_MOUNT_DIR);

--- a/cmd/libsnap-confine-private/snap-dir.c
+++ b/cmd/libsnap-confine-private/snap-dir.c
@@ -32,6 +32,10 @@
 
 static const char *_snap_mount_dir = NULL;
 
+// Function is exported only for tests.
+void sc_set_snap_mount_dir(const char *dir);
+void sc_set_snap_mount_dir(const char *dir) { _snap_mount_dir = dir; }
+
 const char *sc_snap_mount_dir(sc_error **errorp) {
     sc_error *err = NULL;
 

--- a/cmd/libsnap-confine-private/test-utils.c
+++ b/cmd/libsnap-confine-private/test-utils.c
@@ -21,8 +21,6 @@
 #include "error.h"
 #include "utils.h"
 
-#include <glib.h>
-
 #if !GLIB_CHECK_VERSION(2, 69, 0)
 // g_spawn_check_exit_status is considered deprecated since 2.69
 #define g_spawn_check_wait_status(x, y) (g_spawn_check_exit_status (x, y))
@@ -110,4 +108,18 @@ void
 
 	*argcp = argc;
 	*argvp = argv;
+}
+
+extern void sc_set_snap_mount_dir(const char *dir);
+
+void snap_mount_dir_fixture_setup(snap_mount_dir_fixture *fix,
+				  gconstpointer user_data)
+{
+	sc_set_snap_mount_dir((const char *)user_data);
+}
+
+void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture *fix,
+				     gconstpointer user_data)
+{
+	sc_set_snap_mount_dir(NULL);
 }

--- a/cmd/libsnap-confine-private/test-utils.h
+++ b/cmd/libsnap-confine-private/test-utils.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_CONFINE_TEST_UTILS_H
 #define SNAP_CONFINE_TEST_UTILS_H
 
+#include <glib.h>
+
 /**
  * Shell-out to "rm -rf -- $dir" as long as $dir is in /tmp.
  */
@@ -28,5 +30,14 @@ void rm_rf_tmp(const char *dir);
  **/
 void
     __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...);
+
+typedef struct {
+	int unused;
+} snap_mount_dir_fixture;
+
+void snap_mount_dir_fixture_setup(snap_mount_dir_fixture * fix,
+				  gconstpointer user_data);
+void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture * fix,
+				     gconstpointer user_data);
 
 #endif

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -46,6 +46,7 @@
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/locking.h"
 #include "../libsnap-confine-private/mountinfo.h"
+#include "../libsnap-confine-private/snap-dir.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
@@ -244,9 +245,9 @@ static dev_t find_base_snap_device(const char *base_snap_name,
 	// consideration of the mie->root component.
 	dev_t base_snap_dev = 0;
 	char base_squashfs_path[PATH_MAX];
-	sc_must_snprintf(base_squashfs_path,
-			 sizeof base_squashfs_path, "%s/%s/%s",
-			 SNAP_MOUNT_DIR, base_snap_name, base_snap_rev);
+	sc_must_snprintf(base_squashfs_path, sizeof base_squashfs_path,
+			 "%s/%s/%s", sc_snap_mount_dir(NULL), base_snap_name,
+			 base_snap_rev);
 	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	mi = sc_parse_mountinfo(NULL);
 	if (mi == NULL) {

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -17,7 +17,9 @@
 
 #include "snap-confine-args.h"
 #include "snap-confine-args.c"
+
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/test-utils.h"
 
 #include <stdarg.h>
 

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -21,7 +21,6 @@
 
 #include "../libsnap-confine-private/utils.h"
 #include "../libsnap-confine-private/string-utils.h"
-#include "../libsnap-confine-private/test-utils.h"
 
 struct sc_args {
 	// The security tag that the application is intended to run with

--- a/cmd/snap-confine/snap-confine-invocation-test.c
+++ b/cmd/snap-confine/snap-confine-invocation-test.c
@@ -41,17 +41,19 @@ static struct sc_args *test_prepare_args(const char *base, const char *tag) {
     return args;
 }
 
-static void test_sc_invocation_basic(void) {
+static void test_sc_invocation_basic(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core", NULL);
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
-    ;
     sc_init_invocation(&inv, args, "foo");
+
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
+    g_test_queue_free(rootfs_dir);
 
     g_assert_cmpstr(inv.base_snap_name, ==, "core");
     g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
     g_assert_cmpstr(inv.orig_base_snap_name, ==, "core");
-    g_assert_cmpstr(inv.rootfs_dir, ==, SNAP_MOUNT_DIR "/core/current");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo");
     g_assert_cmpstr(inv.snap_name, ==, "foo");
@@ -60,12 +62,14 @@ static void test_sc_invocation_basic(void) {
     g_assert_false(inv.is_normal_mode);
 }
 
-static void test_sc_invocation_instance_key(void) {
+static void test_sc_invocation_instance_key(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core", "snap.foo_bar.app");
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
-    ;
     sc_init_invocation(&inv, args, "foo_bar");
+
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
+    g_test_queue_free(rootfs_dir);
 
     // Check the error that we've got
     g_assert_cmpstr(inv.snap_instance, ==, "foo_bar");
@@ -74,22 +78,25 @@ static void test_sc_invocation_instance_key(void) {
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo_bar.app");
     g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
     g_assert_false(inv.classic_confinement);
-    g_assert_cmpstr(inv.rootfs_dir, ==, SNAP_MOUNT_DIR "/core/current");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
     g_assert_cmpstr(inv.base_snap_name, ==, "core");
     /* derived later */
     g_assert_false(inv.is_normal_mode);
 }
 
-static void test_sc_invocation_base_name(void) {
+static void test_sc_invocation_base_name(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("base-snap", NULL);
 
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation);
     sc_init_invocation(&inv, args, "foo");
 
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/base-snap/current", NULL);
+    g_test_queue_free(rootfs_dir);
+
     g_assert_cmpstr(inv.base_snap_name, ==, "base-snap");
     g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
     g_assert_cmpstr(inv.orig_base_snap_name, ==, "base-snap");
-    g_assert_cmpstr(inv.rootfs_dir, ==, SNAP_MOUNT_DIR "/base-snap/current");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo");
     g_assert_cmpstr(inv.snap_name, ==, "foo");
@@ -98,7 +105,7 @@ static void test_sc_invocation_base_name(void) {
     g_assert_false(inv.is_normal_mode);
 }
 
-static void test_sc_invocation_bad_instance_name(void) {
+static void test_sc_invocation_bad_instance_name(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args(NULL, NULL);
 
     if (g_test_subprocess()) {
@@ -112,7 +119,7 @@ static void test_sc_invocation_bad_instance_name(void) {
     g_test_trap_assert_stderr("snap instance name can contain only one underscore\n");
 }
 
-static void test_sc_invocation_classic(void) {
+static void test_sc_invocation_classic(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
     sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
     int argc;
@@ -127,17 +134,20 @@ static void test_sc_invocation_classic(void) {
     sc_invocation inv SC_CLEANUP(sc_cleanup_invocation) = {0};
     sc_init_invocation(&inv, args, "foo-classic");
 
+    char *rootfs_dir = g_build_filename(sc_snap_mount_dir(NULL), "/core/current", NULL);
+    g_test_queue_free(rootfs_dir);
+
     g_assert_cmpstr(inv.base_snap_name, ==, "core");
     g_assert_cmpstr(inv.executable, ==, "/usr/lib/snapd/snap-exec");
     g_assert_cmpstr(inv.orig_base_snap_name, ==, "core");
-    g_assert_cmpstr(inv.rootfs_dir, ==, SNAP_MOUNT_DIR "/core/current");
+    g_assert_cmpstr(inv.rootfs_dir, ==, rootfs_dir);
     g_assert_cmpstr(inv.security_tag, ==, "snap.foo-classic.app");
     g_assert_cmpstr(inv.snap_instance, ==, "foo-classic");
     g_assert_cmpstr(inv.snap_name, ==, "foo-classic");
     g_assert_true(inv.classic_confinement);
 }
 
-static void test_sc_invocation_tag_name_mismatch(void) {
+static void test_sc_invocation_tag_name_mismatch(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     struct sc_args *args SC_CLEANUP(sc_cleanup_args) = test_prepare_args("core", "snap.foo.app");
 
     if (g_test_subprocess()) {
@@ -153,10 +163,16 @@ static void test_sc_invocation_tag_name_mismatch(void) {
 }
 
 static void __attribute__((constructor)) init(void) {
-    g_test_add_func("/invocation/bad_instance_name", test_sc_invocation_bad_instance_name);
-    g_test_add_func("/invocation/base_name", test_sc_invocation_base_name);
-    g_test_add_func("/invocation/basic", test_sc_invocation_basic);
-    g_test_add_func("/invocation/classic", test_sc_invocation_classic);
-    g_test_add_func("/invocation/instance_key", test_sc_invocation_instance_key);
-    g_test_add_func("/invocation/tag_name_mismatch", test_sc_invocation_tag_name_mismatch);
+    g_test_add("/invocation/bad_instance_name", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_bad_instance_name, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/base_name", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_base_name, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/basic", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_basic, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/classic", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_classic, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/instance_key", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_instance_key, snap_mount_dir_fixture_teardown);
+    g_test_add("/invocation/tag_name_mismatch", snap_mount_dir_fixture, "/snap", snap_mount_dir_fixture_setup,
+               test_sc_invocation_tag_name_mismatch, snap_mount_dir_fixture_teardown);
 }

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/snap-dir.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
@@ -77,7 +78,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 
     // construct rootfs_dir based on base_snap_name
     char mount_point[PATH_MAX] = {0};
-    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", SNAP_MOUNT_DIR, inv->base_snap_name);
+    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", sc_snap_mount_dir(NULL), inv->base_snap_name);
     inv->rootfs_dir = sc_strdup(mount_point);
 
     debug("security tag: %s", inv->security_tag);
@@ -114,7 +115,7 @@ void sc_check_rootfs_dir(sc_invocation *inv) {
         /* For "core" we can still use the ubuntu-core snap. This is helpful in
          * the migration path when new snap-confine runs before snapd has
          * finished obtaining the core snap. */
-        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", SNAP_MOUNT_DIR, "ubuntu-core");
+        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", sc_snap_mount_dir(NULL), "ubuntu-core");
         if (access(mount_point, F_OK) == 0) {
             sc_cleanup_string(&inv->base_snap_name);
             inv->base_snap_name = sc_strdup("ubuntu-core");
@@ -132,7 +133,7 @@ void sc_check_rootfs_dir(sc_invocation *inv) {
          * to help people transition to core16 bases without requiring
          * twice the disk space.
          */
-        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", SNAP_MOUNT_DIR, "core");
+        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", sc_snap_mount_dir(NULL), "core");
         if (access(mount_point, F_OK) == 0) {
             sc_cleanup_string(&inv->base_snap_name);
             inv->base_snap_name = sc_strdup("core");

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -64,6 +64,9 @@
     /dev/pts/[0-9]* rw,
     /dev/tty rw,
 
+    # SNAP_MOUNT_DIR probe logic
+    /proc/1/root/snap r,
+
     # cgroup: devices
     capability sys_admin,
     capability dac_read_search,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -1,6 +1,8 @@
 # Author: Jamie Strandboge <jamie@canonical.com>
 #include <tunables/global>
 
+@{SNAP_MOUNT_DIR_LIST}="{,/var/lib/snapd}/snap"
+
 @LIBEXECDIR@/snap-confine (attach_disconnected) {
     # Include any additional files that snapd chose to generate.
     # - for $HOME on remote file system.
@@ -166,9 +168,9 @@
     # For mounting base dir by dir (write dirs and mount on them)
     /tmp/snap.rootfs_** rw,
     mount options=(remount ro) -> /tmp/snap.rootfs_*/,
-    mount options=(rw rbind) @SNAP_MOUNT_DIR@/*/*/**/ -> /tmp/snap.rootfs_**/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/**/ -> /tmp/snap.rootfs_**/,
     # For mounting individual files
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/** -> /tmp/snap.rootfs_*/**,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/** -> /tmp/snap.rootfs_*/**,
     mount options=(rw rslave) -> /tmp/snap.rootfs_**/,
     # Allow mounting dirs from /
     mount options=(rw rbind) /*/ -> /tmp/snap.rootfs_**/,
@@ -186,7 +188,7 @@
     mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
     mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
     # the next line is for classic system
-    mount options=(rw rbind) @SNAP_MOUNT_DIR@/*/*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/ -> /tmp/snap.rootfs_*/,
     # the next line is for core system
     mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
     # all of the constructed rootfs is a rslave
@@ -263,19 +265,19 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     # allow making re-execed host snap-exec available inside base snaps
-    mount options=(ro bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     # allow making snapd snap tools available inside base snaps
-    mount options=(ro bind) @SNAP_MOUNT_DIR@/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
 
     # /etc/alternatives (classic and normal mode)
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/apparmor/ -> /tmp/snap.rootfs_*/etc/apparmor/,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/apparmor.d/ -> /tmp/snap.rootfs_*/etc/apparmor.d/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor/ -> /tmp/snap.rootfs_*/etc/apparmor/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor.d/ -> /tmp/snap.rootfs_*/etc/apparmor.d/,
 
     # /etc/alternatives (core/legacy mode)
     mount options=(rw bind) /etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
@@ -288,7 +290,7 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/apparmor.d/,
 
     # the /snap directory
-    mount options=(rw rbind) @SNAP_MOUNT_DIR@/ -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/ -> /tmp/snap.rootfs_*/snap/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/snap/,
     # pivot_root preparation and execution
     mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
@@ -320,8 +322,8 @@
     mount options=(rslave) -> /,
 
     # set up mount namespace for parallel instances of classic snaps
-    mount options=(rw rbind) @SNAP_MOUNT_DIR@/{,*/} -> @SNAP_MOUNT_DIR@/{,*/},
-    mount options=(rslave) -> @SNAP_MOUNT_DIR@/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/{,*/} -> @{SNAP_MOUNT_DIR_LIST}/{,*/},
+    mount options=(rslave) -> @{SNAP_MOUNT_DIR_LIST}/,
     mount options=(rslave) -> /var/snap/,
     mount options=(rw rbind) /var/snap/{,*/} -> /var/snap/{,*/},
     mount options=(rw rshared) -> /var/snap/,
@@ -351,8 +353,8 @@
     # for running snaps on classic
     /snap/ r,
     /snap/** r,
-    @SNAP_MOUNT_DIR@/ r,
-    @SNAP_MOUNT_DIR@/** r,
+    @{SNAP_MOUNT_DIR_LIST}/ r,
+    @{SNAP_MOUNT_DIR_LIST}/** r,
 
     # NOTE: at this stage the /snap directory is stable as we have called
     # pivot_root already.

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -175,7 +175,7 @@
     # Allow mounting dirs from /
     mount options=(rw rbind) /*/ -> /tmp/snap.rootfs_**/,
 
-    # LP: #1668659 and parallel instaces of classic snaps
+    # LP: #1668659 and parallel instances of classic snaps
     mount options=(rw rbind) /snap/ -> /snap/,
     mount options=(rw rshared) -> /snap/,
     mount options=(rw rbind) /var/lib/snapd/snap/ -> /var/lib/snapd/snap/,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -42,6 +42,7 @@
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/locking.h"
 #include "../libsnap-confine-private/secure-getenv.h"
+#include "../libsnap-confine-private/snap-dir.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/tool.h"
@@ -320,9 +321,17 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 
 int main(int argc, char **argv)
 {
-	log_startup_stage("snap-confine enter");
-	// Use our super-defensive parser to figure out what we've been asked to do.
 	sc_error *err = NULL;
+
+	log_startup_stage("snap-confine enter");
+
+	// Figure out what is the SNAP_MOUNT_DIR in practice.
+	sc_probe_snap_mount_dir_from_pid_1_mount_ns(AT_FDCWD, &err);
+	sc_die_on_error(err);
+
+	debug("SNAP_MOUNT_DIR (probed): %s", sc_snap_mount_dir(NULL));
+
+	// Use our super-defensive parser to figure out what we've been asked to do.
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 	sc_preserved_process_state proc_state
 	    SC_CLEANUP(sc_cleanup_preserved_process_state) = {


### PR DESCRIPTION
This is based on https://github.com/snapcore/snapd/pull/14068 which contains the first patch in this series (snap-dir.[ch] and snap-dir-test.c). Please disregard that when reviewing.

Bulk of the changes are related to testing sc-invocation. I can break that out if it helps. The rest is fairly straigtforward replacement of `SNAP_MOUNT_DIR` with `sc_snap_mount_dir(NULL)` except when it was used as a compile time string concatenation (only in tests) where a sligthly more verbose construct is in use.

The apparmor profile has two changes: one to allow it to probe (stat,readlink) `/proc/1/root/snap`. This change is contained in the patch "cmd/snap-confine: probe SNAP_MOUNT_DIR on startup". The second change is to remove `@SNAP_MOUNT_DIR@` - sed text replacement - from snap-confie.apparmor.in and replace it with `@{SNAP_MOUNT_DIR_LIST}` - an apparmor parser variable - so that the same loaded profile allows probing and interacting with either of the locations (canonical and alternate).

This works for me locally. I'm opening a draft PR to run tests more widely.

Autoconf still needs `AC_SUBST` on `SNAP_MOUNT_DIR` as we have a number of places that still hard-code the location at compile time - most notably shell scripts (snap-mgmt.sh, snap-mgmt-selinux.sh) and the snad-generator. This will be left as-is until another pass.

Jira: SNAPDENG-22336
Spec: SD-179