### PR TITLE
cmd,sandbox,interfaces: remove support for ubuntu-core-launcher

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -427,16 +427,6 @@ snap-mgmt/snap-mgmt-selinux: snap-mgmt/snap-mgmt-selinux.sh.in Makefile snap-mgm
 endif
 
 ##
-## ubuntu-core-launcher
-##
-
-install-exec-hook::
-	install -d -m 755 $(DESTDIR)$(bindir)
-if BUILD_HOST_BINARIES
-	ln -sf $(libexecdir)/snap-confine $(DESTDIR)$(bindir)/ubuntu-core-launcher
-endif
-
-##
 ## snap-device-helper
 ##
 

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -110,41 +110,6 @@ static void test_sc_nonfatal_parse_args__typical_classic(void)
 	g_assert_null(argv[3]);
 }
 
-static void test_sc_nonfatal_parse_args__ubuntu_core_launcher(void)
-{
-	// Test that typical legacy invocation of snap-confine via the
-	// ubuntu-core-launcher symlink, with duplicated security tag, is parsed
-	// correctly.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
-
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/bin/ubuntu-core-launcher",
-		       "snap.SNAP_NAME.APP_NAME", "snap.SNAP_NAME.APP_NAME",
-		       "/usr/lib/snapd/snap-exec", "--option", "arg", NULL);
-
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
-
-	// Check supported switches and arguments
-	g_assert_cmpstr(sc_args_security_tag(args), ==,
-			"snap.SNAP_NAME.APP_NAME");
-	g_assert_cmpstr(sc_args_executable(args), ==,
-			"/usr/lib/snapd/snap-exec");
-	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
-	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
-
-	// Check remaining arguments
-	g_assert_cmpint(argc, ==, 3);
-	g_assert_cmpstr(argv[0], ==, "/usr/bin/ubuntu-core-launcher");
-	g_assert_cmpstr(argv[1], ==, "--option");
-	g_assert_cmpstr(argv[2], ==, "arg");
-	g_assert_null(argv[3]);
-}
-
 static void test_sc_nonfatal_parse_args__version(void)
 {
 	// Test that snap-confine --version is detected.
@@ -407,8 +372,6 @@ static void __attribute__((constructor)) init(void)
 			test_sc_nonfatal_parse_args__typical);
 	g_test_add_func("/args/sc_nonfatal_parse_args/typical_classic",
 			test_sc_nonfatal_parse_args__typical_classic);
