### PR TITLE
data, packaging: install polkit policy files via data Makefile

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -6,3 +6,4 @@ all install clean:
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
 	$(MAKE) -C desktop $@
+	$(MAKE) -C polkit $@

--- a/data/polkit/Makefile
+++ b/data/polkit/Makefile
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2024 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DATADIR = /usr/share
+POLKITACTIONSDIR := $(DATADIR)/polkit-1/actions
+
+POLKIT_ACTIONS = $(wildcard *.policy)
+
+.PHONY: all
+all: $(POLKIT_ACTIONS)
+
+.PHONY: install
+install: $(POLKIT_ACTIONS)
+	install -d -m 0755 $(DESTDIR)/$(POLKITACTIONSDIR)
+	install -m 0644 -t $(DESTDIR)/$(POLKITACTIONSDIR) $^
+
+.PHONY: clean
+clean:
+	echo "Nothing to see here."

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -146,10 +146,6 @@ package() {
      SNAP_MOUNT_DIR=/var/lib/snapd/snap \
      DESTDIR="$pkgdir"
 
-  # Install polkit policy
-  install -Dm644 data/polkit/io.snapcraft.snapd.policy \
-    "$pkgdir/usr/share/polkit-1/actions/io.snapcraft.snapd.policy"
-
   # Install executables
   install -Dm755 "$srcdir/go/bin/snap" "$pkgdir/usr/bin/snap"
   install -Dm755 "$srcdir/go/bin/snapctl" "$pkgdir/usr/lib/snapd/snapctl"

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -8,8 +8,6 @@ data/completion/bash/snap /usr/share/bash-completion/completions
 data/completion/zsh/_snap /usr/share/zsh/vendor-completions
 # snap/snapd version information
 data/info /usr/lib/snapd/
-# polkit actions
-data/polkit/io.snapcraft.snapd.policy /usr/share/polkit-1/actions/
 # snap-confine stuff
 etc/apparmor.d/usr.lib.snapd.snap-confine.real
 usr/bin/snap

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -737,9 +737,6 @@ rm %{buildroot}%{_libexecdir}/snapd/system-shutdown
 rm -f %{buildroot}%{_unitdir}/snapd.apparmor.service
 rm -f %{buildroot}%{_libexecdir}/snapd/snapd-apparmor
 
-# Install Polkit configuration
-install -m 644 -D data/polkit/io.snapcraft.snapd.policy %{buildroot}%{_datadir}/polkit-1/actions
-
 # Disable re-exec by default
 echo 'SNAP_REEXEC=0' > %{buildroot}%{_sysconfdir}/sysconfig/snapd
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -306,10 +306,6 @@ ln -sf %{_sbindir}/service %{buildroot}%{_sbindir}/rcsnapd.seeded
 ln -sf %{_sbindir}/service %{buildroot}%{_sbindir}/rcsnapd.apparmor
 %endif
 
-# Install Polkit configuration.
-# TODO: This should be handled by data makefile.
-install -m 644 -D %{indigo_srcdir}/data/polkit/io.snapcraft.snapd.policy %{buildroot}%{_datadir}/polkit-1/actions
-
 # Install the "info" data file with snapd version
 # TODO: This should be handled by data makefile.
 install -m 644 -D %{indigo_srcdir}/data/info %{buildroot}%{_libexecdir}/snapd/info

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -6,8 +6,6 @@ data/completion/bash/snap /usr/share/bash-completion/completions
 data/completion/zsh/_snap /usr/share/zsh/vendor-completions
 # snap/snapd version information
 data/info /usr/lib/snapd/
-# polkit actions
-data/polkit/io.snapcraft.snapd.policy /usr/share/polkit-1/actions/
 # udev, must be installed before 80-udisks
 data/udev/rules.d/66-snapd-autoimport.rules /lib/udev/rules.d
 # snap-confine stuff

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -23,8 +23,6 @@ data/completion/zsh/_snap /usr/share/zsh/vendor-completions
 data/udev/rules.d/66-snapd-autoimport.rules /lib/udev/rules.d
 # snap/snapd version information
 data/info /usr/lib/snapd/
-# polkit actions
-data/polkit/io.snapcraft.snapd.policy /usr/share/polkit-1/actions/
 # apt hook
 data/apt/20snapd.conf /etc/apt/apt.conf.d/
 


### PR DESCRIPTION
With the refactoring of the snapcraft packaging in #13370, the polkit policy file got dropped from the snap. Core Desktop depends on this for polkit authorisation to work correctly.

This PR installs the policy file via the makefile in `data/` rather than duplicating it in each distro packaging script.