### PR TITLE
o/snapstate: install components from the store

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -60,6 +60,11 @@ type fakeOp struct {
 	sinfo snap.SideInfo
 	stype snap.Type
 
+	componentName     string
+	componentPath     string
+	componentRev      snap.Revision
+	componentSideInfo snap.ComponentSideInfo
+
 	curSnaps []store.CurrentSnap
 	action   store.SnapAction
 
@@ -1440,12 +1445,21 @@ func (f *fakeSnappyBackend) CurrentInfo(curInfo *snap.Info) {
 	})
 }
 
-func (f *fakeSnappyBackend) ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup) error {
-	f.appendOp(&fakeOp{
+func (f *fakeSnappyBackend) ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup, compsup *snapstate.ComponentSetup) error {
+	op := &fakeOp{
 		op:    kind + ":" + status.String(),
 		name:  snapsup.InstanceName(),
 		revno: snapsup.Revision(),
-	})
+	}
+
+	if compsup != nil {
+		op.componentName = compsup.ComponentName()
+		op.componentPath = compsup.CompPath
+		op.componentRev = compsup.Revision()
+		op.componentSideInfo = *compsup.CompSideInfo
+	}
+
+	f.appendOp(op)
 	return f.maybeErrForLastOp()
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -674,10 +674,14 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				info.Channel = ""
 			}
 			info.InstanceKey = instanceKey
+
 			sar := store.SnapActionResult{
-				Info:      info,
-				Resources: f.snapResources(info),
+				Info: info,
 			}
+			if opts.IncludeResources {
+				sar.Resources = f.snapResources(info)
+			}
+
 			if strings.HasSuffix(snapName, "-with-default-track") && strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
 				sar.RedirectChannel = "2.0/" + a.Channel
 			}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1387,7 +1387,7 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 	f.appendOp(&fakeOp{
 		op:             "remove-snap-data-dir",
 		name:           info.InstanceName(),
-		path:           snap.BaseDataDir(info.SnapName()),
+		path:           snap.BaseDataDir(info.InstanceName()),
 		otherInstances: otherInstances,
 	})
 	return f.maybeErrForLastOp()
@@ -1405,7 +1405,7 @@ func (f *fakeSnappyBackend) RemoveSnapDir(s snap.PlaceInfo, otherInstances bool)
 	f.appendOp(&fakeOp{
 		op:             "remove-snap-dir",
 		name:           s.InstanceName(),
-		path:           snap.BaseDir(s.SnapName()),
+		path:           snap.BaseDir(s.InstanceName()),
 		otherInstances: otherInstances,
 	})
 	return f.maybeErrForLastOp()

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -333,6 +333,17 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				DaemonScope: "user",
 			},
 		}
+	case "channel-for-components":
+		info.Components = map[string]*snap.Component{
+			"test-component": {
+				Type: snap.TestComponent,
+				Name: "test-component",
+			},
+			"kernel-modules-component": {
+				Type: snap.KernelModulesComponent,
+				Name: "kernel-modules-component",
+			},
+		}
 	case "channel-for-dbus-activation":
 		slot := &snap.SlotInfo{
 			Snap:      info,

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -80,7 +80,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 
 type componentInstallFlags struct {
 	RemoveComponentPath bool
-	SkipSecurity        bool
+	SkipProfiles        bool
 }
 
 // doInstallComponent might be called with the owner snap installed or not.
@@ -177,7 +177,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 	}
 
 	// security
-	if !flags.SkipSecurity {
+	if !flags.SkipProfiles {
 		setupSecurity := st.NewTask("setup-profiles", fmt.Sprintf(i18n.G("Setup component %q%s security profiles"), compSi.Component, revisionStr))
 		addTask(setupSecurity)
 	}

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -54,8 +54,9 @@ func expectedComponentInstallTasks(opts int) []string {
 	if opts&compOptIsLocal != 0 {
 		startTasks = []string{"prepare-component"}
 	} else {
-		startTasks = []string{"download-component"}
+		startTasks = []string{"download-component", "validate-component"}
 	}
+
 	// Revision is not the same as the current one installed
 	if opts&compOptRevisionPresent == 0 {
 		startTasks = append(startTasks, "mount-component")

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -45,6 +45,8 @@ const (
 	compTypeIsKernMods
 	// Current component is discarded at the end
 	compCurrentIsDiscarded
+	// Component is being installed with a snap, so skip setup-profiles
+	compOptSkipSecurity
 )
 
 // opts is a bitset with compOpt* as possible values.
@@ -69,7 +71,9 @@ func expectedComponentInstallTasks(opts int) []string {
 		startTasks = append(startTasks, "unlink-current-component")
 	}
 
-	startTasks = append(startTasks, "setup-profiles")
+	if opts&compOptSkipSecurity == 0 {
+		startTasks = append(startTasks, "setup-profiles")
+	}
 
 	// link-component is always present
 	startTasks = append(startTasks, "link-component")

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -22,7 +22,6 @@ package snapstate
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/snapcore/snapd/logger"
@@ -291,16 +290,6 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	}
 	perfTimings.Save(st)
 	st.Unlock()
-
-	// TODO: test this conditional once we are installing local snaps+components
-	// if we're removing the snap file and we are mounting a component for the
-	// firs time, then we know that the component also must be coming from an
-	// emphemeral file. in that case, remove it.
-	if snapsup.RemoveSnapPath {
-		if err := os.Remove(compSetup.CompPath); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/snapcore/snapd/logger"
@@ -290,6 +291,16 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	}
 	perfTimings.Save(st)
 	st.Unlock()
+
+	// TODO: test this conditional once we are installing local snaps+components
+	// if we're removing the snap file and we are mounting a component for the
+	// firs time, then we know that the component also must be coming from an
+	// emphemeral file. in that case, remove it.
+	if snapsup.RemoveSnapPath {
+		if err := os.Remove(compSetup.CompPath); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -644,6 +644,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 			return nil, err
 		}
 
+		// TODO: once component hooks are fully, we will need to take care to
+		// correctly order the tasks that are created for running component
+		// and snap hooks
+
 		for _, t := range beforeLink {
 			addTask(t)
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -631,7 +631,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 			// if we are removing the snap, we can assume that we should remove
 			// the component too
 			RemoveComponentPath: snapsup.RemoveSnapPath,
-			SkipSecurity:        true,
+			// the setup-profiles task that is created for the snap itself
+			// generates the security profiles for the snap and its new components
+			SkipSecurity: true,
 		}, "")
 		if err != nil {
 			return nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -633,7 +633,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 			RemoveComponentPath: snapsup.RemoveSnapPath,
 			// the setup-profiles task that is created for the snap itself
 			// generates the security profiles for the snap and its new components
-			SkipSecurity: true,
+			SkipProfiles: true,
 		}, "")
 		if err != nil {
 			return nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2122,6 +2122,8 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 			return nil, nil, err
 		}
 
