### PR TITLE
i/b/network_manager: allow access to gnutls config for both plug and slot

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -263,14 +263,6 @@ dbus (receive, send)
     path=/fi/w1/wpa_supplicant1{,/**}
     interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
-
-# Allow network manager to manage netplan configuration
-dbus (send)
-    bus=system
-    interface=io.netplan.Netplan
-    path=/io/netplan/Netplan
-    member=Apply
-    peer=(label=unconfined),
 `
 
 const networkManagerConnectedSlotAppArmor = `

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -88,6 +88,8 @@ network packet,
 
 /run/udev/data/* r,
 
+/etc/gnutls/config r,
+
 # Allow read and write access for all netplan configuration files
 # as NetworkManager will start using them to store the network
 # configuration instead of using its own internal keyfile based
@@ -260,6 +262,14 @@ dbus (receive, send)
     bus=system
     path=/fi/w1/wpa_supplicant1{,/**}
     interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
+
+# Allow network manager to manage netplan configuration
+dbus (send)
+    bus=system
+    interface=io.netplan.Netplan
+    path=/io/netplan/Netplan
+    member=Apply
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -88,6 +88,7 @@ network packet,
 
 /run/udev/data/* r,
 
+# Allow access to read the gnutls config
 /etc/gnutls/config r,
 
 # Allow read and write access for all netplan configuration files
@@ -299,9 +300,6 @@ const networkManagerConnectedPlugAppArmor = `
 
 # Allow access to gnutls config
 /etc/gnutls/config r,
-
-# Allow access to the system dbus
-/run/dbus/system_bus_socket rw,
 
 # Allow all access to NetworkManager service
 dbus (receive, send)

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -101,6 +101,9 @@ network packet,
 # in the same place.
 /run/NetworkManager/{,**} rw,
 
+# Allow access to the system dbus
+/run/dbus/system_bus_socket rw,
+
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.
 /etc/network/interfaces r,

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -101,9 +101,6 @@ network packet,
 # in the same place.
 /run/NetworkManager/{,**} rw,
 
-# Allow access to the system dbus
-/run/dbus/system_bus_socket rw,
-
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.
 /etc/network/interfaces r,
@@ -307,6 +304,12 @@ const networkManagerConnectedPlugAppArmor = `
 # to the NetworkManager service.
 
 #include <abstractions/dbus-strict>
+
+# Allow access to gnutls config
+/etc/gnutls/config r,
+
+# Allow access to the system dbus
+/run/dbus/system_bus_socket rw,
 
 # Allow all access to NetworkManager service
 dbus (receive, send)


### PR DESCRIPTION
Additional apparmor denials have come to light for both `nmcli` and `NetworkManager` - this time related to gnutls configuration, which is fine.

Notes around the gnutls configuration file (since it does not actually exist on core systems):
`If the file doesn't exist, built-in defaults are used. To make configuration changes, the /etc/gnutls directory and the config file in it must be created manually, since they are not shipped in the Ubuntu packaging.`

```
[   88.294738] audit: type=1400 audit(1718264509.595:842): apparmor="DENIED" operation="open" class="file" profile="snap.network-manager.nmcli" name="/etc/gnutls/config" pid=4871 comm="nmcli" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[   88.842027] audit: type=1400 audit(1718264510.142:844): apparmor="DENIED" operation="open" class="file" profile="snap.network-manager.networkmanager" name="/etc/gnutls/config" pid=4574 comm="NetworkManager" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[  113.953320] audit: type=1400 audit(1718264535.257:865): apparmor="DENIED" operation="open" class="file" profile="snap.network-manager.nmcli" name="/etc/gnutls/config" pid=5838 comm="nmcli" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[  114.679885] audit: type=1400 audit(1718264535.983:867): apparmor="DENIED" operation="open" class="file" profile="snap.network-manager.nmcli" name="/etc/gnutls/config" pid=5958 comm="nmcli" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[  115.772107] audit: type=1400 audit(1718264537.075:869): apparmor="DENIED" operation="open" class="file" profile="snap.network-manager.nmcli" name="/etc/gnutls/config" pid=5980 comm="nmcli" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```



