### PR TITLE
many: support adding local components to seeds

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -55,6 +55,7 @@ type cmdPrepareImage struct {
 
 	// TODO: introduce SnapWithChannel?
 	Snaps              []string `long:"snap" value-name:"<snap>[=<channel>]"`
+	Components         []string `long:"comp" value-name:"<snap>+<comp>"`
 	ExtraSnaps         []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
 	RevisionsFile      string   `long:"revisions"`
 	WriteRevisionsFile string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
@@ -87,6 +88,8 @@ For preparing classic images it supports a --classic mode`),
 			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"snap": i18n.G("Include the given snap from the store or a local file and/or specify the channel to track for the given snap"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"comp": i18n.G("Include the given component from the store or a local file"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": i18n.G("Extra snaps to be installed (DEPRECATED)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
@@ -123,6 +126,7 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 
 	opts := &image.Options{
 		Snaps:            x.ExtraSnaps,
+		Components:       x.Components,
 		ModelFile:        x.Positional.ModelAssertionFn,
 		Channel:          x.Channel,
 		Architecture:     x.Architecture,

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -131,7 +131,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageExtraSnaps(c *C) {
 	r := cmdsnap.MockImagePrepare(prep)
 	defer r()
 
-	rest, err := cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--channel", "candidate", "--snap", "foo", "--snap", "bar=t/edge", "--snap", "local.snap", "--extra-snaps", "local2.snap", "--extra-snaps", "store-snap"})
+	rest, err := cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--channel", "candidate", "--snap", "foo", "--snap", "bar=t/edge", "--snap", "local.snap", "--extra-snaps", "local2.snap", "--extra-snaps", "store-snap", "--comp", "local.comp", "--comp", "bar+comp1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 
@@ -140,6 +140,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageExtraSnaps(c *C) {
 		Channel:      "candidate",
 		PrepareDir:   "prepare-dir",
 		Snaps:        []string{"foo", "bar", "local.snap", "local2.snap", "store-snap"},
+		Components:   []string{"local.comp", "bar+comp1"},
 		SnapChannels: map[string]string{"bar": "t/edge"},
 	})
 }

--- a/image/options.go
+++ b/image/options.go
@@ -46,6 +46,7 @@ type Options struct {
 
 	// TODO: use OptionsSnap directly here?
 	Snaps        []string
+	Components   []string
 	SnapChannels map[string]string
 
 	// SeedManifest is a pre-provided seed manifest, to allow for

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -293,7 +293,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 			return "", err
 		}
 	}
-	if err := w.SetOptionsSnaps(optsSnaps); err != nil {
+	if err := w.SetOptionsSnaps(optsSnaps, nil); err != nil {
 		return "", err
 	}
 

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -89,6 +89,27 @@ version: 1.0
 type: app
 base: core20
 version: 1.0
+components:
+  comp1:
+    type: test
+  comp2:
+    type: test
+`,
+	"required20+comp1": `component: required20+comp1
+type: test
+version: 1.0
+`,
+	"required20+comp1_kernel": `component: required20+comp1
+type: kernel-modules
+version: 1.0
+`,
+	"required20+comp2": `component: required20+comp2
+type: test
+version: 2.0
+`,
+	"required20+unknown": `component: required20+unknown
+type: test
+version: 2.0
 `,
 	"optional20-a": `name: optional20-a
 type: app

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -306,7 +306,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	w, err := seedwriter.New(model, &opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps(optSnaps)
+	err = w.SetOptionsSnaps(optSnaps, nil)
 	c.Assert(err, IsNil)
 
 	err = w.Start(db, sf)

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -20,6 +20,7 @@
 package seedwriter
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -208,6 +209,14 @@ func (tr *tree16) snapPath(sn *SeedSnap) (string, error) {
 
 func (tr *tree16) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(tr.snapsDirPath, sn.Info.Filename()), nil
+}
+
+func (tr *tree16) componentPath(sn *SeedSnap, sc *SeedComponent) (string, error) {
+	return "", errors.New("components not supported on UC16")
+}
+
+func (tr *tree16) localComponentPath(sc *SeedComponent) (string, error) {
+	return "", errors.New("components not supported on UC16")
 }
 
 func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {


### PR DESCRIPTION
This is a first PR that adds support for seeding components. The parts targeted by this PR are:

- Add support for components in options.yaml
- Add --comp option to snap prepare-image, for local component files of component names
- Copy local component files to seed

Interactions with the store are not in this PR.