### PR TITLE
tests/main: override Python's IO encoding guess

### DIFF
--- a/tests/main/interfaces-snap-refresh-observe/task.yaml
+++ b/tests/main/interfaces-snap-refresh-observe/task.yaml
@@ -9,6 +9,12 @@ details: |
       - /v2/changes{,/<id>}: to read refresh related changes
       - /v2/snaps: to read snaps whose refresh is inhibited
 
+environment:
+    # not all terminals support UTF-8, but Python tries to be smart and attempts
+    # to guess the encoding as if the output would go to the terminal, but in
+    # fact all the test does is pipe the output to jq
+    PYTHONIOENCODING: utf-8
+
 prepare: |
     snap install --edge jq
 

--- a/tests/main/snap-run-inhibition-flow/task.yaml
+++ b/tests/main/snap-run-inhibition-flow/task.yaml
@@ -13,6 +13,10 @@ details: |
 
 environment:
     SNAPD_INHIBIT_DIR: "/var/lib/snapd/inhibit"
+    # not all terminals support UTF-8, but Python tries to be smart and attempts
+    # to guess the encoding as if the output would go to the terminal, but in
+    # fact all the test does is pipe the output to jq
+    PYTHONIOENCODING: utf-8
 
 prepare: |
     snap install --edge jq

--- a/tests/main/theme-install/task.yaml
+++ b/tests/main/theme-install/task.yaml
@@ -13,6 +13,12 @@ details: |
     check governed by the interface works, and that once connected, the API can
     be used to manage themes as described above.
 
+environment:
+    # not all terminals support UTF-8, but Python tries to be smart and attempts
+    # to guess the encoding as if the output would go to the terminal, but in
+    # fact all the test does is pipe the output to jq
+    PYTHONIOENCODING: utf-8
+
 prepare: |
     snap install --edge jq
 


### PR DESCRIPTION
Python will try to guess the IO encoding based on the terminal, but apparently not all terminals support UTF-8, thus causing errors like this:

```
$ PYTHONIOENCODING="ascii" api-client --socket /run/snapd-snap.socket /v2/snaps Traceback (most recent call last):
  File "/snap/api-client/x1/bin/api-client.py", line 40, in <module>
    sys.exit(main(sys.argv))
  File "/snap/api-client/x1/bin/api-client.py", line 36, in main
    print(body.decode('UTF-8'))
UnicodeEncodeError: 'ascii' codec can't encode character '\xa0' in position 3183: ordinal not in range(128)
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
