### PR TITLE
interfaces/builtin/lxd-support: allow LXD to manage its own cgroup

### DIFF
--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -126,6 +126,7 @@ func init() {
 		implicitOnCore:          true,
 		implicitOnClassic:       true,
 		appArmorUnconfinedPlugs: true,
+		controlsDeviceCgroup:    true,
 		baseDeclarationSlots:    lxdSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:    lxdSupportBaseDeclarationPlugs,
 		serviceSnippets:         []string{lxdSupportServiceSnippet}},

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -147,6 +148,14 @@ func (s *LxdSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "@unrestricted\n")
+}
+
+func (s *LxdSupportInterfaceSuite) TestUdevSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, true)
 }
 
 func (s *LxdSupportInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
Set controls-device-cgroup flag for lxd-support interface, thus allowing LXD to self manage the device cgroup and also be exempt from the mandatory device cgroup set up with core24 base.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
