### PR TITLE
interfaces/mpris: Allow unconfined session to reach mpris players

### DIFF
--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -88,6 +88,31 @@ dbus (receive)
     bus=session
     path=/org/mpris/MediaPlayer2
     peer=(label=@{profile_name}),
+
+# Allow unconfined session to interact with the player
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/mpris/MediaPlayer2
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Introspectable
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    interface="org.mpris.MediaPlayer2{,.*}"
+    path=/org/mpris/MediaPlayer2
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/mpris/MediaPlayer2
+    member=PropertiesChanged
+    peer=(label=unconfined),
 `
 
 const mprisConnectedSlotAppArmor = `


### PR DESCRIPTION
This is necessary for mpris players to appear in the unconfined session mpris related GUI.
