### PR TITLE
tests: add extra storage to arch vms in google cloud

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -201,7 +201,7 @@ backends:
         systems:
             - arch-linux-64:
                   workers: 6
-                  storage: 12G
+                  storage: 15G
 
             - centos-7-64:
                   workers: 6


### PR DESCRIPTION
This is to avoid issue like:

error: cannot extract "*" to "/home/test/tmp/kernel": -----
Write on output file failed because No space left on device FATAL ERROR: writer: failed to write file
/home/test/tmp/kernel/modules/5.4.0-182-generic/kernel/nvidia-535srv/bits/nvidia/nv-kernel.o
