### PR TITLE
o/h/ctlcmd: support reading registry views in snapctl

### DIFF
--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -135,7 +135,7 @@ var isConnectedTests = []struct {
 	exitCode: ctlcmd.ClassicSnapCode,
 }}
 
-func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) {
+func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) *snap.Info {
 	info := snaptest.MockSnapCurrent(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active: true,
@@ -150,6 +150,7 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) {
 		TrackingChannel: "stable",
 		CohortKey:       cohortKey,
 	})
+	return info
 }
 
 func (s *isConnectedSuite) testIsConnected(c *C, context *hookstate.Context) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -321,6 +321,10 @@ func (s *viewSuite) TestRegistryNotFound(c *C) {
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
 	c.Assert(err, ErrorMatches, `cannot get "top-level" in registry view acc/foo/bar: matching rules don't map to any values`)
 
+	_, err = view.Get(databag, "")
+	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot get registry view acc/foo/bar: matching rules don't map to any values`)
+
 	err = view.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Adds registry support to `snapctl get` so snaps can access registry views, if they have a matching connected plug for the view and if the registry assertion can be found (locally, for now).