### PR TITLE
o/snapstate: assign properly local revisions and be more careful when removing components

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -158,8 +158,7 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 		addTask(kmodSetup)
 	}
 
-	// We might be replacing a component if a local install, otherwise
-	// this is not really possible.
+	// We might be replacing a component
 	compInstalled := snapst.IsComponentInCurrentSeq(compSi.Component)
 	if compInstalled {
 		unlink := st.NewTask("unlink-current-component", fmt.Sprintf(i18n.G(
@@ -179,8 +178,11 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup *Component
 			compSi.Component, revisionStr))
 	addTask(linkSnap)
 
-	// clean-up previous revision of the component if present
-	if compInstalled {
+	// clean-up previous revision of the component if present and
+	// not used in previous sequence points
+	if compInstalled &&
+		!snapst.IsCurrentComponentRevInAnyNonCurrentSeq(compSetup.CompSideInfo.Component) {
+
 		discardComp := st.NewTask("discard-component", fmt.Sprintf(i18n.G(
 			"Discard previous revision for component %q"),
 			compSi.Component))

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -106,6 +106,7 @@ components:
 	snapstate.Set(s.state, snapName, snapSt)
 
 	c.Check(snapSt.IsComponentInCurrentSeq(cref), Equals, true)
+	c.Check(snapSt.IsCurrentComponentRevInAnyNonCurrentSeq(cref), Equals, false)
 	c.Check(snapSt.IsComponentRevPresent(csi), Equals, true)
 	foundCsi := snapSt.CurrentComponentSideInfo(cref)
 	c.Check(foundCsi, DeepEquals, csi)
@@ -134,6 +135,7 @@ components:
 	snapstate.Set(s.state, snapName, snapSt)
 
 	c.Check(snapSt.IsComponentInCurrentSeq(cref), Equals, false)
+	c.Check(snapSt.IsCurrentComponentRevInAnyNonCurrentSeq(cref), Equals, false)
 	c.Check(snapSt.IsComponentRevPresent(csi), Equals, true)
 	c.Check(snapSt.CurrentComponentSideInfo(cref), IsNil)
 	c.Check(snapSt.CurrentComponentSideInfo(cref2), IsNil)
@@ -161,6 +163,7 @@ components:
 	snapstate.Set(s.state, snapName, snapSt)
 
 	c.Check(snapSt.IsComponentInCurrentSeq(cref), Equals, false)
+	c.Check(snapSt.IsCurrentComponentRevInAnyNonCurrentSeq(cref), Equals, false)
 	c.Check(snapSt.IsComponentRevPresent(csi), Equals, false)
 	c.Check(snapSt.CurrentComponentSideInfo(cref), IsNil)
 	c.Check(snapSt.CurrentComponentSideInfo(cref2), IsNil)
@@ -179,6 +182,8 @@ components:
 		Current: snapRev,
 	}
 	snapstate.Set(s.state, snapName, snapSt)
+
+	c.Check(snapSt.IsCurrentComponentRevInAnyNonCurrentSeq(cref), Equals, false)
 
 	foundCi, err = snapSt.CurrentComponentInfo(cref)
 	c.Check(err, IsNil)
@@ -201,4 +206,17 @@ components:
 
 	_, err = snapSt.CurrentComponentInfos()
 	c.Assert(err, testutil.ErrorIs, snapstate.ErrNoCurrent)
+
+	snapSt = &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(ssi2, []*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
+				sequence.NewRevisionSideState(ssi, []*sequence.ComponentState{sequence.NewComponentState(csi, snap.TestComponent)}),
+			}),
+		Current: snapRev,
+	}
+	snapstate.Set(s.state, snapName, snapSt)
+
+	c.Check(snapSt.IsCurrentComponentRevInAnyNonCurrentSeq(cref), Equals, true)
 }

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -114,15 +114,12 @@ func (m *SnapManager) doPrepareComponent(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if compSetup.Revision().Unset() {
-		// This is a local installation, revision is -1 if the current
-		// one is non-local or not installed, or current one
-		// decremented by one otherwise.
-		revision := snap.R(-1)
-		current := snapSt.CurrentComponentSideInfo(compSetup.CompSideInfo.Component)
-		if current != nil && current.Revision.N < 0 {
-			revision = snap.R(current.Revision.N - 1)
-		}
-		compSetup.CompSideInfo.Revision = revision
+		// This is a local installation, assign -1 to the revision if
+		// no other local revision for the component is found, or
+		// current more negative local revision decremented by one
+		// otherwise.
+		current := snapSt.LocalComponentRevision(compSetup.CompSideInfo.Component.ComponentName)
+		compSetup.CompSideInfo.Revision = snap.R(current.N - 1)
 	}
 
 	t.Set("component-setup", compSetup)

--- a/overlord/snapstate/handlers_components_prepare_test.go
+++ b/overlord/snapstate/handlers_components_prepare_test.go
@@ -21,6 +21,8 @@ package snapstate_test
 
 import (
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -72,16 +74,42 @@ func (s *prepareSnapSuite) TestDoPrepareComponentSimple(c *C) {
 func (s *prepareSnapSuite) TestDoPrepareComponentAlreadyPresent(c *C) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
-	snapRev := snap.R(1)
+	snapRev := snap.R(-11)
 	// Unset component revision
 	compRev := snap.R(0)
 	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev,
+		SnapID: "some-snap-id"}
+	ssi2 := &snap.SideInfo{RealName: snapName, Revision: snap.R(-10),
+		SnapID: "some-snap-id"}
 	ssu := createTestSnapSetup(si, snapstate.Flags{})
 
 	s.state.Lock()
 
-	// state with some component around already
-	setStateWithOneComponent(s.state, snapName, snapRev, compName, snap.R(-1))
+	// state with some components around already
+	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef("some-snap", compName), snap.R(-3))
+	csi2 := snap.NewComponentSideInfo(naming.NewComponentRef("some-snap", compName), snap.R(-2))
+	csi3 := snap.NewComponentSideInfo(naming.NewComponentRef("some-snap", "othercomp"), snap.R(-13))
+	compsSi1 := []*sequence.ComponentState{
+		sequence.NewComponentState(csi1, snap.TestComponent),
+		sequence.NewComponentState(csi2, snap.TestComponent),
+		sequence.NewComponentState(csi3, snap.TestComponent),
+	}
+	csi4 := snap.NewComponentSideInfo(naming.NewComponentRef("some-snap", compName), snap.R(-8))
+	csi5 := snap.NewComponentSideInfo(naming.NewComponentRef("some-snap", "othercomp"), snap.R(-9))
+	compsSi2 := []*sequence.ComponentState{
+		sequence.NewComponentState(csi4, snap.TestComponent),
+		sequence.NewComponentState(csi5, snap.TestComponent),
+	}
+	snapst := &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(ssi, compsSi1),
+				sequence.NewRevisionSideState(ssi2, compsSi2),
+			}),
+		Current: si.Revision,
+	}
+	snapstate.Set(s.state, snapName, snapst)
 
 	t := s.state.NewTask("prepare-component", "task desc")
 	cref := naming.NewComponentRef(snapName, compName)
