### PR TITLE
client,snap: make {Snap,Component}.InstallDate non-pointer

### DIFF
--- a/client/components.go
+++ b/client/components.go
@@ -36,5 +36,5 @@ type Component struct {
 	Description   string             `json:"description"`
 	Revision      snap.Revision      `json:"revision"`
 	InstalledSize int64              `json:"installed-size,omitempty"`
-	InstallDate   *time.Time         `json:"install-date,omitempty"`
+	InstallDate   time.Time          `json:"install-date,omitempty"`
 }

--- a/client/packages.go
+++ b/client/packages.go
@@ -40,7 +40,7 @@ type Snap struct {
 	DownloadSize  int64              `json:"download-size,omitempty"`
 	Icon          string             `json:"icon,omitempty"`
 	InstalledSize int64              `json:"installed-size,omitempty"`
-	InstallDate   *time.Time         `json:"install-date,omitempty"`
+	InstallDate   time.Time          `json:"install-date,omitempty"`
 	Name          string             `json:"name"`
 	Publisher     *snap.StoreAccount `json:"publisher,omitempty"`
 	StoreURL      string             `json:"store-url,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -306,7 +306,7 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(pkg.InstallDate.Equal(time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC)), check.Equals, true)
-	pkg.InstallDate = nil
+	pkg.InstallDate = time.Time{}
 
 	var expectedSnapRefreshInhibit *client.SnapRefreshInhibit
 	if refreshInhibited {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -265,8 +265,8 @@ func (iw *infoWriter) maybePrintRefreshInfo() {
 		return
 	}
 
-	if iw.localSnap.InstallDate != nil && !iw.localSnap.InstallDate.IsZero() {
-		fmt.Fprintf(iw, "refresh-date:\t%s\n", iw.fmtTime(*iw.localSnap.InstallDate))
+	if !iw.localSnap.InstallDate.IsZero() {
+		fmt.Fprintf(iw, "refresh-date:\t%s\n", iw.fmtTime(iw.localSnap.InstallDate))
 	}
 
 	maybePrintHold := func(key string, hold *time.Time) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1118,8 +1118,8 @@ UnitFileState=enabled
 	c.Check(m.InstalledSize, check.FitsTypeOf, int64(0))
 	m.InstalledSize = 0
 	// ditto install-date
-	c.Check(m.InstallDate, check.FitsTypeOf, &time.Time{})
-	m.InstallDate = nil
+	c.Check(m.InstallDate, check.FitsTypeOf, time.Time{})
+	m.InstallDate = time.Time{}
 
 	expected := &daemon.RespJSON{
 		Type:   daemon.ResponseTypeSync,

--- a/snap/component.go
+++ b/snap/component.go
@@ -170,13 +170,12 @@ func ComponentLinkPath(cpi ContainerPlaceInfo, snapRev Revision) string {
 // when its symlink was created. We cannot use the mount directory as lstat
 // returns the date of the root of the container instead of the date when the
 // mount directory was created.
-func ComponentInstallDate(cpi ContainerPlaceInfo, snapRev Revision) *time.Time {
+func ComponentInstallDate(cpi ContainerPlaceInfo, snapRev Revision) time.Time {
 	symLn := ComponentLinkPath(cpi, snapRev)
 	if st, err := os.Lstat(symLn); err == nil {
-		modTime := st.ModTime()
-		return &modTime
+		return st.ModTime()
 	}
-	return nil
+	return time.Time{}
 }
 
 // ComponentSize returns the file size of a component.

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -581,7 +581,7 @@ func (s *infoSuite) TestComponentInstallDate(c *C) {
 	cpi := snap.MinimalComponentContainerPlaceInfo("comp", snap.R(1), "snap")
 
 	// not current -> Zero
-	c.Check(snap.ComponentInstallDate(cpi, snap.R(33)), IsNil)
+	c.Check(snap.ComponentInstallDate(cpi, snap.R(33)).IsZero(), Equals, true)
 
 	//time.Sleep(time.Second)
 	link := snap.ComponentLinkPath(cpi, snap.R(33))

--- a/snap/info.go
+++ b/snap/info.go
@@ -803,19 +803,18 @@ func (s *Info) ExpandSnapVariables(path string) string {
 
 // InstallDate returns the "install date" of the snap.
 //
-// If the snap is not active, it'll return nil; otherwise
+// If the snap is not active, it'll return zero value; otherwise
 // it'll return the modtime of the "current" symlink. Sneaky.
-func (s *Info) InstallDate() *time.Time {
+func (s *Info) InstallDate() time.Time {
 	dir, rev := filepath.Split(s.MountDir())
 	cur := filepath.Join(dir, "current")
 	tag, err := os.Readlink(cur)
 	if err == nil && tag == rev {
 		if st, err := os.Lstat(cur); err == nil {
-			modTime := st.ModTime()
-			return &modTime
+			return st.ModTime()
 		}
 	}
-	return nil
+	return time.Time{}
 }
 
 // IsActive returns whether this snap revision is active.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -403,7 +403,7 @@ func (s *infoSuite) TestInstallDate(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(1)}
 	info := snaptest.MockSnap(c, sampleYaml, si)
 	// not current -> Zero
-	c.Check(info.InstallDate(), IsNil)
+	c.Check(info.InstallDate().IsZero(), Equals, true)
 	c.Check(snap.InstallDate(info.InstanceName()).IsZero(), Equals, true)
 
 	mountdir := info.MountDir()


### PR DESCRIPTION
The zero value of time is perfectly capable of representing no-time. A time.Time value is tiny, making a pointer pretty wasteful.