+		// TODO: we need to handle components here too
+
 		// Do not set any default restart boundaries, we do it when we have access to all
 		// the task-sets in preparation for single-reboot.
 		ts, err := doInstall(st, snapst, *snapsup, nil, noRestartBoundaries, fromChange, inUseFor(deviceCtx))
@@ -3938,6 +3940,8 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
+
+	// TODO: we need to handle components here too
 	return doInstall(st, &snapst, *snapsup, nil, 0, fromChange, nil)
 }
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6284,6 +6284,9 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	// sort these so that we can predict the order of the ops
+	sort.Strings(components)
+
 	if instanceKey != "" {
 		tr := config.NewTransaction(s.state)
 		tr.Set("core", "experimental.parallel-instances", true)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -586,7 +586,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 		Current:         snap.R(2),
 		SnapType:        "app",
 	}
-	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}
+	snapsup := snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}
 	_, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", nil)
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
 }
@@ -639,7 +639,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	defer restore()
 
 	// Attempt to install revision 2 of the snap.
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 	}
 
@@ -703,7 +703,7 @@ func (s *snapmgrTestSuite) TestInstallWithIgnoreRunningProceedsOnBusySnap(c *C) 
 	defer restore()
 
 	// Attempt to install revision 2 of the snap, with the IgnoreRunning flag set.
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "pkg", SnapID: "pkg-id", Revision: snap.R(2)},
 		Flags:    snapstate.Flags{IgnoreRunning: true},
 		Type:     "app",
@@ -766,7 +766,7 @@ func (s *snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	defer restore()
 
 	// Attempt to install revision 2 of the snap.
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 	}
 
@@ -779,7 +779,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
+	snapsup := snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
 	_, err := snapstate.DoInstall(s.state, nil, snapsup, nil, 0, "", nil)
 	c.Assert(err, ErrorMatches, `cannot install reserved snap name 'system'`)
 }
@@ -864,7 +864,7 @@ func (s *snapmgrTestSuite) TestInstallNoRestartBoundaries(c *C) {
 	r := snapstatetest.MockDeviceModel(DefaultModel())
 	defer r()
 
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: "brand-gadget",
 			SnapID:   "brand-gadget",

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6143,52 +6143,86 @@ func (s *snapmgrTestSuite) TestInstallOneSnapMisbehavingGoal(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestInstallZeroComponentsRunThrough(c *C) {
-	const undo = false
-	s.testInstallComponentsRunThrough(c, nil, undo)
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, nil, undo)
 }
 
 func (s *snapmgrTestSuite) TestInstallOneComponentsRunThrough(c *C) {
-	const undo = false
-	s.testInstallComponentsRunThrough(c, []string{"test-component"}, undo)
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component"}, undo)
 }
 
 func (s *snapmgrTestSuite) TestInstallManyComponentsRunThrough(c *C) {
-	const undo = false
-	s.testInstallComponentsRunThrough(c, []string{"test-component", "kernel-modules-component"}, undo)
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
+}
+
+func (s *snapmgrTestSuite) TestInstallInstanceManyComponentsRunThrough(c *C) {
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = "key"
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
 }
 
 func (s *snapmgrTestSuite) TestInstallManyComponentsUndoRunThrough(c *C) {
-	const undo = true
-	s.testInstallComponentsRunThrough(c, []string{"test-component", "kernel-modules-component"}, undo)
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
 }
 
-func undoInstallOps(snapName string, snapRevision snap.Revision, components []string) []fakeOp {
-	snapMount := filepath.Join(dirs.SnapMountDir, filepath.Join(snapName, snapRevision.String()))
+func (s *snapmgrTestSuite) TestInstallInstanceManyComponentsUndoRunThrough(c *C) {
+	const (
+		undo        = true
+		snapName    = "test-snap"
+		instanceKey = "key"
+	)
+	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
+}
+
+func undoInstallOps(snapName, instanceName string, snapRevision snap.Revision, components []string) []fakeOp {
+	snapMount := filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String()))
 	ops := []fakeOp{{
 		op: "update-aliases",
 	}, {
 		op:    "auto-connect:Undoing",
-		name:  snapName,
+		name:  instanceName,
 		revno: snapRevision,
 	}}
 
 	for i := len(components) - 1; i >= 0; i-- {
 		ops = append(ops, fakeOp{
 			op:   "unlink-component",
-			path: snap.ComponentMountDir(components[i], snap.R(i+1), snapName),
+			path: snap.ComponentMountDir(components[i], snap.R(i+1), instanceName),
 		})
 	}
 
 	ops = append(ops, []fakeOp{{
 		op:   "discard-namespace",
-		name: snapName,
+		name: instanceName,
 	}, {
 		op:                     "unlink-snap",
 		path:                   snapMount,
 		unlinkFirstInstallUndo: true,
 	}, {
 		op:    "setup-profiles:Undoing",
-		name:  snapName,
+		name:  instanceName,
 		revno: snapRevision,
 	}}...)
 
@@ -6226,38 +6260,45 @@ func undoInstallOps(snapName string, snapRevision snap.Revision, components []st
 		old:  "<no-old>",
 	}, {
 		op:   "undo-setup-snap-save-data",
-		path: filepath.Join(dirs.SnapDataSaveDir, snapName),
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
 		old:  "<no-old>",
 	}, {
 		op:   "remove-snap-data-dir",
-		name: snapName,
-		path: filepath.Join(dirs.SnapDataDir, snapName),
+		name: instanceName,
+		path: filepath.Join(dirs.SnapDataDir, instanceName),
 	}, {
 		op:    "undo-setup-snap",
-		name:  snapName,
+		name:  instanceName,
 		stype: "app",
 		path:  snapMount,
 	}, {
 		op:   "remove-snap-dir",
-		name: snapName,
-		path: filepath.Join(dirs.SnapMountDir, snapName),
+		name: instanceName,
+		path: filepath.Join(dirs.SnapMountDir, instanceName),
 	}}...)
 
 	return ops
 }
 