@@ -101,9 +129,9 @@ func (s *prepareSnapSuite) TestDoPrepareComponentAlreadyPresent(c *C) {
 
 	var csup snapstate.ComponentSetup
 	t.Get("component-setup", &csup)
-	// Revision should have been set to x2 (-2)
+	// Revision should have been set to x9 (-9)
 	c.Check(csup.CompSideInfo, DeepEquals, snap.NewComponentSideInfo(
-		cref, snap.R(-2),
+		cref, snap.R(-9),
 	))
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -243,3 +243,121 @@ func (s *sequenceTestSuite) TestKernelModulesComponentsForRev(c *C) {
 	c.Check(len(seq.ComponentsWithTypeForRev(snapRev2, snap.KernelModulesComponent)),
 		Equals, 0)
 }
+
+func (s *sequenceTestSuite) TestIsComponentRevInRefSeqPtInAnyOtherSeqPt(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	snapRev2 := snap.R(2)
+	compRev := snap.R(33)
+
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev, SnapID: "some-snap-id"}
+	ssi2 := &snap.SideInfo{RealName: snapName, Revision: snapRev2, SnapID: "some-snap-id"}
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+
+	rev1Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi, snap.TestComponent)}
+	rev2Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi, snap.TestComponent)}
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(ssi, rev1Comps),
+			sequence.NewRevisionSideState(ssi2, rev2Comps),
+		})
+
+	c.Assert(seq.IsComponentRevInRefSeqPtInAnyOtherSeqPt(
+		naming.NewComponentRef(snapName, compName), 0),
+		Equals, true)
+	c.Assert(seq.IsComponentRevInRefSeqPtInAnyOtherSeqPt(
+		naming.NewComponentRef(snapName, compName), 1),
+		Equals, true)
+
+	csi2 := snap.NewComponentSideInfo(cref, snap.R(5))
+	rev3Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi2, snap.TestComponent)}
+	seq = snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(ssi, rev1Comps),
+			sequence.NewRevisionSideState(ssi2, rev3Comps),
+		})
+
+	c.Assert(seq.IsComponentRevInRefSeqPtInAnyOtherSeqPt(
+		naming.NewComponentRef(snapName, compName), 0),
+		Equals, false)
+	c.Assert(seq.IsComponentRevInRefSeqPtInAnyOtherSeqPt(
+		naming.NewComponentRef(snapName, compName), 1),
+		Equals, false)
+}
+
+func (s *sequenceTestSuite) TestLocalRevision(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const compName2 = "mycomp2"
+	snapRev := snap.R(-1)
+	snapRev2 := snap.R(-2)
+	compRev := snap.R(-33)
+
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev, SnapID: "some-snap-id"}
+	ssi2 := &snap.SideInfo{RealName: snapName, Revision: snapRev2, SnapID: "some-snap-id"}
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	cref2 := naming.NewComponentRef(snapName, compName2)
+	csi2 := snap.NewComponentSideInfo(cref2, snap.R(-45))
+	cref3 := naming.NewComponentRef(snapName, compName)
+	csi3 := snap.NewComponentSideInfo(cref3, snap.R(-2))
+	cref4 := naming.NewComponentRef(snapName, compName)
+	csi4 := snap.NewComponentSideInfo(cref4, snap.R(-34))
+
+	rev1Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi2, snap.KernelModulesComponent),
+		sequence.NewComponentState(csi, snap.TestComponent)}
+	rev2Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi3, snap.TestComponent),
+		sequence.NewComponentState(csi4, snap.TestComponent)}
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(ssi2, rev2Comps),
+			sequence.NewRevisionSideState(ssi, rev1Comps),
+		})
+
+	c.Assert(seq.MinimumLocalRevision(), Equals, snap.R(-2))
+	c.Assert(seq.MinimumLocalComponentRevision(compName), Equals, snap.R(-34))
+	c.Assert(seq.MinimumLocalComponentRevision(compName2), Equals, snap.R(-45))
+}
+
+func (s *sequenceTestSuite) TestNoLocalRevision(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	const compName2 = "mycomp2"
+	snapRev := snap.R(1)
+	snapRev2 := snap.R(2)
+	compRev := snap.R(33)
+
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev, SnapID: "some-snap-id"}
+	ssi2 := &snap.SideInfo{RealName: snapName, Revision: snapRev2, SnapID: "some-snap-id"}
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	cref2 := naming.NewComponentRef(snapName, compName2)
+	csi2 := snap.NewComponentSideInfo(cref2, snap.R(45))
+	cref3 := naming.NewComponentRef(snapName, compName)
+	csi3 := snap.NewComponentSideInfo(cref3, snap.R(2))
+	cref4 := naming.NewComponentRef(snapName, compName)
+	csi4 := snap.NewComponentSideInfo(cref4, snap.R(34))
+
+	rev1Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi2, snap.KernelModulesComponent),
+		sequence.NewComponentState(csi, snap.TestComponent)}
+	rev2Comps := []*sequence.ComponentState{
+		sequence.NewComponentState(csi3, snap.TestComponent),
+		sequence.NewComponentState(csi4, snap.TestComponent)}
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(ssi2, rev2Comps),
+			sequence.NewRevisionSideState(ssi, rev1Comps),
+		})
+
+	c.Assert(seq.MinimumLocalRevision(), Equals, snap.R(0))
+	c.Assert(seq.MinimumLocalComponentRevision(compName), Equals, snap.R(0))
+	c.Assert(seq.MinimumLocalComponentRevision(compName2), Equals, snap.R(0))
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -399,16 +399,28 @@ func (snapst *SnapState) IsComponentInCurrentSeq(cref naming.ComponentRef) bool 
 	return snapst.Sequence.ComponentSideInfoForRev(idx, cref) != nil
 }
 
