### PR TITLE
tests: increase the number of workers we use in openstack

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -11,7 +11,7 @@
         systems:
             - ubuntu-22.04-arm-64:
                 image: ubuntu-jammy-22.04-arm64
-                workers: 1
+                workers: 6
 
             - fedora-40-64:
                 image: fedora-40-64
@@ -19,13 +19,13 @@
     
             - opensuse-15.5-64:
                 image: opensuse-15.5-64
-                workers: 1
+                workers: 6
 
             - centos-9-64:
                 image: centos-9-64
-                workers: 1
+                workers: 6
 
             - debian-12-64:
                 image: debian-12-64
-                workers: 1
+                workers: 6
 


### PR DESCRIPTION
This is needed for the nightly cron job where we run all the openstack systems