-func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []string, undo bool) {
+func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, instanceKey string, components []string, undo bool) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
 	const (
-		snapName = "test-snap"
-		snapID   = "test-snap-id"
-		channel  = "channel-for-components"
+		snapID  = "test-snap-id"
+		channel = "channel-for-components"
 	)
 	snapRevision := snap.R(11)
 
 	sort.Strings(components)
+
+	instanceName := snap.InstanceName(snapName, instanceKey)
 
 	// we start without the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
@@ -6271,7 +6312,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 	}
 
 	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
-		c.Assert(info.SnapName(), DeepEquals, snapName)
+		c.Assert(info.InstanceName(), DeepEquals, instanceName)
 		var results []store.SnapResourceResult
 		for i, compName := range components {
 			results = append(results, store.SnapResourceResult{
@@ -6289,7 +6330,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 	}
 
 	target := snapstate.StoreInstallGoal(snapstate.StoreSnap{
-		InstanceName: snapName,
+		InstanceName: instanceName,
 		Components:   components,
 		RevOpts:      snapstate.RevisionOptions{Channel: channel},
 	})
@@ -6299,7 +6340,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 	})
 	c.Assert(err, IsNil)
 
-	c.Check(info.SnapName(), Equals, snapName)
+	c.Check(info.InstanceName(), Equals, instanceName)
 	c.Check(info.Channel, Equals, channel)
 	c.Check(info.Revision, Equals, snapRevision)
 
@@ -6307,7 +6348,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 		compMntDir string, snapInfo *snap.Info, csi *snap.ComponentSideInfo,
 	) (*snap.ComponentInfo, error) {
 		for i, compName := range components {
-			if compMntDir == snap.ComponentMountDir(compName, snap.R(i+1), snapName) {
+			if compMntDir == snap.ComponentMountDir(compName, snap.R(i+1), instanceName) {
 				return &snap.ComponentInfo{}, nil
 			}
 		}
@@ -6339,19 +6380,19 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 	downloads := []fakeDownload{{
 		macaroon: s.user.StoreMacaroon,
 		name:     snapName,
-		target:   filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, snapRevision)),
+		target:   filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, snapRevision)),
 	}}
 	for i, compName := range components {
 		downloads = append(downloads, fakeDownload{
 			macaroon: s.user.StoreMacaroon,
 			name:     fmt.Sprintf("%s+%s", snapName, compName),
-			target:   filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s+%s_%d.comp", snapName, compName, i+1)),
+			target:   filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s+%s_%d.comp", instanceName, compName, i+1)),
 		})
 	}
 	c.Check(s.fakeStore.downloads, DeepEquals, downloads)
 	c.Check(s.fakeStore.seenPrivacyKeys["privacy-key"], Equals, true, Commentf("salts seen: %v", s.fakeStore.seenPrivacyKeys))
 
-	snapFileName := fmt.Sprintf("%s_%v.snap", snapName, snapRevision)
+	snapFileName := fmt.Sprintf("%s_%v.snap", instanceName, snapRevision)
 
 	// ops that happens before component tasks
 	expected := fakeOps{{
@@ -6361,7 +6402,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
 			Action:       "install",
-			InstanceName: snapName,
+			InstanceName: instanceName,
 			Channel:      channel,
 			Resources:    components,
 		},
@@ -6372,7 +6413,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 		name: snapName,
 	}, {
 		op:    "validate-snap:Doing",
-		name:  snapName,
+		name:  instanceName,
 		revno: snapRevision,
 	}, {
 		op:  "current",
@@ -6388,16 +6429,16 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 		},
 	}, {
 		op:    "setup-snap",
-		name:  snapName,
+		name:  instanceName,
 		path:  filepath.Join(dirs.SnapBlobDir, snapFileName),
 		revno: snapRevision,
 	}, {
 		op:   "copy-data",
-		path: filepath.Join(dirs.SnapMountDir, filepath.Join(snapName, snapRevision.String())),
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
 		old:  "<no-old>",
 	}, {
 		op:   "setup-snap-save-data",
-		path: filepath.Join(dirs.SnapDataSaveDir, snapName),
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
 	}}
 
 	// ops for mounting a component (but not yet linking it)
@@ -6406,14 +6447,16 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 			Component: naming.NewComponentRef(snapName, compName),
 			Revision:  snap.R(i + 1),
 		}
