### PR TITLE
cmd/snap-seccomp: fix default action on deny filter in devmode

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -918,7 +918,13 @@ func compile(content []byte, out string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create allow seccomp filter: %s", err)
 		}
-		secFilterDeny, err = seccomp.NewFilter(complainAct)
+
+		// Deny filter uses "act allow" as a default action, as it is only
+		// populated with deny rules. Any matching it does results in an
+		// explicit denial. When seccomp profiles are loaded the most
+		// restrictive action is used, so without any matching allow rules in
+		// the same filter, all system calls would be forever denied.
+		secFilterDeny, err = seccomp.NewFilter(seccomp.ActAllow)
 		if err != nil {
 			return fmt.Errorf("cannot create deny seccomp filter: %s", err)
 		}
@@ -934,6 +940,11 @@ func compile(content []byte, out string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create seccomp filter: %s", err)
 		}
+		// Deny filter uses "act allow" as a default action, as it is only
+		// populated with deny rules. Any matching it does results in an
+		// explicit denial. When seccomp profiles are loaded the most
+		// restrictive action is used, so without any matching allow rules in
+		// the same filter, all system calls would be forever denied.
 		secFilterDeny, err = seccomp.NewFilter(seccomp.ActAllow)
 		if err != nil {
 			return fmt.Errorf("cannot create seccomp filter: %s", err)


### PR DESCRIPTION
Recent change to seccomp processing has introduced a regression from commit 182b8ae699e39bd3707cec80777f58e5baed34c6 "snap-seccomp, snap-confine, i/seccomp, tests: rework seccomp denylist * snap-{seccomp,confine}: rework seccomp denylist" where the deny processing of devmode snaps was incorrectly logging *all* system calls (not denying, just logging). Restore the correct default action on the deny filter to "allow", as the deny filter explicitly denies on matching system calls.

Jira: SNAPDENG-22672
Thanks-To: Canonical Certification Team
