### PR TITLE
cmd/snap: add `debug api` command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -801,3 +801,9 @@ func (c *Client) MigrateSnapHome(snaps []string) (changeID string, err error) {
 
 	return c.doAsync("POST", "/v2/debug", nil, nil, bytes.NewReader(body))
 }
+
+// DebugRaw allows to make raw queries to the API with the intention of using it
+// from the debug code.
+func (client *Client) DebugRaw(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader) (*http.Response, error) {
+	return client.raw(ctx, method, urlpath, query, headers, body)
+}

--- a/cmd/snap/cmd_debug_api.go
+++ b/cmd/snap/cmd_debug_api.go
@@ -1,0 +1,144 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/logger"
+)
+
+var longDebugAPIHelp = `
+Execute a raw query to snapd API. Complex input can be read from stdin, while
+output is printed to stdout. See examples below:
+
+List all snaps:
+$ snap debug api /v2/snaps
+
+Find snaps with name foo:
+$ snap debug api '/v2/find?name=foo'
+
+Request refresh of snap 'some-snap':
+$ echo '{"action": "refresh"}' | snap debug api -X POST \
+      -H 'Content-Type: application/json' /v2/snaps/some-snap
+`
+
+type cmdDebugAPI struct {
+	clientMixin
+
+	Headers []string `short:"H" long:"header"`
+	Method  string   `short:"X" long:"request"`
+	Fail    bool     `long:"fail"`
+	// TODO support -F/--form like curl
+	// TODO support -d/--data like curl
+
+	Positional struct {
+		PathAndQuery string `positional-arg-name:"<path-and-query>"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+func init() {
+	addDebugCommand("api",
+		"Execute raw query to snapd API",
+		longDebugAPIHelp,
+		func() flags.Commander {
+			return &cmdDebugAPI{}
+		}, map[string]string{
+			"header":  "Set header (can be repeated multiple times), header kind and value are separated with ': '",
+			"request": "HTTP method to use (defaults to GET)",
+			"fail":    "Fail on request errors",
+		}, nil)
+}
+
+func (x *cmdDebugAPI) Execute(args []string) error {
+	method := x.Method
+	switch method {
+	case "GET", "POST", "PUT":
+	case "":
+		method = "GET"
+	default:
+		return fmt.Errorf("unsupported method %q", method)
+	}
+
+	var in io.Reader
+	switch method {
+	case "POST", "PUT":
+		in = Stdin
+	}
+
+	u, err := url.Parse(x.Positional.PathAndQuery)
+	if err != nil {
+		return err
+	}
+
+	hdrs := x.Headers
+	reqHdrs := make(map[string]string, len(hdrs))
+	for _, hdr := range x.Headers {
+		before, after, sep := strings.Cut(hdr, ": ")
+		if !sep {
+			return fmt.Errorf("cannot parse header %q", hdr)
+		}
+		reqHdrs[before] = after
+	}
+	logger.Debugf("url: %v", u.Path)
+	logger.Debugf("query: %v", u.RawQuery)
+	logger.Debugf("headers: %s", reqHdrs)
+
+	rsp, err := x.client.DebugRaw(context.Background(), method, u.Path, u.Query(), reqHdrs, in)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	logger.Debugf("response: %v", rsp.Status)
+	logger.Debugf("response headers: %v", rsp.Header)
+	logger.Debugf("response length: %v", rsp.ContentLength)
+
+	if rsp.Header.Get("Content-Type") == "application/json" {
+		// pretty print JSON response by default
+
+		var temp map[string]interface{}
+		if err := json.NewDecoder(rsp.Body).Decode(&temp); err != nil {
+			return err
+		}
+		enc := json.NewEncoder(Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(temp); err != nil {
+			return err
+		}
+	} else {
+		if _, err := io.Copy(Stdout, rsp.Body); err != nil {
+			return err
+		}
+	}
+
+	if x.Fail && rsp.StatusCode >= 400 {
+		// caller wants to fail on non success requests
+		return fmt.Errorf("request failed with status %v", rsp.Status)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add a new `snap debug api` command which can be used to execute raw queries against snapd API. This is supposed to be a replacement for curl which is not part of the base snaps and thus, especially on core, needs to be installed separately using --devmode.

Trigger snap refresh:

```
$ echo '{"action": "refresh"}' | sudo SNAPD_DEBUG=1 snap debug api --pretty \
    -X POST -H  'Content-Type=application/json' '/v2/snaps/toolbox'
2024/06/24 12:32:39.856855 logger.go:93: DEBUG: re-exec not supported on distro "arch" yet
2024/06/24 12:32:39.857264 logger.go:93: DEBUG: url: /v2/snaps/toolbox
2024/06/24 12:32:39.857275 logger.go:93: DEBUG: query: 
2024/06/24 12:32:39.857280 logger.go:93: DEBUG: headers: map[Content-Type:application/json]
{
  "change": "2992",
  "result": null,
  "status": "Accepted",
  "status-code": 202,
  "type": "async"
}
```

Grab some static output:
```
$  snap debug api --pretty /v2/changes/2990 | tail -10                                                                          
        "spawn-time": "2024-06-24T12:28:38.606671208+02:00",
        "status": "Done",
        "summary": "Monitoring snap \"toolbox\" to determine whether extra refresh steps are required"
      }
    ]
  },
  "status": "OK",
  "status-code": 200,
  "type": "sync"
}
```

Or stacktraces from pprof:

```
$ sudo snap debug api '/v2/debug/pprof/goroutine' > stacktraces
...
$ go tool pprof -traces ./stacktraces | head -10
File: snapd
Type: goroutine
Time: Jun 24, 2024 at 12:41pm (CEST)
-----------+-------------------------------------------------------
         1   runtime.notetsleepg
             os/signal.signal_recv
             os/signal.loop
-----------+-------------------------------------------------------
         1   runtime.goroutineProfileWithLabels
             runtime/pprof.runtime_goroutineProfileWithLabels
```

Related: SNAPDENG-23792