-		filename := fmt.Sprintf("%v_%d.comp", csi.Component, i+1)
+
+		containerName := fmt.Sprintf("%s+%s", instanceName, compName)
+		filename := fmt.Sprintf("%s_%d.comp", containerName, i+1)
 
 		expected = append(expected, []fakeOp{{
 			op:   "storesvc-download",
 			name: csi.Component.String(),
 		}, {
 			op:                "validate-component:Doing",
-			name:              snapName,
+			name:              instanceName,
 			revno:             snapRevision,
 			componentName:     compName,
 			componentPath:     filepath.Join(dirs.SnapBlobDir, filename),
@@ -6421,7 +6464,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 			componentSideInfo: csi,
 		}, {
 			op:                "setup-component",
-			containerName:     csi.Component.String(),
+			containerName:     containerName,
 			containerFileName: filename,
 		}}...)
 
@@ -6439,7 +6482,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 
 	expected = append(expected, []fakeOp{{
 		op:    "setup-profiles:Doing",
-		name:  snapName,
+		name:  instanceName,
 		revno: snapRevision,
 	}, {
 		op: "candidate",
@@ -6451,32 +6494,32 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 		},
 	}, {
 		op:   "link-snap",
-		path: filepath.Join(dirs.SnapMountDir, filepath.Join(snapName, snapRevision.String())),
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
 	}}...)
 
 	// ops for linking components
 	for i, compName := range components {
 		expected = append(expected, []fakeOp{{
 			op:   "link-component",
-			path: snap.ComponentMountDir(compName, snap.R(i+1), snapName),
+			path: snap.ComponentMountDir(compName, snap.R(i+1), instanceName),
 		}}...)
 	}
 
 	// ops that follow linking components
 	expected = append(expected, []fakeOp{{
 		op:    "auto-connect:Doing",
-		name:  snapName,
+		name:  instanceName,
 		revno: snapRevision,
 	}, {
 		op: "update-aliases",
 	}}...)
 
 	if undo {
-		expected = append(expected, undoInstallOps(snapName, snapRevision, components)...)
+		expected = append(expected, undoInstallOps(snapName, instanceName, snapRevision, components)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
-			name:  snapName,
+			name:  instanceName,
 			revno: snapRevision,
 		})
 	}
@@ -6487,14 +6530,14 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, components []st
 
 	if undo {
 		var snapst snapstate.SnapState
-		err = snapstate.Get(s.state, snapName, &snapst)
+		err = snapstate.Get(s.state, instanceName, &snapst)
 		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 		c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
 	} else {
 		// verify snap in the system state
 		var snapst snapstate.SnapState
-		err = snapstate.Get(s.state, snapName, &snapst)
+		err = snapstate.Get(s.state, instanceName, &snapst)
 		c.Assert(err, IsNil)
 
 		c.Check(snapst.Active, Equals, true)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6407,7 +6407,6 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 			Action:       "install",
 			InstanceName: instanceName,
 			Channel:      channel,
-			Resources:    components,
 		},
 		revno:  snapRevision,
 		userID: 1,

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -555,7 +555,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 		SnapType:        "app",
 	}
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", nil)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", nil)
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
 }
 
@@ -612,7 +612,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	}
 
 	// And observe that we cannot refresh because the snap is busy.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\), pids: 1234`)
 
 	// Don't record time since it wasn't a failed refresh
@@ -678,7 +678,7 @@ func (s *snapmgrTestSuite) TestInstallWithIgnoreRunningProceedsOnBusySnap(c *C) 
 	}
 
 	// And observe that we do so despite the running app.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 	c.Assert(err, IsNil)
 
 	// The state confirms that the refresh operation was not postponed.
@@ -739,7 +739,7 @@ func (s *snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	}
 
 	// And observe that refresh occurred regardless of the running process.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 	c.Assert(err, IsNil)
 }
 
@@ -748,7 +748,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	defer s.state.Unlock()
 
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "", nil)
+	_, err := snapstate.DoInstall(s.state, nil, snapsup, nil, 0, "", nil)
 	c.Assert(err, ErrorMatches, `cannot install reserved snap name 'system'`)
 }
 
@@ -843,7 +843,7 @@ func (s *snapmgrTestSuite) TestInstallNoRestartBoundaries(c *C) {
 
 	// Ensure that restart boundaries were set on 'link-snap' as a part of doInstall
 	// when the flag noRestartBoundaries is not set
-	ts1, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, 0, "", inUseCheck)
+	ts1, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, nil, 0, "", inUseCheck)
 	c.Assert(err, IsNil)
 
 	linkSnap1 := ts1.MaybeEdge(snapstate.MaybeRebootEdge)
