### PR TITLE
tests: remove centos 7 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -617,7 +617,7 @@ jobs:
             tests: 'tests/...'
           - group: centos
             backend: google-distro-2
-            systems: 'centos-7-64 centos-9-64'
+            systems: 'centos-9-64'
             tests: 'tests/...'
           - group: debian-req
             backend: google-distro-1

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -141,21 +141,20 @@ BUG_REPORT_URL="https://bugs.launchpad.net/elementary/+filebug"`
 
 func (s *ReleaseTestSuite) TestFamilyOSRelease(c *C) {
 	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
-	dump := `NAME="CentOS Linux"
-VERSION="9 (Core)"
+	dump := `NAME="CentOS Stream"
+VERSION="9"
 ID="centos"
 ID_LIKE="rhel fedora"
 VERSION_ID="9"
-PRETTY_NAME="CentOS Linux 9 (Core)"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="CentOS Stream 9"
 ANSI_COLOR="0;31"
+LOGO="fedora-logo-icon"
 CPE_NAME="cpe:/o:centos:centos:9"
-HOME_URL="https://www.centos.org/"
-BUG_REPORT_URL="https://bugs.centos.org/"
-
-CENTOS_MANTISBT_PROJECT="CentOS-9"
-CENTOS_MANTISBT_PROJECT_VERSION="9"
-REDHAT_SUPPORT_PRODUCT="centos"
-REDHAT_SUPPORT_PRODUCT_VERSION="9"`
+HOME_URL="https://centos.org/"
+BUG_REPORT_URL="https://issues.redhat.com/"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"`
 	err := os.WriteFile(mockOSRelease, []byte(dump), 0644)
 	c.Assert(err, IsNil)
 

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -142,20 +142,20 @@ BUG_REPORT_URL="https://bugs.launchpad.net/elementary/+filebug"`
 func (s *ReleaseTestSuite) TestFamilyOSRelease(c *C) {
 	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
 	dump := `NAME="CentOS Linux"
-VERSION="7 (Core)"
+VERSION="9 (Core)"
 ID="centos"
 ID_LIKE="rhel fedora"
-VERSION_ID="7"
-PRETTY_NAME="CentOS Linux 7 (Core)"
+VERSION_ID="9"
+PRETTY_NAME="CentOS Linux 9 (Core)"
 ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:centos:centos:7"
+CPE_NAME="cpe:/o:centos:centos:9"
 HOME_URL="https://www.centos.org/"
 BUG_REPORT_URL="https://bugs.centos.org/"
 
-CENTOS_MANTISBT_PROJECT="CentOS-7"
-CENTOS_MANTISBT_PROJECT_VERSION="7"
+CENTOS_MANTISBT_PROJECT="CentOS-9"
+CENTOS_MANTISBT_PROJECT_VERSION="9"
 REDHAT_SUPPORT_PRODUCT="centos"
-REDHAT_SUPPORT_PRODUCT_VERSION="7"`
+REDHAT_SUPPORT_PRODUCT_VERSION="9"`
 	err := os.WriteFile(mockOSRelease, []byte(dump), 0644)
 	c.Assert(err, IsNil)
 
@@ -164,7 +164,7 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"`
 
 	os := release.ReadOSRelease()
 	c.Check(os.ID, Equals, "centos")
-	c.Check(os.VersionID, Equals, "7")
+	c.Check(os.VersionID, Equals, "9")
 	c.Check(os.IDLike, DeepEquals, []string{"rhel", "fedora"})
 }
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -221,10 +221,6 @@ backends:
                   workers: 6
                   storage: 15G
 
-            - centos-7-64:
-                  workers: 6
-                  storage: preserve-size
-                  image: centos-7-64
             - centos-9-64:
                   workers: 6
                   storage: preserve-size
@@ -431,9 +427,6 @@ backends:
             - debian-sid-64:
                   username: debian
                   password: debian
-            - centos-7-64:
-                  username: centos
-                  password: centos
             - amazon-linux-2-64:
                   username: ec2-user
                   password: ec2-user
