### PR TITLE
registry:  validate view names on registry creation

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -189,6 +189,10 @@ func New(account string, registryName string, views map[string]interface{}, sche
 	}
 
 	for name, v := range views {
+		if !validSubkey.Match([]byte(name)) {
+			return nil, fmt.Errorf("cannot define view %q: name must conform to %s", name, subkeyRegex)
+		}
+
 		viewMap, ok := v.(map[string]interface{})
 		if !ok || len(viewMap) == 0 {
 			return nil, fmt.Errorf("cannot define view %q: view must be non-empty map", name)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -47,6 +47,10 @@ func (*viewSuite) TestNewRegistry(c *C) {
 			err: `cannot define registry: no views`,
 		},
 		{
+			registry: map[string]interface{}{"0-a": map[string]interface{}{}},
+			err:      `cannot define view "0-a": name must conform to [a-z](?:-?[a-z0-9])*`,
+		},
+		{
 			registry: map[string]interface{}{"bar": "baz"},
 			err:      `cannot define view "bar": view must be non-empty map`,
 		},
@@ -118,7 +122,8 @@ func (*viewSuite) TestNewRegistry(c *C) {
 		cmt := Commentf("test number %d", i+1)
 		registry, err := registry.New("acc", "foo", tc.registry, registry.NewJSONSchema())
 		if tc.err != "" {
-			c.Assert(err, ErrorMatches, tc.err, cmt)
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, tc.err, cmt)
 		} else {
 			c.Assert(err, IsNil, cmt)
 			c.Check(registry, Not(IsNil), cmt)


### PR DESCRIPTION
When creating registries, constrain view names to a simpler pattern (like the storage path elements).