@@ -853,7 +853,7 @@ func (s *snapmgrTestSuite) TestInstallNoRestartBoundaries(c *C) {
 	c.Check(linkSnap1.Get("restart-boundary", &boundary), IsNil)
 
 	// Ensure that restart boundaries are not set when we do provide the noRestartBoundaries flag
-	ts2, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, snapstate.NoRestartBoundaries, "", inUseCheck)
+	ts2, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, nil, snapstate.NoRestartBoundaries, "", inUseCheck)
 	c.Assert(err, IsNil)
 
 	linkSnap2 := ts2.MaybeEdge(snapstate.MaybeRebootEdge)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6307,8 +6307,8 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
 
 	compNameToType := func(name string) snap.ComponentType {
-		typ, ok := strings.CutSuffix(name, "-component")
-		if !ok {
+		typ := strings.TrimSuffix(name, "-component")
+		if typ == name {
 			c.Fatalf("unexpected component name %q", name)
 		}
 		return snap.ComponentType(typ)

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -438,7 +438,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 		{
 			op:             "remove-snap-data-dir",
 			name:           "some-snap_instance",
-			path:           filepath.Join(dirs.SnapDataDir, "some-snap"),
+			path:           filepath.Join(dirs.SnapDataDir, "some-snap_instance"),
 			otherInstances: true,
 		},
 		{
@@ -461,7 +461,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 		{
 			op:             "remove-snap-dir",
 			name:           "some-snap_instance",
-			path:           filepath.Join(dirs.SnapMountDir, "some-snap"),
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance"),
 			otherInstances: true,
 		},
 	}
@@ -592,7 +592,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 		{
 			op:             "remove-snap-data-dir",
 			name:           "some-snap_instance",
-			path:           filepath.Join(dirs.SnapDataDir, "some-snap"),
+			path:           filepath.Join(dirs.SnapDataDir, "some-snap_instance"),
 			otherInstances: true,
 		},
 		{
@@ -615,7 +615,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 		{
 			op:             "remove-snap-dir",
 			name:           "some-snap_instance",
-			path:           filepath.Join(dirs.SnapMountDir, "some-snap"),
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance"),
 			otherInstances: true,
 		},
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8101,7 +8101,7 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 	ts, err := snapstate.LinkNewBaseOrKernel(s.state, "some-kernel", "")
 	c.Assert(err, IsNil)
 	tasks := ts.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap"}, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	tPrepare := tasks[0]
 	var tLink, tUpdateGadgetAssets *state.Task
 	if opts&needsKernelSetup != 0 {
@@ -8129,7 +8129,7 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 	ts, err = snapstate.LinkNewBaseOrKernel(s.state, "some-base", "")
 	c.Assert(err, IsNil)
 	tasks = ts.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	c.Assert(tasks, HasLen, 2)
 	tPrepare = tasks[0]
 	tLink = tasks[1]
@@ -8223,7 +8223,7 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 	c.Assert(err, IsNil)
 	c.Assert(tsNew, NotNil)
 	tasks := tsNew.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap", "test-task"}, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(nonReLinkKinds)))
 	// since this is the kernel, we have our task + test task + update-gadget-assets + link-snap
 	var tLink, tUpdateGadgetAssets *state.Task
 	if opts&needsKernelSetup != 0 {
@@ -8267,7 +8267,7 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 	c.Assert(err, IsNil)
 	c.Assert(tsNew, NotNil)
 	tasks = tsNew.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	// since this is the base, we have our task + link-snap only
 	c.Assert(tasks, HasLen, 2)
 	tLink = tasks[1]
@@ -8296,7 +8296,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadget(c *C) {
 	ts, err := snapstate.SwitchToNewGadget(s.state, "some-gadget", "")
 	c.Assert(err, IsNil)
 	tasks := ts.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeGadget, 0, 0, []string{"prepare-snap"}, kindsToSet(append(nonReLinkKinds, "link-snap"))))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(
+		snap.TypeGadget, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
+	)
 	c.Assert(tasks, HasLen, 3)
 	tPrepare := tasks[0]
 	tUpdateGadgetAssets := tasks[1]
@@ -8431,7 +8433,9 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetTasks(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tsNew, NotNil)
 	tasks := tsNew.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeGadget, 0, 0, []string{"prepare-snap", "test-task"}, kindsToSet(append(nonReLinkKinds, "link-snap"))))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(
+		snap.TypeGadget, 0, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
+	)
 	// since this is the gadget, we have our task + test task + update assets + update cmdline
 	c.Assert(tasks, HasLen, 4)
 	tUpdateGadgetAssets := tasks[2]

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -383,6 +383,7 @@ func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker
 	runner.AddHandler("remove-profiles", fakeHandler, fakeHandler)
 	runner.AddHandler("discard-conns", fakeHandler, fakeHandler)
 	runner.AddHandler("validate-snap", fakeHandler, nil)
+	runner.AddHandler("validate-component", fakeHandler, nil)
 	runner.AddHandler("transition-ubuntu-core", fakeHandler, nil)
 	runner.AddHandler("transition-to-snapd-snap", fakeHandler, nil)
 	runner.AddHandler("update-gadget-assets", fakeHandler, nil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -68,7 +68,7 @@ import (
 func verifyUpdateTasks(c *C, typ snap.Type, opts, discards int, ts *state.TaskSet) {
 	kinds := taskKinds(ts.Tasks())
 
-	expected := expectedDoInstallTasks(typ, unlinkBefore|cleanupAfter|opts, discards, nil, nil)
+	expected := expectedDoInstallTasks(typ, unlinkBefore|cleanupAfter|opts, discards, nil, nil, nil)
 	if opts&doesReRefresh != 0 {
 		expected = append(expected, "check-rerefresh")
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -10224,7 +10224,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 		SnapType: string(snap.TypeApp),
 	}
 	snapstate.Set(s.state, "some-snap", snapst)
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 		Flags:    snapstate.Flags{IsAutoRefresh: true},
 	}
@@ -10642,7 +10642,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 		SnapType: string(snap.TypeApp),
 	}
 	snapstate.Set(s.state, "some-snap", snapst)
-	snapsup := &snapstate.SnapSetup{
+	snapsup := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 		Flags:    snapstate.Flags{IsAutoRefresh: true},
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -12463,7 +12463,7 @@ type: snapd
 				panic(err)
 			}
 		}
-		return s.fakeBackend.ForeignTask(kind, status, snapsup)
+		return s.fakeBackend.ForeignTask(kind, status, snapsup, nil)
 	}
 
 	s.o.TaskRunner().AddHandler("auto-connect", fakeAutoConnect, fakeAutoConnect)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -10229,7 +10229,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 		Flags:    snapstate.Flags{IsAutoRefresh: true},
 	}
 
-	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 
 	var busyErr *snapstate.TimedBusySnapError
 	c.Assert(errors.As(err, &busyErr), Equals, true)
