### PR TITLE
tests: fix fedora-40 issues and remove centos-8 support in tests

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -8,6 +8,8 @@
             HTTPS_PROXY: 'http://squid.internal:3128'
             http_proxy: 'http://squid.internal:3128'
             https_proxy: 'http://squid.internal:3128'
+            no_proxy: '127.0.0.1,ubuntu.com'
+            NO_PROXY: '127.0.0.1,ubuntu.com'
         systems:
             - ubuntu-22.04-64:
                 image: ubuntu-22.04-64

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -18,7 +18,6 @@ systems:
   - -ubuntu-20.04-*
   - -ubuntu-core-*
   - -centos-7-*
-  - -centos-8-*
   - -centos-9-*
 
 prepare: |

--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -25,13 +25,6 @@ execute: |
             systemctl mask systemd-vconsole-setup.service
             systemctl reset-failed systemd-vconsole-setup.service
             ;;
-        centos-8-*)
-            # tries to load ipmi_si module which fails with ENODEV
-            systemctl reset-failed systemd-modules-load.service
-            # These transient units attempt to update the man page cache, but
-            # fail with the error "Warning! D-Bus connection terminated."
-            systemctl reset-failed 'run-*'
-            ;;
     esac
 
     if systemctl status | grep "State: [d]egraded"; then

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -27,6 +27,7 @@ systems:
     - -debian-*
     - -fedora-38-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-39-*  # test-snapd-eds is incompatible with eds version shipped with the distro
+    - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -22,6 +22,7 @@ systems:
     - -debian-*
     - -fedora-38-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-39-*  # test-snapd-eds is incompatible with eds version shipped with the distro
+    - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -13,10 +13,10 @@ systems:
   - -amazon-linux-2-*    # fails to start service daemon-containerd
   - -amazon-linux-2023-* # fails to start service daemon-containerd
   - -centos-7-*          # doesn't have libseccomp >= 2.4
-  - -centos-8-*          # fails to start service daemon-containerd
   - -centos-9-*          # fails to start service daemon-containerd
   - -fedora-38-*         # fails to start service daemon-containerd
-  - -fedora-39-*      # fails to start service daemon-containerd
+  - -fedora-39-*         # fails to start service daemon-containerd
+  - -fedora-40-*         # fails to start service daemon-containerd
   - -ubuntu-14.04-*      # doesn't have libseccomp >= 2.4
   - -ubuntu-*-32         # no microk8s snap for 32 bit systems
   - -arch-linux-*        # XXX: no curl to the pod for unknown reasons

--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -34,6 +34,10 @@ execute: |
 
     echo "Now without DNS resolver with ipv4"
     UBUNTU_IP="$(getent ahostsv4 www.ubuntu.com|awk '{print $1 }' | head -n1)"
+    # when ubuntu.com is configured in no_proxy, then we need to add the ip as well
+    if echo "$NO_PROXY" | MATCH 'ubuntu.com'; then
+        export NO_PROXY="$NO_PROXY","$UBUNTU_IP"
+    fi
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://$UBUNTU_IP" > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, see comment above
     MATCH "ShouldRetryError: true" < output.txt
@@ -49,6 +53,10 @@ execute: |
 
     echo "Now without DNS resolver for ipv6"
     UBUNTU_IP="$(getent ahostsv6 www.ubuntu.com|awk '{print $1 }' | head -n1)"
+    # when ubuntu.com is configured in no_proxy, then we need to add the ip as well
+    if echo "$NO_PROXY" | MATCH 'ubuntu.com'; then
+        export NO_PROXY="$NO_PROXY","$UBUNTU_IP"
+    fi
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry "http://[$UBUNTU_IP]" > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, see comment above
     MATCH "ShouldRetryError: true" < output.txt

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -58,7 +58,7 @@ execute: |
     # also network manager dispatcher service is raising a denial
     #
     # ausearch exits with 1 when there are no denials, which we expect on
-    # centos-8, but not on centos-7
+    # centos-9, but not on centos-7
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
     grep -v -E 'avc:  denied  { map_create } for  pid=[0-9]+ comm="systemd"' < avc-after | \
     grep -v -E 'avc:  denied  { getattr } for  pid=[0-9]+ comm="which" path="/usr/bin/hostname" .*NetworkManager_dispatcher_dhclient_t' | \

--- a/tests/main/snap-logs-journal/task.yaml
+++ b/tests/main/snap-logs-journal/task.yaml
@@ -7,7 +7,6 @@ details: |
 systems:
   - -amazon-linux-2-*
   - -centos-7-*
-  - -centos-8-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -9,7 +9,6 @@ details: |
 systems:
   - -amazon-linux-2-*
   - -centos-7-*
-  - -centos-8-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -15,7 +15,6 @@ backends:
 systems:
   - -amazon-linux-2-*
   - -centos-7-*
-  - -centos-8-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*


### PR DESCRIPTION
This change fixes some errors that are reproduced in fedora-40 executed in openstack backend.
Also it is removed the centos-8 support in tests.
