### PR TITLE
tests: updated the backends list used for openstack

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -9,8 +9,12 @@
             http_proxy: 'http://squid.internal:3128'
             https_proxy: 'http://squid.internal:3128'
         systems:
-            - ubuntu-22.04-arm-64:
-                image: ubuntu-jammy-22.04-arm64
+            - ubuntu-22.04-64:
+                image: ubuntu-22.04-64
+                workers: 6
+
+            - ubuntu-24.04-64:
+                image: ubuntu-24.04-64
                 workers: 6
 
             - fedora-40-64:


### PR DESCRIPTION
ubuntu arm-64 is removed because it fails to boot in nightly 
ubuntu jammy and noble are added to be executed in nighty run