@@ -10657,7 +10657,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 	// don't create a pre-download task if one exists w/ these statuses
 	for _, status := range []state.Status{state.DoStatus, state.DoingStatus} {
 		task.SetStatus(status)
-		ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+		ts, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 
 		var busyErr *snapstate.TimedBusySnapError
 		c.Assert(errors.As(err, &busyErr), Equals, true)
@@ -10675,7 +10675,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 
 	// a "Done" pre-download is ignored since the auto-refresh it causes might also be done
 	task.SetStatus(state.DoneStatus)
-	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, nil, 0, "", inUseCheck)
 	c.Assert(err, FitsTypeOf, &snapstate.TimedBusySnapError{})
 	c.Assert(ts.Tasks(), HasLen, 1)
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -80,6 +80,15 @@ type target struct {
 	components []componentTarget
 }
 
+// componentTarget represents the data needed to setup a component for installation.
+type componentTarget struct {
+	// setup is a partially initialized ComponentSetup struct that contains the
+	// data needed to find the component that will be installed.
+	setup ComponentSetup
+	// info contains the snap.ComponentInfo for the component to be installed.
+	info *snap.ComponentInfo
+}
+
 // setups returns the completed SnapSetup and slice of ComponentSetup structs
 // for the target snap.
 func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSetup, error) {
@@ -117,15 +126,6 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		InstanceKey:        t.info.InstanceKey,
 		ExpectedProvenance: t.info.SnapProvenance,
 	}, compsups, nil
-}
-
-// componentTarget represents the data needed to setup a component for installation.
-type componentTarget struct {
-	// setup is a partially initialized ComponentSetup struct that contains the
-	// data needed to find the component that will be installed.
-	setup ComponentSetup
-	// info contains the snap.ComponentInfo for the component to be installed.
-	info *snap.ComponentInfo
 }
 
 // InstallGoal represents a single snap or a group of snaps to be installed.

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -334,8 +334,8 @@ func componentFromResource(name string, sar store.SnapResourceResult, info *snap
 		return ComponentTarget{}, fmt.Errorf("%q is not a component for snap %q", name, info.SnapName())
 	}
 