@@ -822,12 +815,10 @@ prepare: |
 
     # Enable EPEL see https://docs.fedoraproject.org/en-US/epel/
     case "$SPREAD_SYSTEM" in
-        centos-7-*)
-            yum install -y epel-release
-            ;;
         centos-9-*)
             dnf config-manager --set-enabled crb
             dnf install -y epel-release epel-next-release
+            ;;
     esac
 
     case "$SPREAD_SYSTEM" in
@@ -861,7 +852,7 @@ prepare: |
                 echo "deltas are not supported on $SPREAD_SYSTEM, use NO_DELTA=1 when running spread"
                 exit 1
                 ;;
-            amazon-*|centos-7-*)
+            amazon-*)
                 yum install -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)
                 ;;
             fedora-*|centos-*)

--- a/tests/lib/external/snapd-testing-tools/spread.yaml
+++ b/tests/lib/external/snapd-testing-tools/spread.yaml
@@ -29,8 +29,6 @@ backends:
             - amazon-linux-2023-64:
                 storage: preserve-size
                 storage: preserve-size
-            - centos-7-64:
-                storage: preserve-size
             - centos-9-64:
                 storage: preserve-size
             - opensuse-15.5-64:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -62,7 +62,7 @@ distro_name_package() {
         ubuntu-*|debian-*)
             debian_name_package "$@"
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             amazon_name_package "$@"
             ;;
         fedora-*|centos-*)
@@ -108,7 +108,7 @@ distro_install_local_package() {
             # shellcheck disable=SC2086
             apt install $flags "$@"
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             quiet yum -y localinstall "$@"
             ;;
         fedora-*|centos-*)
@@ -194,7 +194,7 @@ distro_install_package() {
             quiet eatmydata apt-get install $APT_FLAGS -y "${pkg_names[@]}"
             retval=$?
             ;;
-        amazon-linux-2-*|centos-7-*)
+        amazon-linux-2-*)
             # shellcheck disable=SC2086
             quiet yum -y install $YUM_FLAGS "${pkg_names[@]}"
             retval=$?
@@ -254,7 +254,7 @@ distro_purge_package() {
             # behind while purging in prepare
             eatmydata apt-get remove -y --purge -y "$@"
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             quiet yum -y remove "$@"
             ;;
         fedora-*|centos-*)
@@ -279,7 +279,7 @@ distro_update_package_db() {
         ubuntu-*|debian-*)
             quiet eatmydata apt-get update
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             quiet yum clean all
             quiet yum makecache
             ;;
@@ -305,7 +305,7 @@ distro_clean_package_cache() {
         ubuntu-*|debian-*)
             quiet eatmydata apt-get clean
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             yum clean all
             ;;
         fedora-*|centos-*)
@@ -329,7 +329,7 @@ distro_auto_remove_packages() {
         ubuntu-*|debian-*)
             quiet eatmydata apt-get -y autoremove
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             quiet yum -y autoremove
             ;;
         fedora-*|centos-*)
@@ -351,7 +351,7 @@ distro_query_package_info() {
         ubuntu-*|debian-*)
             apt-cache policy "$1"
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             yum info "$1"
             ;;
         fedora-*|centos-*)
@@ -867,7 +867,7 @@ pkg_dependencies(){
             pkg_dependencies_ubuntu_generic
             pkg_dependencies_ubuntu_classic
             ;;
-        amazon-*|centos-7-*)
+        amazon-*)
             pkg_dependencies_amazon
             ;;
         centos-*)

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -17,7 +17,6 @@ systems:
   - -ubuntu-18.04-*
   - -ubuntu-20.04-*
   - -ubuntu-core-*
-  - -centos-7-*
   - -centos-9-*
 
 prepare: |

--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -11,7 +11,6 @@ systems:
     - -ubuntu-14.04-*  # no tests.session
     - -ubuntu-core-*  # no session bus (except for core20+)
     - -amazon-linux-2-*  # no session bus
-    - -centos-7-*  # no session bus
 
 prepare: |
     echo "Given a snap declaring an autopilot-introspection plug in installed"

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -13,7 +13,6 @@ systems:
     - -ubuntu-core-*  # dbus interface disallows unconfined access on core,
                       # in addition, up until core20 session bus was not supported
     - -amazon-linux-2-* # session bus is not supported
