### PR TITLE
o/configstate/configcore: include newlines in proxy entries added to /etc/environment

### DIFF
--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -21,11 +21,11 @@
 package configcore
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
@@ -72,7 +72,11 @@ func updateEtcEnvironmentConfig(path string, config map[string]string) error {
 	if toWrite != nil {
 		// XXX: would be great to atomically write but /etc/environment
 		//      is a single bind mount :/
-		return os.WriteFile(path, []byte(strings.Join(toWrite, "\n")), 0644)
+		var buf bytes.Buffer
+		for _, entry := range toWrite {
+			fmt.Fprintln(&buf, entry)
+		}
+		return os.WriteFile(path, buf.Bytes(), 0644)
 	}
 
 	return nil

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -105,7 +105,8 @@ func (s *proxySuite) TestConfigureProxy(c *C) {
 
 		c.Check(s.mockEtcEnvironment, testutil.FileEquals, fmt.Sprintf(`
 PATH="/usr/bin"
-%[1]s_proxy=%[1]s://example.com`, proto))
+%[1]s_proxy=%[1]s://example.com
+`, proto))
 	}
 }
 
@@ -122,7 +123,8 @@ func (s *proxySuite) TestConfigureNoProxy(c *C) {
 
 	c.Check(s.mockEtcEnvironment, testutil.FileEquals, `
 PATH="/usr/bin"
-no_proxy=example.com,bar.com`)
+no_proxy=example.com,bar.com
+`)
 }
 
 func (s *proxySuite) TestConfigureProxyStore(c *C) {


### PR DESCRIPTION
Proxy entries added to /etc/environment did not end with a newline, hence any entries appended later manually, would end up being concatenated and produce garbage.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
