### PR TITLE
cmd/snap-seccomp: fix support for @complain and ~ rules

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -918,7 +918,13 @@ func compile(content []byte, out string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create allow seccomp filter: %s", err)
 		}
-		secFilterDeny, err = seccomp.NewFilter(complainAct)
+
+		// Deny filter uses "act allow" as a default action, as it is only
+		// populated with deny rules. Any matching it does results in an
+		// explicit denial. When seccomp profiles are loaded the most
+		// restrictive action is used, so without any matching allow rules in
+		// the same filter, all system calls would be forever denied.
+		secFilterDeny, err = seccomp.NewFilter(seccomp.ActAllow)
 		if err != nil {
 			return fmt.Errorf("cannot create deny seccomp filter: %s", err)
 		}
@@ -934,6 +940,11 @@ func compile(content []byte, out string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create seccomp filter: %s", err)
 		}
+		// Deny filter uses "act allow" as a default action, as it is only
+		// populated with deny rules. Any matching it does results in an
+		// explicit denial. When seccomp profiles are loaded the most
+		// restrictive action is used, so without any matching allow rules in
+		// the same filter, all system calls would be forever denied.
 		secFilterDeny, err = seccomp.NewFilter(seccomp.ActAllow)
 		if err != nil {
 			return fmt.Errorf("cannot create seccomp filter: %s", err)

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -499,6 +499,7 @@ func (s *snapSeccompSuite) TestCompile(c *C) {
 		{"ioctl - TIOCSTI", "ioctl;native;-,99", Deny},
 		{"ioctl - !TIOCSTI", "ioctl;native;-,TIOCSTI", Deny},
 		{"ioctl\n~ioctl - TIOCSTI", "ioctl;native;-,TIOCSTI", DenyExplicit},
+		{"@complain\nioctl\n~ioctl - TIOCSTI", "ioctl;native;-,TIOCSTI", Allow},
 		// also check we can deny multiple uses of ioctl but still allow
 		// others
 		{"ioctl\n~ioctl - TIOCSTI\n~ioctl - TIOCLINUX\nioctl - !TIOCSTI", "ioctl;native;-,TIOCSTI", DenyExplicit},


### PR DESCRIPTION
This branch depends on and includes https://github.com/snapcore/snapd/pull/14083

It was recently noted that ~ (deny rules) do not properly implement
devmode/complain mode. Fix this and add missing unit tests.

Jira: SNAPDENG-22672
Thanks-To: Canonical Certification Team