-    - -centos-7-*       # session bus is not supported
 
 prepare: |
     echo "Give a snap declaring a dbus slot in installed"

--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -7,7 +7,6 @@ details: |
 
 systems:
     - -amazon-linux-2-*
-    - -centos-7-*
     - -ubuntu-14.04-*
     - -ubuntu-core-*
 

--- a/tests/main/interfaces-desktop/task.yaml
+++ b/tests/main/interfaces-desktop/task.yaml
@@ -8,7 +8,6 @@ details: |
 
 systems:
     - -amazon-linux-2-*
-    - -centos-7-*
     - -ubuntu-14.04-*
     - -ubuntu-core-*
 

--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -4,9 +4,6 @@ details: |
     The kernel-module-load interface allows to statically control kernel module
     loading in a way that can be constrained via snap-declaration.
 
-# The bfq module is not present in centos7
-systems: [-centos-7-*]
-
 environment:
     SNAP_NAME: test-snapd-kernel-module-load
 

--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -14,7 +14,6 @@ details: |
 # s390x does not support locationd
 systems:
     - -amazon-linux-2-* # no session services
-    - -centos-7-* # no session services
     - -ubuntu-*-s390x # no support for locationd
     - -ubuntu-14.04-* # no tests.session support
     - -ubuntu-core-* # no session services (except for core20+)

--- a/tests/main/interfaces-network-status-classic/task.yaml
+++ b/tests/main/interfaces-network-status-classic/task.yaml
@@ -12,8 +12,6 @@ systems:
   - -ubuntu-core-*
   # stub portal implementation doesn't seem to start on 14.04
   - -ubuntu-14.04-*
-  # CentOS 7 does not include Python 3 D-Bus bindings
-  - -centos-7-*
   # Amazon-linux does not include Python 3 D-Bus bindings
   - -amazon-linux-2-*
   - -amazon-linux-2023-*

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -12,7 +12,6 @@ backends:
 systems:
   - -amazon-linux-2-*    # fails to start service daemon-containerd
   - -amazon-linux-2023-* # fails to start service daemon-containerd
-  - -centos-7-*          # doesn't have libseccomp >= 2.4
   - -centos-9-*          # fails to start service daemon-containerd
   - -fedora-38-*         # fails to start service daemon-containerd
   - -fedora-39-*         # fails to start service daemon-containerd

--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -16,7 +16,6 @@ details: |
 # memory cgroup is disabled
 systems:
   - -ubuntu-14.04-*
-  - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*

--- a/tests/main/selinux-data-context/task.yaml
+++ b/tests/main/selinux-data-context/task.yaml
@@ -24,11 +24,6 @@ execute: |
     test-snapd-sh.sh -c "mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar"
 
     expected_label="unconfined_t"
-    if os.query is-centos 7; then
-        # on centos-7, the policy or systemd seems to lack the necessary transition
-        # for the user service
-        expected_label="unconfined_service_t"
-    fi
     tests.session -u test exec sh -c 'test-snapd-sh.sh -c "id -Z"' | MATCH ":${expected_label}:"
     tests.session -u test exec sh -c "test-snapd-sh.sh -c 'mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar'"
 

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -58,7 +58,7 @@ execute: |
     # also network manager dispatcher service is raising a denial
     #
     # ausearch exits with 1 when there are no denials, which we expect on
-    # centos-9, but not on centos-7
+    # centos-9
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
     grep -v -E 'avc:  denied  { map_create } for  pid=[0-9]+ comm="systemd"' < avc-after | \
     grep -v -E 'avc:  denied  { getattr } for  pid=[0-9]+ comm="which" path="/usr/bin/hostname" .*NetworkManager_dispatcher_dhclient_t' | \

--- a/tests/main/snap-handle-link/task.yaml
+++ b/tests/main/snap-handle-link/task.yaml
@@ -8,7 +8,6 @@ details: |
 
 systems:
     - -amazon-linux-2-*  # does not support systemd --user
