### PR TITLE
interfaces/display-control: allow changing lvds backlight brightness and power

### DIFF
--- a/interfaces/builtin/display_control.go
+++ b/interfaces/builtin/display_control.go
@@ -86,6 +86,8 @@ dbus (send)
 
 # Allow changing backlight
 /sys/devices/**/**/drm/card[0-9]/card[0-9]*/*_backlight/brightness w,
+/sys/devices/platform/lvds_backlight/backlight/lvds_backlight/brightness rw,
+/sys/devices/platform/lvds_backlight/backlight/lvds_backlight/bl_power rw,
 `
 
 type displayControlInterface struct {

--- a/interfaces/builtin/display_control_test.go
+++ b/interfaces/builtin/display_control_test.go
@@ -101,6 +101,8 @@ func (s *displayControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "(dereferenced)/sys/class/backlight/bar_backlight/{,**} r,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "autodetected backlight: foo_backlight\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "(dereferenced)/sys/class/backlight/foo_backlight/{,**} r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/devices/platform/lvds_backlight/backlight/lvds_backlight/brightness rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/devices/platform/lvds_backlight/backlight/lvds_backlight/bl_power rw,`)
 }
 
 func (s *displayControlInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
This PR allows developers to control brightness and backlight power of LVDS screen.
