### PR TITLE
i/builtin: add registry interface

### DIFF
--- a/asserts/registry.go
+++ b/asserts/registry.go
@@ -22,7 +22,6 @@ package asserts
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/snapcore/snapd/registry"
@@ -54,10 +53,6 @@ func (ar *Registry) Registry() *registry.Registry {
 	return ar.registry
 }
 
-var (
-	validRegistryName = regexp.MustCompile("^[a-z0-9](?:-?[a-z0-9])*$")
-)
-
 func assembleRegistry(assert assertionBase) (Assertion, error) {
 	authorityID := assert.AuthorityID()
 	accountID := assert.HeaderString("account-id")
@@ -65,7 +60,7 @@ func assembleRegistry(assert assertionBase) (Assertion, error) {
 		return nil, fmt.Errorf("authority-id and account-id must match, registry assertions are expected to be signed by the issuer account: %q != %q", authorityID, accountID)
 	}
 
-	name, err := checkStringMatches(assert.headers, "name", validRegistryName)
+	name, err := checkStringMatches(assert.headers, "name", registry.ValidRegistryName)
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/builtin/registry.go
+++ b/interfaces/builtin/registry.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/registry"
+	"github.com/snapcore/snapd/snap"
+)
+
+// The registry interface can be plugged by snaps that want to access specific
+// registry views. Plugs are auto-connected if the registry's account is the
+// same as the snap's publisher.
+const registrySummary = `allows accessing a registry through a view`
+
+const registryBaseDeclarationSlots = `
+  registry:
+    allow-installation:
+      slot-snap-type:
+        - core
+`
+const registryBaseDeclarationPlugs = `
+  registry:
+    allow-auto-connection:
+      plug-attributes:
+        account: $PLUG_PUBLISHER_ID
+`
+
+// registryInterface allows accessing a registry through a view
+type registryInterface struct {
+	commonInterface
+}
+
+func (iface *registryInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	account, ok := plug.Attrs["account"].(string)
+	if !ok || account == "" {
+		return fmt.Errorf(`registry plug must have an "account" attribute`)
+	}
+	if !asserts.IsValidAccountID(account) {
+		return fmt.Errorf(`registry plug must have a valid "account" attribute: format mismatch`)
+	}
+
+	view, ok := plug.Attrs["view"].(string)
+	if !ok || view == "" {
+		return fmt.Errorf(`registry plug must have a "view" attribute`)
+	}
+
+	if err := validateView(view); err != nil {
+		return fmt.Errorf(`registry plug must have a valid "view" attribute: %w`, err)
+	}
+
+	role, ok := plug.Attrs["role"].(string)
+	if !ok || (role != "observer" && role != "manager") {
+		return fmt.Errorf(`registry plug "role" attribute must be "observer" or "manager"`)
+	}
+
+	return nil
+}
+
+func validateView(view string) error {
+	parts := strings.Split(view, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("expected registry and view names separated by a single '/': %s", view)
+	}
+
+	if !registry.ValidRegistryName.MatchString(parts[0]) {
+		return fmt.Errorf("invalid registry name: %s does not match '%s'", parts[0], registry.ValidRegistryName.String())
+	}
+
+	if !registry.ValidViewName.MatchString(parts[1]) {
+		return fmt.Errorf("invalid view name: %s does not match '%s'", parts[1], registry.ValidViewName.String())
+	}
+
+	return nil
+}
+
+func init() {
+	registerIface(&registryInterface{
+		commonInterface: commonInterface{
+			name:                 "registry",
+			summary:              registrySummary,
+			baseDeclarationPlugs: registryBaseDeclarationPlugs,
+			baseDeclarationSlots: registryBaseDeclarationSlots,
+			implicitOnClassic:    true,
+			implicitOnCore:       true,
+		}})
+}

