### PR TITLE
o/snapstate, tests: allow mixing revision and channel on snap install

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -549,10 +549,26 @@ func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curS
 			return nil, err
 		}
 
+		var channel string
+		switch {
+		case !rev.Unset():
+			// if we're setting a revision from a validation set, we don't want
+			// to send a channel, since we don't know if that revision is in
+			// that channel
+			channel = ""
+		case sn.Channel == "":
+			// otherwise, we want to make sure to set a default channel if
+			// possible. this case shouldn't ever really happen, since SeedSnaps
+			// should have a channel set
+			channel = "stable"
+		default:
+			channel = sn.Channel
+		}
+
 		byName[sn.SnapName()] = sn
 		revisions[sn.SnapName()] = rev
 		snapToDownloadOptions[i].Snap = sn
-		snapToDownloadOptions[i].Channel = sn.Channel
+		snapToDownloadOptions[i].Channel = channel
 		snapToDownloadOptions[i].Revision = rev
 		snapToDownloadOptions[i].CohortKey = s.wideCohortKey
 		snapToDownloadOptions[i].ValidationSets = vss

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -679,12 +679,8 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				sar.Resources = f.snapResources(info)
 			}
 
-			if strings.HasSuffix(snapName, "-with-default-track") {
-				if strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
-					sar.RedirectChannel = "2.0/" + a.Channel
-				} else if a.Channel == "" {
-					sar.RedirectChannel = "2.0/stable"
-				}
+			if strings.HasSuffix(snapName, "-with-default-track") && strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
+				sar.RedirectChannel = "2.0/" + a.Channel
 			}
 			res = append(res, sar)
 			continue

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -670,9 +670,6 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				revno:  info.Revision,
 				userID: userID,
 			})
-			if !a.Revision.Unset() {
-				info.Channel = ""
-			}
 			info.InstanceKey = instanceKey
 
 			sar := store.SnapActionResult{

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -679,8 +679,12 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				sar.Resources = f.snapResources(info)
 			}
 
-			if strings.HasSuffix(snapName, "-with-default-track") && strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
-				sar.RedirectChannel = "2.0/" + a.Channel
+			if strings.HasSuffix(snapName, "-with-default-track") {
+				if strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
+					sar.RedirectChannel = "2.0/" + a.Channel
+				} else if a.Channel == "" {
+					sar.RedirectChannel = "2.0/stable"
+				}
 			}
 			res = append(res, sar)
 			continue

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1995,15 +1995,6 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThroughChannel(c *C) {
 	s.testInstallWithRevisionRunThrough(c, snapName, channel, defaultTrack)
 }
 
-func (s *snapmgrTestSuite) TestInstallWithRevisionRunThroughDefaultTrack(c *C) {
-	const (
-		channel      = ""
-		snapName     = "some-snap-with-default-track"
-		defaultTrack = "2.0/stable"
-	)
-	s.testInstallWithRevisionRunThrough(c, snapName, channel, defaultTrack)
-}
-
 func (s *snapmgrTestSuite) TestInstallWithRevisionRunThroughDefaultTrackWithChannel(c *C) {
 	const (
 		channel      = "edge"

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2009,6 +2009,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 				Action:       "install",
 				InstanceName: "some-snap",
 				Revision:     snap.R(42),
+				Channel:      "some-channel",
 			},
 			revno:  snap.R(42),
 			userID: 1,
@@ -2033,6 +2034,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 				RealName: "some-snap",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
+				Channel:  "some-channel",
 			},
 		},
 		{
@@ -2061,6 +2063,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 				RealName: "some-snap",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
+				Channel:  "some-channel",
 			},
 		},
 		{
@@ -2120,6 +2123,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 		RealName: "some-snap",
 		Revision: snap.R(42),
 		SnapID:   "some-snap-id",
+		Channel:  "some-channel",
 	})
 
 	// verify snaps in the system state
@@ -2136,6 +2140,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
+		Channel:  "some-channel",
 	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 }
@@ -2688,6 +2693,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 				Action:       "install",
 				InstanceName: "some-snap",
 				Revision:     snap.R(42),
+				Channel:      "some-channel",
 			},
 			revno:  snap.R(42),
 			userID: 1,
@@ -2793,6 +2799,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 				RealName: "some-snap",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
+				Channel:  "some-channel",
 			},
 		},
 		{
@@ -2821,6 +2828,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 				RealName: "some-snap",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
+				Channel:  "some-channel",
 			},
 		},
 		{
@@ -2990,7 +2998,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
 			RealName: "snap2",
 			SnapID:   "snap2-id",
-			Channel:  "",
+			Channel:  "some-other-channel",
 			Revision: snap.R(21),
 		}, nil))
 	}
@@ -3159,6 +3167,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 			Action:       "install",
 			InstanceName: "snap-content-plug",
 			Revision:     snap.R(42),
