### PR TITLE
o/snapstate: install components and snaps from file

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -55,10 +55,12 @@ func installSeedSnap(st *state.State, sn *seed.Snap, flags snapstate.Flags, prqt
 		flags.DevMode = true
 	}
 
-	t := snapstate.PathInstallGoal("", sn.Path, sn.SideInfo, snapstate.RevisionOptions{
+	// TODO: this will need to account for components in the future
+
+	goal := snapstate.PathInstallGoal("", sn.Path, sn.SideInfo, nil, snapstate.RevisionOptions{
 		Channel: sn.Channel,
 	})
-	info, ts, err := snapstate.InstallOne(context.Background(), st, t, snapstate.Options{
+	info, ts, err := snapstate.InstallOne(context.Background(), st, goal, snapstate.Options{
 		Flags:         flags,
 		PrereqTracker: prqt,
 		Seed:          true,

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -70,7 +70,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 		CompSideInfo: csi,
 		CompType:     compInfo.Type,
 		CompPath:     path,
-		Flags: componentInstallFlags{
+		componentInstallFlags: componentInstallFlags{
 			// The file passed around is temporary, make sure it gets removed.
 			RemoveComponentPath: true,
 		},
@@ -80,8 +80,8 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 }
 
 type componentInstallFlags struct {
-	RemoveComponentPath bool
-	SkipProfiles        bool
+	RemoveComponentPath bool `json:"remove-component-path,omitempty"`
+	SkipProfiles        bool `json:"skip-profiles,omitempty"`
 }
 
 // doInstallComponent might be called with the owner snap installed or not.
@@ -147,7 +147,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 				compSi.Component, revisionStr))
 		addTask(mount)
 	} else {
-		if compSetup.Flags.RemoveComponentPath {
+		if compSetup.RemoveComponentPath {
 			// If the revision is local, we will not need the
 			// temporary snap. This can happen when e.g.
 			// side-loading a local revision again. The path is
@@ -178,7 +178,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 	}
 
 	// security
-	if !compSetup.Flags.SkipProfiles {
+	if !compSetup.SkipProfiles {
 		setupSecurity := st.NewTask("setup-profiles", fmt.Sprintf(i18n.G("Setup component %q%s security profiles"), compSi.Component, revisionStr))
 		addTask(setupSecurity)
 	}

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -70,12 +70,13 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 		CompSideInfo: csi,
 		CompType:     compInfo.Type,
 		CompPath:     path,
+		Flags: componentInstallFlags{
+			// The file passed around is temporary, make sure it gets removed.
+			RemoveComponentPath: true,
+		},
 	}
 
-	return doInstallComponent(st, &snapst, compSetup, snapsup, componentInstallFlags{
-		// The file passed around is temporary, make sure it gets removed.
-		RemoveComponentPath: true,
-	}, "")
+	return doInstallComponent(st, &snapst, compSetup, snapsup, "")
 }
 
 type componentInstallFlags struct {
@@ -85,7 +86,7 @@ type componentInstallFlags struct {
 
 // doInstallComponent might be called with the owner snap installed or not.
 func doInstallComponent(st *state.State, snapst *SnapState, compSetup *ComponentSetup,
-	snapsup *SnapSetup, flags componentInstallFlags, fromChange string) (*state.TaskSet, error) {
+	snapsup *SnapSetup, fromChange string) (*state.TaskSet, error) {
 
 	// TODO check for experimental flag that will hide temporarily components
 
@@ -146,7 +147,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 				compSi.Component, revisionStr))
 		addTask(mount)
 	} else {
-		if flags.RemoveComponentPath {
+		if compSetup.Flags.RemoveComponentPath {
 			// If the revision is local, we will not need the
 			// temporary snap. This can happen when e.g.
 			// side-loading a local revision again. The path is
@@ -177,7 +178,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 	}
 
 	// security
-	if !flags.SkipProfiles {
+	if !compSetup.Flags.SkipProfiles {
 		setupSecurity := st.NewTask("setup-profiles", fmt.Sprintf(i18n.G("Setup component %q%s security profiles"), compSi.Component, revisionStr))
 		addTask(setupSecurity)
 	}

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -295,7 +295,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	// if we're removing the snap file and we are mounting a component for the
 	// first time, then we know that the component also must be coming from an
 	// emphemeral file. in that case, remove it.
-	if snapsup.RemoveSnapPath {
+	if compSetup.RemoveComponentPath {
 		if err := os.Remove(compSetup.CompPath); err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -293,7 +293,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	st.Unlock()
 
 	// if we're removing the snap file and we are mounting a component for the
-	// firs time, then we know that the component also must be coming from an
+	// first time, then we know that the component also must be coming from an
 	// emphemeral file. in that case, remove it.
 	if snapsup.RemoveSnapPath {
 		if err := os.Remove(compSetup.CompPath); err != nil {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/snapcore/snapd/logger"
@@ -290,6 +291,15 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	}
 	perfTimings.Save(st)
 	st.Unlock()
+
+	// if we're removing the snap file and we are mounting a component for the
+	// firs time, then we know that the component also must be coming from an
+	// emphemeral file. in that case, remove it.
+	if snapsup.RemoveSnapPath {
+		if err := os.Remove(compSetup.CompPath); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -202,6 +202,9 @@ type ComponentSetup struct {
 	// DownloadInfo contains information about how to download this component.
 	// Will be nil if the component should be sourced from a local file.
 	DownloadInfo *snap.DownloadInfo `json:"download-info,omitempty"`
+	// Flags is a set of flags that control the behavior of the component
+	// installation/update.
+	Flags componentInstallFlags `json:"flags"`
 }
 
 func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType, compPath string) *ComponentSetup {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -202,9 +202,9 @@ type ComponentSetup struct {
 	// DownloadInfo contains information about how to download this component.
 	// Will be nil if the component should be sourced from a local file.
 	DownloadInfo *snap.DownloadInfo `json:"download-info,omitempty"`
-	// Flags is a set of flags that control the behavior of the component
-	// installation/update.
-	Flags componentInstallFlags `json:"flags"`
+	// componentInstallFlags is a set of flags that control the behavior of the
+	// component's installation/update.
+	componentInstallFlags
 }
 
 func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType, compPath string) *ComponentSetup {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -627,14 +627,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 
 	tasksAfterLinkSnap := make([]*state.Task, 0, len(compsups))
 	for _, compsup := range compsups {
-		compTaskSet, err := doInstallComponent(st, snapst, &compsup, &snapsup, componentInstallFlags{
-			// if we are removing the snap, we can assume that we should remove
-			// the component too
-			RemoveComponentPath: snapsup.RemoveSnapPath,
-			// the setup-profiles task that is created for the snap itself
-			// generates the security profiles for the snap and its new components
-			SkipProfiles: true,
-		}, "")
+		compTaskSet, err := doInstallComponent(st, snapst, &compsup, &snapsup, fromChange)
 		if err != nil {
 			return nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1367,7 +1367,7 @@ func addPrereq(prqt PrereqTracker, info *snap.Info) {
 // local revision and sideloading, or full metadata in which case it
 // the snap will appear as installed from the store.
 func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel string, flags Flags, prqt PrereqTracker) (*state.TaskSet, *snap.Info, error) {
-	target := PathInstallGoal(instanceName, path, si, RevisionOptions{
+	target := PathInstallGoal(instanceName, path, si, nil, RevisionOptions{
 		Channel: channel,
 	})
 	info, ts, err := InstallOne(context.Background(), st, target, Options{
@@ -1446,8 +1446,7 @@ func InstallPathWithDeviceContext(st *state.State, si *snap.SideInfo, path, name
 		opts = &RevisionOptions{}
 	}
 
-	target := PathInstallGoal(name, path, si, *opts)
-
+	target := PathInstallGoal(name, path, si, nil, *opts)
 	_, ts, err := InstallOne(context.Background(), st, target, Options{
 		Flags:         flags,
 		UserID:        userID,

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -116,7 +116,11 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 
 	afterLinkSnap := make([]string, 0, len(components))
 	for range components {
-		compTasks := expectedComponentInstallTasks(compOptSkipSecurity)
+		compOpts := compOptSkipSecurity
+		if opts&localSnap != 0 {
+			compOpts |= compOptIsLocal
+		}
+		compTasks := expectedComponentInstallTasks(compOpts)
 		for i, t := range compTasks {
 			if t == "link-component" {
 				afterLinkSnap = append(afterLinkSnap, compTasks[i:]...)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1077,7 +1077,7 @@ func (s *snapmgrTestSuite) TestInstallPathTooEarly(c *C) {
 	defer r()
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
-	t := snapstate.PathInstallGoal("some-snap", mockSnap, &snap.SideInfo{RealName: "some-snap"}, snapstate.RevisionOptions{})
+	t := snapstate.PathInstallGoal("some-snap", mockSnap, &snap.SideInfo{RealName: "some-snap"}, nil, snapstate.RevisionOptions{})
 	_, _, err := snapstate.InstallWithGoal(context.Background(), s.state, t, snapstate.Options{
 		Seed: true,
 	})
@@ -6568,6 +6568,262 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 		c.Assert(snapst.Sequence.Revisions[0].Components, DeepEquals, compst)
 
 		c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FilePresent)
+	}
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathNoneRunThrough(c *C) {
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, nil, undo)
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathOneRunThrough(c *C) {
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component"}, undo)
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyRunThrough(c *C) {
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = ""
+	)
+	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyInstanceRunThrough(c *C) {
+	const (
+		undo        = false
+		snapName    = "test-snap"
+		instanceKey = "key"
+	)
+	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathInstanceRunThroughUndo(c *C) {
+	const (
+		undo        = true
+		snapName    = "test-snap"
+		instanceKey = "key"
+	)
+	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
+}
+
+func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, snapName, instanceKey string, compNames []string, undo bool) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	sort.Strings(compNames)
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
+	const snapID = "test-snap-id"
+	snapRevision := snap.R(11)
+	instanceName := snap.InstanceName(snapName, instanceKey)
+
+	compNameToType := func(name string) snap.ComponentType {
+		typ, ok := strings.CutSuffix(name, "-component")
+		if !ok {
+			c.Fatalf("unexpected component name %q", name)
+		}
+		return snap.ComponentType(typ)
+	}
+
+	components := make(map[*snap.ComponentSideInfo]string, len(compNames))
+	for i, compName := range compNames {
+		csi := &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(i + 1),
+		}
+
+		componentYaml := fmt.Sprintf(`component: %s
+type: %s
+version: 1.0
+`, csi.Component, compNameToType(compName))
+
+		components[csi] = snaptest.MakeTestComponent(c, componentYaml)
+	}
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, snapInfo *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		for i, compName := range compNames {
+			if compMntDir == snap.ComponentMountDir(compName, snap.R(i+1), instanceName) {
+				return &snap.ComponentInfo{}, nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected component mount dir %q", compMntDir)
+	}))
+
+	snapPath := makeTestSnap(c, `name: test-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+`)
+	chg := s.state.NewChange("install", "install a local snap")
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(instanceName, snapPath, si, components, snapstate.RevisionOptions{})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{
+		Flags: snapstate.Flags{Required: true},
+	})
+	c.Assert(err, IsNil)
+	c.Check(info.InstanceName(), Equals, instanceName)
+	c.Check(info.Revision, Equals, snapRevision)
+
+	chg.AddAll(ts)
+
+	if undo {
+		last := ts.Tasks()[len(ts.Tasks())-1]
+		terr := s.state.NewTask("error-trigger", "provoking total undo")
+		terr.WaitFor(last)
+		chg.AddTask(terr)
+	}
+
+	s.settle(c)
+
+	c.Assert(chg.IsReady(), Equals, true, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+
+	if undo {
+		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	} else {
+		c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	}
+
+	expected := fakeOps{{
+		op:  "current",
+		old: "<no-current>",
+	}, {
+		op:    "setup-snap",
+		name:  instanceName,
+		path:  snapPath,
+		revno: snapRevision,
+	}, {
+		op:   "copy-data",
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
+		old:  "<no-old>",
+	}, {
+		op:   "setup-snap-save-data",
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+	}}
+
+	for i, compName := range compNames {
+		containerName := fmt.Sprintf("%s+%s", instanceName, compName)
+		filename := fmt.Sprintf("%s_%d.comp", containerName, i+1)
+		expected = append(expected, fakeOp{
+			op:                "setup-component",
+			containerName:     containerName,
+			containerFileName: filename,
+		})
+
+		if strings.HasPrefix(compName, string(snap.KernelModulesComponent)) {
+			expected = append(expected, fakeOp{
+				op:           "setup-kernel-modules-components",
+				currentComps: []*snap.ComponentSideInfo{},
+				compsToInstall: []*snap.ComponentSideInfo{{
+					Component: naming.NewComponentRef(snapName, compName),
+					Revision:  snap.R(i + 1),
+				}},
+			})
+		}
+	}
+
+	expected = append(expected, []fakeOp{{
+		op:    "setup-profiles:Doing",
+		name:  instanceName,
+		revno: snapRevision,
+	}, {
+		op:    "candidate",
+		sinfo: *si,
+	}, {
+		op:   "link-snap",
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
+	}}...)
+
+	for i, compName := range compNames {
+		expected = append(expected, fakeOp{
+			op:   "link-component",
+			path: snap.ComponentMountDir(compName, snap.R(i+1), instanceName),
+		})
+	}
+
+	expected = append(expected, []fakeOp{{
+		op:    "auto-connect:Doing",
+		name:  instanceName,
+		revno: snapRevision,
+	}, {
+		op: "update-aliases",
+	}}...)
+
+	if undo {
+		expected = append(expected, undoInstallOps(snapName, instanceName, snapRevision, compNames)...)
+	} else {
+		expected = append(expected, fakeOp{
+			op:    "cleanup-trash",
+			name:  instanceName,
+			revno: snapRevision,
+		})
+	}
+
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	if undo {
+		var snapst snapstate.SnapState
+		err = snapstate.Get(s.state, instanceName, &snapst)
+		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+	} else {
+		// verify snap in the system state
+		var snapst snapstate.SnapState
+		err = snapstate.Get(s.state, instanceName, &snapst)
+		c.Assert(err, IsNil)
+
+		c.Check(snapst.Active, Equals, true)
+		c.Check(snapst.TrackingChannel, Equals, "")
+		c.Check(snapst.Required, Equals, true)
+
+		c.Check(snapst.CurrentSideInfo(), DeepEquals, &snap.SideInfo{
+			RealName: snapName,
+			Revision: snapRevision,
+			SnapID:   snapID,
+		})
+
+		var compst []*sequence.ComponentState
+		for i, compName := range compNames {
+			compst = append(compst, &sequence.ComponentState{
+				SideInfo: &snap.ComponentSideInfo{
+					Component: naming.NewComponentRef(snapName, compName),
+					Revision:  snap.R(i + 1),
+				},
+				CompType: compNameToType(compName),
+			})
+		}
+
+		// make sure that all of our components are accounted for
+		c.Assert(snapst.Sequence.Revisions[0].Components, DeepEquals, compst)
 	}
 }
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6874,3 +6874,87 @@ func printTasks(ts []*state.Task) string {
 	}
 	return b.String()
 }
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathInvalidComponentFile(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		snapID        = "test-snap-id"
+		snapName      = "test-snap"
+		componentName = "test-component"
+	)
+	snapRevision := snap.R(11)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, componentName),
+		Revision:  snap.R(1),
+	}
+
+	compPath := filepath.Join(c.MkDir(), "invalid-component")
+	err := os.WriteFile(compPath, []byte("invalid-component"), 0644)
+	c.Assert(err, IsNil)
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: compPath,
+	}
+
+	snapPath := makeTestSnap(c, `name: test-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+	_, _, err = snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsFromPathInvalidComponentName(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		snapID        = "test-snap-id"
+		snapName      = "test-snap"
+		componentName = "Bad-component"
+	)
+	snapRevision := snap.R(11)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, componentName),
+		Revision:  snap.R(1),
+	}
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: "",
+	}
+
+	snapPath := makeTestSnap(c, `name: test-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid snap name: "%s"`, componentName))
+}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6655,8 +6655,8 @@ func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, snapNam
 	instanceName := snap.InstanceName(snapName, instanceKey)
 
 	compNameToType := func(name string) snap.ComponentType {
-		typ, ok := strings.CutSuffix(name, "-component")
-		if !ok {
+		typ := strings.TrimSuffix(name, "-component")
+		if typ == name {
 			c.Fatalf("unexpected component name %q", name)
 		}
 		return snap.ComponentType(typ)

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -608,16 +609,20 @@ type pathInstallGoal struct {
 	revOpts RevisionOptions
 	// sideInfo contains extra information about the snap.
 	sideInfo *snap.SideInfo
+	// components is a mapping of component side infos to paths that should be
+	// installed alongside this snap.
+	components map[*snap.ComponentSideInfo]string
 }
 
 // PathInstallGoal creates a new InstallGoal to install a snap from a given from
 // a path on disk. If instanceName is not provided, si.RealName will be used.
-func PathInstallGoal(instanceName, path string, si *snap.SideInfo, opts RevisionOptions) InstallGoal {
+func PathInstallGoal(instanceName, path string, si *snap.SideInfo, components map[*snap.ComponentSideInfo]string, opts RevisionOptions) InstallGoal {
 	return &pathInstallGoal{
 		instanceName: instanceName,
 		path:         path,
 		revOpts:      opts,
 		sideInfo:     si,
+		components:   components,
 	}
 }
 
@@ -677,15 +682,39 @@ func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts O
 		return nil, err
 	}
 
+	comps, err := installableComponentsFromPaths(info, p.components)
+	if err != nil {
+		return nil, err
+	}
+
 	inst := target{
 		setup: SnapSetup{
 			SnapPath:  p.path,
 			Channel:   channel,
 			CohortKey: p.revOpts.CohortKey,
 		},
-		info:   info,
-		snapst: snapst,
+		info:       info,
+		snapst:     snapst,
+		components: comps,
 	}
 
 	return []target{inst}, nil
+}
+
+func installableComponentsFromPaths(info *snap.Info, components map[*snap.ComponentSideInfo]string) ([]ComponentSetup, error) {
+	setups := make([]ComponentSetup, 0, len(components))
+	for csi, path := range components {
+		compInfo, _, err := backend.OpenComponentFile(path, info, csi)
+		if err != nil {
+			return nil, err
+		}
+
+		setups = append(setups, ComponentSetup{
+			CompPath:     path,
+			CompSideInfo: csi,
+			CompType:     compInfo.Type,
+		})
+	}
+
+	return setups, nil
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -95,6 +95,27 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		return SnapSetup{}, nil, err
 	}
 
+	compsups := make([]ComponentSetup, 0, len(t.components))
+	for _, comp := range t.components {
+		compsups = append(compsups, ComponentSetup{
+			CompSideInfo: comp.CompSideInfo,
+			CompType:     comp.CompType,
+			CompPath:     comp.CompPath,
+			DownloadInfo: comp.DownloadInfo,
+
+			Flags: componentInstallFlags{
+				// if we're removing the snap, then we should remove the
+				// components too
+				RemoveComponentPath: flags.RemoveSnapPath,
+
+				// since target is always used to setup components and snaps at
+				// the same time, individual components should not be create
+				// setup-profiles tasks.
+				SkipProfiles: true,
+			},
+		})
+	}
+
 	providerContentAttrs := defaultProviderContentAttrs(st, t.info, opts.PrereqTracker)
 	return SnapSetup{
 		Channel:      t.setup.Channel,
@@ -113,7 +134,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		PlugsOnly:          len(t.info.Slots) == 0,
 		InstanceKey:        t.info.InstanceKey,
 		ExpectedProvenance: t.info.SnapProvenance,
-	}, t.components, nil
+	}, compsups, nil
 }
 
 // InstallGoal represents a single snap or a group of snaps to be installed.

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -103,7 +103,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 			CompPath:     comp.CompPath,
 			DownloadInfo: comp.DownloadInfo,
 
-			Flags: componentInstallFlags{
+			componentInstallFlags: componentInstallFlags{
 				// if we're removing the snap, then we should remove the
 				// components too
 				RemoveComponentPath: flags.RemoveSnapPath,

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -682,7 +683,7 @@ func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts O
 		return nil, err
 	}
 
-	comps, err := installableComponentsFromPaths(info, p.components)
+	comps, err := componentSetupsFromPaths(info, p.components)
 	if err != nil {
 		return nil, err
 	}
@@ -701,10 +702,10 @@ func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts O
 	return []target{inst}, nil
 }
 
-func installableComponentsFromPaths(info *snap.Info, components map[*snap.ComponentSideInfo]string) ([]ComponentSetup, error) {
+func componentSetupsFromPaths(snapInfo *snap.Info, components map[*snap.ComponentSideInfo]string) ([]ComponentSetup, error) {
 	setups := make([]ComponentSetup, 0, len(components))
 	for csi, path := range components {
-		compInfo, _, err := backend.OpenComponentFile(path, info, csi)
+		compInfo, err := validatedComponentInfo(path, csi, snapInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -717,4 +718,18 @@ func installableComponentsFromPaths(info *snap.Info, components map[*snap.Compon
 	}
 
 	return setups, nil
+}
+
+func validatedComponentInfo(path string, csi *snap.ComponentSideInfo, si *snap.Info) (*snap.ComponentInfo, error) {
+	if err := csi.Component.Validate(); err != nil {
+		return nil, err
+	}
+	componentInfo, cont, err := backend.OpenComponentFile(path, si, csi)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open snap file: %v", err)
+	}
+	if err := snap.ValidateComponentContainer(cont, csi.Component.String(), logger.Noticef); err != nil {
+		return nil, err
+	}
+	return componentInfo, nil
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -705,7 +705,7 @@ func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts O
 func componentSetupsFromPaths(snapInfo *snap.Info, components map[*snap.ComponentSideInfo]string) ([]ComponentSetup, error) {
 	setups := make([]ComponentSetup, 0, len(components))
 	for csi, path := range components {
-		compInfo, err := validatedComponentInfo(path, csi, snapInfo)
+		compInfo, err := validatedComponentInfo(path, snapInfo, csi)
 		if err != nil {
 			return nil, err
 		}
@@ -720,7 +720,7 @@ func componentSetupsFromPaths(snapInfo *snap.Info, components map[*snap.Componen
 	return setups, nil
 }
 
-func validatedComponentInfo(path string, csi *snap.ComponentSideInfo, si *snap.Info) (*snap.ComponentInfo, error) {
+func validatedComponentInfo(path string, si *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
 	if err := csi.Component.Validate(); err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	. "gopkg.in/check.v1"
 )
@@ -174,4 +176,53 @@ func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 
 	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
+}
+
+func (s *TargetTestSuite) TestInstallWithComponentsFromPath(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		snapID   = "test-snap-id"
+		compName = "test-component"
+		snapYaml = `name: test-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+`
+		componentYaml = `component: test-snap+test-component
+type: test
+version: 1.0
+`
+	)
+
+	snapRevision := snap.R(2)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+	snapPath := makeTestSnap(c, snapYaml)
+
+	csi := &snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, compName),
+		Revision:  snap.R(3),
+	}
+	components := map[*snap.ComponentSideInfo]string{
+		csi: snaptest.MakeTestComponent(c, componentYaml),
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, snapName)
+	c.Check(info.Components[compName].Name, Equals, compName)
+
+	verifyInstallTasksWithComponents(c, snap.TypeApp, localSnap, 0, []string{compName}, ts)
 }


### PR DESCRIPTION
This allows us to install snaps and components from files at the same time. Based on https://github.com/snapcore/snapd/pull/14092, first commit is 12afed26cc9e5e454233a7b838b0cbf26ad7dc54.