### PR TITLE
daemon: fix data race accessing requestedRestart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -512,12 +512,13 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	// needsFullShutdown is whether the entire system will
 	// shutdown or not as a consequence of this request
 	needsFullShutdown := false
-	switch d.requestedRestart {
+	restartType := d.requestedRestart
+	switch restartType {
 	case restart.RestartSystem, restart.RestartSystemNow, restart.RestartSystemHaltNow, restart.RestartSystemPoweroffNow:
 		needsFullShutdown = true
 	}
 	immediateShutdown := false
-	switch d.requestedRestart {
+	switch restartType {
 	case restart.RestartSystemNow, restart.RestartSystemHaltNow, restart.RestartSystemPoweroffNow:
 		immediateShutdown = true
 	}
@@ -528,7 +529,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	// before not accepting any new client connections we need to write the
 	// maintenance.json file for potential clients to see after the daemon stops
 	// responding so they can read it correctly and handle the maintenance
-	if err := d.updateMaintenanceFile(d.requestedRestart); err != nil {
+	if err := d.updateMaintenanceFile(restartType); err != nil {
 		logger.Noticef("error writing maintenance file: %v", err)
 	}
 


### PR DESCRIPTION
Data race was picked up in the tests:

```
==================
WARNING: DATA RACE
Write at 0x00c00041a648 by goroutine 175:
  github.com/snapcore/snapd/daemon.(*Daemon).HandleRestart()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon.go:446 +0x198
  github.com/snapcore/snapd/overlord/restart.(*RestartManager).handleRestart()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/restart/restart.go:242 +0x10e
  github.com/snapcore/snapd/overlord/restart.Request()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/restart/restart.go:348 +0xd0
  github.com/snapcore/snapd/overlord/standby.(*StandbyOpinions).Start.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/standby/standby.go:102 +0xe4

Previous read at 0x00c00041a648 by goroutine 171:
  github.com/snapcore/snapd/daemon.(*Daemon).Stop()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon.go:531 +0x211
  github.com/snapcore/snapd/daemon.(*daemonSuite).TestRestartIntoSocketModeNoNewChanges()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon_test.go:1372 +0x3ed
  runtime.call16()
      /snap/go/10630/src/runtime/asm_amd64.s:770 +0x42
  reflect.Value.Call()
      /snap/go/10630/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:775 +0x9c5
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xe9

Goroutine 175 (running) created at:
  github.com/snapcore/snapd/overlord/standby.(*StandbyOpinions).Start()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/overlord/standby/standby.go:96 +0xfc
  github.com/snapcore/snapd/daemon.(*Daemon).initStandbyHandling()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon.go:320 +0x69c
  github.com/snapcore/snapd/daemon.(*Daemon).Start()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon.go:379 +0x93d
  github.com/snapcore/snapd/daemon.(*daemonSuite).TestRestartIntoSocketModeNoNewChanges()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon_test.go:1359 +0x134
  runtime.call16()
      /snap/go/10630/src/runtime/asm_amd64.s:770 +0x42
  reflect.Value.Call()
      /snap/go/10630/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:775 +0x9c5
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xe9

Goroutine 171 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x5ba
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x155
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x419
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x3c6
  gopkg.in/check%2ev1.Run()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x44
  gopkg.in/check%2ev1.RunAll()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x124
  gopkg.in/check%2ev1.TestingT()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x5d3
  github.com/snapcore/snapd/daemon.Test()
      /home/runner/work/snapd/snapd/src/github.com/snapcore/snapd/daemon/daemon_test.go:63 +0x26
  testing.tRunner()
      /snap/go/10630/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /snap/go/10630/src/testing/testing.go:1742 +0x44
==================
OK: 682 passed
--- FAIL: Test (71.79s)
    testing.go:1398: race detected during execution of test
FAIL
FAIL	github.com/snapcore/snapd/daemon	72.143s
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
