### PR TITLE
registry: restrict path patterns

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -364,7 +364,7 @@ func validateRequestStoragePair(request, storage string) error {
 }
 
 var (
-	subkeyRegex      = "(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*"
+	subkeyRegex      = "[a-z](?:-?[a-z0-9])*"
 	validSubkey      = regexp.MustCompile(fmt.Sprintf("^%s$", subkeyRegex))
 	validPlaceholder = regexp.MustCompile(fmt.Sprintf("^{%s}$", subkeyRegex))
 	// TODO: decide on what the format should be for aliases in schemas

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1241,6 +1241,10 @@ func (s *viewSuite) TestBadRequestPaths(c *C) {
 			request: "a.b-",
 			errMsg:  `invalid subkey "b-"`,
 		},
+		{
+			request: "0-b",
+			errMsg:  `invalid subkey "0-b"`,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/registry/schema_test.go
+++ b/registry/schema_test.go
@@ -959,7 +959,7 @@ func (*schemaSuite) TestBadAliasName(c *C) {
 
 	_, err := registry.ParseSchema(schemaStr)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, `cannot parse alias name "-foo": must match ^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$`)
+	c.Assert(err.Error(), Equals, `cannot parse alias name "-foo": must match ^[a-z](?:-?[a-z0-9])*$`)
 }
 
 func (*schemaSuite) TestIntegerHappy(c *C) {


### PR DESCRIPTION
Restricts paths of views to not allow numbers as the first character.