### PR TITLE
i/prompting: do not error on unexpected apparmor permission

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -194,7 +195,15 @@ func AbstractPermissionsFromAppArmorPermissions(iface string, permissions interf
 		}
 	}
 	if filePerms != notify.FilePermission(0) {
-		return nil, fmt.Errorf("cannot map AppArmor permission to abstract permission for the %s interface: %q", iface, filePerms)
+		logger.Noticef("WARNING: cannot map AppArmor permission to abstract permission for the %s interface: %q", iface, filePerms)
+		// Replying to request sends back original (allow | deny) permissions as
+		// allowed, so permissions which are unknown/excluded here will still be
+		// included in the final reply notification (as we desire).
+		//
+		// XXX: If we instead send back the explicit permissions which the user
+		// allowed (or denied), need to be careful to re-include permissions
+		// which were originally requested but were not mapped to abstract
+		// permissions.
 	}
 	return abstractPerms, nil
 }

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -429,6 +429,18 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c
 			notify.AA_MAY_EXEC | notify.AA_MAY_WRITE | notify.AA_MAY_READ,
 			[]string{"read", "write", "execute"},
 		},
+		{
+			// Check that unmapped permissions are discarded without error
+			"home",
+			notify.AA_MAY_READ | notify.AA_MAY_GETCRED,
+			[]string{"read"},
+		},
+		{
+			// Check that unknown permissions are discarded without error
+			"home",
+			notify.AA_MAY_READ | notify.FilePermission(1<<17),
+			[]string{"read"},
+		},
 	}
 	for _, testCase := range cases {
 		perms, err := prompting.AbstractPermissionsFromAppArmorPermissions(testCase.iface, testCase.perms)
@@ -457,16 +469,6 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 			"foo",
 			notify.AA_MAY_READ,
 			"cannot map the given interface to list of available permissions.*",
-		},
-		{
-			"home",
-			notify.FilePermission(1 << 17),
-			"cannot map AppArmor permission to abstract permission for the home interface.*",
-		},
-		{
-			"home",
-			notify.AA_MAY_GETATTR | notify.AA_MAY_READ,
-			"cannot map AppArmor permission to abstract permission for the home interface.*",
 		},
 	}
 	for _, testCase := range cases {


### PR DESCRIPTION
Rather than returning an error when there is no abstract permission mapping to a received AppArmor file permission, instead log a message with a warning and omit AppArmor permission from the abstract permissions list.

Because the final reply notification is constructed from the originally-requested permissions, rather than the AppArmor permissions corresponding to the abstract permissions the user supplied, the ignored unexpected permission will still be included in the reply.

If, in the future, this changes, further changes will be required to ensure that requested permissions which are not mapped to an abstract permission are still included in the reply notification message.

This is a follow-up of #14142 and relates to https://github.com/olivercalder/snapd/pull/36 and SNAPDENG-24104.
