### PR TITLE
interfaces/builtin/raw-usb: add Raspberry Pi 5 raw-usb paths

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -46,6 +46,8 @@ const rawusbConnectedPlugAppArmor = `
 /sys/devices/pci**/usb[0-9]** r,
 /sys/devices/platform/soc**/*.usb**/usb[0-9]** r,
 /sys/devices/platform/scb/*.pcie/pci**/usb[0-9]** r,
+/sys/devices/platform/axi/*.pcie/*.usb/xhci-hcd.[0-9]*/usb[0-9]** r,
+/sys/devices/platform/axi/*.usb/usb[0-9]** r,
 
 /run/udev/data/c16[67]:[0-9] r, # ACM USB modems
 /run/udev/data/b180:*    r, # various USB block devices


### PR DESCRIPTION
The Raspberry Pi 5 has a totally [reworked USB topology](https://www.raspberrypi.com/news/rp1-the-silicon-controlling-raspberry-pi-5-i-o-designed-here-at-raspberry-pi/#:~:text=USB%20topology%20for%20improved%20bandwidth). This also means the USB devices are available under a different path under `/sys/devices/platform`. 

A `tree` of `/sys/devices/platform/axi` is attached: 
[tree-sys.device.platform.axi.txt](https://github.com/user-attachments/files/16065757/tree-sys.device.platform.axi.txt)


This PR adds the two new paths for the Raspberry Pi 5 to the `raw-usb` interface.

Solves LP bug: https://bugs.launchpad.net/snapd/+bug/2071319