+			Channel:      "stable",
 		},
 		revno:  snap.R(42),
 		userID: 1,
@@ -3243,6 +3252,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 			RealName: "snap-content-plug",
 			SnapID:   "snap-content-plug-id",
 			Revision: snap.R(42),
+			Channel:  "stable",
 		},
 	}, {
 		op:    "setup-snap",
@@ -3266,6 +3276,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 			RealName: "snap-content-plug",
 			SnapID:   "snap-content-plug-id",
 			Revision: snap.R(42),
+			Channel:  "stable",
 		},
 	}, {
 		op:   "link-snap",
@@ -4835,6 +4846,7 @@ func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevis
 			Action:       "install",
 			Revision:     snap.R(11),
 			InstanceName: "some-snap",
+			Channel:      "stable",
 			Flags:        store.SnapActionIgnoreValidation,
 		},
 		revno: snap.R(11),

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -317,7 +317,10 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 			channel = sn.RevOpts.Channel
 		default:
 			// this should only ever happen if the caller requested a specific
-			// revision to be installed (without specifying a channel)
+			// revision to be installed (without specifying a channel). note
+			// that we won't actually end up tracking "stable", it will get
+			// mapped to "latest/stable" by SnapState.SetTrackingChannel in
+			// doLinkSnap
 			channel = "stable"
 		}
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -418,6 +418,12 @@ func completeStoreAction(action *store.SnapAction, revOpts RevisionOptions, igno
 		// caller provided some validation sets, nothing to do but send them
 		// to the store
 		action.ValidationSets = revOpts.ValidationSets
+
+		// the channel here should be cleared out. if the validation sets that
+		// we are sending require a specific revision, we don't know if that
+		// revision will be part of any requested channel. the caller still
+		// might choose to track any channel in the RevisionOptions.
+		action.Channel = ""
 	default:
 		vsets, err := enforcedSets()
 		if err != nil {
@@ -470,14 +476,11 @@ func completeStoreAction(action *store.SnapAction, revOpts RevisionOptions, igno
 			// we ignore the cohort if a validation set requires that the
 			// snap is pinned to a specific revision
 			action.CohortKey = ""
-		}
-	}
 
-	// clear out the channel if we're requesting a specific revision, which
-	// could be because the user requested a specific revision or because a
-	// validation set requires it
-	if !action.Revision.Unset() {
-		action.Channel = ""
+			// since we're constraining this snap to a revision required by a
+			// validation set, we shouldn't supply a channel.
+			action.Channel = ""
+		}
 	}
 
 	return nil
@@ -1201,6 +1204,10 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 		return target{}, fmt.Errorf("cannot install local snap %q: %v != %v (revision mismatch)", update.InstanceName, update.RevOpts.Revision, si.Revision)
 	}
 
