### PR TITLE
daemon, cmd/snapd: propagate context

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -61,6 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO look into signal.NotifyContext
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	if err := run(ch); err != nil {
@@ -117,6 +119,8 @@ func runWatchdog(d *daemon.Daemon) (*time.Ticker, error) {
 var checkRunningConditionsRetryDelay = 300 * time.Second
 
 func run(ch chan os.Signal) error {
+	ctx := context.Background()
+
 	t0 := time.Now().Truncate(time.Millisecond)
 	snapdenv.SetUserAgentFromVersion(snapdtool.Version, sandbox.ForceDevMode)
 
@@ -143,7 +147,7 @@ func run(ch chan os.Signal) error {
 
 	d.Version = snapdtool.Version
 
-	if err := d.Start(); err != nil {
+	if err := d.Start(ctx); err != nil {
 		return err
 	}
 

--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -608,7 +608,7 @@ func (s *aliasesSuite) TestInstallUnaliased(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags.Unaliased, check.Equals, true)
@@ -635,7 +635,7 @@ func (s *aliasesSuite) TestInstallIgnoreRunning(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags.IgnoreRunning, check.Equals, true)
@@ -661,7 +661,7 @@ func (s *aliasesSuite) TestInstallPrefer(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags.Prefer, check.Equals, true)

--- a/daemon/api_cohort.go
+++ b/daemon/api_cohort.go
@@ -20,7 +20,6 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -53,7 +52,7 @@ func postCohorts(c *Command, r *http.Request, user *auth.UserState) Response {
 		return SyncResponse(map[string]string{})
 	}
 
-	cohorts, err := storeFrom(c.d).CreateCohorts(context.TODO(), inst.Snaps)
+	cohorts, err := storeFrom(c.d).CreateCohorts(r.Context(), inst.Snaps)
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -105,10 +105,10 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 		return BadRequest(err.Error())
 	}
 
-	return streamOneSnap(c, action, user)
+	return streamOneSnap(r.Context(), c, action, user)
 }
 
-func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) Response {
+func streamOneSnap(ctx context.Context, c *Command, action snapDownloadAction, user *auth.UserState) Response {
 	secret, err := downloadTokensSecret(c.d)
 	if err != nil {
 		return InternalError(err.Error())
@@ -125,7 +125,7 @@ func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) 
 			CohortKey:    action.CohortKey,
 			Channel:      action.Channel,
 		}}
-		results, _, err := theStore.SnapAction(context.TODO(), nil, actions, nil, user, nil)
+		results, _, err := theStore.SnapAction(ctx, nil, actions, nil, user, nil)
 		if err != nil {
 			return errToResponse(err, []string{action.SnapName}, InternalError, "cannot download snap: %v")
 		}
@@ -148,7 +148,7 @@ func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) 
 	}
 
 	if !action.HeaderPeek {
-		stream, status, err := theStore.DownloadStream(context.TODO(), action.SnapName, ss.Info, action.resumePosition, user)
+		stream, status, err := theStore.DownloadStream(ctx, action.SnapName, ss.Info, action.resumePosition, user)
 		if err != nil {
 			return InternalError(err.Error())
 		}

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -135,7 +135,7 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 
 		notices, err = st.WaitNotices(ctx, filter)
 		if errors.Is(err, context.Canceled) {
-			return BadRequest("request canceled")
+			return InternalError("request canceled")
 		}
 		// DeadlineExceeded will occur if timeout elapses; in that case return
 		// an empty list of notices, not an error.

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -631,7 +631,7 @@ func (s *noticesSuite) TestNoticesRequestCancelled(c *C) {
 	c.Assert(err, IsNil)
 	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;", dirs.SnapdSocket)
 	rsp := s.errorReq(c, req, nil)
-	c.Check(rsp.Status, Equals, 400)
+	c.Check(rsp.Status, Equals, 500)
 	c.Check(rsp.Message, Matches, "request canceled")
 
 	elapsed := time.Since(start)

--- a/daemon/api_sections.go
+++ b/daemon/api_sections.go
@@ -20,7 +20,6 @@
 package daemon
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/snapcore/snapd/overlord/auth"
@@ -44,8 +43,7 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	theStore := storeFrom(c.d)
 
-	// TODO: use a per-request context
-	sections, err := theStore.Sections(context.TODO(), user)
+	sections, err := theStore.Sections(r.Context(), user)
 	switch err {
 	case nil:
 		// pass

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -644,6 +644,7 @@ func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err := decoder.Decode(&inst); err != nil {
 		return BadRequest("cannot decode request body into snap instruction: %v", err)
 	}
+	inst.ctx = r.Context()
 
 	// TODO: inst.Amend, etc?
 	if inst.Channel != "" || !inst.Revision.Unset() || inst.DevMode || inst.JailMode || inst.CohortKey != "" || inst.LeaveCohort || inst.Prefer {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -791,7 +791,7 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 	}, nil
 }
 
-func snapEnforceValidationSets(_ context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
+func snapEnforceValidationSets(ctx context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	if len(inst.ValidationSets) > 0 && len(inst.Snaps) != 0 {
 		return nil, fmt.Errorf("snap names cannot be specified with validation sets to enforce")
 	}
@@ -819,7 +819,7 @@ func snapEnforceValidationSets(_ context.Context, inst *snapInstruction, st *sta
 			return nil, err
 		}
 
-		tss, affected, err = meetSnapConstraintsForEnforce(inst, st, vErr)
+		tss, affected, err = meetSnapConstraintsForEnforce(ctx, inst, st, vErr)
 		if err != nil {
 			return nil, err
 		}
@@ -837,7 +837,7 @@ func snapEnforceValidationSets(_ context.Context, inst *snapInstruction, st *sta
 	}, nil
 }
 
-func meetSnapConstraintsForEnforce(inst *snapInstruction, st *state.State, vErr *snapasserts.ValidationSetsValidationError) ([]*state.TaskSet, []string, error) {
+func meetSnapConstraintsForEnforce(ctx context.Context, inst *snapInstruction, st *state.State, vErr *snapasserts.ValidationSetsValidationError) ([]*state.TaskSet, []string, error) {
 	// Save the sequence numbers so we can pin them later when enforcing the sets again
 	pinnedSeqs := make(map[string]int, len(inst.ValidationSets))
 
@@ -878,7 +878,7 @@ func meetSnapConstraintsForEnforce(inst *snapInstruction, st *state.State, vErr 
 		pinnedSeqs[fmt.Sprintf("%s/%s", account, name)] = sequence
 	}
 
-	return snapstateResolveValSetsEnforcementError(context.TODO(), st, vErr, pinnedSeqs, inst.userID)
+	return snapstateResolveValSetsEnforcementError(ctx, st, vErr, pinnedSeqs, inst.userID)
 }
 
 func snapRemoveMany(_ context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -689,7 +689,7 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		inst := &daemon.SnapInstruction{Action: "refresh"}
 		st := d.Overlord().State()
 		st.Lock()
-		res, err := inst.DispatchForMany()(inst, st)
+		res, err := inst.DispatchForMany()(context.Background(), inst, st)
 		st.Unlock()
 		c.Assert(err, check.IsNil)
 		c.Check(res.Summary, check.Equals, tst.msg)
@@ -715,7 +715,7 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "refresh"}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh all snaps: no updates`)
@@ -743,7 +743,7 @@ func (s *snapsSuite) TestRefreshAllRestoresValidationSets(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "refresh"}
 	st := d.Overlord().State()
 	st.Lock()
-	_, err := inst.DispatchForMany()(inst, st)
+	_, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.ErrorMatches, "boom")
 	c.Check(refreshSnapAssertions, check.Equals, true)
@@ -778,7 +778,7 @@ func (s *snapsSuite) TestRefreshManyTransactionally(c *check.C) {
 	}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
@@ -809,7 +809,7 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "refresh", Snaps: []string{"foo", "bar"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
@@ -841,7 +841,7 @@ func (s *snapsSuite) TestRefreshManyIgnoreRunning(c *check.C) {
 	}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
@@ -866,7 +866,7 @@ func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "refresh", Snaps: []string{"foo"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Refresh snap "foo"`)
@@ -885,7 +885,7 @@ func (s *snapsSuite) TestInstallMany(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "install", Snaps: []string{"foo", "bar"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Install snaps "foo", "bar"`)
@@ -912,7 +912,7 @@ func (s *snapsSuite) TestInstallManyTransactionally(c *check.C) {
 
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Install snaps "foo", "bar"`)
@@ -929,7 +929,7 @@ func (s *snapsSuite) TestInstallManyEmptyName(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "install", Snaps: []string{"", "bar"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(res, check.IsNil)
 	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
@@ -947,7 +947,7 @@ func (s *snapsSuite) TestRemoveMany(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "remove", Snaps: []string{"foo", "bar"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Remove snaps "foo", "bar"`)
@@ -966,7 +966,7 @@ func (s *snapsSuite) TestRemoveManyWithPurge(c *check.C) {
 	inst := &daemon.SnapInstruction{Action: "remove", Purge: true, Snaps: []string{"foo", "bar"}}
 	st := d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Remove snaps "foo", "bar"`)
@@ -2134,7 +2134,7 @@ func (s *snapsSuite) TestInstall(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 	c.Check(calledName, check.Equals, "fake")
 }
@@ -2159,7 +2159,7 @@ func (s *snapsSuite) TestInstallWithQuotaGroup(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 	c.Check(calledFlags.QuotaGroupName, check.Equals, "test-group")
 }
@@ -2185,7 +2185,7 @@ func (s *snapsSuite) TestInstallDevMode(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags.DevMode, check.Equals, true)
@@ -2211,7 +2211,7 @@ func (s *snapsSuite) TestInstallJailMode(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags.JailMode, check.Equals, true)
@@ -2231,7 +2231,7 @@ func (s *snapsSuite) TestInstallJailModeDevModeOS(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.ErrorMatches, "this system cannot honour the jailmode flag")
 }
 
@@ -2247,7 +2247,7 @@ func (s *snapsSuite) TestInstallJailModeDevMode(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.ErrorMatches, "cannot use devmode and jailmode flags together")
 }
 
@@ -2273,7 +2273,7 @@ func (s *snapsSuite) TestInstallCohort(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	msg, _, err := inst.Dispatch()(inst, st)
+	msg, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 	c.Check(calledName, check.Equals, "fake")
 	c.Check(calledCohort, check.Equals, "To the legion of the lost ones, to the cohort of the damned.")
@@ -2304,7 +2304,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	flags := snapstate.Flags{}
@@ -2330,7 +2330,7 @@ func (s *snapsSuite) TestInstallEmptyName(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.ErrorMatches, "cannot install snap with empty name")
 }
 
@@ -2471,7 +2471,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(assertstateCalledUserID, check.Equals, 17)
@@ -2510,7 +2510,7 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	flags := snapstate.Flags{}
@@ -2544,7 +2544,7 @@ func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	_, _, err := inst.Dispatch()(inst, st)
+	_, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(calledFlags, check.DeepEquals, snapstate.Flags{Classic: true})
@@ -2578,7 +2578,7 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	flags := snapstate.Flags{}
@@ -2616,7 +2616,7 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	flags := snapstate.Flags{}
@@ -2651,7 +2651,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(cohort, check.Equals, "xyzzy")
@@ -2681,7 +2681,7 @@ func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 
 	c.Check(*leave, check.Equals, true)
@@ -2730,7 +2730,7 @@ func (s *snapsSuite) TestSwitchInstruction(c *check.C) {
 		inst.Channel = t.channel
 
 		st.Lock()
-		summary, _, err := inst.Dispatch()(inst, st)
+		summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 		st.Unlock()
 		c.Check(err, check.IsNil)
 
@@ -2765,7 +2765,7 @@ func (s *snapsSuite) testRevertSnap(inst *daemon.SnapInstruction, c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	summary, _, err := inst.Dispatch()(inst, st)
+	summary, _, err := inst.Dispatch()(context.Background(), inst, st)
 	c.Check(err, check.IsNil)
 	if inst.Revision.Unset() {
 		c.Check(queue, check.DeepEquals, []string{inst.Snaps[0]})
@@ -3037,7 +3037,7 @@ func (s *snapsSuite) TestRefreshEnforce(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Enforce validation sets "foo/bar=2", "foo/baz" for snaps "install-snap", "update-snap"`)
 	c.Check(res.Affected, check.DeepEquals, []string{"install-snap", "update-snap"})
@@ -3145,7 +3145,7 @@ func (s *snapsSuite) TestRefreshEnforceWithPreexistingSet(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Enforce validation sets "foo/new=2" for snaps "install-snap"`)
 	c.Check(res.Affected, check.DeepEquals, []string{"install-snap"})
@@ -3178,7 +3178,7 @@ func (s *snapsSuite) TestRefreshEnforceTryEnforceValidationSetsError(c *check.C)
 	st.Lock()
 	defer st.Unlock()
 
-	_, err := inst.DispatchForMany()(inst, st)
+	_, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.ErrorMatches, `boom`)
 	c.Check(refreshSnapAssertions, check.Equals, 1)
 	c.Check(snapstateEnforceSnaps, check.Equals, 0)
@@ -3186,7 +3186,7 @@ func (s *snapsSuite) TestRefreshEnforceTryEnforceValidationSetsError(c *check.C)
 	// ValidationSetsValidationError is expected and fine
 	tryEnforceErr = &snapasserts.ValidationSetsValidationError{}
 
-	_, err = inst.DispatchForMany()(inst, st)
+	_, err = inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Check(refreshSnapAssertions, check.Equals, 2)
 	c.Check(snapstateEnforceSnaps, check.Equals, 1)
@@ -3219,7 +3219,7 @@ func (s *snapsSuite) TestRefreshEnforceWithSnapsIsAnError(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	_, err := inst.DispatchForMany()(inst, st)
+	_, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.ErrorMatches, `snap names cannot be specified with validation sets to enforce`)
 	c.Check(refreshSnapAssertions, check.Equals, false)
 	c.Check(tryEnforceValidationSets, check.Equals, false)
@@ -3247,7 +3247,7 @@ func (s *snapsSuite) TestRefreshEnforceSetsNoUnmetConstraints(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	resp, err := inst.DispatchForMany()(inst, st)
+	resp, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Check(resp.Affected, check.IsNil)
 	c.Check(resp.Tasksets, check.IsNil)
@@ -3304,7 +3304,7 @@ func (s *snapsSuite) TestHoldAllRefreshes(c *check.C) {
 			HoldLevel: "auto-refresh",
 		}
 
-		res, err := inst.DispatchForMany()(inst, st)
+		res, err := inst.DispatchForMany()(context.Background(), inst, st)
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.Not(check.IsNil))
 		c.Assert(res.Affected, check.IsNil)
@@ -3338,7 +3338,7 @@ func (s *snapsSuite) TestHoldManyRefreshes(c *check.C) {
 			HoldLevel: "auto-refresh",
 		}
 
-		res, err := inst.DispatchForMany()(inst, st)
+		res, err := inst.DispatchForMany()(context.Background(), inst, st)
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.IsNil)
 		c.Assert(res.Affected, check.DeepEquals, snaps)
@@ -3371,7 +3371,7 @@ func (s *snapsSuite) TestHoldRefresh(c *check.C) {
 			HoldLevel: "general",
 		}
 
-		summary, tasksets, err := inst.Dispatch()(inst, st)
+		summary, tasksets, err := inst.Dispatch()(context.Background(), inst, st)
 		c.Assert(err, check.IsNil)
 		c.Assert(tasksets, check.IsNil)
 		c.Assert(summary, check.Equals, `Hold general refreshes for "some-snap"`)
@@ -3397,7 +3397,7 @@ func (s *snapsSuite) TestUnholdAllRefreshes(c *check.C) {
 		Action: "unhold",
 	}
 
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.Not(check.IsNil))
 	c.Assert(res.Affected, check.IsNil)
@@ -3424,7 +3424,7 @@ func (s *snapsSuite) TestUnholdManyRefreshes(c *check.C) {
 		Snaps:  snaps,
 	}
 
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.IsNil)
 	c.Assert(res.Affected, check.DeepEquals, snaps)
@@ -3449,7 +3449,7 @@ func (s *snapsSuite) TestUnholdRefresh(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	summary, tasksets, err := inst.Dispatch()(inst, st)
+	summary, tasksets, err := inst.Dispatch()(context.Background(), inst, st)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(tasksets, check.IsNil)

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -20,7 +20,6 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -75,7 +74,7 @@ func listSnapshots(c *Command, r *http.Request, user *auth.UserState) Response {
 	st := c.d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	sets, err := snapshotList(context.TODO(), st, setID, strutil.CommaSeparatedList(r.URL.Query().Get("snaps")))
+	sets, err := snapshotList(r.Context(), st, setID, strutil.CommaSeparatedList(r.URL.Query().Get("snaps")))
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -181,7 +180,7 @@ func getSnapshotExport(c *Command, r *http.Request, user *auth.UserState) Respon
 		return BadRequest("'id' must be a positive base 10 number; got %q", sid)
 	}
 
-	export, err := snapshotExport(context.TODO(), st, setID)
+	export, err := snapshotExport(r.Context(), st, setID)
 	if err != nil {
 		return BadRequest("cannot export %v: %v", setID, err)
 	}
@@ -208,7 +207,7 @@ func doSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Respons
 
 	// XXX: check that we have enough space to import the compressed snapshots
 	st := c.d.overlord.State()
-	setID, snapNames, err := snapshotImport(context.TODO(), st, limitedBodyReader)
+	setID, snapNames, err := snapshotImport(r.Context(), st, limitedBodyReader)
 	if err != nil {
 		return BadRequest(err.Error())
 	}

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -216,7 +217,7 @@ func doSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Respons
 	return SyncResponse(result)
 }
 
-func snapshotMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
+func snapshotMany(_ context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	setID, snapshotted, ts, err := snapshotSave(st, inst.Snaps, inst.Users, inst.SnapshotOptions)
 	if err != nil {
 		return nil, err

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -64,7 +64,7 @@ func (s *snapshotSuite) TestSnapshotManyOptionsNone(c *check.C) {
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Snapshot snaps "foo", "bar"`)
@@ -91,7 +91,7 @@ func (s *snapshotSuite) TestSnapshotManyOptionsFull(c *check.C) {
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Snapshot snaps "foo", "bar"`)
@@ -110,7 +110,7 @@ func (s *snapshotSuite) TestSnapshotManyError(c *check.C) {
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
+	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Check(res, check.IsNil)
 	c.Check(err, check.ErrorMatches, `snap "foo" is not installed`)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -320,7 +320,8 @@ func (d *Daemon) initStandbyHandling() {
 	d.standbyOpinions.Start()
 }
 
-// Start the Daemon
+// Start the Daemon. Takes a context which will be used as the base request
+// context in the embedded http.Server.
 func (d *Daemon) Start(ctx context.Context) (err error) {
 	if d.expectedRebootDidNotHappen {
 		// we need to schedule and wait for a system restart

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -90,7 +90,8 @@ type Daemon struct {
 
 	expectedRebootDidNotHappen bool
 
-	mu sync.Mutex
+	mu     sync.Mutex
+	cancel func()
 }
 
 // A ResponseFunc handles one of the individual verbs for a method
@@ -320,7 +321,7 @@ func (d *Daemon) initStandbyHandling() {
 }
 
 // Start the Daemon
-func (d *Daemon) Start() error {
+func (d *Daemon) Start(ctx context.Context) (err error) {
 	if d.expectedRebootDidNotHappen {
 		// we need to schedule and wait for a system restart
 		d.tomb.Kill(nil)
@@ -331,6 +332,15 @@ func (d *Daemon) Start() error {
 	if d.overlord == nil {
 		panic("internal error: no Overlord")
 	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	d.cancel = cancel
+	defer func() {
+		// cancel the context on any errors
+		if err != nil {
+			cancel()
+		}
+	}()
 
 	to, reasoning, err := d.overlord.StartupTimeout()
 	if err != nil {
@@ -355,6 +365,13 @@ func (d *Daemon) Start() error {
 	d.serve = &http.Server{
 		Handler:   logit(d.router),
 		ConnState: d.connTracker.trackConn,
+		BaseContext: func(net.Listener) context.Context {
+			// requests will use the context provided to Start, as
+			// the caller will likely cancel it when appropriate
+			// thus canceling any outstanding requests to the snapd
+			// API
+			return ctx
+		},
 	}
 
 	// enable standby handling
@@ -480,6 +497,10 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	}
 	if d.overlord == nil {
 		return fmt.Errorf("internal error: no Overlord")
+	}
+
+	if d.cancel != nil {
+		d.cancel()
 	}
 
 	d.tomb.Kill(nil)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -327,7 +328,7 @@ func (s *daemonSuite) TestMaintenanceJsonDeletedOnStart(c *check.C) {
 	s.markSeeded(d)
 
 	// after starting, maintenance.json should be removed
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	c.Assert(dirs.SnapdMaintenanceFile, testutil.FileAbsent)
 	d.Stop(nil)
 }
@@ -631,7 +632,7 @@ version: 1`, si)
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l2, accept: snapAccept}
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{extendedTimeoutUSec, "READY=1"})
 
@@ -679,7 +680,7 @@ func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	stoppedYet := false
 	defer func() {
 		if !stoppedYet {
@@ -770,7 +771,7 @@ version: 1`, si)
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: snapL, accept: snapAccept}
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 
 	snapdAccepting := make(chan struct{})
 	go func() {
@@ -865,7 +866,7 @@ func (s *daemonSuite) TestGracefulStopHasLimits(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: snapL, accept: snapAccept}
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 
 	snapdAccepting := make(chan struct{})
 	go func() {
@@ -961,7 +962,7 @@ func (s *daemonSuite) testRestartSystemWiring(c *check.C, prep func(d *Daemon), 
 		return nil
 	}
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	defer d.Stop(nil)
 
 	st := d.overlord.State()
@@ -1166,7 +1167,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -1219,7 +1220,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -1278,7 +1279,7 @@ func (s *daemonSuite) TestRestartExpectedRebootDidNotHappen(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(n, check.Equals, 1)
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{"READY=1"})
 
@@ -1352,7 +1353,7 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {
 	// go into socket activation mode
 	s.markSeeded(d)
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
 		c.Check(d.overlord.StateEngine().Ensure(), check.IsNil)
@@ -1382,7 +1383,7 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
 	s.markSeeded(d)
 	st := d.overlord.State()
 
-	c.Assert(d.Start(), check.IsNil)
+	c.Assert(d.Start(context.Background()), check.IsNil)
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
 		c.Check(d.overlord.StateEngine().Ensure(), check.IsNil)
@@ -1475,5 +1476,5 @@ func (s *daemonSuite) TestHandleUnexpectedRestart(c *check.C) {
 	// mark as already seeded
 	s.markSeeded(d)
 
-	c.Assert(d.Start(), check.Equals, ErrNoFailureRecoveryNeeded)
+	c.Assert(d.Start(context.Background()), check.Equals, ErrNoFailureRecoveryNeeded)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1577,20 +1577,3 @@ func (s *daemonSuite) TestRequestContextPropagated(c *check.C) {
 	c.Assert(v, check.DeepEquals, "hello")
 	d.Stop(nil)
 }
-
-func (s *daemonSuite) TestRequestContextHijacked(c *check.C) {
-	d := s.newTestDaemon(c)
-
-	// mark as already seeded
-	s.markSeeded(d)
-
-	c.Assert(d.Init(), check.IsNil)
-	c.Assert(d.Start(context.Background()), check.IsNil)
-
-	// since the tests aren't in a package, we directly hijack d.cancel
-	c.Assert(d.cancel, check.NotNil)
-	cancel := d.cancel
-	defer cancel()
-	d.cancel = nil
-	d.Stop(nil)
-}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1370,6 +1370,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 	target := PathInstallGoal(instanceName, path, si, RevisionOptions{
 		Channel: channel,
 	})
+	// TODO have caller pass a context
 	info, ts, err := InstallOne(context.Background(), st, target, Options{
 		Flags:         flags,
 		PrereqTracker: prqt,
@@ -1674,6 +1675,7 @@ func InstallMany(st *state.State, names []string, revOpts []*RevisionOptions, us
 	}
 
 	target := StoreInstallGoal(snaps...)
+	// TODO have caller pass a context
 	infos, tss, err := InstallWithGoal(context.Background(), st, target, Options{
 		Flags:  *flags,
 		UserID: userID,


### PR DESCRIPTION
This is another take at #13961, but this time around the branch is attempting at a refactor of how the context is propagated and how it interacts with cancelation.

Related: SNAPDENG-22871