### PR TITLE
cmd/snap: fix JSON keys not being validated on snap set -t

### DIFF
--- a/client/clientutil/config_test.go
+++ b/client/clientutil/config_test.go
@@ -21,6 +21,7 @@ package clientutil_test
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/snapcore/snapd/client/clientutil"
 	. "gopkg.in/check.v1"
@@ -79,4 +80,220 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 		"foo": `{"bar": 1`,
 	})
 	c.Assert(keys, DeepEquals, []string{"foo"})
+}
+
+func (s *parseSuite) TestJSONValidation(c *C) {
+
+	invalidJson := []string{
+		`key={"key0":"val0",:"val1","key2":{"key3":"val2","key4":"val3","key5":{"key6":"val4","key7":"val5"}},"key8":{"key9":{"key10":"val6"}}}`,
+		`key={"key0":"val0","key1":"val1","key2"{"key3":"val2","key4":"val3",` +
+			`"key5":{"key6":"val4","key7":"val5"}},"key8":{"key9":{"key10":"val6"}},` +
+			`"key11":[{"key12":"val7"},{"key13":"val8"},{"key14":["val9","val10"]}]}`,
+		`key={"key0": ["a", "b" "c"]}`,
+		`key=[{"key1": "a"} {"key2": "b"}]`,
+		`key=[{"key1": "a"}, {"key2": "b}]`,
+		`key={"key1": [123, "abc"}`,
+		`key={"key1": {"key2": "a", "key2",: ["b"]}}`,
+		`key={"key": {"key1": ,"value"}}`,
+	}
+
+	for _, json := range invalidJson {
+		_, _, err := clientutil.ParseConfigValues([]string{json}, nil)
+		// When ParseConfigValues is called with invalid JSON,
+		// it store the string as-is.
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			fmt.Printf("JSON: %v\n", json)
+		}
+		c.Check(err, IsNil)
+	}
+
+	invalidJsonKeys := []string{
+		`key={"key0":"val0","key1":"val1","key2":{"key3":"val2","key4":"val3","key5":{"INVALID":"val4","key7":"val5"}},"key8":{"key9":{"key10":"val6"}}}`,
+		`key={"key0":"val0","key1":"val1","key2":{"key3":"val2","key4":"val3",` +
+			`"key5":{"key6":"val4","key7":"val5"}},"key8":{"key9":{"key10":"val6"}},` +
+			`"key11":[{"key12":"val7"},{"KEY13":"val8"},{"key14":["val9","val10"]}]}`,
+		`key={"KEY0": ["a", "b", "c"]}`,
+		`key=[{"key1": "a"}, {"KEY2": "b"}]`,
+		`key={"KEY1": [123, "abc"]}`,
+		`key={"key1": {"key2": "a", "KEY2": ["b"]}}`,
+		`key={"KEY1": [[123, 456], [789]]}`,
+		`key={"key": {"KEY1": "value"}}`,
+		`key={"KEY": "val", "KEY": "val"}`,
+	}
+
+	for _, json := range invalidJsonKeys {
+		_, _, err := clientutil.ParseConfigValues([]string{json}, nil)
+		if err == nil {
+			fmt.Printf("Failed on:\n%v\n", json)
+		}
+		c.Check(err, ErrorMatches, "invalid option name:.*", Commentf("json: `%s`"))
+	}
+}
+
+func (s *parseSuite) TestValidateJSONKeysHappy(c *C) {
+	validJsons := []interface{}{
+		// key={"key0": ["a", "b", "c"]}
+		map[string]interface{}{
+			"key0": []interface{}{"a", "b", "c"},
+		},
+		// key=[{"key1": "a"}, {"key2": "b"}]
+		[]map[string]interface{}{
+			{"key1": "a"},
+			{"key2": "b"},
+		},
+		// key=[{"key1": "a"}, {"key2": "b"}]
+		[]interface{}{
+			map[string]interface{}{"key1": "a"},
+			map[string]interface{}{"key2": "b"},
+		},
+		// key="123"
+		"123",
+		// key=123
+		123,
+		// key=[123, 456]
+		[]interface{}{123, 456},
+		// key={"key1": [123, "abc"]}
+		map[string]interface{}{
+			"key1": []interface{}{123, "abc"},
+		},
+		// key={"key1": {["a", "b"]}}
+		map[string]interface{}{
+			"key1": map[string]interface{}{
+				"key2": []interface{}{"a", "b"},
+			},
+		},
+		// key={"key1": [[123, 456], [789]]}
+		map[string]interface{}{
+			"key1": []interface{}{
+				[]interface{}{123, 456},
+				[]interface{}{789},
+			},
+		},
+		// key=[[123, 456], [789]]
+		[]interface{}{
+			[]interface{}{123, 456},
+			[]interface{}{789},
+		},
+		// key=[123, [456, 789]]
+		[]interface{}{
+			123,
+			[]interface{}{456, 789},
+		},
+		// key={"key": {"key": "value"}}
+		map[string]interface{}{
+			"key": map[string]interface{}{
+				"key": "value",
+			},
+		},
+		// key={"key0":"val0","key1":"val1","key2":{"key3":"val2","key4":"val3","key5":{"key6":"val4","key7":"val5"}},"key8":{"key9":{"key10":"val6"}}}
+		map[string]interface{}{
+			"key0": "val0",
+			"key1": "val1",
+			"key2": map[string]interface{}{
+				"key3": "val2",
+				"key4": "val3",
+				"key5": map[string]interface{}{
+					"key6": "val4",
+					"key7": "val5",
+				},
+			},
+			"key8": map[string]interface{}{
+				"key9": map[string]interface{}{
+					"key10": "val6",
+				},
+			},
+		},
+	}
+
+	for _, json := range validJsons {
+		err := clientutil.ValidateJSONKeys(json)
+		if err != nil {
+			fmt.Printf("Failed on:\n%+v\n", json)
+		}
+		c.Check(err, IsNil)
+	}
+
+}
+
+func (s *parseSuite) TestValidateJSONKeysUnhappy(c *C) {
+	validJsons := []interface{}{
+		// key={"KEY0": ["a", "b", "c"]}
+		map[string]interface{}{
+			"KEY0": []interface{}{"a", "b", "c"},
+		},
+		// key=[{"key1": "a"}, {"KEY2": "b"}]
+		[]map[string]interface{}{
+			{"key1": "a"},
+			{"KEY2": "b"},
+		},
+		// key={"KEY1": [123, "abc"]}
+		map[string]interface{}{
+			"KEY1": []interface{}{123, "abc"},
+		},
+		// key={"key1": {"KEY2": ["a", "b"]}}
+		map[string]interface{}{
+			"key1": map[string]interface{}{
+				"KEY2": []interface{}{"a", "b"},
+			},
+		},
+		// key={"KEY1": [[123, 456], [789]]}
+		map[string]interface{}{
+			"KEY1": []interface{}{
+				[]interface{}{123, 456},
+				[]interface{}{789},
+			},
+		},
+		// key={"key": {"KEY": "value"}}
+		map[string]interface{}{
+			"key": map[string]interface{}{
+				"KEY": "value",
+			},
+		},
+		// key={"key0":"val0","key1":"val1","key2":{"key3":"val2","key4":"val3","key5":{"key6":"val4","KEY7":"val5"}},"key8":{"key9":{"key10":"val6"}}}
+		map[string]interface{}{
+			"key0": "val0",
+			"key1": "val1",
+			"key2": map[string]interface{}{
+				"key3": "val2",
+				"key4": "val3",
+				"key5": map[string]interface{}{
+					"key6": "val4",
+					"KEY7": "val5",
+				},
+			},
+			"key8": map[string]interface{}{
+				"key9": map[string]interface{}{
+					"key10": "val6",
+				},
+			},
+		},
+		// key={"key0":"val0","key1":"val1","key2":{"key3":"val2","key4":"val3","key5":{"key6":"val4","key7":"val5"}},"key8":{"key9":{"KEY10":"val6"}}}
+		map[string]interface{}{
+			"key0": "val0",
+			"key1": "val1",
+			"key2": map[string]interface{}{
+				"key3": "val2",
+				"key4": "val3",
+				"key5": map[string]interface{}{
+					"key6": "val4",
+					"key7": "val5",
+				},
+			},
+			"key8": map[string]interface{}{
+				"key9": map[string]interface{}{
+					"KEY10": "val6",
+				},
+			},
+		},
+	}
+
+	for _, json := range validJsons {
+		err := clientutil.ValidateJSONKeys(json)
+		if err == nil {
+			fmt.Printf("Succeed on:\n%+v\n", json)
+		}
+		c.Check(err, ErrorMatches, "invalid option name:.*", Commentf("invalid option name:.*"))
+	}
+
 }

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -35,14 +35,23 @@ import (
 
 var validKey = regexp.MustCompile("^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$")
 
+// ValidateKey checks if the provided key matches the validKey regex pattern.
+// It returns an error if the key is invalid, otherwise nil.
+func ValidateKey(key string) error {
+	if !validKey.MatchString(key) {
+		return fmt.Errorf("invalid option name: %q", key)
+	}
+	return nil
+}
+
 func ParseKey(key string) (subkeys []string, err error) {
 	if key == "" {
 		return []string{}, nil
 	}
 	subkeys = strings.Split(key, ".")
 	for _, subkey := range subkeys {
-		if !validKey.MatchString(subkey) {
-			return nil, fmt.Errorf("invalid option name: %q", subkey)
+		if err = ValidateKey(subkey); err != nil {
+			return nil, err
 		}
 	}
 	return subkeys, nil

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -340,3 +340,102 @@ func (s *configHelpersSuite) TestPatch(c *C) {
 		"b2": map[string]interface{}{"c": "C"},
 	})
 }
+
+func (s *configHelpersSuite) TestValidateKeyHappy(c *C) {
+	validKeys := []string{
+		"42-the-answer",
+		"dashes-between-are-ok",
+		"abcdefghijklmnopqrstuvwxyz",
+		"foo",
+		"test-foo",
+		"a",
+		"ab",
+		"abc",
+		"a1",
+		"a1b2c3",
+		"a-b",
+		"abc-123",
+		"abc-123-def",
+		"a0",
+		"abc-123-xyz",
+	}
+	for _, key := range validKeys {
+		c.Check(config.ValidateKey(key), IsNil)
+	}
+}
+
+func (s *configHelpersSuite) TestValidateKeyUnhappy(c *C) {
+
+	invalidKeys := []string{
+		"NOUPPERCASE",
+		"NO_SCREM_SNACK_CASE",
+		"no0nesingleUppercase",
+		"no spaces",
+		"?no-special-chars",
+		"no-specia!-chars",
+		"42",
+		"-42-",
+		"-abc",
+		"abc-",
+		"abc--123",
+		"ABC",
+		"abc_123",
+		"a!@#",
+		"@",
+		"!",
+		"#",
+	}
+
+	for _, key := range invalidKeys {
+		c.Check(config.ValidateKey(key), NotNil)
+	}
+}
+
+func (s *configHelpersSuite) TestParseKeyHappy(c *C) {
+	validkeys := []string{
+		"",
+		"one",
+		"one.two",
+		"one.two.three",
+		"one.two.three.four",
+		"one.two.three.four.five",
+		"one.two.three.four.five.six",
+		"one.two.three.four.five.six.seven",
+		"one.two.three.four.five.six.seven.eight",
+		"one.two.three.four.five.six.seven.eight.nine",
+		"one.two.three.four.five.six.seven.eight.nine.ten",
+		"42theanswer.one.two.three",
+		"42-one-two-three.one123",
+		"42-one-two-three.one123.123two",
+	}
+
+	for _, key := range validkeys {
+		_, err := config.ParseKey(key)
+		c.Check(err, IsNil)
+	}
+
+}
+
+func (s *configHelpersSuite) TestParseKeyUnhappy(c *C) {
+	invalidKeys := []string{
+		".",
+		"one.",
+		".one",
+		"one..two",
+		"one.two.",
+		"one.two..three",
+		"one.two.three.",
+		"one.two.three..four",
+		"one.two.three.four.",
+		"four.42.two",
+		"four.two.42",
+		"four.ONE.42",
+		"four. .42",
+		"four. . ",
+	}
+
+	for _, key := range invalidKeys {
+		_, err := config.ParseKey(key)
+		c.Check(err, NotNil)
+	}
+}


### PR DESCRIPTION
When passing JSON in the `snap set -t` command, the keys were not being validated.

- Add: Reusable function to validate snap set keys
- tests: Write tests to demonstrate functionality
- fixes: https://bugs.launchpad.net/snapd/+bug/2072331
