### PR TITLE
tests: fix upgrade-from-release test in ubuntu noble

### DIFF
--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -17,7 +17,7 @@ restore: |
     distro_install_build_snapd
 
 execute: |
-    if os.query is-ubuntu 24.04; then
+    if os.query is-ubuntu 24.10; then
         echo "Ubuntu noble is skipped until it is released."
         exit
     fi
@@ -48,6 +48,7 @@ execute: |
     fi
 
     declare -A EXPECTED_SNAPD_VERSIONS=(
+        ["24.04"]='2.63\+24.04'
         ["23.10"]='2.60.4\+23.10'
         ["22.04"]='2.55.3\+22.04'
         ["20.04"]='2.44.3\+20.04'

--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -18,7 +18,7 @@ restore: |
 
 execute: |
     if os.query is-ubuntu 24.10; then
-        echo "Ubuntu noble is skipped until it is released."
+        echo "Ubuntu oracular is skipped until it is released."
         exit
     fi
 


### PR DESCRIPTION
update the test to include the proper snapd version and skip it in ubuntu  24.10