### PR TITLE
tests/main/lxd: use ubuntu-daily for 24.10

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -45,9 +45,8 @@ execute: |
     DEB=$(basename "$GOHOME"/snapd_*.deb)
     
     lxd.lxc exec ubuntu -- apt update
-    # As for ubuntu noble it is not using the official image, snapd is not installed by default
-    # This should be removed once the official image is released
-    if os.query is-ubuntu 24.04; then
+    # As for ubuntu noble container, no snaps are seeded, so install some
+    if os.query is-ubuntu-ge 24.04; then
         lxd.lxc exec ubuntu -- apt install -y snapd
         lxd.lxc exec ubuntu -- snap install "$core_snap"
     fi

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -23,8 +23,8 @@ execute: |
     fi
 
     REMOTE=ubuntu
-    # There isn't an official image for noble yet, let's use the daily one
-    if os.query is-ubuntu 24.04; then
+    # There isn't an official image for 24.10 yet, let's use the daily one
+    if os.query is-ubuntu 24.10; then
         REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -27,8 +27,8 @@ prepare: |
     "$TESTSTOOLS"/lxd-state prepare-snap
 
     REMOTE=ubuntu
-    # There isn't an official image for noble yet, let's use the daily one
-    if os.query is-ubuntu 24.04; then
+    # There isn't an official image for 24.10 yet, let's use the daily one
+    if os.query is-ubuntu 24.10; then
       REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -10,8 +10,8 @@ prepare: |
   "$TESTSTOOLS"/lxd-state prepare-snap
 
   REMOTE=ubuntu
-  # There isn't an official image for noble yet, let's use the daily one
-  if os.query is-ubuntu 24.04; then
+  # There isn't an official image for 24.10 yet, let's use the daily one
+  if os.query is-ubuntu 24.10; then
       REMOTE=ubuntu-daily
   fi
   VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -88,8 +88,8 @@ execute: |
 
     # There isn't an official image for noble yet, let's use the community one
     REMOTE=ubuntu
-    # There isn't an official image for noble yet, let's use the daily one
-    if os.query is-ubuntu 24.04; then
+    # There isn't an official image for 24.10 yet, let's use the daily one
+    if os.query is-ubuntu 24.10; then
         REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"


### PR DESCRIPTION
Use ubuntu-daily remote for 24.10.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