-	if fmt.Sprintf("component/%s", comp.Type) != sar.Type {
-		return ComponentTarget{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", comp.Type, sar.Type)
+	if typ := fmt.Sprintf("component/%s", comp.Type); typ != sar.Type {
+		return ComponentTarget{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", typ, sar.Type)
 	}
 
 	compName := naming.NewComponentRef(info.SnapName(), name)

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -95,7 +95,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 
 	compsups := make([]ComponentSetup, 0, len(t.components))
 	for _, comp := range t.components {
-		compsups = append(compsups, comp.compsup())
+		compsups = append(compsups, comp.setup)
 	}
 
 	providerContentAttrs := defaultProviderContentAttrs(st, t.info, opts.PrereqTracker)
@@ -126,15 +126,6 @@ type componentTarget struct {
 	setup ComponentSetup
 	// info contains the snap.ComponentInfo for the component to be installed.
 	info *snap.ComponentInfo
-}
-
-func (c *componentTarget) compsup() ComponentSetup {
-	return ComponentSetup{
-		DownloadInfo: c.setup.DownloadInfo,
-		CompPath:     c.setup.CompPath,
-		CompSideInfo: &c.info.ComponentSideInfo,
-		CompType:     c.info.Type,
-	}
 }
 
 // InstallGoal represents a single snap or a group of snaps to be installed.
@@ -356,18 +347,22 @@ func componentFromResource(name string, sar store.SnapResourceResult, info *snap
 
 	compName := naming.NewComponentRef(info.SnapName(), name)
 
+	csi := snap.ComponentSideInfo{
+		Component: compName,
+		Revision:  snap.R(sar.Revision),
+	}
+
 	return componentTarget{
 		setup: ComponentSetup{
 			DownloadInfo: &sar.DownloadInfo,
+			CompSideInfo: &csi,
+			CompType:     comp.Type,
 		},
 		info: &snap.ComponentInfo{
-			Component: compName,
-			Type:      comp.Type,
-			Version:   sar.Version,
-			ComponentSideInfo: snap.ComponentSideInfo{
-				Component: compName,
-				Revision:  snap.R(sar.Revision),
-			},
+			Component:         compName,
+			Type:              comp.Type,
+			Version:           sar.Version,
+			ComponentSideInfo: csi,
 		},
 	}, nil
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -490,7 +490,7 @@ func InstallWithGoal(ctx context.Context, st *state.State, goal InstallGoal, opt
 			instFlags |= skipConfigure
 		}
 
-		ts, err := doInstall(st, &t.snapst, &snapsup, instFlags, opts.FromChange, inUseFor(opts.DeviceCtx))
+		ts, err := doInstall(st, &t.snapst, &snapsup, nil, instFlags, opts.FromChange, inUseFor(opts.DeviceCtx))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -221,11 +221,16 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 		return vsets, nil
 	}
 
+	includeResources := false
 	actions := make([]*store.SnapAction, 0, len(s.snaps))
 	for _, sn := range s.snaps {
 		action, err := installActionForStoreTarget(sn, opts, enforcedSets)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(sn.Components) > 0 {
+			includeResources = true
 		}
 
 		actions = append(actions, action)
@@ -236,7 +241,9 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 		return nil, err
 	}
 
-	refreshOpts, err := refreshOptions(st, nil)
+	refreshOpts, err := refreshOptions(st, &store.RefreshOptions{
+		IncludeResources: includeResources,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +359,6 @@ func installActionForStoreTarget(t StoreSnap, opts Options, enforcedSets func() 
 		Channel:      t.RevOpts.Channel,
 		Revision:     t.RevOpts.Revision,
 		CohortKey:    t.RevOpts.CohortKey,
-		Resources:    t.Components,
 	}
 
 	switch {

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -69,7 +69,7 @@ type Options struct {
 type target struct {
 	// setup is a partially initialized SnapSetup that contains the data needed
 	// to find the snap file that will be installed.
-	setup *SnapSetup
+	setup SnapSetup
 	// info contains the snap.info for the snap to be installed.
 	info *snap.Info
 	// snapst is the current state of the target snap, prior to installation.
@@ -77,7 +77,7 @@ type target struct {
 	// example, talking to the store).
 	snapst SnapState
 	// components is a list of components to install with this snap.
-	components []ComponentTarget
+	components []componentTarget
 }
 
 // setups returns the completed SnapSetup and slice of ComponentSetup structs
@@ -95,12 +95,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 
 	compsups := make([]ComponentSetup, 0, len(t.components))
 	for _, comp := range t.components {
-		compsups = append(compsups, ComponentSetup{
-			DownloadInfo: comp.Setup.DownloadInfo,
-			CompPath:     comp.Setup.CompPath,
-			CompSideInfo: &comp.Info.ComponentSideInfo,
-			CompType:     comp.Info.Type,
-		})
+		compsups = append(compsups, comp.compsup())
 	}
 
 	providerContentAttrs := defaultProviderContentAttrs(st, t.info, opts.PrereqTracker)
@@ -124,19 +119,28 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 	}, compsups, nil
 }
 
+// componentTarget represents the data needed to setup a component for installation.
+type componentTarget struct {
+	// setup is a partially initialized ComponentSetup struct that contains the
+	// data needed to find the component that will be installed.
+	setup ComponentSetup
+	// info contains the snap.ComponentInfo for the component to be installed.
+	info *snap.ComponentInfo
+}
+
+func (c *componentTarget) compsup() ComponentSetup {
+	return ComponentSetup{
+		DownloadInfo: c.setup.DownloadInfo,
+		CompPath:     c.setup.CompPath,
+		CompSideInfo: &c.info.ComponentSideInfo,
+		CompType:     c.info.Type,
+	}
+}
+
 // InstallGoal represents a single snap or a group of snaps to be installed.
 type InstallGoal interface {
 	// toInstall returns the data needed to setup the snaps for installation.
 	toInstall(context.Context, *state.State, Options) ([]target, error)
-}
-
-// ComponentTarget represents the data needed to setup a component for installation.
-type ComponentTarget struct {
-	// Setup is a partially initialized ComponentSetup struct that contains the
-	// data needed to find the component that will be installed.
-	Setup *ComponentSetup
-	// Info contains the snap.ComponentInfo for the component to be installed.
-	Info *snap.ComponentInfo
 }
 
 // storeInstallGoal implements the InstallGoal interface and represents a group of
@@ -303,7 +307,7 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 		}
 
 		installs = append(installs, target{
-			setup: &SnapSetup{
+			setup: SnapSetup{
 				DownloadInfo: &r.DownloadInfo,
 				Channel:      channel,
 				CohortKey:    sn.RevOpts.CohortKey,
@@ -317,13 +321,13 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 	return installs, err
 }
 
-func requestedComponentsFromActionResult(sn StoreSnap, sar store.SnapActionResult) ([]ComponentTarget, error) {
+func requestedComponentsFromActionResult(sn StoreSnap, sar store.SnapActionResult) ([]componentTarget, error) {
 	mapping := make(map[string]store.SnapResourceResult, len(sar.Resources))
 	for _, res := range sar.Resources {
 		mapping[res.Name] = res
 	}
 
-	installables := make([]ComponentTarget, 0, len(sn.Components))
+	installables := make([]componentTarget, 0, len(sn.Components))
 	for _, comp := range sn.Components {
 		res, ok := mapping[comp]
 		if !ok {
@@ -340,23 +344,23 @@ func requestedComponentsFromActionResult(sn StoreSnap, sar store.SnapActionResul
 	return installables, nil
 }
 
-func componentFromResource(name string, sar store.SnapResourceResult, info *snap.Info) (ComponentTarget, error) {
+func componentFromResource(name string, sar store.SnapResourceResult, info *snap.Info) (componentTarget, error) {
 	comp, ok := info.Components[name]
 	if !ok {
-		return ComponentTarget{}, fmt.Errorf("%q is not a component for snap %q", name, info.SnapName())
+		return componentTarget{}, fmt.Errorf("%q is not a component for snap %q", name, info.SnapName())
 	}
 
 	if typ := fmt.Sprintf("component/%s", comp.Type); typ != sar.Type {
-		return ComponentTarget{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", typ, sar.Type)
+		return componentTarget{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", typ, sar.Type)
 	}
 
 	compName := naming.NewComponentRef(info.SnapName(), name)
 
-	return ComponentTarget{
-		Setup: &ComponentSetup{
+	return componentTarget{
+		setup: ComponentSetup{
 			DownloadInfo: &sar.DownloadInfo,
 		},
-		Info: &snap.ComponentInfo{
+		info: &snap.ComponentInfo{
 			Component: compName,
 			Type:      comp.Type,
 			Version:   sar.Version,
@@ -541,7 +545,7 @@ func InstallWithGoal(ctx context.Context, st *state.State, goal InstallGoal, opt
 		// sort the components by name to ensure we always install components in the
 		// same order
 		sort.Slice(t.components, func(i, j int) bool {
-			return t.components[i].Info.Component.String() < t.components[j].Info.Component.String()
+			return t.components[i].info.Component.String() < t.components[j].info.Component.String()
 		})
 	}
 
@@ -695,7 +699,7 @@ func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts O
 	}
 
 	inst := target{
-		setup: &SnapSetup{
+		setup: SnapSetup{
 			SnapPath:  p.path,
 			Channel:   channel,
 			CohortKey: p.revOpts.CohortKey,

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
@@ -523,6 +524,14 @@ func InstallWithGoal(ctx context.Context, st *state.State, goal InstallGoal, opt
 	// we should check it here as well to be safe
 	if opts.ExpectOneSnap && len(targets) != 1 {
 		return nil, nil, ErrExpectedOneSnap
+	}
+
+	for _, t := range targets {
+		// sort the components by name to ensure we always install components in the
+		// same order
+		sort.Slice(t.components, func(i, j int) bool {
+			return t.components[i].Info.Component.String() < t.components[j].Info.Component.String()
+		})
 	}
 
 	installInfos := make([]minimalInstallInfo, 0, len(targets))

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -338,10 +338,10 @@ func componentSetupFromResource(name string, sar store.SnapResourceResult, info 
 		return ComponentSetup{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", typ, sar.Type)
 	}
 
-	compName := naming.NewComponentRef(info.SnapName(), name)
+	cref := naming.NewComponentRef(info.SnapName(), name)
 
 	csi := snap.ComponentSideInfo{
-		Component: compName,
+		Component: cref,
 		Revision:  snap.R(sar.Revision),
 	}
 

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -42,7 +42,7 @@ func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
 		}
 	}
 
-	goal := snapstate.StoreGoal(snapstate.StoreSnap{
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
 		InstanceName: "test-snap",
 		Components:   []string{"test-component"},
 		RevOpts: snapstate.RevisionOptions{

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -1,0 +1,66 @@
+package snapstate_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+	. "gopkg.in/check.v1"
+)
+
+type TargetTestSuite struct {
+	snapmgrBaseTest
+}
+
+var _ = Suite(&TargetTestSuite{})
+
+func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: "http://example.com/mycomp",
+				},
+				Name:      compName,
+				Revision:  1,
+				Type:      fmt.Sprintf("component/%s", snap.TestComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreGoal(snapstate.StoreSnap{
+		InstanceName: "test-snap",
+		Components:   []string{"test-component"},
+		RevOpts: snapstate.RevisionOptions{
+			Channel: channel,
+		},
+	})
+
+	infos, tss, err := snapstate.InstallWithGoal(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(infos, HasLen, 1)
+	c.Assert(tss, HasLen, 1)
+
+	info := infos[0]
+	c.Check(info.InstanceName(), Equals, snapName)
+	c.Check(info.Channel, Equals, channel)
+	c.Check(info.Components[compName].Name, Equals, compName)
+
+	ts := tss[0]
+
+	verifyInstallTasksWithComponents(c, snap.TypeApp, 0, 0, []string{compName}, ts)
+}

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -31,7 +31,7 @@ func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
 		return []store.SnapResourceResult{
 			{
 				DownloadInfo: snap.DownloadInfo{
-					DownloadURL: "http://example.com/mycomp",
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
 				},
 				Name:      compName,
 				Revision:  1,
@@ -43,24 +43,135 @@ func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
 	}
 
 	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
-		InstanceName: "test-snap",
-		Components:   []string{"test-component"},
+		InstanceName: snapName,
+		Components:   []string{compName},
 		RevOpts: snapstate.RevisionOptions{
 			Channel: channel,
 		},
 	})
 
-	infos, tss, err := snapstate.InstallWithGoal(context.Background(), s.state, goal, snapstate.Options{})
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
 	c.Assert(err, IsNil)
-	c.Assert(infos, HasLen, 1)
-	c.Assert(tss, HasLen, 1)
 
-	info := infos[0]
 	c.Check(info.InstanceName(), Equals, snapName)
 	c.Check(info.Channel, Equals, channel)
 	c.Check(info.Components[compName].Name, Equals, compName)
 
-	ts := tss[0]
-
 	verifyInstallTasksWithComponents(c, snap.TypeApp, 0, 0, []string{compName}, ts)
+}
+
+func (s *TargetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      "missing-component",
+				Revision:  1,
+				Type:      fmt.Sprintf("component/%s", snap.TestComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: snapName,
+		Components:   []string{compName},
+		RevOpts: snapstate.RevisionOptions{
+			Channel: channel,
+		},
+	})
+
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot find component "%s" in snap resources`, compName))
+}
+
+func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      compName,
+				Revision:  1,
+				Type:      fmt.Sprintf("component/%s", snap.KernelModulesComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: snapName,
+		Components:   []string{compName},
+		RevOpts: snapstate.RevisionOptions{
+			Channel: channel,
+		},
+	})
+
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(
+		`.*inconsistent component type \("component/%s" in snap, "component/%s" in component\)`, snap.TestComponent, snap.KernelModulesComponent,
+	))
+}
+
+func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		compName = "test-missing-component"
+		channel  = "channel-for-components"
+	)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      compName,
+				Revision:  1,
+				Type:      fmt.Sprintf("component/%s", snap.TestComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: snapName,
+		Components:   []string{compName},
+		RevOpts: snapstate.RevisionOptions{
+			Channel: channel,
+		},
+	})
+
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
 }

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -206,9 +206,8 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 			CohortKey:    helloCohortKey,
-			Resources:    resources,
 		},
-	}, nil, nil, nil)
+	}, nil, nil, &store.RefreshOptions{IncludeResources: len(resources) > 0})
 	c.Assert(err, IsNil)
 	c.Assert(aresults, HasLen, 0)
 	c.Assert(results, HasLen, 1)


### PR DESCRIPTION
This PR enables us to install components and a snap from the store at the same time. Note that installing components from the store for an already installed snap is not yet handled yet, as that interaction with the store is more complex, requiring the usage of both channel and revision.

First relevant commit is 97dad459a4e9410994c02942c795b882c3e52791, based on https://github.com/snapcore/snapd/pull/14070.