### PR TITLE
i/prompting/constraints: map get-attr and set-attr to read and write

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -137,8 +137,8 @@ var (
 	// and if it does not, it should be interpreted as AA_MAY_READ.
 	interfaceFilePermissionsMaps = map[string]map[string]notify.FilePermission{
 		"home": {
-			"read":    notify.AA_MAY_READ,
-			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			"read":    notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
+			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 			"execute": notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
 		},
 	}

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -465,7 +465,7 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 		},
 		{
 			"home",
-			notify.AA_MAY_GETATTR | notify.AA_MAY_READ,
+			notify.AA_MAY_GETCRED | notify.AA_MAY_READ,
 			"cannot map AppArmor permission to abstract permission for the home interface.*",
 		},
 	}
@@ -485,12 +485,12 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsHappy(c *
 		{
 			"home",
 			[]string{"read"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
 		},
 		{
 			"home",
 			[]string{"write"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			notify.AA_MAY_OPEN | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 		},
 		{
 			"home",
@@ -500,12 +500,12 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsHappy(c *
 		{
 			"home",
 			[]string{"read", "execute"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
 		},
 		{
 			"home",
 			[]string{"execute", "write", "read"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 		},
 	}
 	for _, testCase := range cases {

--- a/sandbox/apparmor/notify/permission.go
+++ b/sandbox/apparmor/notify/permission.go
@@ -32,9 +32,9 @@ const (
 	AA_MAY_OPEN
 	// AA_MAY_RENAME implies that a process may rename a file.
 	AA_MAY_RENAME
-	// AA_MAY_SETATTR is not checked by the kernel but may appear in messages.
+	// AA_MAY_SETATTR implies that a process may modify file attributes.
 	AA_MAY_SETATTR
-	// AA_MAY_GETATTR is not checked by the kernel but may appear in messages.
+	// AA_MAY_GETATTR implies that a process may read file attributes.
 	AA_MAY_GETATTR
 	// AA_MAY_SETCRED is not used in the kernel.
 	AA_MAY_SETCRED

--- a/sandbox/apparmor/notify/permission.go
+++ b/sandbox/apparmor/notify/permission.go
@@ -32,9 +32,9 @@ const (
 	AA_MAY_OPEN
 	// AA_MAY_RENAME implies that a process may rename a file.
 	AA_MAY_RENAME
-	// AA_MAY_SETATTR is not checked by the kernel.
+	// AA_MAY_SETATTR is not checked by the kernel but may appear in messages.
 	AA_MAY_SETATTR
-	// AA_MAY_GETATTR is not checked by the kernel.
+	// AA_MAY_GETATTR is not checked by the kernel but may appear in messages.
 	AA_MAY_GETATTR
 	// AA_MAY_SETCRED is not used in the kernel.
 	AA_MAY_SETCRED


### PR DESCRIPTION
It was previously believed that `AA_MAY_SETATTR` and `AA_MAY_GETATTR` would not appear in notification messages from the kernel. However, that is not the case, and we want to be able to handle these similar to other writes and reads, respectively. As such, add them to the permissions map for the home interface.

This should address a bug identified by @sminez and tracked as part of SNAPDENG-23750 and related to https://github.com/canonical/aa-prompting-test/pull/12 and https://github.com/canonical/aa-prompting-test/pull/15.