### PR TITLE
home: Make interface autoconnect in core desktop

### DIFF
--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -40,6 +40,7 @@ const homeBaseDeclarationSlots = `
     deny-auto-connection:
       -
         on-classic: false
+        on-core-desktop: false
       -
         plug-attributes:
           read: all


### PR DESCRIPTION
Core Desktop, like Classic environment, requires the home interface to be auto-connectable.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
