### PR TITLE
tests/smoke/install: allow DEBUG traces in stderr output

### DIFF
--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -31,7 +31,7 @@ execute: |
     echo "Ensure that the snap can be run as root"
     test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log
     MATCH "^hello$" < stdout.log
-    if [ -s stderr.log ]; then
+    if grep -v DEBUG stderr.log ; then
         echo "stderr.log must be empty but it is not: (run as root)"
         cat stderr.log
         exit 1
@@ -40,7 +40,7 @@ execute: |
     echo "Ensure that the snap can be run as the user"
     su -l -c "test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log" test
     MATCH "^hello$" < stdout.log
-    if [ -s stderr.log ]; then
+    if grep -v DEBUG stderr.log ; then
         echo "stderr.log must be empty but it is not: (run as user)"
         cat stderr.log
         exit 1


### PR DESCRIPTION
We run these tests in core-initrd PRs and we would like snapd debug traces enabled in that case.