### PR TITLE
cmd/snap: inhibit snap run during snap removal

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -523,6 +523,9 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 		}
 
 		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), x.client, snapName, appName)
+		if errors.Is(err, errOngoingSnapRefresh) {
+			return fmt.Errorf(i18n.G("cannot run %q, snap is being refreshed"), snapName)
+		}
 		if errors.Is(err, errInhibitedForRemove) {
 			return fmt.Errorf(i18n.G("cannot run %q, snap is being removed"), snapName)
 		}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -514,7 +514,7 @@ func checkSnapRunInhibitionConflict(app *snap.AppInfo) error {
 
 	// We started without a hint lock file, if it exists now this means that a
 	// refresh might have started and retry is needed.
-	if osutil.FileExists(runinhibit.HintFile(app.Snap.InstanceName())) {
+	if osutil.FileExists(runinhibit.HintFile(snapName)) {
 		return errSnapRefreshConflict
 	}
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -523,6 +523,9 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 		}
 
 		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), x.client, snapName, appName)
+		if errors.Is(err, errInhibitedForRemove) {
+			return fmt.Errorf(i18n.G("cannot run %q, snap is being removed"), snapName)
+		}
 		if errors.Is(err, errSnapRefreshConflict) {
 			// Possible race condition detected, let's retry.
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -522,7 +522,7 @@ func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
 			return fmt.Errorf("race condition detected, snap-run can only retry once")
 		}
 
-		info, app, hintFlock, err := maybeWaitWhileInhibited(context.Background(), x.client, snapName, appName)
+		info, app, hintFlock, err := waitWhileInhibited(context.Background(), x.client, snapName, appName)
 		if errors.Is(err, errOngoingSnapRefresh) {
 			return fmt.Errorf(i18n.G("cannot run %q, snap is being refreshed"), snapName)
 		}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -319,14 +319,29 @@ func (s *RunSuite) TestSnapRunAppRunsChecksRefreshInhibitionLock(c *check.C) {
 	checkHintFileNotLocked(c, "snapname")
 }
 
-func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLock(c *check.C) {
+func (s *RunSuite) testSnapRunAppRunsChecksRemoveInhibitionLock(c *check.C, svc bool) {
 	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
 		return runinhibit.HintInhibitedForRemove, runinhibit.InhibitInfo{}, nil
 	})
 	defer restore()
 
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
-	c.Assert(err, check.ErrorMatches, `snap "snapname" is being removed`)
+	cmd := "snapname.app"
+	if svc {
+		cmd = "snapname.svc"
+	}
+
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", cmd, "--arg1"})
+	c.Assert(err, check.ErrorMatches, `cannot run "snapname", snap is being removed`)
+}
+
+func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLock(c *check.C) {
+	const svc = false
+	s.testSnapRunAppRunsChecksRemoveInhibitionLock(c, svc)
+}
+
+func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLockService(c *check.C) {
+	const svc = true
+	s.testSnapRunAppRunsChecksRemoveInhibitionLock(c, svc)
 }
 
 func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLockError(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -354,7 +354,7 @@ func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLockError(c *check.C)
 	c.Assert(err, check.ErrorMatches, "boom!")
 }
 
