### PR TITLE
daemon: add terminate flag to snap remove action

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -148,6 +148,7 @@ var (
 	snapstateTryPath                        = snapstate.TryPath
 	snapstateUpdate                         = snapstate.Update
 	snapstateUpdateMany                     = snapstate.UpdateMany
+	snapstateRemove                         = snapstate.Remove
 	snapstateRemoveMany                     = snapstate.RemoveMany
 	snapstateResolveValSetsEnforcementError = snapstate.ResolveValidationSetsEnforcementError
 	snapstateRevert                         = snapstate.Revert

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -219,6 +219,14 @@ func MockSnapstateUpdateMany(mock func(context.Context, *state.State, []string, 
 	}
 }
 
+func MockSnapstateRemove(mock func(st *state.State, name string, revision snap.Revision, flags *snapstate.RemoveFlags) (*state.TaskSet, error)) (restore func()) {
+	oldSnapstateRemove := snapstateRemove
+	snapstateRemove = mock
+	return func() {
+		snapstateRemove = oldSnapstateRemove
+	}
+}
+
 func MockSnapstateRemoveMany(mock func(*state.State, []string, *snapstate.RemoveFlags) ([]string, []*state.TaskSet, error)) (restore func()) {
 	oldSnapstateRemoveMany := snapstateRemoveMany
 	snapstateRemoveMany = mock

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3298,6 +3298,8 @@ func canRemove(st *state.State, si *snap.Info, snapst *SnapState, removeAll bool
 type RemoveFlags struct {
 	// Remove the snap without creating snapshot data
 	Purge bool
+	// Kill running snap apps and services
+	Terminate bool
 }
 
 // Remove returns a set of tasks for removing snap.


### PR DESCRIPTION
This is needed in preparation for the new `snap remove --terminate` flag.

This PR introduces the `terminate` REST API flag which is passed through to remove operations and will be used later to kill running snap apps and services.

This PR is part 2 of implementing force removal of snaps according to [SD174 - Force removal of snaps](https://docs.google.com/document/d/1ikDI-vPJO6YYFHOyFJ5hfK5L5Gv8voMeY8HJvxNWujw/edit#bookmark=id.5l2budzsqbb) spec.

For context:
- Part 1: https://github.com/snapcore/snapd/pull/14126
- Part 3.1: https://github.com/snapcore/snapd/pull/14160
- Part 3.2: https://github.com/snapcore/snapd/pull/14189