### PR TITLE
tests: properly build snapd snap

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,18 +21,26 @@ concurrency:
 
 jobs:
   snap-builds:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         toolchain:
           - default
           - FIPS
+        version:
+          # test version is a build of snapd with test keys and should
+          # only be installed by test runners. The pristine versions
+          # are the build that should be installed by human users.
+          - pristine
+          - test
     # only build the snap for pull requests, it's not needed on release branches
     # or on master since we have launchpad build recipes which do this already
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Select Go toolchain
       run: |
@@ -48,8 +56,21 @@ jobs:
                 exit 1
                 ;;
         esac
+        case "${{ matrix.version }}" in
+            pristine)
+                rm -f test-build
+                ;;
+            test)
+                touch test-build
+                ;;
+        esac
 
     - name: Build snapd snap
+      uses: snapcore/action-build@v1
+      with:
+        snapcraft-channel: 8.x/stable
+
+    - name: Build test snapd snap
       uses: snapcore/action-build@v1
       with:
         snapcraft-channel: 8.x/stable
@@ -71,7 +92,7 @@ jobs:
     - name: Uploading snapd snap artifact
       uses: actions/upload-artifact@v3
       with:
-        name: snap-files-${{ matrix.toolchain }}
+        name: snap-files-${{ matrix.toolchain }}-${{ matrix.version }}
         path: "*.snap"
 
   cache-build-deps:
@@ -592,7 +613,7 @@ jobs:
         verbose: true
 
   spread:
-    needs: [unit-tests]
+    needs: [unit-tests, snap-builds]
     # have spread jobs run on master on PRs only, but on both PRs and pushes to
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
@@ -793,6 +814,19 @@ jobs:
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 
+    - name: Download built snap
+      uses: actions/download-artifact@v3
+      with:
+        name: snap-files-default-test
+        pattern: snapd_1337.*.snap
+        path: "${{ github.workspace }}/built-snap"
+
+    - name: Rename imported snap
+      run: |
+        for snap in built-snap/snapd_1337.*.snap; do
+          mv "${snap}" "${snap}.keep"
+        done
+
     - name: Run spread tests
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread') && ( !startsWith(matrix.group, 'nested-') || contains(github.event.pull_request.labels.*.name, 'Run nested') )"
       env:
@@ -806,6 +840,16 @@ jobs:
             export NESTED_BUILD_SNAPD_FROM_CURRENT=true
             export NESTED_ENABLE_KVM=true
           fi
