### PR TITLE
many: update component-related TODOs to use TODO:COMPS

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -214,8 +214,8 @@ func doValidateComponent(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// TODO: check the provenance stored inside the component blob against what
-	// we expect from the assertion (similar to
+	// TODO:COMPS: check the provenance stored inside the component blob against
+	// what we expect from the assertion (similar to
 	// snapasserts.CheckProvenanceWithVerifiedRevision)
 
 	return nil

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -55,7 +55,7 @@ func installSeedSnap(st *state.State, sn *seed.Snap, flags snapstate.Flags, prqt
 		flags.DevMode = true
 	}
 
-	// TODO: this will need to account for components in the future
+	// TODO:COMPS: this will need to account for components in the future
 
 	goal := snapstate.PathInstallGoal("", sn.Path, sn.SideInfo, nil, snapstate.RevisionOptions{
 		Channel: sn.Channel,

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -581,7 +581,6 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) (err error)
 		return fmt.Errorf("snap %q has no %q plug", connRef.PlugRef.Snap, connRef.PlugRef.Name)
 	}
 
-	// TODO: should the repo return an app set here?
 	plugAppSet, err := appSetForSnapRevision(st, plug.Snap)
 	if err != nil {
 		return fmt.Errorf("building app set for snap %q: %v", plug.Snap.InstanceName(), err)
@@ -593,7 +592,6 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) (err error)
 		return fmt.Errorf("snap %q has no %q slot", connRef.SlotRef.Snap, connRef.SlotRef.Name)
 	}
 
-	// TODO: should the repo return an app set here?
 	slotAppSet, err := appSetForSnapRevision(st, slot.Snap)
 	if err != nil {
 		return fmt.Errorf("building app set for snap %q: %v", slot.Snap.InstanceName(), err)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1102,7 +1102,7 @@ func snapsWithSecurityProfiles(st *state.State) ([]*interfaces.SnapAppSet, error
 				continue
 			}
 
-			// TODO: add components to SnapState.PendingSecurity
+			// TODO:COMPS: add components to SnapState.PendingSecurity
 			set, err := interfaces.NewSnapAppSet(snapInfo, nil)
 			if err != nil {
 				logger.Noticef("cannot build app set for snap %q: %s", instanceName, err)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2238,8 +2238,8 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeFromComponent(c *C, sn
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// TODO: we'll need to update this to handle refreshing components once that
-	// work is done
+	// TODO:COMPS: we'll need to update this to handle refreshing components
+	// once that work is done
 
 	s.o.TaskRunner().AddHandler("mock-link-component-n-witness", func(task *state.Task, tomb *tomb.Tomb) error { // do handler
 		s.state.Lock()

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -166,9 +166,9 @@ func (m *SnapManager) doDownloadComponent(t *state.Task, tomb *tomb.Tomb) error 
 		snapsup.InstanceName(),
 	)
 
-	// TODO: to be consistent with snaps, this should be able to point somewhere
-	// else, based on a path that is in the compsup. this would be used for
-	// creating new recovery systems, like it is now for snaps
+	// TODO:COMPS: to be consistent with snaps, this should be able to point
+	// somewhere else, based on a path that is in the compsup. this would be
+	// used for creating new recovery systems, like it is now for snaps
 	target := cpi.MountFile()
 
 	sto := Store(st, deviceCtx)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -235,7 +235,7 @@ func (compsu *ComponentSetup) Revision() snap.Revision {
 // * Installing/refreshing a snap with components
 // * Installing/refreshing a snap without any components
 func ComponentSetupsForTask(t *state.Task) ([]*ComponentSetup, error) {
-	// TODO: handle remaining cases in this switch:
+	// TODO:COMPS: handle remaining cases in this switch:
 	// * installing multiple components for an already installed snap
 	// * installing/refreshing a snap with components
 	switch {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -637,8 +637,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 			return nil, err
 		}
 
-		// TODO: once component hooks are fully, we will need to take care to
-		// correctly order the tasks that are created for running component
+		// TODO:COMPS: once component hooks are fully, we will need to take care
+		// to correctly order the tasks that are created for running component
 		// and snap hooks
 
 		for _, t := range beforeLink {
@@ -2122,7 +2122,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 			return nil, nil, err
 		}
 
-		// TODO: we need to handle components here too
+		// TODO:COMPS: we need to handle components here too
 
 		// Do not set any default restart boundaries, we do it when we have access to all
 		// the task-sets in preparation for single-reboot.
@@ -3942,7 +3942,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		InstanceKey: snapst.InstanceKey,
 	}
 
-	// TODO: we need to handle components here too
+	// TODO:COMPS: we need to handle components here too
 	return doInstall(st, &snapst, *snapsup, nil, 0, fromChange, nil)
 }
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -301,8 +301,6 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 			snapst = &SnapState{}
 		}
 
-		// TODO: is it safe to pull the channel from here? i'm not sure what
-		// this will actually look like as a response from the real store
 		channel := r.RedirectChannel
 		if r.RedirectChannel == "" {
 			channel = sn.RevOpts.Channel
@@ -428,7 +426,7 @@ func installActionForStoreTarget(t StoreSnap, opts Options, enforcedSets func() 
 			)
 		}
 
-		// TODO: handle validation sets and components here
+		// TODO:COMPS: handle validation sets and components here
 
 		action.ValidationSets = requiredSets
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -269,7 +269,6 @@ func addAndBindImplicitComponentHook(componentInfo *ComponentInfo, snapInfo *Inf
 		return
 	}
 
-	// TODO: ignore unsupported implicit component hooks, or return an error?
 	if !IsComponentHookSupported(hook) {
 		logger.Noticef("ignoring unsupported implicit hook %q for component %q", componentInfo.Component, hook)
 		return


### PR DESCRIPTION
We're using `TODO:COMPS` to make component-related TODOs harder to forget. This change updates already-existing TODOs I've written related to components. I also removed a few outdated TODOs that have been addressed.