### PR TITLE
tests: use chown USER:GROUP instead of USER.GROUP

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -41,7 +41,7 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid) 
     }
     // Since we may be running from a setuid but not setgid executable, switch
     // to the effective group to root so that the mkdirat call creates a cgroup
-    // that is always owned by root.root.
+    // that is always owned by root:root.
     sc_identity old = sc_set_effective_identity(sc_root_group_identity());
     if (mkdirat(parent_fd, name, 0755) < 0 && errno != EEXIST) {
         die("cannot create cgroup hierarchy %s/%s", parent, name);

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -26,7 +26,7 @@
  *
  * The code assumes that an existing hierarchy rooted at "parent". It follows
  * up with a sub-hierarchy called "name", creating it if necessary. The created
- * sub-hierarchy is made to belong to root.root and the specified process is
+ * sub-hierarchy is made to belong to root:root and the specified process is
  * moved there.
  **/
 void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);

--- a/cmd/libsnap-confine-private/privs-test.c
+++ b/cmd/libsnap-confine-private/privs-test.c
@@ -24,11 +24,11 @@
 static void test_sc_privs_drop(void)
 {
 	if (geteuid() != 0 || getuid() == 0) {
-		g_test_skip("run this test after chown root.root; chmod u+s");
+		g_test_skip("run this test after chown root:root; chmod u+s");
 		return;
 	}
 	if (getegid() != 0 || getgid() == 0) {
-		g_test_skip("run this test after chown root.root; chmod g+s");
+		g_test_skip("run this test after chown root:root; chmod g+s");
 		return;
 	}
 	if (g_test_subprocess()) {

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -322,7 +322,7 @@ static void sc_initialize_ns_fstab(const char *snap_instance_name)
 		die("cannot open %s", info_path);
 	}
 	if (fchown(fd, 0, 0) < 0) {
-		die("cannot chown %s to root.root", info_path);
+		die("cannot chown %s to root:root", info_path);
 	}
 	// The stream now owns the file descriptor.
 	stream = fdopen(fd, "w");

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -112,7 +112,7 @@ static void setup_private_tmp(const char *snap_instance)
 		die("%s has unexpected ownership / permissions",
 		    SNAP_PRIVATE_TMP_ROOT_DIR);
 	}
-	// Create /tmp/snap-private-tmp/snap.$SNAP_INSTANCE_NAME/ 0700 root.root.
+	// Create /tmp/snap-private-tmp/snap.$SNAP_INSTANCE_NAME/ 0700 root:root.
 	sc_must_snprintf(base, sizeof(base), "snap.%s", snap_instance);
 	if (mkdirat(private_tmp_root_fd, base, 0700) < 0 && errno != EEXIST) {
 		die("cannot create base directory: %s", base);
@@ -130,7 +130,7 @@ static void setup_private_tmp(const char *snap_instance)
 		die("%s/%s has unexpected ownership / permissions",
 		    SNAP_PRIVATE_TMP_ROOT_DIR, base);
 	}
-	// Create /tmp/$PRIVATE/snap.$SNAP_NAME/tmp 01777 root.root Ignore EEXIST since we
+	// Create /tmp/$PRIVATE/snap.$SNAP_NAME/tmp 01777 root:root Ignore EEXIST since we
 	// want to reuse and we will open with O_NOFOLLOW, below.
 	if (mkdirat(base_dir_fd, "tmp", 01777) < 0 && errno != EEXIST) {
 		die("cannot create private tmp directory %s/tmp", base);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -963,7 +963,7 @@ void sc_store_ns_info(const sc_invocation *inv)
 		die("cannot open %s", info_path);
 	}
 	if (fchown(fd, 0, 0) < 0) {
-		die("cannot chown %s to root.root", info_path);
+		die("cannot chown %s to root:root", info_path);
 	}
 	// The stream now owns the file descriptor.
 	stream = fdopen(fd, "w");

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -221,7 +221,7 @@ func MkDir(dirFd int, dirName string, name string, perm os.FileMode, uid sys.Use
 			// Close the FD we opened if we fail here since the caller will get
 			// an error and won't assume responsibility for the FD.
 			sysClose(newFd)
-			return -1, fmt.Errorf("cannot chown directory %q to %d.%d: %v", filepath.Join(dirName, name), uid, gid, err)
+			return -1, fmt.Errorf("cannot chown directory %q to %d:%d: %v", filepath.Join(dirName, name), uid, gid, err)
 		}
 		// As soon as we find a place that is safe to write we can switch off
 		// the restricted mode (and thus any subsequent checks). This is