+	if update.RevOpts.Channel != "" && update.SideInfo.Channel != "" && update.RevOpts.Channel != update.SideInfo.Channel {
+		return target{}, fmt.Errorf("cannot install local snap %q: %v != %v (channel mismatch)", update.InstanceName, update.RevOpts.Channel, si.Channel)
+	}
+
 	info, err := validatedInfoFromPathAndSideInfo(update.InstanceName, update.Path, si)
 	if err != nil {
 		return target{}, err
@@ -1209,6 +1216,10 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 	var trackingChannel string
 	if snapst.IsInstalled() {
 		trackingChannel = snapst.TrackingChannel
+	}
+
+	if update.RevOpts.Channel == "" {
+		update.RevOpts.Channel = update.SideInfo.Channel
 	}
 
 	channel, err := resolveChannel(update.InstanceName, trackingChannel, update.RevOpts.Channel, opts.DeviceCtx)

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -317,9 +317,7 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 			channel = sn.RevOpts.Channel
 		default:
 			// this should only ever happen if the caller requested a specific
-			// revision to be installed (without specifying a channel), but the
-			// store didn't return a redirect channel. this would happen if the
-			// snap doens't have a default track
+			// revision to be installed (without specifying a channel)
 			channel = "stable"
 		}
 

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -301,3 +301,192 @@ func (s *TargetTestSuite) TestInvalidPathGoals(c *C) {
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
+
+func (s *TargetTestSuite) TestInstallFromStoreDefaultChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "some-snap",
+	})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap")
+	c.Check(info.Channel, Equals, "stable")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+}
+
+func (s *TargetTestSuite) TestInstallFromPathDefaultChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}
+
+	goal := snapstate.PathInstallGoal(si.RealName, snapPath, si, nil, snapstate.RevisionOptions{})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap")
+	c.Check(info.Channel, Equals, "")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "")
+}
+
+func (s *TargetTestSuite) TestInstallFromPathSideInfoChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+		Channel:  "edge",
+	}
+
+	goal := snapstate.PathInstallGoal(si.RealName, snapPath, si, nil, snapstate.RevisionOptions{})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap")
+	c.Check(info.Channel, Equals, "edge")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "edge")
+}
+
+func (s *TargetTestSuite) TestInstallFromPathRevOptsChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}
+
+	goal := snapstate.PathInstallGoal(si.RealName, snapPath, si, nil, snapstate.RevisionOptions{
+		Channel: "edge",
+	})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap")
+
+	// should be missing here, since the side info doesn't have a channel. we're
+	// just setting the tracked channel in the revision options
+	c.Check(info.Channel, Equals, "")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "edge")
+}
+
+func (s *TargetTestSuite) TestInstallFromPathRevOptsSideInfoChannelMismatch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+		Channel:  "stable",
+	}
+
+	goal := snapstate.PathInstallGoal(si.RealName, snapPath, si, nil, snapstate.RevisionOptions{
+		Channel: "edge",
+	})
+
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot install local snap "some-snap": edge != stable \(channel mismatch\)`)
+}
+
+func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "some-snap",
+		RevOpts: snapstate.RevisionOptions{
+			Channel:  "stable",
+			Revision: snap.R(7),
+		},
+	})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap")
+	c.Check(info.Channel, Equals, "stable")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapsup.Revision(), Equals, snap.R(7))
+}
+
+func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannelWithRedirectChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "some-snap-with-default-track",
+		RevOpts: snapstate.RevisionOptions{
+			Channel:  "stable",
+			Revision: snap.R(7),
+		},
+	})
+
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "some-snap-with-default-track")
+
+	// note that this is the effective channel, not the tracked channel. this
+	// doesn't have to be the same as the channel in the SnapSetup, and it is
+	// really only here to let us know exactly where the snap came from.
+	c.Check(info.Channel, Equals, "stable")
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "2.0/stable")
+	c.Check(snapsup.Revision(), Equals, snap.R(7))
+}

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -419,9 +419,6 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			ValidationSets:   valsetKeyComponents,
 			IgnoreValidation: ignoreValidation,
 		}
-		if !a.Revision.Unset() {
-			a.Channel = ""
-		}
 
 		if a.Action == "install" {
 			installNum++

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -193,12 +193,17 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadSnapOptions) (d
 
 	logger.Debugf("Going to download snap %q %s.", name, &opts)
 
+	channel := opts.Channel
+	if channel == "" {
+		channel = "stable"
+	}
+
 	actions := []*store.SnapAction{{
 		Action:       "download",
 		InstanceName: name,
 		Revision:     opts.Revision,
 		CohortKey:    opts.CohortKey,
-		Channel:      opts.Channel,
+		Channel:      channel,
 	}}
 
 	sars, _, err := sto.SnapAction(context.TODO(), nil, actions, nil, nil, nil)
@@ -323,11 +328,9 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 
 	actions := make([]*store.SnapAction, 0, len(toDownload))
 	for _, sn := range toDownload {
-		// One cannot specify both a channel and specific revision. The store
-		// will return an error if do this.
 		channel := sn.Channel
-		if !sn.Revision.Unset() {
-			channel = ""
+		if channel == "" {
+			channel = "stable"
 		}
 
 		actions = append(actions, &store.SnapAction{

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -191,11 +191,6 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadSnapOptions) (d
 		opts.TargetDir = pwd
 	}
 
-	if !opts.Revision.Unset() {
-		// XXX: is this really necessary (and, if it is, shoudn't we error out instead)
-		opts.Channel = ""
-	}
-
 	logger.Debugf("Going to download snap %q %s.", name, &opts)
 
 	actions := []*store.SnapAction{{

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -193,17 +193,12 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadSnapOptions) (d
 
 	logger.Debugf("Going to download snap %q %s.", name, &opts)
 
-	channel := opts.Channel
-	if channel == "" {
-		channel = "stable"
-	}
-
 	actions := []*store.SnapAction{{
 		Action:       "download",
 		InstanceName: name,
 		Revision:     opts.Revision,
 		CohortKey:    opts.CohortKey,
-		Channel:      channel,
+		Channel:      opts.Channel,
 	}}
 
 	sars, _, err := sto.SnapAction(context.TODO(), nil, actions, nil, nil, nil)
@@ -328,15 +323,10 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 
 	actions := make([]*store.SnapAction, 0, len(toDownload))
 	for _, sn := range toDownload {
-		channel := sn.Channel
-		if channel == "" {
-			channel = "stable"
-		}
-
 		actions = append(actions, &store.SnapAction{
 			Action:         "download",
 			InstanceName:   sn.Snap.SnapName(), // XXX consider using snap-id first
-			Channel:        channel,
+			Channel:        sn.Channel,
 			Revision:       sn.Revision,
 			CohortKey:      sn.CohortKey,
 			Flags:          actionFlag,

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/tooling"
 	"github.com/snapcore/snapd/testutil"
@@ -85,6 +86,9 @@ func (s *toolingSuite) SetUpTest(c *C) {
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	s.tsto = tooling.MockToolingStore(s)
+	s.storeActionsBunchSizes = nil
+	s.storeActions = nil
+	s.curSnaps = nil
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
 	s.SetupAssertSigning("canonical")
@@ -390,7 +394,50 @@ func (s *toolingSuite) TestDownloadSnap(c *C) {
 	c.Check(dlSnap.Info.SnapName(), Equals, "core")
 	c.Check(dlSnap.RedirectChannel, Equals, "")
 
+	c.Assert(s.storeActions, HasLen, 1)
+	// make sure that we provided stable as a default channel
+	c.Check(s.storeActions[0].Channel, Equals, "stable")
+
 	c.Check(logbuf.String(), Matches, `.* DEBUG: Going to download snap "core" `+opts.String()+".\n")
+}
+
+func (s *toolingSuite) TestDownloadMany(c *C) {
+	// env shenanigans
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	debug, hadDebug := os.LookupEnv("SNAPD_DEBUG")
+	os.Setenv("SNAPD_DEBUG", "1")
+	if hadDebug {
+		defer os.Setenv("SNAPD_DEBUG", debug)
+	} else {
+		defer os.Unsetenv("SNAPD_DEBUG")
+	}
+
+	s.setupSnaps(c, map[string]string{
+		"core": "canonical",
+	}, "")
+
+	dir := c.MkDir()
+	beforeDownload := func(info *snap.Info) (string, error) {
+		return filepath.Join(dir, "core.snap"), nil
+	}
+
+	downloaded, err := s.tsto.DownloadMany([]tooling.SnapToDownload{{
+		Snap:     naming.NewSnapRef("core", "core-id"),
+		Revision: snap.R(1),
+	}}, nil, tooling.DownloadManyOptions{
+		BeforeDownloadFunc: beforeDownload,
+	})
+	c.Assert(err, IsNil)
+
+	dlSnap := downloaded["core"]
+	c.Check(dlSnap.Info.SnapName(), Equals, "core")
+	c.Check(dlSnap.Path, Matches, filepath.Join(dir, "core.snap"))
+
+	c.Assert(s.storeActions, HasLen, 1)
+	// make sure that we provided stable as a default channel
+	c.Check(s.storeActions[0].Channel, Equals, "stable")
 }
 
 func (s *toolingSuite) TestSetAssertionMaxFormats(c *C) {

--- a/tests/main/mix-revision-and-channel/task.yaml
+++ b/tests/main/mix-revision-and-channel/task.yaml
@@ -9,10 +9,9 @@ restore: |
   snap remove test-snap-with-channel-and-revision
 
 execute: |
-  # TODO: enable this check once the store's implementation is fixed
   # install a snap with a channel and revision from a channel that is missing
   # the revision, should fail
-  # not snap install --channel=latest/stable --revision=2 test-snap-with-channel-and-revision
+  not snap install --channel=latest/stable --revision=2 test-snap-with-channel-and-revision
 
   # install a snap with a channel and revision
   snap install --channel=latest/stable --revision=1 test-snap-with-channel-and-revision

--- a/tests/main/mix-revision-and-channel/task.yaml
+++ b/tests/main/mix-revision-and-channel/task.yaml
@@ -1,0 +1,29 @@
+summary: Test installing a snap while providing a channel and revision.
+
+details: |
+  Verifies that we can install a snap while providing a channel and revision.
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
+
+restore: |
+  snap remove test-snap-with-channel-and-revision
+
+execute: |
+  # TODO: enable this check once the store's implementation is fixed
+  # install a snap with a channel and revision from a channel that is missing
+  # the revision, should fail
+  # not snap install --channel=latest/stable --revision=2 test-snap-with-channel-and-revision
+
+  # install a snap with a channel and revision
+  snap install --channel=latest/stable --revision=1 test-snap-with-channel-and-revision
+  snap list test-snap-with-channel-and-revision | MATCH '1\s+latest/stable'
+
+  snap remove test-snap-with-channel-and-revision
+
+  # revision 1 isn't the tip of candidate, but it was released to the channel,
+  # so we should be able to install it
+  snap install --channel=latest/candidate --revision=1 test-snap-with-channel-and-revision
+  snap list test-snap-with-channel-and-revision | MATCH '1\s+latest/candidate'
+
+  snap refresh test-snap-with-channel-and-revision
+  snap list test-snap-with-channel-and-revision | MATCH '2\s+latest/candidate'


### PR DESCRIPTION
This removes the code that silently removes channels from actions that are sent to the store when the action also contains a channel.

We do continue to remove the channel when an action either contains specific validation sets, or if the action's revision comes from an enforced validation set.