### PR TITLE
tests: install pylint in nightly tiobe tics run

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -80,6 +80,7 @@ jobs:
       run: |
           sudo snap refresh --channel=latest/stable go
           go install honnef.co/go/tools/cmd/staticcheck@latest
+          sudo apt install -y pylint
 
     - name: TICS scan
       run: |


### PR DESCRIPTION
pylint is missing from the environment. TiCS uses pylint for CS of python.
