### PR TITLE
daemon: ensure stability of components list in snap info

### DIFF
--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/snapcore/snapd/client"
@@ -280,6 +281,12 @@ func mapLocal(about aboutSnap, sd clientutil.StatusDecorator) *client.Snap {
 	return result
 }
 
+type compsByName []client.Component
+
+func (c compsByName) Len() int           { return len(c) }
+func (c compsByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c compsByName) Less(i, j int) bool { return c[i].Name < c[j].Name }
+
 func fillComponentInfo(about aboutSnap) []client.Component {
 	localSnap, snapst := about.info, about.snapst
 	comps := make([]client.Component, 0, len(about.info.Components))
@@ -324,6 +331,9 @@ func fillComponentInfo(about aboutSnap) []client.Component {
 			Description: comp.Description,
 		})
 	}
+
+	// for test stability
+	sort.Sort(compsByName(comps))
 
 	return comps
 }


### PR DESCRIPTION
Information about components of a snap is repacked from a map to a list. Since map iteration does not guarantee stability, we need to sort the list of components to keep the tests reliable.

Fixes the following failure:
```
FAIL: api_snaps_test.go:1611: snapsSuite.TestMapLocalFieldsWithComponents

api_snaps_test.go:1809:
    c.Check(daemon.MapLocal(about, nil), check.DeepEquals, expected)
... obtained *client.Snap = &client.Snap{...}
... expected *client.Snap = &client.Snap{...}
... Difference:
...     Components[2].Name: "comp-4" != "comp-3"
...     Components[2].Summary: "" != "summary 3"
...     Components[2].Description: "" != "description 3"
...     Components[3].Name: "comp-3" != "comp-4"
...     Components[3].Summary: "summary 3" != ""
...     Components[3].Description: "description 3" != ""
```

