### PR TITLE
o/snapstate: properly ignore prereqs during remodels

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -335,15 +335,6 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 			return false, nil
 		}
 
-		// if we are remodeling, then we should return early due to the way that
-		// tasks are ordered by the remodeling code. specifically, all snap
-		// downloads during a remodel happen prior to snap installation. thus,
-		// we cannot wait for snaps to be installed here. see remodelTasks for
-		// more information on how the tasks are ordered.
-		if deviceCtx.ForRemodeling() {
-			return false, nil
-		}
-
 		// snap is being installed, retry later
 		return true, nil
 	}
@@ -367,6 +358,15 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 	if ok, err := inProgress(snapName); err != nil {
 		return nil, err
 	} else if ok {
+		// if we are remodeling, then we should return early due to the way that
+		// tasks are ordered by the remodeling code. specifically, all snap
+		// downloads during a remodel happen prior to snap installation. thus,
+		// we cannot wait for snaps to be installed here. see remodelTasks for
+		// more information on how the tasks are ordered.
+		if deviceCtx.ForRemodeling() {
+			return nil, nil
+		}
+
 		return nil, onInFlight
 	}
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -836,6 +837,12 @@ func (s *prereqSuite) TestDoPrereqSkipDuringRemodel(c *C) {
 		Remodeling: true,
 	})
 	defer restore()
+
+	// replace the store here so we can force an error if we actually call
+	// InstallWithDeviceContext. if we do not do this, and we fail to properly
+	// handle the remodel case, InstallWithDeviceContext will return a
+	// ChangeConflictError, which is then ignored, making this test invalid
+	snapstate.ReplaceStore(s.state, storetest.Store{})
 
 	// install snapd so that prerequisites handler won't try to install it
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{


### PR DESCRIPTION
This fixes `google-nested:ubuntu-20.04-64:tests/nested/manual/remodel-offline:local_snaps`, which was failing when trying to talk to the store to install a prereq. This also updates a unit test to help prevent this regression in the future.