### PR TITLE
tests: set SNAP_MOUNT_DIR in debug section

### DIFF
--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -33,6 +33,7 @@ restore: |
     done
 
 debug: |
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     ls -ld "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine" || true
     ls -ld "$SNAP_MOUNT_DIR/ubuntu-core/current/usr/lib/snapd/snap-confine" || true
     ls -ld /usr/lib/snapd/snap-confine || true


### PR DESCRIPTION
The debug section was always broken, as they do not share environment variables with the other sections.

This should fix an error seen in the wild:

  2024-06-19 13:05:09 Error debugging
  google:ubuntu-20.04-64:tests/main/security-setuid-root (jun191226-580356) :
  /bin/bash: line 92: SNAP_MOUNT_DIR: unbound variable
