### PR TITLE
i/builtin: enable locking in apparmor custom-device for device write

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -329,7 +329,7 @@ func (iface *customDeviceInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 
 	var devicePaths []string
 	_ = slot.Attr("devices", &devicePaths)
-	emitRule(devicePaths, "rw")
+	emitRule(devicePaths, "rwk")
 
 	var readDevicePaths []string
 	_ = slot.Attr("read-devices", &readDevicePaths)

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -393,8 +393,8 @@ func (s *CustomDeviceInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
-	c.Check(plugSnippet, testutil.Contains, `"/dev/input/event[0-9]" rw,`)
-	c.Check(plugSnippet, testutil.Contains, `"/dev/input/mice" rw,`)
+	c.Check(plugSnippet, testutil.Contains, `"/dev/input/event[0-9]" rwk,`)
+	c.Check(plugSnippet, testutil.Contains, `"/dev/input/mice" rwk,`)
 	c.Check(plugSnippet, testutil.Contains, `"/dev/js*" r,`)
 	c.Check(plugSnippet, testutil.Contains, `"/bar" rw,`)
 	c.Check(plugSnippet, testutil.Contains, `"/dev/input/by-id/*" r,`)


### PR DESCRIPTION
`custom-device` gives [rw apparmor rule](https://github.com/snapcore/snapd/blob/master/interfaces/builtin/custom_device.go#L332) while `rwk` is needed for some device (i.e: /dev/AMA0, the serial port on PI 4).

The raw-usb interface access rights to [/dev/ttyUSB* with rwk](https://github.com/snapcore/snapd/blob/master/interfaces/builtin/raw_usb.go#L38).

This PR replace in the `custom-device` interface the permissions for write device from `rw` to `rwk`.