+
+          case "${{ matrix.systems }}" in
+            *-arm-*)
+              TESTS_USE_PREBUILT_SNAPD_SNAP=false
+              ;;
+            *)
+              TESTS_USE_PREBUILT_SNAPD_SNAP=true
+              ;;
+          esac
+          export TESTS_USE_PREBUILT_SNAPD_SNAP
 
           if [[ "${{ matrix.systems }}" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -211,6 +211,9 @@ parts:
           echo "-- appending FIPS tag to version $VERSION"
           VERSION="$VERSION-fips"
       fi
+      if [ -f test-build ]; then
+          VERSION="1337.${VERSION}"
+      fi
       craftctl set version="$VERSION"
 
       ./get-deps.sh --skip-unused-check

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,8 @@ environment:
     # a global setting for LXD channel to use in the tests
     # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
     LXD_SNAP_CHANNEL: "latest/candidate"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
+    OLD_UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     SNAPCRAFT_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
@@ -107,6 +108,8 @@ environment:
     NESTED_REPACK_GADGET_SNAP: '$(HOST: echo "${NESTED_REPACK_GADGET_SNAP:-true}")'
     NESTED_REPACK_BASE_SNAP: '$(HOST: echo "${NESTED_REPACK_BASE_SNAP:-true}")'
     NESTED_FORCE_MS_KEYS: '$(HOST: echo "${NESTED_FORCE_MS_KEYS:-false}")'
+    # Whether we should use snapd snap ./built-snap/ directory
+    TESTS_USE_PREBUILT_SNAPD_SNAP: '$(HOST: echo "${TESTS_USE_PREBUILT_SNAPD_SNAP:-false}")'
 
 backends:
     google:
@@ -241,15 +244,16 @@ backends:
         location: snapd-spread/us-central1-a
         plan: t2a-standard-1
         halt-timeout: 2h
+        kill-timeout: 60m
         systems:
             - ubuntu-20.04-arm-64:
                   image: ubuntu-os-cloud/ubuntu-2004-lts-arm64
                   workers: 8
-                  storage: 12G
+                  storage: 15G
             - ubuntu-22.04-arm-64:
                   image: ubuntu-os-cloud/ubuntu-2204-lts-arm64
                   workers: 8
-                  storage: 12G
+                  storage: 15G
             - ubuntu-core-22-arm-64:
                   image: ubuntu-22.04-arm-64
                   workers: 6
@@ -1182,10 +1186,12 @@ suites:
             . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial || os.query is-arm; then
+            if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 # also ubuntu-image binary is not prebuilt for arm instances
+                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+            elif os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                get_ubuntu_image
@@ -1207,7 +1213,7 @@ suites:
             tests.nested prepare
             if os.query is-xenial && ! command -v ubuntu-image >/dev/null; then
                 # This is needed because the snap in removed during on restore-each
-                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             fi
         restore-each: |
             tests.nested vm remove
@@ -1239,10 +1245,12 @@ suites:
             . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial || os.query is-arm; then
+            if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 # also ubuntu-image binary is not prebuilt for arm instances
+                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+            elif os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 get_ubuntu_image
@@ -1300,10 +1308,12 @@ suites:
             . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial || os.query is-arm; then
+            if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 # also ubuntu-image binary is not prebuilt for arm instances
+                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+            elif os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 get_ubuntu_image
@@ -1363,10 +1373,12 @@ suites:
             . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial || os.query is-arm; then
+            if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 # also ubuntu-image binary is not prebuilt for arm instances
+                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+            elif os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 get_ubuntu_image

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -595,23 +595,33 @@ nested_prepare_snapd() {
         echo "Repacking snapd snap"
         local snap_name output_name snap_id
         if nested_is_core_16_system; then
-            snap_name="core"
-            output_name="core-from-snapd-deb.snap"
-            snap_id="99T7MUlRhtI3U0QFgl5mXXESAiSwt776"
+            if [ ! -f "$NESTED_ASSETS_DIR/core-from-snapd-deb.snap" ]; then
+                "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap core "$NESTED_ASSETS_DIR"
+                cp "$NESTED_ASSETS_DIR/core-from-snapd-deb.snap" "$(nested_get_extra_snaps_path)/core-from-snapd-deb.snap"
+            fi
+            # sign the snapd snap with fakestore if requested
+            if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
+                "$TESTSTOOLS"/store-state make-snap-installable --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/core-from-snapd-deb.snap" "99T7MUlRhtI3U0QFgl5mXXESAiSwt776"
+            fi
         else
-            snap_name="snapd"
-            output_name="snapd-from-deb.snap"
-            snap_id="PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
-        fi
-
-        if [ ! -f "$NESTED_ASSETS_DIR/$output_name" ]; then
-            "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap_name" "$NESTED_ASSETS_DIR"
-        fi
-        cp "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
-
-        # sign the snapd snap with fakestore if requested
-        if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-            "$TESTSTOOLS"/store-state make-snap-installable --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/$output_name" "$snap_id"
+            for f in "${NESTED_ASSETS_DIR}"/snapd_*.snap; do
+                snap_name="$(basename "${f}")"
+                break
+            done
+            if [ ! -f "${NESTED_ASSETS_DIR}/${snap_name}" ]; then
+                # shellcheck source=tests/lib/prepare.sh
+                . "$TESTSLIB"/prepare.sh
+                build_snapd_snap "$NESTED_ASSETS_DIR"
+                for f in "${NESTED_ASSETS_DIR}"/snapd_*.snap; do
+                    snap_name="$(basename "${f}")"
+                    break
+                done
+                cp "${NESTED_ASSETS_DIR}/${snap_name}" "$(nested_get_extra_snaps_path)/"
+            fi
+            # sign the snapd snap with fakestore if requested
+            if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
+                "$TESTSTOOLS"/store-state make-snap-installable --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/${snap_name}" "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+            fi
         fi
     fi
 }

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -460,90 +460,79 @@ prepare_classic() {
     fi
 }
 
-repack_snapd_snap_with_deb_content() {
-    local TARGET="$1"
-
-    local UNPACK_DIR="/tmp/snapd-unpack"
-    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-    # clean snap apparmor.d to ensure we put the right snap-confine apparmor
-    # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
-    # usr.lib.snapd.snap-confine.real everywhere else
-    rm -f "$UNPACK_DIR"/etc/apparmor.d/*
-
-    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/snapd
-    snap pack "$UNPACK_DIR" "$TARGET"
-    rm -rf "$UNPACK_DIR"
+ensure_snapcraft() {
+    if ! command -v snapcraft; then
+        snap install --channel="${SNAPCRAFT_SNAP_CHANNEL}" snapcraft --classic
+        "$TESTSTOOLS"/lxd-state prepare-snap
+    fi
 }
 
-repack_core_snap_with_tweaks() {
-    local CORESNAP="$1"
-    local TARGET="$2"
-
-    local UNPACK_DIR="/tmp/core-unpack"
-    unsquashfs -no-progress -d "$UNPACK_DIR" "$CORESNAP"
-
-    mkdir -p "$UNPACK_DIR"/etc/systemd/journald.conf.d
-    cat <<EOF > "$UNPACK_DIR"/etc/systemd/journald.conf.d/to-console.conf
-[Journal]
-ForwardToConsole=yes
-TTYPath=/dev/ttyS0
-MaxLevelConsole=debug
-EOF
-    mkdir -p "$UNPACK_DIR"/etc/systemd/system/snapd.service.d
-cat <<EOF > "$UNPACK_DIR"/etc/systemd/system/snapd.service.d/logging.conf
-[Service]
-Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
-StandardOutput=journal+console
-StandardError=journal+console
-EOF
-
-    cp "${SPREAD_PATH}"/data/completion/bash/complete.sh "${UNPACK_DIR}"/usr/lib/snapd/complete.sh
-
-    snap pack --filename="$TARGET" "$UNPACK_DIR"
-
-    rm -rf "$UNPACK_DIR"
+cleanup_snapcraft() {
+    snap remove --purge lxd || true
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
+    snap remove --purge snapcraft || true
 }
 
-repack_kernel_snap() {
-    local TARGET=$1
-    local VERSION
-    local UNPACK_DIR
-    local CHANNEL
+run_snapcraft() {
+    ensure_snapcraft
+    if ! (cd "${PROJECT_PATH}" && snapcraft "$@"); then
+        # shellcheck disable=SC2012
+        tail -n1000 "${HOME}/.local/state/snapcraft/log/$(ls -t "${HOME}/.local/state/snapcraft/log/" -1 | head -n1)"
+        false
+    fi
+    cleanup_snapcraft
+}
 
-    VERSION=$(nested_get_version)
-    if [ "$VERSION" = 16 ]; then
-        CHANNEL=latest
+build_snapd_snap() {
+    local TARGET
+    local snapd_snap_cache
+    TARGET="${1}"
+
+    snapd_snap_cache="${WORK_DIR:-/tmp/work-dir}/snapd_snap"
+    mkdir -p "${snapd_snap_cache}"
+    for snap in "${snapd_snap_cache}"/snapd_*.snap; do
+        if ! [ -f "${snap}" ]; then
+            if [ "${TESTS_USE_PREBUILT_SNAPD_SNAP}" = true ]; then
+                cp "${PROJECT_PATH}/built-snap"/snapd_1337.*.snap.keep "${snapd_snap_cache}/snapd_from_ci.snap"
+            else
+                [ -d "${TARGET}" ] || mkdir "${TARGET}"
+                chmod -R go+r "${PROJECT_PATH}/tests"
+                run_snapcraft --use-lxd --verbosity quiet --output="snapd_from_snapcraft.snap"
+                mv "${PROJECT_PATH}"/snapd_from_snapcraft.snap "${snapd_snap_cache}"
+            fi
+        fi
+        break
+    done
+
+    cp "${snapd_snap_cache}"/snapd_*.snap "${TARGET}/"
+}
+
+build_snapd_snap_with_run_mode_firstboot_tweaks() {
+    local snapd_snap_cache
+    local TARGET
+
+    TARGET="${1}"
+
+    snapd_snap_cache="${WORK_DIR:-/tmp/work-dir}/snapd_snap_with_tweaks"
+    mkdir -p "${snapd_snap_cache}"
+    for snap in "${snapd_snap_cache}"/snapd_*.snap; do
+        if [ -f "${snap}" ]; then
+            cp "${snap}" "${TARGET}/"
+            return
+        fi
+    done
+
+    if [ "${TESTS_USE_PREBUILT_SNAPD_SNAP}" = true ]; then
+        cp "${PROJECT_PATH}/built-snap"/snapd_1337.*.snap.keep "/tmp/snapd_from_snapcraft.snap"
     else
-        CHANNEL=$VERSION
+        chmod -R go+r "${PROJECT_PATH}/tests"
+        run_snapcraft --use-lxd --verbosity quiet --output="snapd_from_snapcraft.snap"
+        mv "${PROJECT_PATH}/snapd_from_snapcraft.snap" "/tmp/snapd_from_snapcraft.snap"
     fi
 
-    echo "Repacking kernel snap"
-    UNPACK_DIR=/tmp/kernel-unpack
-    snap download --basename=pc-kernel --channel="$CHANNEL/${KERNEL_CHANNEL}" pc-kernel
-    unsquashfs -no-progress -d "$UNPACK_DIR" pc-kernel.snap
-    snap pack --filename="$TARGET" "$UNPACK_DIR"
-
-    rm -rf pc-kernel.snap "$UNPACK_DIR"
-}
-
-repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks() {
-    local TARGET="$1"
-
     local UNPACK_DIR="/tmp/snapd-unpack"
-    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-
-    # data/preseed.json is not included in the deb, use the latest
-    # version from source tree to replace the one in the re-packed snapd snap.
-    cp "$PROJECT_PATH/data/preseed.json" "$UNPACK_DIR"/usr/lib/snapd
-
-    # clean snap apparmor.d to ensure we put the right snap-confine apparmor
-    # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
-    # usr.lib.snapd.snap-confine.real everywhere else
-    rm -f "$UNPACK_DIR"/etc/apparmor.d/*
-
-    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/snapd
+    rm -rf "${UNPACK_DIR}"
+    unsquashfs -no-progress -d "$UNPACK_DIR" /tmp/snapd_from_snapcraft.snap
 
     # now install a unit that sets up enough so that we can connect
     cat > "$UNPACK_DIR"/lib/systemd/system/snapd.spread-tests-run-mode-tweaks.service <<'EOF'
@@ -613,10 +602,61 @@ touch /root/spread-setup-done
 EOF
     chmod 0755 "$UNPACK_DIR"/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh
 
+    mkdir -p "${snapd_snap_cache}"
+    snap pack "$UNPACK_DIR" "${snapd_snap_cache}/"
+    rm -rf "$UNPACK_DIR"
+    cp "${snapd_snap_cache}"/snapd_*.snap "${TARGET}/"
+}
+
+repack_core_snap_with_tweaks() {
+    local CORESNAP="$1"
+    local TARGET="$2"
+
+    local UNPACK_DIR="/tmp/core-unpack"
+    unsquashfs -no-progress -d "$UNPACK_DIR" "$CORESNAP"
+
+    mkdir -p "$UNPACK_DIR"/etc/systemd/journald.conf.d
+    cat <<EOF > "$UNPACK_DIR"/etc/systemd/journald.conf.d/to-console.conf
+[Journal]
+ForwardToConsole=yes
+TTYPath=/dev/ttyS0
+MaxLevelConsole=debug
+EOF
+    mkdir -p "$UNPACK_DIR"/etc/systemd/system/snapd.service.d
+cat <<EOF > "$UNPACK_DIR"/etc/systemd/system/snapd.service.d/logging.conf
+[Service]
+Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
+StandardOutput=journal+console
+StandardError=journal+console
+EOF
+
     cp "${SPREAD_PATH}"/data/completion/bash/complete.sh "${UNPACK_DIR}"/usr/lib/snapd/complete.sh
 
-    snap pack "$UNPACK_DIR" "$TARGET"
+    snap pack --filename="$TARGET" "$UNPACK_DIR"
+
     rm -rf "$UNPACK_DIR"
+}
+
+repack_kernel_snap() {
+    local TARGET=$1
+    local VERSION
+    local UNPACK_DIR
+    local CHANNEL
+
+    VERSION=$(nested_get_version)
+    if [ "$VERSION" = 16 ]; then
+        CHANNEL=latest
+    else
+        CHANNEL=$VERSION
+    fi
+
+    echo "Repacking kernel snap"
+    UNPACK_DIR=/tmp/kernel-unpack
+    snap download --basename=pc-kernel --channel="$CHANNEL/${KERNEL_CHANNEL}" pc-kernel
+    unsquashfs -no-progress -d "$UNPACK_DIR" pc-kernel.snap
+    snap pack --filename="$TARGET" "$UNPACK_DIR"
+
+    rm -rf pc-kernel.snap "$UNPACK_DIR"
 }
 
 # Builds kernel snap with bad kernel.efi, in different ways
@@ -1006,11 +1046,6 @@ setup_reflash_magic() {
     # need to be seeded to proceed with snap install
     snap wait system seed.loaded
 
-    # download the snapd snap for all uc systems except uc16
-    if ! is_test_target_core 16; then
-        snap download "--channel=${SNAPD_CHANNEL}" snapd
-    fi
-
     # we cannot use "snaps.names tool" here because no snaps are installed yet
     core_name="core"
     if is_test_target_core 18; then
@@ -1039,7 +1074,7 @@ setup_reflash_magic() {
     elif is_test_target_core 16; then
         # the new ubuntu-image expects mkfs to support -d option, which was not
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-        snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+        snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
         # shellcheck source=tests/lib/image.sh
         . "$TESTSLIB/image.sh"
@@ -1060,21 +1095,21 @@ setup_reflash_magic() {
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if is_test_target_core 18; then
-        repack_snapd_snap_with_deb_content "$IMAGE_HOME"
+        build_snapd_snap "${IMAGE_HOME}"
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
     elif is_test_target_core 20; then
-        repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
+        build_snapd_snap_with_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
     elif is_test_target_core 22; then
-        repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
+        build_snapd_snap_with_run_mode_firstboot_tweaks "$IMAGE_HOME"
         if os.query is-arm; then
             cp "$TESTSLIB/assertions/ubuntu-core-22-arm64.model" "$IMAGE_HOME/pc.model"
         else
             cp "$TESTSLIB/assertions/ubuntu-core-22-amd64.model" "$IMAGE_HOME/pc.model"
         fi
     elif is_test_target_core 24; then
-        repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
+        build_snapd_snap_with_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-24-amd64.model" "$IMAGE_HOME/pc.model"
     else
         # FIXME: install would be better but we don't have dpkg on
@@ -1234,7 +1269,7 @@ EOF
             BASE=core24
         fi
         snap download "${BASE}" --channel="$BASE_CHANNEL" --basename="${BASE}"
-        
+
         # we want to download the specific channel referenced by $BASE_CHANNEL, 
         # but if we just seed that revision and $BASE_CHANNEL != $IMAGE_CHANNEL,
         # then immediately on booting, snapd will refresh from the revision that
@@ -1257,7 +1292,7 @@ EOF
         else 
             mv "${BASE}.snap" "${IMAGE_HOME}/${BASE}.snap"
         fi
-        
+
         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap ${IMAGE_HOME}/${BASE}.snap"
     fi
     local UBUNTU_IMAGE="$GOHOME"/bin/ubuntu-image

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -146,25 +146,6 @@ repack_snapd_deb_into_snap() {
             # cleanup
             rm -rf core-unpacked
             ;;
-        snapd)
-            # use snapd from edge as a recent snap that should be close to what we will
-            # have in the snapd deb
-            snap download snapd --basename=snapd --edge
-            unsquashfs -d ./snapd-unpacked snapd.snap
-            rm snapd.snap
-
-            # extract all the files from the snapd deb
-            dpkg-deb -x "$deb_file" ./snapd-unpacked
-            # copy preseed config, like we do in snapcraft.yaml for the snap
-            # build
-            cp -av "$PROJECT_PATH/data/preseed.json" ./snapd-unpacked/usr/lib/snapd/
-
-            # repack into the target dir specified
-            snap pack --filename=snapd-from-deb.snap  snapd-unpacked "$target_dir"
-
-            # cleanup
-            rm -rf snapd-unpacked
-            ;;
         *)
             echo "snaps-state: use either core or snapd snaps for repack, snapd $snap_name not supported"
             show_help

--- a/tests/lib/uc20-recovery.sh
+++ b/tests/lib/uc20-recovery.sh
@@ -44,7 +44,7 @@ transition_to_recover_mode(){
 
     # with the external backend, we do not have the special snapd snap with
     # the first-boot run mode tweaks as created from $TESTLIB/prepare.sh's 
-    # repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks func
+    # build_snapd_snap_with_run_mode_firstboot_tweaks func
     # so instead to get the spread gopath and other data needed to continue
     # the test, we need to add a .ssh/rc script which copies all of the data
     # from /host/ubuntu-data in recover mode to the tmpfs /home, see

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -18,8 +18,8 @@ environment:
 prepare: |
   #shellcheck source=tests/lib/prepare.sh
   . "$TESTSLIB"/prepare.sh
-  snap download "--channel=${SNAPD_CHANNEL}" snapd
-  repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks /tmp
+  mkdir -p /tmp/tweaked-snapd-snap
+  build_snapd_snap_with_run_mode_firstboot_tweaks /tmp/tweaked-snapd-snap
 
   snap pack systemusers-snap
 
@@ -36,6 +36,7 @@ prepare: |
   gendeveloper1 show-key | gpg --homedir=~/.snap/gnupg --import
 
 restore: |
+  rm -rf /tmp/tweaked-snapd-snap
   rm -rf "$PREPARE_IMAGE_DIR"
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
 
@@ -47,7 +48,13 @@ execute: |
   export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
   echo "Running pre-seeding"
-  SNAPD_SNAP=$(ls /tmp/snapd*.snap)
+  for f in /tmp/tweaked-snapd-snap/snapd*.snap; do
+    if [ "${SNAPD_SNAP:+set}" = set ]; then
+      echo "found multiple snaps in /tmp/tweaked-snapd-snap" 1>&2
+      exit 1
+    fi
+    SNAPD_SNAP="${f}"
+  done
 
   # XXX: confusingly, the name of our test key is actually " (test)".
   SNAPD_DEBUG=1 snap prepare-image --preseed --preseed-sign-key=" (test)" --channel=stable \

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -40,7 +40,7 @@ prepare: |
 
   # shellcheck source=tests/lib/prepare.sh
   . "$TESTSLIB"/prepare.sh
-  build_snapd_snap_with_run_mode_firstboot_tweaks .
+  build_snapd_snap_with_run_mode_firstboot_tweaks "$PWD"
   mv snapd_*.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 

--- a/tests/main/preseed-lxd/task.yaml
+++ b/tests/main/preseed-lxd/task.yaml
@@ -37,8 +37,11 @@ prepare: |
   mount /dev/nbd0p1 "$IMAGE_MOUNTPOINT"
 
   # add snapd from this branch into the seed
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-  mv snapd-from-deb.snap snapd.snap
+
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap_with_run_mode_firstboot_tweaks .
+  mv snapd_*.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 
   if [ ! -x /usr/bin/lxc ]; then

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -27,8 +27,10 @@ prepare: |
   mount_ubuntu_image "$(pwd)/cloudimg.img" "$IMAGE_MOUNTPOINT"
 
   # add snapd from this branch into the seed
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-  mv snapd-from-deb.snap snapd.snap
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap_with_run_mode_firstboot_tweaks .
+  mv snapd_*.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 
   # for images that are already preseeded, we need to undo the preseeding there

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -29,7 +29,7 @@ prepare: |
   # add snapd from this branch into the seed
   # shellcheck source=tests/lib/prepare.sh
   . "$TESTSLIB"/prepare.sh
-  build_snapd_snap_with_run_mode_firstboot_tweaks .
+  build_snapd_snap_with_run_mode_firstboot_tweaks "$PWD"
   mv snapd_*.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -22,17 +22,6 @@ execute: |
     snap install test-snapd-sh
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
-    # The 16.04 build is static as it goes into the snapd snap but 14.04
-    # is dynamically linked.
-    if ! os.query is-trusty; then
-        echo "Ensure snap-seccomp is statically linked"
-        # FIXME: use dirs.sh in 2.27+
-        if ldd /usr/lib/snapd/snap-seccomp | MATCH libseccomp ; then
-            echo "found dynamically linked libseccomp, we need a staticly linked one"
-            exit 1
-        fi
-    fi
-
     # from the old test_complain
     echo "Test that the @complain keyword works"
     rm -f "${PROFILE}.bin2"

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -7,7 +7,8 @@ details: |
 # Run only on ubuntu classic because this re-execs. We have a
 # separate test for UC18 already and on UC16 we always have a core
 # snap so we don't need to test there.
-systems: [ubuntu-1*, ubuntu-2*]
+# Snapd snap is not available on i386 anymore. So we stick with 64 bits.
+systems: [ubuntu-1*-64, ubuntu-2*-64]
 
 environment:
     # uploading large snap triggers OOM
@@ -25,8 +26,7 @@ execute: |
     echo "Create modified snapd snap"
     #shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
-    snap download --edge snapd
-    repack_snapd_snap_with_deb_content /tmp
+    build_snapd_snap /tmp
 
     echo "Ensure core is gone so that we can have snapd"
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -122,20 +122,6 @@ execute: |
             ;;
     esac
 
-    sha256_of_snap_file() {
-        local snapfile=$1
-        local filename=$2
-        local tmpdir
-        tmpdir=$(mktemp -d)
-
-        unsquashfs -d "$tmpdir/out" "$snapfile" "$filename" &>/dev/null
-
-        local sum
-        sum="$(sha256sum "$tmpdir/out/$filename")"
-        rm -rf "$tmpdir"
-        echo "$sum" | awk '{print $1}'
-    }
-
     # Skip test repack when the sru validation is being executed, in this
     # scenario the deb package used comes from the sru and repack is not done
     if [ "$SRU_VALIDATION" = 1 ]; then
@@ -149,20 +135,10 @@ execute: |
         test -e core/core-from-snapd-deb.snap
         rm -rf core
 
-        "$TESTSTOOLS"/snaps-state repack-snapd-deb-into-snap snapd "$PWD"/snapd
-        test -e snapd/snapd-from-deb.snap
-        # Check the binary in the snap is the same than the installed in the system
-        test "$(sha256_of_snap_file snapd/snapd-from-deb.snap /usr/lib/snapd/snapd)" = "$(sha256sum /usr/lib/snapd/snapd | awk '{print $1}')"
-        rm -rf snapd
-
         cp "$SPREAD_PATH"/../snapd_*.deb current_snapd.deb
         "$TESTSTOOLS"/snaps-state repack-snapd-deb-into-snap core "$PWD"/core current_snapd.deb
         test -e core/core-from-snapd-deb.snap
         rm -rf core
-
-        "$TESTSTOOLS"/snaps-state repack-snapd-deb-into-snap snapd "$PWD"/snapd current_snapd.deb
-        test -e snapd/snapd-from-deb.snap
-        rm -rf snapd
 
         "$TESTSTOOLS"/snaps-state repack-snapd-deb-into-snap core "$PWD"/core noexist.deb 2>&1 | MATCH "snaps-state: deb file used to repack not found: noexist.deb"
     fi

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -94,11 +94,15 @@ execute: |
             
         else
             # build the snapd snap for this run
-            "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-            remote.push "$PWD/snapd-from-deb.snap"
+            # shellcheck source=tests/lib/prepare.sh
+            . "$TESTSLIB"/prepare.sh
+            mkdir -p snap-output
+            build_snapd_snap snap-output
+            mv snap-output/snapd_*.snap snapd.snap
+            remote.push "$PWD/snapd.snap"
 
             # install the snapd snap
-            remote.exec "sudo snap install snapd-from-deb.snap --dangerous"
+            remote.exec "sudo snap install snapd.snap --dangerous"
         fi
     fi
 

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -53,7 +53,9 @@ prepare: |
         else 
             # uc18 uses snapd snap
             test-snapd-curl.curl -s -o snapd_2.45.snap "$SNAPD_2_45_SNAPD_SNAP"
-            cp snapd_2.45.snap "$(tests.nested get extra-snaps-path)"
+            # repack to prevent automatic refresh
+            unsquashfs -d snapd-snap snapd_2.45.snap
+            snap pack snapd-snap/ "$(tests.nested get extra-snaps-path)"
         fi
     fi
 
@@ -103,11 +105,15 @@ execute: |
             tests.nested wait-for ssh
         else
             # build the snapd snap for this run
-            "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-            remote.push "$PWD/snapd-from-deb.snap"
+            # shellcheck source=tests/lib/prepare.sh
+            . "$TESTSLIB"/prepare.sh
+            mkdir -p snap-output
+            build_snapd_snap snap-output
+            mv snap-output/snapd_*.snap snapd.snap
+            remote.push "$PWD/snapd.snap"
 
             # install the snapd snap
-            remote.exec "sudo snap install snapd-from-deb.snap --dangerous"
+            remote.exec "sudo snap install snapd.snap --dangerous"
         fi
     fi
 

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -21,9 +21,11 @@ prepare: |
       exit
   fi
 
-  "$TESTSTOOLS"/snaps-state repack-snapd-deb-into-snap snapd
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap .
   echo "Repack the snapd snap with a marker file"
-  unsquashfs -d snapd-snap snapd-from-deb.snap
+  unsquashfs -d snapd-snap snapd_*.snap
 
   echo "Leave a marker file that triggers boot config assets to be injected"
   echo 'bootassetstesting' > snapd-snap/usr/lib/snapd/bootassetstesting

--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -46,9 +46,10 @@ environment:
 prepare: |
   # always build the snapd snap from this branch - on the new variant it gets
   # put into the image, on the old variant it will be refreshed to
-  snap download --channel="latest/edge" snapd
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-  mv snapd-from-deb.snap snapd-from-branch.snap  
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap .
+  mv snapd_*.snap snapd-from-branch.snap
 
   # on both variants we use a local, non-asserted version of the snapd snap
   # for the startwithnew variant, we use the snapd from this branch, for the

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -27,8 +27,10 @@ prepare: |
   # into seeds/ to make snap-preseed and the test happy.
 
   # add snapd from this branch into the seed
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-  mv snapd-from-deb.snap snapd.snap
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap .
+  mv snapd_*.snap snapd.snap
   inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
 
   # test-postgres-system-usernames injected below uses core18 base, while the

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -23,7 +23,10 @@ prepare: |
   tests.nested create-vm core
 
   # for refresh in later step of the test
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap .
+  mv snapd_*.snap snapd.snap
 
 execute: |
   remote.exec "sudo snap wait system seed.loaded"
@@ -47,6 +50,6 @@ execute: |
   fi
 
   echo "Now refresh snapd with current tree"
-  remote.push "snapd-from-deb.snap"
-  remote.exec "sudo snap install snapd-from-deb.snap --dangerous" || true
+  remote.push "snapd.snap"
+  remote.exec "sudo snap install snapd.snap --dangerous" || true
   remote.exec "snap list snapd" | MATCH "snapd .* x1 "

--- a/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
+++ b/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
@@ -24,7 +24,7 @@ environment:
   # meh snap-state doesn't have a consistent naming for these snaps, so we can't
   # just do "$SNAPD_SOURCE_SNAP-from-deb.snap"
   REPACKED_SNAP_NAME/core: core-from-snapd-deb.snap
-  REPACKED_SNAP_NAME/snapd: snapd-from-deb.snap
+  REPACKED_SNAP_NAME/snapd: snapd-new.snap
 
   # a specific vulnerable snapd version we can base our image on
   VULN_SNAP_REV_URL/snapd: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_14549.snap
@@ -43,7 +43,17 @@ prepare: |
   mount_ubuntu_image "$(tests.nested get images-path)/$IMAGE_NAME" "$IMAGE_MOUNTPOINT"
 
   # repack the deb into the snap we want
-  "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$SNAPD_SOURCE_SNAP"
+  case "$SNAPD_SOURCE_SNAP" in
+    core)
+      "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$SNAPD_SOURCE_SNAP"
+    ;;
+    snapd)
+      # shellcheck source=tests/lib/prepare.sh
+      . "$TESTSLIB"/prepare.sh
+      build_snapd_snap .
+      mv snapd_*.snap "${REPACKED_SNAP_NAME}"
+    ;;
+  esac
 
   # add the known vulnerable version of snapd into the seed, dangerously
   curl -s -o "$SNAPD_SOURCE_SNAP-vuln.snap" "$VULN_SNAP_REV_URL"


### PR DESCRIPTION
Now we build also the test version of snapd snap in `snap-builds` workflow job. We copy this into the spread tests. And we use that snap, which we only instrument instead of copying the snapd deb build.

If the snap is not available, then we build it in spread. On CI, this happens on arm since the workflow does not build it. It will also happen when triggering test manually.