--- a/interfaces/builtin/registry_test.go
+++ b/interfaces/builtin/registry_test.go
@@ -119,13 +119,13 @@ func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
 		},
 		{
 			account: "my-acc",
-			view:    "_foo/bar",
-			err:     `registry plug must have a valid "view" attribute: invalid registry name: _foo does not match '^[a-z0-9](?:-?[a-z0-9])*$'`,
+			view:    "0-foo/bar",
+			err:     `registry plug must have a valid "view" attribute: invalid registry name: 0-foo does not match '^[a-z](?:-?[a-z0-9])*$'`,
 		},
 		{
 			account: "my-acc",
-			view:    "foo/_bar",
-			err:     `registry plug must have a valid "view" attribute: invalid view name: _bar does not match '^[a-z](?:-?[a-z0-9])*$'`,
+			view:    "foo/0-bar",
+			err:     `registry plug must have a valid "view" attribute: invalid view name: 0-bar does not match '^[a-z](?:-?[a-z0-9])*$'`,
 		},
 		{
 			account: "my-acc",

--- a/interfaces/builtin/registry_test.go
+++ b/interfaces/builtin/registry_test.go
@@ -1,0 +1,191 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+type registrySuite struct {
+	iface    interfaces.Interface
+	slot     *interfaces.ConnectedSlot
+	slotInfo *snap.SlotInfo
+	plug     *interfaces.ConnectedPlug
+	plugInfo *snap.PlugInfo
+}
+
+var _ = Suite(&registrySuite{
+	iface: builtin.MustInterface("registry"),
+})
+
+const plugYaml = `name: plugger
+version: 1.0
+type: app
+plugs:
+ read-ssid:
+  interface: registry
+  account: foo
+  view: bar/baz
+apps:
+ app:
+  command: foo
+  plugs: [read-ssid]
+`
+
+const slotYaml = `name: core
+version: 1.0
+type: os
+slots:
+ registry:
+  interface: registry
+`
+
+func (s *registrySuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, plugYaml, nil, "read-ssid")
+	s.slot, s.slotInfo = MockConnectedSlot(c, slotYaml, nil, "registry")
+}
+
+func (s *registrySuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "registry")
+}
+
+func (s *registrySuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
+	type testcase struct {
+		account string
+		view    string
+		role    string
+		err     string
+	}
+
+	tcs := []testcase{
+		{
+			account: "my-acc",
+			view:    "network/wifi",
+			role:    "manager",
+		},
+		{
+			account: "my-acc",
+			view:    "network/wifi",
+			role:    "observer",
+		},
+		{
+			err: `registry plug must have an "account" attribute`,
+		},
+		{
+			account: "my-acc",
+			err:     `registry plug must have a "view" attribute`,
+		},
+		{
+			account: "my-acc",
+			view:    "reg/view",
+			err:     `registry plug "role" attribute must be "observer" or "manager"`,
+		},
+
+		{
+			account: "my-acc",
+			view:    "foobar",
+			err:     `registry plug must have a valid "view" attribute: expected registry and view names separated by a single '/': foobar`,
+		},
+		{
+			account: "my-acc",
+			view:    "_foo/bar",
+			err:     `registry plug must have a valid "view" attribute: invalid registry name: _foo does not match '^[a-z0-9](?:-?[a-z0-9])*$'`,
+		},
+		{
+			account: "my-acc",
+			view:    "foo/_bar",
+			err:     `registry plug must have a valid "view" attribute: invalid view name: _bar does not match '^[a-z](?:-?[a-z0-9])*$'`,
+		},
+		{
+			account: "my-acc",
+			view:    "foo/bar",
+			role:    "other-role",
+			err:     `registry plug "role" attribute must be "observer" or "manager"`,
+		},
+		{
+			account: "_my-acc",
+			view:    "foo/bar",
+			err:     `registry plug must have a valid "account" attribute: format mismatch`,
+		},
+	}
+
+	for _, tc := range tcs {
+		var accLine, viewLine, roleLine string
+		if tc.account != "" {
+			accLine = fmt.Sprintf("  account: %s\n", tc.account)
+		}
+		if tc.view != "" {
+			viewLine = fmt.Sprintf("  view: %s\n", tc.view)
+		}
+		if tc.role != "" {
+			roleLine = fmt.Sprintf("  role: %s\n", tc.role)
+		}
+
+		mockSnapYaml := `name: ssid-reader
+version: 1.0
+plugs:
+ read-ssid:
+  interface: registry
+` + accLine + viewLine + roleLine
+
+		info := snaptest.MockInfo(c, mockSnapYaml, nil)
+		plug := info.Plugs["read-ssid"]
+		err := interfaces.BeforePreparePlug(s.iface, plug)
+		if tc.err == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, tc.err)
+		}
+	}
+}
+
+func (s *registrySuite) TestRegistryDoesntAddRules(c *C) {
+	apparmorSpec := apparmor.NewSpecification(s.plug.AppSet())
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
+	c.Assert(apparmorSpec.SnippetForTag("snap.plugger.app"), Equals, "")
+
+	seccompSpec := seccomp.NewSpecification(s.plug.AppSet())
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), HasLen, 0)
+	c.Check(seccompSpec.SnippetForTag("snap.plugger.app"), Equals, "")
+
+	udevSpec := udev.NewSpecification(s.plug.AppSet())
+	err = udevSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(udevSpec.Snippets(), HasLen, 0)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1346,6 +1346,7 @@ func (s *baseDeclSuite) TestValidity(c *C) {
 		"userns":                  true,
 		"wayland":                 true,
 		"xilinx-dma":              true,
+		"registry":                true,
 	}
 
 	for _, iface := range all {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -165,7 +165,18 @@ const (
 	Alt
 )
 
-var typeStrings = [...]string{"int", "number", "string", "bool", "map", "array", "any", "alt"}
+var (
+	typeStrings = [...]string{"int", "number", "string", "bool", "map", "array", "any", "alt"}
+
+	ValidRegistryName = regexp.MustCompile("^[a-z0-9](?:-?[a-z0-9])*$")
+	ValidViewName     = validSubkey
+
+	validSubkey      = regexp.MustCompile(fmt.Sprintf("^%s$", subkeyRegex))
+	validPlaceholder = regexp.MustCompile(fmt.Sprintf("^{%s}$", subkeyRegex))
+	// TODO: decide on what the format should be for aliases in schemas
+	validAliasName = validSubkey
+	subkeyRegex    = "[a-z](?:-?[a-z0-9])*"
+)
 
 // Registry holds a series of related views.
 type Registry struct {
@@ -189,7 +200,7 @@ func New(account string, registryName string, views map[string]interface{}, sche
 	}
 
 	for name, v := range views {
-		if !validSubkey.Match([]byte(name)) {
+		if !ValidViewName.Match([]byte(name)) {
 			return nil, fmt.Errorf("cannot define view %q: name must conform to %s", name, subkeyRegex)
 		}
 
@@ -366,14 +377,6 @@ func validateRequestStoragePair(request, storage string) error {
 
 	return nil
 }
-
-var (
-	subkeyRegex      = "[a-z](?:-?[a-z0-9])*"
-	validSubkey      = regexp.MustCompile(fmt.Sprintf("^%s$", subkeyRegex))
-	validPlaceholder = regexp.MustCompile(fmt.Sprintf("^{%s}$", subkeyRegex))
-	// TODO: decide on what the format should be for aliases in schemas
-	validAliasName = validSubkey
-)
 
 type validationOptions struct {
 	// allowPlaceholder means that placeholders are accepted when validating.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -168,7 +168,7 @@ const (
 var (
 	typeStrings = [...]string{"int", "number", "string", "bool", "map", "array", "any", "alt"}
 
-	ValidRegistryName = regexp.MustCompile("^[a-z0-9](?:-?[a-z0-9])*$")
+	ValidRegistryName = validSubkey
 	ValidViewName     = validSubkey
 
 	validSubkey      = regexp.MustCompile(fmt.Sprintf("^%s$", subkeyRegex))

--- a/run-checks
+++ b/run-checks
@@ -115,7 +115,8 @@ missing_interface_spread_test() {
     for iface in $(go run ./tests/lib/list-interfaces.go) ; do
         search="plugs: \\[ $iface \\]"
         case "$iface" in
-            bool-file|gpio|pwm|dsp|netlink-driver|hidraw|i2c|iio|serial-port|spi)
+            # TODO: remove registry once we test the interface in the spread test
+            bool-file|gpio|pwm|dsp|netlink-driver|hidraw|i2c|iio|serial-port|spi|registry)
                 # skip gadget provided interfaces for now
                 continue
                 ;;


### PR DESCRIPTION
Add a registry interface that snaps can use to access a particular registry view.