@@ -281,7 +281,7 @@ func MkFile(dirFd int, dirName string, name string, perm os.FileMode, uid sys.Us
 	if made {
 		// Chown the file if we made it.
 		if err := sysFchown(newFd, uid, gid); err != nil {
-			return fmt.Errorf("cannot chown file %q to %d.%d: %v", filepath.Join(dirName, name), uid, gid, err)
+			return fmt.Errorf("cannot chown file %q to %d:%d: %v", filepath.Join(dirName, name), uid, gid, err)
 		}
 	}
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -59,8 +59,8 @@ create_test_user(){
     echo >> /etc/sudoers
     echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-    chown test.test -R "$SPREAD_PATH"
-    chown test.test "$SPREAD_PATH/../"
+    chown test:test -R "$SPREAD_PATH"
+    chown test:test "$SPREAD_PATH/../"
 }
 
 build_deb(){
@@ -288,7 +288,7 @@ prepare_project() {
     # declare the "quiet" wrapper
 
     if [ "$SPREAD_BACKEND" = "external" ]; then
-        chown test.test -R "$PROJECT_PATH"
+        chown test:test -R "$PROJECT_PATH"
         exit 0
     fi
 
@@ -300,7 +300,7 @@ prepare_project() {
         fi
         echo test:ubuntu | sudo chpasswd
         echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test
-        chown test.test -R "$PROJECT_PATH"
+        chown test:test -R "$PROJECT_PATH"
         exit 0
     fi
 
@@ -574,7 +574,7 @@ prepare_project() {
     done
 
     # go mod runs as root and will leave strange permissions
-    chown test.test -R "$SPREAD_PATH"
+    chown test:test -R "$SPREAD_PATH"
 
     if [ "$BUILD_SNAPD_FROM_CURRENT" = true ]; then
         case "$SPREAD_SYSTEM" in

--- a/tests/lib/ramdisk.sh
+++ b/tests/lib/ramdisk.sh
@@ -3,6 +3,6 @@
 setup_ramdisk(){
     if [ ! -e /dev/ram0 ]; then
         mknod -m 660 /dev/ram0 b 1 0
-        chown root.disk /dev/ram0
+        chown root:disk /dev/ram0
     fi
 }

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -24,7 +24,7 @@ execute: |
       snap install --dangerous test-snapd-core-migration_1_all.snap
       su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="16"'
 
-      # The mount namespace information file is owned by root.root and has mode 0644
+      # The mount namespace information file is owned by root:root and has mode 0644
       # even though the user invoking the snap command was non-root.
       MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
       test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0
@@ -73,7 +73,7 @@ execute: |
       snap install --dangerous test-snapd-core-migration_2_all.snap
       su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="18"'
 
-      # The mount namespace information file is owned by root.root and has mode 0644
+      # The mount namespace information file is owned by root:root and has mode 0644
       # even though the user invoking the snap command was non-root.
       MATCH 'base-snap-name=core18' < /run/snapd/ns/snap.test-snapd-core-migration.info
       test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0

--- a/tests/main/cifs-home/task.yaml
+++ b/tests/main/cifs-home/task.yaml
@@ -68,7 +68,7 @@ prepare: |
       tests.cleanup defer rmdir /var/home
     fi
     mkdir /var/home/test-remote
-    chown test-remote.test-remote /var/home/test-remote
+    chown test-remote:test-remote /var/home/test-remote
     tests.cleanup defer rm -rf /var/home/test-remote
     # TODO: it would be nice to successfully pass ",posix" option and get things to mount.
     mount -t cifs //127.0.0.1/var-home/test-remote /home/test-remote -o vers=3.1.1,nomapposix,mfsymlinks,username=test-remote,password=secret,uid=54321,gid=54321

--- a/tests/main/core-snap-not-test-test/task.yaml
+++ b/tests/main/core-snap-not-test-test/task.yaml
@@ -1,4 +1,4 @@
-summary: Files inside the core snap are not owned by test.test
+summary: "Files inside the core snap are not owned by test:test"
 
 details: |
     Verify that the files inside the core snap are not owned by the test user.

--- a/tests/nested/manual/core20-auto-remove-user/task.yaml
+++ b/tests/nested/manual/core20-auto-remove-user/task.yaml
@@ -139,7 +139,7 @@ execute: |
     local ASSERT="$1"
     if ! remote.exec "test -e /dev/ram0"; then
       remote.exec "sudo mknod -m 660 /dev/ram0 b 1 0"
-      remote.exec "sudo chown root.disk /dev/ram0"
+      remote.exec "sudo chown root:disk /dev/ram0"
     fi
     remote.exec "sudo mkfs.ext3 /dev/ram0"
     remote.exec "sudo mount /dev/ram0 /mnt"

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -62,7 +62,7 @@ prepare: |
     lxc file push --quiet hello.py mycontainer/var/lib/test/hello.py
 
     # Copy our python script there.
-    lxc exec mycontainer -- chown ubuntu.ubuntu /var/lib/test
+    lxc exec mycontainer -- chown ubuntu:ubuntu /var/lib/test
 
 restore: |
     # Remove the container we may have set up.

--- a/tests/unit/c-unit-tests-clang/task.yaml
+++ b/tests/unit/c-unit-tests-clang/task.yaml
@@ -35,5 +35,5 @@ execute: |
     cd "$build_dir"
     # Build and run unit tests as root and as a user
     make check
-    chown -R test.test "$build_dir"
+    chown -R test:test "$build_dir"
     su test -c 'make check'

--- a/tests/unit/c-unit-tests-gcc/task.yaml
+++ b/tests/unit/c-unit-tests-gcc/task.yaml
@@ -32,5 +32,5 @@ execute: |
     cd "$build_dir"
     # Build and run unit tests as root and as a user
     make check
-    chown -R test.test "$build_dir"
+    chown -R test:test "$build_dir"
     su test -c 'make check'


### PR DESCRIPTION
The syntax with the dot is deprecated, and modern chown warns about it:

    + chown root.disk /dev/ram0
    chown: warning: '.' should be ':': root.disk