-    - -centos-7-*  # does not support systemd --user
     - -ubuntu-14.04-*  # not supported as desktop OS, systemd too old for tests.session
     - -ubuntu-core-*  # test exercises regular xdg-open, not the custom one in ubuntu-core
 

--- a/tests/main/snap-logs-journal/task.yaml
+++ b/tests/main/snap-logs-journal/task.yaml
@@ -6,7 +6,6 @@ details: |
 # requires systemd v245+
 systems:
   - -amazon-linux-2-*
-  - -centos-7-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -8,7 +8,6 @@ details: |
 # and this is tested in the snap-quota spread test.
 systems:
   - -ubuntu-14.04-*
-  - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -8,7 +8,6 @@ details: |
 # requires systemd v245+
 systems:
   - -amazon-linux-2-*
-  - -centos-7-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -12,7 +12,6 @@ details: |
 # memory cgroup is disabled
 systems:
   - -ubuntu-14.04-*
-  - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -14,7 +14,6 @@ backends:
 # requires systemd v245+
 systems:
   - -amazon-linux-2-*
-  - -centos-7-*
   - -ubuntu-14.04-*
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -10,7 +10,6 @@ details: |
 # spread instead
 systems:
   - -ubuntu-14.04-*
-  - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*

--- a/tests/main/snap-routine-portal-info/task.yaml
+++ b/tests/main/snap-routine-portal-info/task.yaml
@@ -19,7 +19,6 @@ details: |
 systems:
     - -ubuntu-14.04-*
     - -amazon-linux-*
-    - -centos-7-*
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop

--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -11,7 +11,6 @@ systems:
     - -ubuntu-core-16-*
     # Systemd on CentOS 7/Amazon Linux 2 does not have the user@uid unit
     - -amazon-linux-2-*
-    - -centos-7-*
 
 prepare: |
     # Ensure that snapd.session-agent.socket is enabled. This may not

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -12,9 +12,8 @@ details: |
 systems:
     # Ubuntu 14.04 does not have a complete systemd implementation
     - -ubuntu-14.04-*
-    # Systemd on CentOS 7/Amazon Linux 2 does not have the user@uid unit
+    # Systemd on Amazon Linux 2 does not have the user@uid unit
     - -amazon-linux-2-*
-    - -centos-7-*
     # fails regularly with "curl: Recv failure: connection reset by peer"
     - -ubuntu-core-16-*
 

--- a/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
+++ b/tests/main/snap-session-agent-unavailable-to-snaps/task.yaml
@@ -8,9 +8,8 @@ details: |
 systems:
     # Ubuntu 14.04 does not have a complete systemd implementation
     - -ubuntu-14.04-*
-    # Systemd on CentOS 7/Amazon Linux 2 does not have the user@uid unit
+    # Systemd on Amazon Linux 2 does not have the user@uid unit
     - -amazon-linux-2-*
-    - -centos-7-*
 
 prepare: |
     # Ensure that snapd.session-agent.socket is enabled.  This may not

--- a/tests/main/snap-user-service-restart-on-upgrade/task.yaml
+++ b/tests/main/snap-user-service-restart-on-upgrade/task.yaml
@@ -9,8 +9,6 @@ systems:
     - -ubuntu-14.04-*
     # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
     - -amazon-linux-2-*
-    # Centos 7 gives error "Unit user@12345.service not loaded."
-    - -centos-7-*
 
     # TODO: dbus issue
     - -ubuntu-core-22-*

--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -9,8 +9,6 @@ systems:
     - -ubuntu-14.04-*
     # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
     - -amazon-linux-2-*
-    # Centos 7 gives error "Unit user@12345.service not loaded."
-    - -centos-7-*
 
 kill-timeout: 10m
 

--- a/tests/main/snap-user-service-start-on-install/task.yaml
+++ b/tests/main/snap-user-service-start-on-install/task.yaml
@@ -10,8 +10,6 @@ systems:
     - -ubuntu-14.04-*
     # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
     - -amazon-linux-2-*
