### PR TITLE
cmd: make sure there are no crashes if no api data is returned

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -727,7 +727,8 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 		return err
 	}
 
-	if changedSnaps.hasChanges() {
+	// changedSnaps might be nil in some operations with the fakestore
+	if changedSnaps != nil && changedSnaps.hasChanges() {
 		if err := showDone(x.client, chg, changedSnaps, "install", opts, x.getEscapes()); err != nil {
 			return err
 		}
@@ -740,8 +741,10 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 
 	// show skipped
 	seen := make(map[string]bool)
-	for _, name := range changedSnaps.names {
-		seen[name] = true
+	if changedSnaps != nil {
+		for _, name := range changedSnaps.names {
+			seen[name] = true
+		}
 	}
 	for _, name := range names {
 		if !seen[name] {
@@ -846,7 +849,8 @@ func (x *cmdRefresh) refreshMany(snaps []string, opts *client.SnapOptions) error
 		return err
 	}
 
-	if changedSnaps.hasChanges() {
+	// changedSnaps might be nil in some operations with the fakestore
+	if changedSnaps != nil && changedSnaps.hasChanges() {
 		return showDone(x.client, chg, changedSnaps, "refresh", opts, x.getEscapes())
 	}
 


### PR DESCRIPTION
Make sure that snap refresh/install does not crash if a change has no api data. This is not happening in usual interactions with the store, but it does in some cases when we use the fakestore, which is breaking some integration tests.

The error seen when this happens is:
```
2024-07-08T15:13:08.6779600Z goroutine 1 [running]:
2024-07-08T15:13:08.6780335Z main.main.func1()
2024-07-08T15:13:08.6781075Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/main.go:497 +0x54
2024-07-08T15:13:08.6781480Z panic({0x558477cadfe0?, 0x558478289ba0?})
2024-07-08T15:13:08.6782031Z /usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
2024-07-08T15:13:08.6782516Z main.(*changedSnapsData).hasChanges(...)
2024-07-08T15:13:08.6783130Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/cmd_snap_op.go:387
2024-07-08T15:13:08.6785780Z main.(*cmdRefresh).refreshMany(0xc000000840, {0x558478309360?, 0x0?, 0xc00037fb88?}, 0xc00037fa08)
2024-07-08T15:13:08.6786531Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/cmd_snap_op.go:849 +0x122
2024-07-08T15:13:08.6787291Z main.(*cmdRefresh).Execute(0xc000000840, {0x558477d68860?, 0x55847785a101?, 0xc0001123c0?})
2024-07-08T15:13:08.6788055Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/cmd_snap_op.go:1035 +0x625
2024-07-08T15:13:08.6789308Z github.com/jessevdk/go-flags.(*Parser).ParseArgs(0xc0001d7b90, {0xc000036050, 0x1, 0x1})
2024-07-08T15:13:08.6790700Z /home/gopath/src/github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags/parser.go:335 +0xb19
2024-07-08T15:13:08.6791344Z github.com/jessevdk/go-flags.(*Parser).Parse(...)
2024-07-08T15:13:08.6792389Z /home/gopath/src/github.com/snapcore/snapd/vendor/github.com/jessevdk/go-flags/parser.go:191
2024-07-08T15:13:08.6792656Z main.run()
2024-07-08T15:13:08.6793379Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/main.go:540 +0x70
2024-07-08T15:13:08.6793671Z main.main()
2024-07-08T15:13:08.6794285Z /home/gopath/src/github.com/snapcore/snapd/cmd/snap/main.go:502 +0x4be
2024-07-08T15:13:08.6794715Z -----
```