### PR TITLE
cmd,daemon: changes in api data to show components information

### DIFF
--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -491,9 +491,8 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
 	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"snap-name":      expectedInstanceName,
-		"snap-names":     []interface{}{expectedInstanceName},
-		"component-name": expectedCompSideInfo.Component.ComponentName,
+		"components": map[string]interface{}{
+			expectedInstanceName: []interface{}{expectedCompSideInfo.Component.ComponentName}},
 	})
 
 	summary = chg.Summary()

--- a/tests/main/component/task.yaml
+++ b/tests/main/component/task.yaml
@@ -64,11 +64,15 @@ execute: |
   install_comp x1
   install_comp x2
 
+  # Check message on installation
+  snap install --dangerous snap-with-comps+comp1_1.0.comp |
+      MATCH 'component comp1 1\.0 for snap-with-comps 1\.0 installed'
+
   # TODO: add checks for components removals when implemented by snapd
   # For the moment, remove the snap and then manually the components
   snap remove snap-with-comps
   cd /etc/systemd/system/
-  systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
+  systemctl stop -- *'snap\x2dwith\x2dcomps-components-mnt-comp1-x3.mount'
   cd -
-  rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x2.mount'
+  rm /etc/systemd/system/*'-snap\x2dwith\x2dcomps-components-mnt-comp1-x3.mount'
   rm -rf "$SNAP_MOUNT_DIR"/snap-with-comps/


### PR DESCRIPTION
Changes to start send and processing components data on installation. With this we can show better messages on installation of a local component.