-    # Centos 7 gives error "Unit user@12345.service not loaded."
-    - -centos-7-*
 
 kill-timeout: 10m
 

--- a/tests/main/snap-user-service-upgrade-failure/task.yaml
+++ b/tests/main/snap-user-service-upgrade-failure/task.yaml
@@ -9,8 +9,6 @@ systems:
     - -ubuntu-14.04-*
     # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
     - -amazon-linux-2-*
-    # Centos 7 gives error "Unit user@12345.service not loaded."
-    - -centos-7-*
 
     # TODO: dbus issue
     - -ubuntu-core-22-*

--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -9,8 +9,6 @@ systems:
     - -ubuntu-14.04-*
     # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
     - -amazon-linux-2-*
-    # Centos 7 gives error "Unit user@12345.service not loaded."
-    - -centos-7-*
 
 kill-timeout: 10m
 

--- a/tests/main/system-usernames-illegal/task.yaml
+++ b/tests/main/system-usernames-illegal/task.yaml
@@ -12,7 +12,7 @@ details: |
 # List of expected snap install failures due to libseccomp/golang-seccomp being
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these.
-systems: [-amazon-linux-2-*, -centos-7-*, -ubuntu-14.04-*]
+systems: [-amazon-linux-2-*, -ubuntu-14.04-*]
 
 execute: |
     snap_path=$("$TESTSTOOLS"/snaps-state pack-local test-snapd-illegal-system-username)

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -12,7 +12,7 @@ details: |
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     snap install --edge test-snapd-daemon-user

--- a/tests/main/system-usernames-missing-user/task.yaml
+++ b/tests/main/system-usernames-missing-user/task.yaml
@@ -9,7 +9,7 @@ details: |
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     groupadd --system snap_daemon

--- a/tests/main/system-usernames-snap-scoped/task.yaml
+++ b/tests/main/system-usernames-snap-scoped/task.yaml
@@ -13,7 +13,7 @@ details: |
 # - also exclude centos 7 because of old libseccomp (the
 #   system-usernames test is already checking which distributions have the
 #   needed support, so there's no need to replicate that code here)
-systems: [-ubuntu-14.04-*, -centos-7-*]
+systems: [-ubuntu-14.04-*]
 
 environment:
     STORE_DIR: $(pwd)/fake-store-blobdir

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -23,7 +23,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "centos-7-64 ubuntu-14"
+    EXFAIL: "ubuntu-14"
     SNAP_USER/snap_daemon: snap_daemon
     SNAP_USER/_daemon_: _daemon_
     SNAP_USER_UID/snap_daemon: 584788

--- a/tests/main/system-users-are-created/task.yaml
+++ b/tests/main/system-users-are-created/task.yaml
@@ -12,7 +12,7 @@ details: |
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 environment:
     SNAP_USER/snap_daemon: snap_daemon

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -13,7 +13,6 @@ details: |
 # a user session environment there
 systems:
     - -amazon-linux-2-*
-    - -centos-7-*
     - -ubuntu-14.04-*
     - -ubuntu-core-*
 

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -12,7 +12,6 @@ details: |
 # a user session environment there
 systems:
     - -amazon-linux-2-*  # does not support systemd --user
-    - -centos-7-*  # does not support systemd --user
     - -ubuntu-14.04-*  # not supported as desktop OS, systemd too old for tests.session
     - -ubuntu-core-*  # test exercises regular xdg-settings, not the custom one in ubuntu-core
 

--- a/tests/regression/rhbz-1708991/task.yaml
+++ b/tests/regression/rhbz-1708991/task.yaml
@@ -14,10 +14,6 @@ details: |
 systems: [fedora-*, centos-*]
 
 prepare: |
-    if [[ "$SPREAD_SYSTEM" == centos-7-* ]]; then
-        tests.pkgs install systemd-resolved
-    fi
-
     getenforce > enforcing.mode
 
     # Enable enforcing mode, our policy is already marked as permissive, so we


### PR DESCRIPTION
Centos-7 is EOL since June-30

Also included changes imported from snapd-testing-tools where also centos-7 support has been removed.