### PR TITLE
tests/main/snap-quota-journal: fix match to include optional decimal part

### DIFF
--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -79,7 +79,7 @@ execute: |
   
   # Ensure that the new size is printed in the journal logs. We requested 64MB but
   # this will most likely print out as 61.0M, so lets be a bit flexible
-  "$TESTSTOOLS"/journal-state get-log --namespace snap-group-one | MATCH "max 6[0-9].[0-9]M,"
+  "$TESTSTOOLS"/journal-state get-log --namespace snap-group-one | MATCH "max 6[0-9](.[0-9])?M,"
 
   # Ensure that the unit file is correct
   echo "Ensuring the unit file is correct"


### PR DESCRIPTION
Newer systemd does not report decimal parts of the size if the size is already rounded to the unit size.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