+// IsCurrentComponentRevInAnyNonCurrentSeq tells us if the component cref in
+// the revision for the current snap is used in another sequence point too.
+func (snapst *SnapState) IsCurrentComponentRevInAnyNonCurrentSeq(cref naming.ComponentRef) bool {
+	currentIdx := snapst.LastIndex(snapst.Current)
+	if currentIdx == -1 {
+		return false
+	}
+
+	return snapst.Sequence.IsComponentRevInRefSeqPtInAnyOtherSeqPt(cref, currentIdx)
+}
+
 // LocalRevision returns the "latest" local revision. Local revisions
 // start at -1 and are counted down.
 func (snapst *SnapState) LocalRevision() snap.Revision {
-	var local snap.Revision
-	for _, si := range snapst.Sequence.SideInfos() {
-		if si.Revision.Local() && si.Revision.N < local.N {
-			local = si.Revision
-		}
-	}
-	return local
+	return snapst.Sequence.MinimumLocalRevision()
+}
+
+// LocalComponentRevision returns the "latest" local revision for the compName
+// component. Local revisions start at -1 and are counted down. 0 will be
+// returned if no local revision for the component is found.
+func (snapst *SnapState) LocalComponentRevision(compName string) snap.Revision {
+	return snapst.Sequence.MinimumLocalComponentRevision(compName)
 }
 
 // CurrentSideInfo returns the side info for the revision indicated by snapst.Current in the snap revision sequence if there is one.


### PR DESCRIPTION
* Look at all sequence points to assign a local revision. We want it to be unique across all sequence points, as otherwise we would be duplicating file names.
* Look at all the sequence to find out if we can remove a component container when we are replacing it, as it might be used still in a non-current sequence point to where we might want to revert eventually.