### PR TITLE
sandbox/apparmor: do not skip ABI 4.0 from host parser

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -819,15 +819,8 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
-			// Detect but ignore apparmor 4.0 ABI support.
-			//
-			// At present this causes some bugs with mqueue mediation that can
-			// be avoided by pinning to 3.0 (which is also supported on
-			// apparmor 4). Once the mqueue issue is analyzed and fixed, this
-			// can be replaced with a --policy-features=hostAbi40File pin like
-			// we do below.
 			if fi, err := os.Lstat(hostAbi40File); err == nil && !fi.IsDir() {
-				logger.Debugf("apparmor 4.0 ABI detected but ignored")
+				return exec.Command(path, "--policy-features", hostAbi40File), false, nil
 			}
 
 			// Perhaps 3.0?

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -75,6 +75,80 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 	c.Check(err, Equals, nil)
 }
 
+func (*apparmorSuite) TestAppArmorHostAppArmorParserWithJustAbi3(c *C) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
+	defer mockParserCmd.Restore()
+
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	defer restore()
+
+	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return false })
+	defer restore()
+
+	abiDir := filepath.Join(fakeroot, "etc", "apparmor.d", "abi")
+	c.Assert(os.MkdirAll(abiDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(abiDir, "3.0"), nil, 0755), IsNil)
+
+	cmd, internal, err := apparmor.AppArmorParser()
+	c.Check(err, IsNil)
+	c.Check(cmd.Path, Equals, mockParserCmd.Exe())
+	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(abiDir, "3.0")})
+	c.Check(internal, Equals, false)
+}
+
+func (*apparmorSuite) TestAppArmorHostAppArmorParserWithAbi3And4(c *C) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
+	defer mockParserCmd.Restore()
+
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	defer restore()
+
+	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return false })
+	defer restore()
+
+	abiDir := filepath.Join(fakeroot, "etc", "apparmor.d", "abi")
+	c.Assert(os.MkdirAll(abiDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(abiDir, "3.0"), nil, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(abiDir, "4.0"), nil, 0755), IsNil)
+
+	cmd, internal, err := apparmor.AppArmorParser()
+	c.Check(err, IsNil)
+	c.Check(cmd.Path, Equals, mockParserCmd.Exe())
+	// When both are present, ABI 4 is preferred.
+	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(abiDir, "4.0")})
+	c.Check(internal, Equals, false)
+}
+
+func (*apparmorSuite) TestAppArmorHostAppArmorParserWithJustAbi4(c *C) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
+	defer mockParserCmd.Restore()
+
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	defer restore()
+
+	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return false })
+	defer restore()
+
+	abiDir := filepath.Join(fakeroot, "etc", "apparmor.d", "abi")
+	c.Assert(os.MkdirAll(abiDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(abiDir, "4.0"), nil, 0755), IsNil)
+
+	cmd, internal, err := apparmor.AppArmorParser()
+	c.Check(err, IsNil)
+	c.Check(cmd.Path, Equals, mockParserCmd.Exe())
+	c.Check(cmd.Args, DeepEquals, []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(abiDir, "4.0")})
+	c.Check(internal, Equals, false)
+}
+
 func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
 	fakeroot := c.MkDir()
 	dirs.SetRootDir(fakeroot)


### PR DESCRIPTION
The state of AppArmor 4 in Ubuntu 24.04 and 24.10 is now sufficient for
using in snapd. The recently-added version-aware feature check guarantee
that features such as mqueue are not used when the parser is not
sufficiently up-to-date.