### PR TITLE
many: support killing running snap apps 

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 )
 
@@ -232,6 +233,18 @@ func HookSecurityTag(snapName, hookName string) string {
 // are not associated to an app or hook in the snap.
 func NoneSecurityTag(snapName, uniqueName string) string {
 	return ScopedSecurityTag(snapName, "none", uniqueName)
+}
+
+// TransientScopeGlob returns the glob pattern matching
+// snap's transient scope units.
+//
+// e.g. snap.hello-world.sh-4706fe54-7802-4808-aa7e-ae8b567239e0.scope
+func TransientScopeGlob(snapName string) (string, error) {
+	snapSecurityTag := SecurityTag(snapName)
+	unitPrefix, err := systemd.SecurityTagToUnitName(snapSecurityTag)
+	// XXX: Should we also match snap components glob pattern (i.e. snap.name+*.*.scope?
+	// snap.name.*.scope
+	return unitPrefix + ".*.scope", err
 }
 
 // BaseDataDir returns the base directory for snap data locations.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2367,6 +2367,38 @@ hooks:
 	c.Check(hook.SecurityTag(), Equals, "snap.test-snap_instance.hook.install")
 }
 
+func (s *infoSuite) TestTransientScopeGlob(c *C) {
+	pattern, err := snap.TransientScopeGlob("some-snap")
+	c.Assert(err, IsNil)
+	c.Check(pattern, Equals, "snap.some-snap.*.scope")
+	matched, err := filepath.Match(pattern, "snap.some-snap.some-app-4706fe54-7802-4808-aa7e-ae8b567239e0.scope")
+	c.Assert(err, IsNil)
+	c.Check(matched, Equals, true)
+}
+
+func (s *infoSuite) TestTransientScopeGlobInstance(c *C) {
+	pattern, err := snap.TransientScopeGlob("some-snap_instance-1")
+	c.Assert(err, IsNil)
+	c.Check(pattern, Equals, "snap.some-snap_instance-1.*.scope")
+	// matches instance
+	matched, err := filepath.Match(pattern, "snap.some-snap_instance-1.some-app-4706fe54-7802-4808-aa7e-ae8b567239e0.scope")
+	c.Assert(err, IsNil)
+	c.Check(matched, Equals, true)
+	// but not other instances
+	matched, err = filepath.Match(pattern, "snap.some-snap_instance-2.some-app-4706fe54-7802-4808-aa7e-ae8b567239e0.scope")
+	c.Assert(err, IsNil)
+	c.Check(matched, Equals, false)
+	// or the main snap
+	matched, err = filepath.Match(pattern, "snap.some-snap.some-app-4706fe54-7802-4808-aa7e-ae8b567239e0.scope")
+	c.Assert(err, IsNil)
+	c.Check(matched, Equals, false)
+}
+
+func (s *infoSuite) TestTransientScopeError(c *C) {
+	_, err := snap.TransientScopeGlob("invalid?name")
+	c.Assert(err.Error(), Equals, "invalid character in security tag: '?'")
+}
+
 func (s *infoSuite) TestComponentMountDir(c *C) {
 	dir := snap.ComponentMountDir("comp", snap.R(1), "snap")
 	c.Check(dir, Equals, filepath.Join(dirs.SnapMountDir, "snap", "components", "mnt", "comp", "1"))

--- a/snap/types.go
+++ b/snap/types.go
@@ -145,6 +145,15 @@ const (
 	StopReasonOther   ServiceStopReason = ""
 )
 
+// TODO: merge ServiceStopReason, AppKillReason and removeAliasesReason
+type AppKillReason string
+
+const (
+	KillReasonRemove      AppKillReason = "remove"
+	KillReasonForceRemove AppKillReason = "force-remove"
+	KillReasonOther       AppKillReason = ""
+)
+
 // DaemonScope represents the scope of the daemon running under systemd
 type DaemonScope string
 

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -217,6 +217,10 @@ func (s *emulation) ListMountUnits(snapName, origin string) ([]string, error) {
 	return nil, &notImplementedError{"ListMountUnits"}
 }
 
+func (s *emulation) ListUnits(pattern string) ([]string, error) {
+	return nil, &notImplementedError{"ListUnits"}
+}
+
 func (s *emulation) Mask(service string) error {
 	_, err := systemctlCmd("--root", s.rootDir, "mask", service)
 	return err

--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -28,6 +28,7 @@ import (
 var (
 	SessionInfoCmd                     = sessionInfoCmd
 	ServiceControlCmd                  = serviceControlCmd
+	AppControlCmd                      = appControlCmd
 	ServiceStatusCmd                   = serviceStatusCmd
 	PendingRefreshNotificationCmd      = pendingRefreshNotificationCmd
 	FinishRefreshNotificationCmd       = finishRefreshNotificationCmd

--- a/usersession/agent/response.go
+++ b/usersession/agent/response.go
@@ -96,6 +96,7 @@ const (
 	errorKindLoginRequired  = errorKind("login-required")
 	errorKindServiceControl = errorKind("service-control")
 	errorKindServiceStatus  = errorKind("service-status")
+	errorKindAppControl     = errorKind("app-control")
 )
 
 type errorValue interface{}


### PR DESCRIPTION
This is needed in preparation for the new `snap remove --terminate` flag.

This PR introduces a new `/v1/app-control` userd endpoint that currently only support killing snap apps. This endpoint will be invoked by snapd during removal of snaps when the `--terminate` flag is used.

Calling `client.AppsKill` would do the following for each user session:
- Find running snap apps transient scope units (matching pattern `snap.<snap-name>.*.scope`)
- Send SIGKILL signal to those running snap apps

Looking up snap's transient units and killing them is delegated to systemd by calling `systemctl`.

This PR is part 3.1 of implementing force removal of snaps according to [SD174 - Force removal of snaps](https://docs.google.com/document/d/1ikDI-vPJO6YYFHOyFJ5hfK5L5Gv8voMeY8HJvxNWujw/edit#bookmark=id.a0tjy47ryi3e) spec.

For context:
- Part 1:  https://github.com/snapcore/snapd/pull/14126
- Part 2:  https://github.com/snapcore/snapd/pull/14144
- Part 3.2: https://github.com/snapcore/snapd/pull/14189