### PR TITLE
i/b/network_manager: add mptcp paths as available for network-manager to support MPTCP sockets

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -71,6 +71,8 @@ network packet,
 @{PROC}/sys/net/netfilter/ r,
 @{PROC}/sys/net/netfilter/** rw,
 @{PROC}/sys/net/nf_conntrack_max rw,
+@{PROC}/sys/net/mptcp/ r,
+@{PROC}/sys/net/mptcp/** rw,
 
 # Needed for systemd's dhcp implementation
 @{PROC}/sys/kernel/random/boot_id r,


### PR DESCRIPTION
Network-manager on core24 seems to be accessing the /sys/net/mptcp paths now to detect whether MPTCP sockets are available.

More specifically `/proc/sys/net/mptcp/enabled` is being denied by apparmor, but we should allow network-manager to handle all the variables under this path.

This PR is to enable support for that in network-manager.

Docs for MPTCP: https://docs.kernel.org/networking/mptcp-sysctl.html