### PR TITLE
snapcraft: improve FIPS snap build, pull FIPS libraries from core22

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -311,7 +311,7 @@ parts:
             # snap, snap-repair and snap-bootstrap (where snap-bootstrap isn't
             # part of the snapd snap)
             bin/snap|lib/snapd/snapd|lib/snapd/snap-repair)
-              TAGS+=(goexperiment.opensslcrypto requirefips)
+              TAGS+=(goexperiment.opensslcrypto)
               ;;
           esac
         fi

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -86,7 +86,6 @@ parts:
       - libbrotli1
       - libc6
       - libcap2
-      - libssl3
       - libexpat1
       - libfreetype6
       - libgcc-s1
@@ -364,6 +363,27 @@ parts:
     override-prime: |
       craftctl default
       python3 "${CRAFT_PROJECT_DIR}/build-aux/snap/local/patch-dl.py" "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"
+
+  libcrypto-fips:
+    plugin: nil
+    source: .
+    after:
+      - snapd
+    override-pull: |
+      craftctl default
+      if [ -f fips-build ]; then
+        # grab the core22 from fips-updates channel
+        snap download --channel fips-updates/stable --basename core22-fips core22
+      fi
+    override-build: |
+      if [ -f fips-build ]; then
+        unsquashfs -d core22-fips-squashfs-root core22-fips.snap \
+          'usr/lib/*-linux-gnu*/engines-3' \
+          'usr/lib/*-linux-gnu*/ossl-modules-3' \
+          'usr/lib/*-linux-gnu*/libssl.so.3' \
+          'usr/lib/*-linux-gnu*/libcrypto.so.3'
+        cp -av core22-fips-squashfs-root/* "${CRAFT_PART_INSTALL}"
+      fi
 
   check-linker:
     plugin: nil

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -376,6 +376,10 @@ parts:
         snap download --channel fips-updates/stable --basename core22-fips core22
       fi
     override-build: |
+      # TODO this is really a hack as we should likely be using on LP; The snapd
+      # snap should include the information about a particular openssl version
+      # which was included in the build but the core22 FIPS variant snap has
+      # been stripped off of the manifest.
       if [ -f fips-build ]; then
         unsquashfs -d core22-fips-squashfs-root core22-fips.snap \
           'usr/lib/*-linux-gnu*/engines-3' \


### PR DESCRIPTION
A set of improvements for building the snapd snap cherry picked from https://github.com/snapcore/snapd/pull/13978/files. First, drop the `requirefips` build tag, as FIPS compliance enforcement will be enabled at runtime. Next, since we already have a FIPS enabled core22 snap published, use that snap as a donor of the FIPS openssl libraries and modules.