-func (s *RunSuite) TestSnapRunAppRefreshAppAwarenessUnsetSkipsInhibitionLockCheck(c *check.C) {
+func (s *RunSuite) TestSnapRunAppRefreshAppAwarenessUnsetSkipsInhibitionLockWait(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
@@ -372,13 +372,8 @@ func (s *RunSuite) TestSnapRunAppRefreshAppAwarenessUnsetSkipsInhibitionLockChec
 	// unset refresh-app-awareness flag
 	c.Assert(os.RemoveAll(features.RefreshAppAwareness.ControlFile()), check.IsNil)
 
-	restore := snaprun.MockWaitWhileInhibited(func(ctx context.Context, snapName string, notInhibited func(ctx context.Context) error, inhibited func(ctx context.Context, hint runinhibit.Hint, inhibitInfo *runinhibit.InhibitInfo) (cont bool, err error), interval time.Duration) (flock *osutil.FileLock, retErr error) {
-		return nil, fmt.Errorf("runinhibit.WaitWhileInhibited should not have been called")
-	})
-	defer restore()
-
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
-	c.Assert(err, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `cannot run "snapname", snap is being refreshed`)
 }
 
 func (s *RunSuite) TestSnapRunAppNewRevisionAfterInhibition(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -320,10 +320,8 @@ func (s *RunSuite) TestSnapRunAppRunsChecksRefreshInhibitionLock(c *check.C) {
 }
 
 func (s *RunSuite) testSnapRunAppRunsChecksRemoveInhibitionLock(c *check.C, svc bool) {
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		return runinhibit.HintInhibitedForRemove, runinhibit.InhibitInfo{}, nil
-	})
-	defer restore()
+	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
+	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRemove, inhibitInfo), check.IsNil)
 
 	cmd := "snapname.app"
 	if svc {
@@ -342,16 +340,6 @@ func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLock(c *check.C) {
 func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLockService(c *check.C) {
 	const svc = true
 	s.testSnapRunAppRunsChecksRemoveInhibitionLock(c, svc)
-}
-
-func (s *RunSuite) TestSnapRunAppRunsChecksRemoveInhibitionLockError(c *check.C) {
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		return runinhibit.HintInhibitedForRemove, runinhibit.InhibitInfo{}, fmt.Errorf("boom!")
-	})
-	defer restore()
-
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
-	c.Assert(err, check.ErrorMatches, "boom!")
 }
 
 func (s *RunSuite) TestSnapRunAppRefreshAppAwarenessUnsetSkipsInhibitionLockWait(c *check.C) {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -434,12 +434,6 @@ func MockWaitWhileInhibited(f func(ctx context.Context, snapName string, notInhi
 	return restore
 }
 
-func MockIsLocked(f func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error)) (restore func()) {
-	restore = testutil.Backup(&runinhibitIsLocked)
-	runinhibitIsLocked = f
-	return restore
-}
-
 func MockInhibitionFlow(flow inhibitionFlow) (restore func()) {
 	old := newInhibitionFlow
 	newInhibitionFlow = func(cli *client.Client, name string) inhibitionFlow {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -434,6 +434,12 @@ func MockWaitWhileInhibited(f func(ctx context.Context, snapName string, notInhi
 	return restore
 }
 
+func MockIsLocked(f func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error)) (restore func()) {
+	restore = testutil.Backup(&runinhibitIsLocked)
+	runinhibitIsLocked = f
+	return restore
+}
+
 func MockInhibitionFlow(flow inhibitionFlow) (restore func()) {
 	old := newInhibitionFlow
 	newInhibitionFlow = func(cli *client.Client, name string) inhibitionFlow {

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -122,6 +122,10 @@ func waitWhileInhibited(ctx context.Context, cli *client.Client, snapName string
 		}
 	}
 
+	if info == nil || app == nil {
+		return nil, nil, nil, fmt.Errorf("internal error: info and app cannot be nil")
+	}
+
 	return info, app, hintFlock, nil
 }
 

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -44,6 +44,10 @@ var runinhibitIsLocked = runinhibit.IsLocked
 // which could alter the current snap revision.
 var errSnapRefreshConflict = fmt.Errorf("snap refresh conflict detected")
 
+// errInhibitedForRemove indicates that snap is inhibited from running because
+// it is being removed.
+var errInhibitedForRemove = fmt.Errorf("snap is being removed")
+
 // maybeWaitWhileInhibited is a wrapper for waitWhileInhibited that skips waiting
 // if refresh-app-awareness flag is disabled and early-exits when snap run is
 // inhibited for removal.
@@ -52,9 +56,8 @@ func maybeWaitWhileInhibited(ctx context.Context, cli *client.Client, snapName s
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	// XXX: do we want to allow services to start during removal?
 	if inhibitedForRemove {
-		return nil, nil, nil, fmt.Errorf(i18n.G("snap %q is being removed"), snapName)
+		return nil, nil, nil, errInhibitedForRemove
 	}
 
 	// wait only if refresh-app-awareness flag is enabled

--- a/cmd/snap/inhibit_test.go
+++ b/cmd/snap/inhibit_test.go
@@ -35,6 +35,7 @@ import (
 	snaprun "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -65,6 +66,9 @@ func (flow *fakeInhibitionFlow) FinishInhibitionNotification(ctx context.Context
 func (s *RunSuite) TestWaitWhileInhibitedRunThrough(c *C) {
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
@@ -122,6 +126,9 @@ func (s *RunSuite) TestWaitWhileInhibitedErrorOnStartNotification(c *C) {
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
 
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
 
@@ -154,6 +161,9 @@ func (s *RunSuite) TestWaitWhileInhibitedErrorOnStartNotification(c *C) {
 func (s *RunSuite) TestWaitWhileInhibitedErrorOnFinishNotification(c *C) {
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
@@ -212,6 +222,9 @@ func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *C) {
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
 
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), IsNil)
 
@@ -241,6 +254,9 @@ func (s *RunSuite) TestWaitWhileInhibitedContextCancellationOnError(c *C) {
 func (s *RunSuite) TestWaitWhileInhibitedGateRefreshNoNotification(c *C) {
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R(11)})
+
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedGateRefresh, inhibitInfo), IsNil)

--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -61,6 +61,8 @@ const (
 	// HintInhibitedForPreDownload represents inhibition of a "snap run" while a
 	// pre-download is triggering a refresh.
 	HintInhibitedForPreDownload Hint = "pre-download"
+	// HintInhibitedForRemove represents inhibition of a "snap run" while a remove change is being performed.
+	HintInhibitedForRemove Hint = "remove"
 )
 
 const hintFilePostfix = "lock"


### PR DESCRIPTION
This is needed in preparation for the new `snap remove` `--terminate` flag.

New snap app runs must be inhibited before we start killing the running apps to avoid having new runs in the window between killing currently running and unlinking the snap binaries.

This PR is part 1 of implementing force removal of snaps according to [SD174 - Force removal of snaps](https://docs.google.com/document/d/1ikDI-vPJO6YYFHOyFJ5hfK5L5Gv8voMeY8HJvxNWujw/edit#bookmark=id.loect9uz09x5) spec.

For context:
- Part 2: https://github.com/snapcore/snapd/pull/14144
- Part 3.1: https://github.com/snapcore/snapd/pull/14160
- Part 3.2: https://github.com/snapcore/snapd/pull/14189