### PR TITLE
o/snapstate: make a managed refresh schedule not require any additional checks

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/utils"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -62,6 +63,17 @@ func NewRepository() *Repository {
 	}
 
 	return repo
+}
+
+func ResetRepository(repo *Repository) {
+	osutil.MustBeTestBinary("cannot use the ResetRepository method outside of tests")
+	repo.ifaces = make(map[string]Interface)
+	repo.hotplugIfaces = make(map[string]Interface)
+	repo.plugs = make(map[string]map[string]*snap.PlugInfo)
+	repo.slots = make(map[string]map[string]*snap.SlotInfo)
+	repo.slotPlugs = make(map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection)
+	repo.plugSlots = make(map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection)
+	repo.appSets = make(map[string]*SnapAppSet)
 }
 
 // Interface returns an interface with a given name.

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -46,10 +46,10 @@ func init() {
 }
 
 func reportOrIgnoreInvalidManageRefreshes(tr RunTransaction, optName string) error {
-	// check if the option is set as part of transaction changes; if not than
-	// it's already set in the config state and we shouldn't error out about it
-	// now. refreshScheduleManaged will do the right thing when refresh cannot
-	// be managed anymore.
+	// check if the option is set as part of transaction changes; if not
+	// than it's already set in the config state and we shouldn't error out
+	// about it now since the required conditions were met at the time it
+	// got set
 	for _, k := range tr.Changes() {
 		if k == "core."+optName {
 			return fmt.Errorf("cannot set schedule to managed")
@@ -109,6 +109,8 @@ func validateRefreshSchedule(tr RunTransaction) error {
 		st.Lock()
 		defer st.Unlock()
 
+		// ensure there is a snap entitled to managing the refreshes
+		// in an autonomic manner
 		if !devicestate.CanManageRefreshes(st) {
 			return reportOrIgnoreInvalidManageRefreshes(tr, "refresh.timer")
 		}
@@ -136,6 +138,7 @@ func validateRefreshSchedule(tr RunTransaction) error {
 		st.Lock()
 		defer st.Unlock()
 
+		// see the comment around refresh.timer
 		if !devicestate.CanManageRefreshes(st) {
 			return reportOrIgnoreInvalidManageRefreshes(tr, "refresh.schedule")
 		}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -270,7 +270,6 @@ func delayedCrossMgrInit() {
 		snapstate.AddCheckSnapCallback(checkGadgetRemodelCompatible)
 	})
 	snapstate.CanAutoRefresh = canAutoRefresh
-	snapstate.CanManageRefreshes = CanManageRefreshes
 	snapstate.IsOnMeteredConnection = netutil.IsOnMeteredConnection
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.RemodelingChange = RemodelingChange

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -307,15 +307,14 @@ func interfaceConnected(st *state.State, snapName, ifName string) bool {
 	return err == nil && len(conns) > 0
 }
 
-// CanManageRefreshes returns true if the device can be
-// switched to the "core.refresh.schedule=managed" mode.
+// CanManageRefreshes returns true if a snap entitled to setting the
+// refresh-schedule to managed is installed in the system and the relevant
+// interface is currently connected.
 //
 // TODO:
 //   - Move the CanManageRefreshes code into the ifstate
 //   - Look at the connections and find the connection for snapd-control
 //     with the managed attribute
-//   - Take the snap from this connection and look at the snapstate to see
-//     if that snap has a snap declaration (to ensure it comes from the store)
 func CanManageRefreshes(st *state.State) bool {
 	snapStates, err := snapstate.All(st)
 	if err != nil {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -39,6 +39,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -14458,9 +14459,12 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 
+	var reqsLock sync.Mutex
 	var reqs []string
 	s.storeObserver = func(r *http.Request) {
 		c.Logf("request %v\n", r)
+		reqsLock.Lock()
+		defer reqsLock.Unlock()
 		reqs = append(reqs, r.URL.String())
 	}
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -14425,7 +14425,7 @@ func makeMockRepoWithConnectedSnaps(c *C, repo *interfaces.Repository, info11, c
 }
 
 func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, hasPendingSecurityProfiles bool) {
-	// This test exists to verify that any distruptions of a refresh
+	// This test exists to verify that any disruptions of a refresh
 	// will maintain any pre-existing connection that was held before
 	// the snap is marked inactive. The goal of this test is to run all
 	// tasks that involve something making the snap unavailable/not active
@@ -14437,7 +14437,7 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 	// This was selected based on a customer case. Prior to version 2.58 this
 	// would cause the connection to be dropped, if a well-timed restart of snapd
 	// would occur during a refresh. In 2.58 a fix for this was merged, and this
-	// test shall be passing.
+	// test should be passing.
 	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
@@ -14605,8 +14605,7 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 		// reflected by the repo
 		c.Assert(err, ErrorMatches, `snap "snap-with-snapd-control" has no .* "snapd-control"`)
 		c.Assert(ref, HasLen, 0)
-		// but returns false without the fix, yet we still made no
-		// auto-refresh requests as checked earlier
+		// but returns false without the fix
 		c.Check(devicestate.CanManageRefreshes(st), Equals, false)
 	}
 

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -131,7 +131,6 @@ type autoRefresh struct {
 	lastRefreshSchedule string
 	nextRefresh         time.Time
 	lastRefreshAttempt  time.Time
-	managedDeniedLogged bool
 
 	restoredMonitoring bool
 }
@@ -524,25 +523,12 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (sched []*timeutil.S
 
 	// user requests refreshes to be managed by an external snap
 	if scheduleConf == "managed" {
-		if CanManageRefreshes == nil || !CanManageRefreshes(m.state) {
-			// there's no snap to manage refreshes so use default schedule
-			if !m.managedDeniedLogged {
-				logger.Noticef("managed refresh schedule denied, no properly configured snapd-control")
-				m.managedDeniedLogged = true
-			}
-
-			return defaultRefreshSchedule, defaultRefreshScheduleStr, false, nil
-		}
-
 		if m.lastRefreshSchedule != "managed" {
 			logger.Noticef("refresh is managed via the snapd-control interface")
 			m.lastRefreshSchedule = "managed"
 		}
-		m.managedDeniedLogged = false
-
 		return nil, "managed", legacy, nil
 	}
-	m.managedDeniedLogged = false
 
 	if scheduleConf == "" {
 		return defaultRefreshSchedule, defaultRefreshScheduleStr, false, nil

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -61,7 +61,6 @@ const defaultMaxInhibitionDays = 14
 // hooks setup by devicestate
 var (
 	CanAutoRefresh        func(st *state.State) (bool, error)
-	CanManageRefreshes    func(st *state.State) bool
 	IsOnMeteredConnection func() (bool, error)
 
 	defaultRefreshSchedule = func() []*timeutil.Schedule {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -173,11 +173,6 @@ func (s *autoRefreshTestSuite) TestLastRefresh(c *C) {
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshManaged(c *C) {
-	snapstate.CanManageRefreshes = func(st *state.State) bool {
-		return true
-	}
-	defer func() { snapstate.CanManageRefreshes = nil }()
-
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
@@ -220,11 +215,6 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshManaged(c *C) {
 }
 
 func (s *autoRefreshTestSuite) TestRefreshManagedTimerWins(c *C) {
-	snapstate.CanManageRefreshes = func(st *state.State) bool {
-		return true
-	}
-	defer func() { snapstate.CanManageRefreshes = nil }()
-
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -249,11 +239,6 @@ func (s *autoRefreshTestSuite) TestRefreshManagedTimerWins(c *C) {
 }
 
 func (s *autoRefreshTestSuite) TestRefreshManagedIsRespected(c *C) {
-	snapstate.CanManageRefreshes = func(st *state.State) bool {
-		c.Fatalf("unexpected call")
-		return false
-	}
-
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -73,7 +73,7 @@ func (r *refreshHints) needsUpdate() (bool, error) {
 
 func (r *refreshHints) refresh() error {
 	scheduleConf, _, _ := getRefreshScheduleConf(r.state)
-	refreshManaged := scheduleConf == "managed" && CanManageRefreshes(r.state)
+	refreshManaged := scheduleConf == "managed"
 
 	var err error
 	perfTimings := timings.New(map[string]string{"ensure": "refresh-hints"})

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -48,6 +48,7 @@ type recordingStore struct {
 	storetest.Store
 
 	ops            []string
+	opOpts         []store.RefreshOptions
 	refreshedSnaps []*snap.Info
 }
 
@@ -66,7 +67,13 @@ func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.C
 			panic("expected refresh actions")
 		}
 	}
+	actionOpts := store.RefreshOptions{}
+	if opts != nil {
+		actionOpts = *opts
+	}
+
 	r.ops = append(r.ops, "list-refresh")
+	r.opOpts = append(r.opOpts, actionOpts)
 
 	res := []store.SnapActionResult{}
 	for _, rs := range r.refreshedSnaps {
@@ -126,11 +133,34 @@ func (s *refreshHintsTestSuite) SetUpTest(c *C) {
 	})
 }
 
-func (s *refreshHintsTestSuite) TestLastRefresh(c *C) {
+func (s *refreshHintsTestSuite) TestListRefresh(c *C) {
 	rh := snapstate.NewRefreshHints(s.state)
 	err := rh.Ensure()
 	c.Check(err, IsNil)
 	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+	c.Check(s.store.opOpts, DeepEquals, []store.RefreshOptions{
+		{PrivacyKey: "privacy-key"},
+	})
+}
+
+func (s *refreshHintsTestSuite) TestListRefreshReportsManaged(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	err := tr.Set("core", "refresh.timer", "managed")
+	c.Assert(err, IsNil)
+	tr.Commit()
+
+	s.state.Unlock()
+	rh := snapstate.NewRefreshHints(s.state)
+	err = rh.Ensure()
+	s.state.Lock()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+	c.Check(s.store.opOpts, DeepEquals, []store.RefreshOptions{
+		{RefreshManaged: true, PrivacyKey: "privacy-key"},
+	})
 }
 
 func (s *refreshHintsTestSuite) TestLastRefreshNoRefreshNeeded(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4225,13 +4225,6 @@ func (s *snapmgrTestSuite) testEnsureRefreshesDisabledViaSnapdControl(c *C, conf
 	})
 	defer restore()
 
-	// pretend the device is refresh-control: managed
-	oldCanManageRefreshes := snapstate.CanManageRefreshes
-	snapstate.CanManageRefreshes = func(*state.State) bool {
-		return true
-	}
-	defer func() { snapstate.CanManageRefreshes = oldCanManageRefreshes }()
-
 	tr := config.NewTransaction(st)
 	confSet(tr)
 	tr.Commit()


### PR DESCRIPTION
Drop the additional check to CanManageRefreshes() when the refresh schedule is
already set to 'managed'. This was originally a way to ensure that there is at
least one snap entitled to directly manage the refreshes or fall back to the
default auto-refresh schedule. However, the conditions in which the fallback
would be applied are incorrect and could lead to a situation when snapd would
trigger an auto-refresh even while a snap which is entitled to using a managed
refresh schedule is being refreshed (due to the snapd-control being temporarily
disconnected). On top of this, since the device was once switched to managed, it
clearly means that it was entitled to do so and it was intentional, hence we
should not accidentally break the expectations.

An attempt to fix this was introduced in 01ef5a91df5710367e1508a65724cc2267ccca82 which landed in 2.58, but when refreshing snapd from a version prior to 2.58, the pending security bits would not be set in the state and thus the new code would not be triggered as expected.