-	g_test_add_func("/args/sc_nonfatal_parse_args/ubuntu_core_launcher",
-			test_sc_nonfatal_parse_args__ubuntu_core_launcher);
 	g_test_add_func("/args/sc_nonfatal_parse_args/version",
 			test_sc_nonfatal_parse_args__version);
 	g_test_add_func("/args/sc_nonfatal_parse_args/nothing_to_parse",

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -71,19 +71,6 @@ struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
 	if (args == NULL) {
 		die("cannot allocate memory for command line arguments object");
 	}
-	// Check if we're being called through the ubuntu-core-launcher symlink.
-	// When this happens we want to skip the first positional argument as it is
-	// the security tag repeated (legacy).
-	bool ignore_first_tag = false;
-	char *basename = strrchr(argv[0], '/');
-	if (basename != NULL) {
-		// NOTE: this is safe because we, at most, may move to the NUL byte
-		// that compares to an empty string.
-		basename += 1;
-		if (strcmp(basename, "ubuntu-core-launcher") == 0) {
-			ignore_first_tag = true;
-		}
-	}
 	// Parse option switches.
 	int optind;
 	for (optind = 1; optind < argc; ++optind) {
@@ -141,12 +128,6 @@ struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
 	for (; optind < argc; ++optind) {
 		if (args->security_tag == NULL) {
 			// The first positional argument becomes the security tag.
-			if (ignore_first_tag) {
-				// Unless we are called as ubuntu-core-launcher, then we just
-				// swallow and ignore that security tag altogether.
-				ignore_first_tag = false;
-				continue;
-			}
 			args->security_tag = sc_strdup(argv[optind]);
 		} else if (args->executable == NULL) {
 			// The second positional argument becomes the executable name.

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -45,10 +45,6 @@ struct sc_args;
  *
  * Snap confine understands very specific arguments.
  *
- * The argument vector can begin with "ubuntu-core-launcher" (with an optional
- * path) which implies that the first arctual argument (argv[1]) is a copy of
- * argv[2] and can be discarded.
- *
  * The argument vector is scanned, left to right, to look for switches that
  * start with the minus sign ('-'). Recognized options are stored and
  * memorized. Unrecognized options return an appropriate error object.

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -17,13 +17,13 @@
  *
  */
 
-// Package apparmor implements integration between snappy and
-// ubuntu-core-launcher around apparmor.
+// Package apparmor implements integration between snappy and snap-confine
+// around apparmor.
 //
 // Snappy creates apparmor profiles for each application (for each snap)
-// present in the system.  Upon each execution of ubuntu-core-launcher
-// application process is launched under the profile. Prior to that the profile
-// must be parsed, compiled and loaded into the kernel using the support tool
+// present in the system.  Upon each execution of snap-confine application
+// process is launched under the profile. Prior to that the profile must be
+// parsed, compiled and loaded into the kernel using the support tool
 // "apparmor_parser".
 //
 // Each apparmor profile contains a simple <header><content><footer> structure.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -373,7 +373,7 @@ var templateCommon = `
   /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/@{SNAP_REVISION}/** wl,
   /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/** wl,
 
-  # The ubuntu-core-launcher creates an app-specific private restricted /tmp
+  # The snap-confine program creates an app-specific private restricted /tmp
   # and will fail to launch the app if something goes wrong. As such, we can
   # simply allow full access to /tmp.
   /tmp/   r,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -190,9 +190,9 @@ const systemObserveConnectedPlugSecComp = `
 
 # ptrace can be used to break out of the seccomp sandbox, but ps requests
 # 'ptrace (trace)' from apparmor. 'ps' does not need the ptrace syscall though,
-# so we deny the ptrace here to make sure we are always safe.
-# Note: may uncomment once ubuntu-core-launcher understands @deny rules and
-# if/when we conditionally deny this in the future.
+# so we deny the ptrace here to make sure we are always safe. Note: may
+# uncomment once snap-confine understands @deny rules and if/when we
+# conditionally deny this in the future.
 #@deny ptrace
 `
 

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -39,7 +39,7 @@ func serviceName(snapName, distinctServiceSuffix string) string {
 	return snap.ScopedSecurityTag(snapName, "interface", distinctServiceSuffix) + ".service"
 }
 
-// Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
+// Backend is responsible for maintaining special systemd units.
 type Backend struct {
 	preseed bool
 }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -204,6 +204,5 @@ package() {
   rm -fv "$pkgdir"/usr/lib/systemd/system/snapd.core-fixup.*
   # and scripts
   rm -fv "$pkgdir/usr/lib/snapd/snapd.core-fixup.sh"
-  rm -fv "$pkgdir/usr/bin/ubuntu-core-launcher"
   rm -fv "$pkgdir/usr/lib/snapd/system-shutdown"
 }

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -19,9 +19,6 @@ usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapd-apparmor /usr/lib/snapd/
-# for compatibility with ancient snap installs that wrote the shell based
-# wrapper scripts instead of the modern symlinks
-usr/bin/ubuntu-core-launcher
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-device-helper
 usr/lib/snapd/snap-discard-ns

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -703,8 +703,6 @@ pushd ./cmd
 chmod 0755 %{buildroot}%{_sharedstatedir}/snapd/void
 # We don't use AppArmor
 rm -rfv %{buildroot}%{_sysconfdir}/apparmor.d
-# ubuntu-core-launcher is dead
-rm -fv %{buildroot}%{_bindir}/ubuntu-core-launcher
 popd
 
 # Install all systemd and dbus units, and env files

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -167,12 +167,6 @@ install::
 	install -m 755 -d $(DESTDIR)$(localstatedir)/cache/snapd
 	install -m 755 -d $(DESTDIR)$(datadir)/polkit-1/actions
 
-# Remove traces of ubuntu-core-launcher. It is a phased-out executable that is
-# still partially present in the tree but should be removed in the subsequent
-# release.
-install::
-	rm -f $(DESTDIR)$(bindir)/ubuntu-core-launcher
-
 # Do not ship snap-preseed. It is currently only useful on ubuntu and tailored
 # for preseeding of ubuntu cloud images due to certain assumptions about
 # runtime environment of the host and of the preseeded image.

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -23,9 +23,6 @@ usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
-# for compatibility with ancient snap installs that wrote the shell based
-# wrapper scripts instead of the modern symlinks
-usr/bin/ubuntu-core-launcher
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-device-helper
 usr/lib/snapd/snap-discard-ns

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -35,9 +35,6 @@ usr/lib/snapd/snap-mgmt
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-discard-ns
 usr/share/man/
-# for compatibility with ancient snap installs that wrote the shell based
-# wrapper scripts instead of the modern symlinks
-usr/bin/ubuntu-core-launcher
 
 # gdb helper
 usr/lib/snapd/snap-gdb-shim

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -295,8 +295,6 @@ func (s *appArmorSuite) TestLoadedApparmorProfilesParsesAndFiltersData(c *C) {
 		// The pi2-piglow.{background,foreground}.snap entries are the only
 		// ones that should be reported by the function.
 		`/sbin/dhclient (enforce)
-/usr/bin/ubuntu-core-launcher (enforce)
-/usr/bin/ubuntu-core-launcher (enforce)
 /usr/lib/NetworkManager/nm-dhcp-client.action (enforce)
 /usr/lib/NetworkManager/nm-dhcp-helper (enforce)
 /usr/lib/connman/scripts/dhclient-script (enforce)

--- a/spread.yaml
+++ b/spread.yaml
@@ -1068,8 +1068,7 @@ suites:
             distro_purge_package snapd
             case "$SPREAD_SYSTEM" in
                 arch-*)
-                    # there is no snap-confine and ubuntu-core-launcher
-                    # in Arch
+                    # In Arch there is no separate snap-confine package.
                     ;;
                 *)
                     distro_purge_package snap-confine ubuntu-core-launcher


### PR DESCRIPTION
The ubuntu-core-launcher is the old name of snap-confine, back in the early days of snapd 2.x where snapd was still generating shell scripts for launching all snap applications. There was no such code anywhere for nearly a decade and keeping the special mode around is not necessary anymore.

There are several changes broken out as distinct patches:
- removal of special mode from snap-confine argument parser
- removal of automake logic to install a symlink ubuntu-core-launcher -> snap-confine
- removal of installation or removal of ubuntu-core-launcher symlink in distribution packaging
- edits of comments referencing ubuntu-core-launcher in sandbox and interfaces packages
- tweak to spread.yaml comment referencing ubuntu-core-launcher

There are some remaining references that depend on the empty transitional package and upgrades from ancient version of classic package that have been left intact.

Jira: SNAPDENG-23247