### PR TITLE
many: add support for seeding components from the store

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -94,7 +94,8 @@ func fetchSnapAssertionsDirect(tsto *tooling.ToolingStore, snapPath string, snap
 	}
 	f := tsto.AssertionFetcher(db, save)
 
-	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, nil, f, db)
+	// TODO:COMPS: support downloading components
+	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, nil, nil, f, db)
 	return assertPath, err
 }
 

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -348,7 +348,8 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 				return recoverySystemDir, fmt.Errorf("internal error: no assertions for asserted snap with ID: %v", info.SnapID)
 			}
 		}
-		if err := w.SetInfo(sn, info); err != nil {
+		// TODO:COMPS: consider components
+		if err := w.SetInfo(sn, info, nil); err != nil {
 			return recoverySystemDir, err
 		}
 		localARefs[sn] = aRefs

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -392,8 +392,12 @@ func componentSetupFromResource(name string, sar store.SnapResourceResult, info 
 		return ComponentSetup{}, fmt.Errorf("%q is not a component for snap %q", name, info.SnapName())
 	}
 
-	if typ := fmt.Sprintf("component/%s", comp.Type); typ != sar.Type {
-		return ComponentSetup{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", typ, sar.Type)
+	typ, err := store.ResourceToComponentType(sar.Type)
+	if err != nil {
+		return ComponentSetup{}, fmt.Errorf("%q is not a component resource", sar.Type)
+	}
+	if typ != comp.Type {
+		return ComponentSetup{}, fmt.Errorf("inconsistent component type (%q in snap, %q in component)", comp.Type, typ)
 	}
 
 	cref := naming.NewComponentRef(info.SnapName(), name)

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -136,8 +136,47 @@ func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 
 	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
 	c.Assert(err, ErrorMatches, fmt.Sprintf(
-		`.*inconsistent component type \("component/%s" in snap, "component/%s" in component\)`, snap.TestComponent, snap.KernelModulesComponent,
+		`.*inconsistent component type \("%s" in snap, "%s" in component\)`, snap.TestComponent, snap.KernelModulesComponent,
 	))
+}
+
+func (s *TargetTestSuite) TestInstallWithComponentsOtherResource(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "test-snap"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      compName,
+				Revision:  1,
+				Type:      "otherresource/restype",
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: snapName,
+		Components:   []string{compName},
+		RevOpts: snapstate.RevisionOptions{
+			Channel: channel,
+		},
+	})
+
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(
+		`.*"otherresource/restype" is not a component resource`))
 }
 
 func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -408,7 +408,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)
-		w.SetInfo(sn, info)
+		w.SetInfo(sn, info, nil)
 		if aRefs != nil {
 			localARefs[sn] = aRefs
 		}
@@ -437,7 +437,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 
 			info := s.AssertedSnapInfo(name)
 			c.Assert(info, NotNil, Commentf("no snap info for %q", name))
-			err := w.SetInfo(sn, info)
+			err := w.SetInfo(sn, info, nil)
 			c.Assert(err, IsNil)
 
 			if _, err := os.Stat(sn.Path); err == nil {

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -40,7 +40,7 @@ type policy20 struct {
 	warningf func(format string, a ...interface{})
 }
 
-var errNotAllowedExceptForDangerous = errors.New("cannot override channels, add devmode snaps, local snaps, or extra snaps with a model of grade higher than dangerous")
+var errNotAllowedExceptForDangerous = errors.New("cannot override channels, add devmode snaps, local snaps, or extra snaps/components with a model of grade higher than dangerous")
 
 func (pol *policy20) checkAllowedDangerous() error {
 	if pol.model.Grade() != asserts.ModelDangerous {

--- a/tests/lib/assertions/pc24-with-comps-dangerous.json
+++ b/tests/lib/assertions/pc24-with-comps-dangerous.json
@@ -1,0 +1,49 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "test-snapd",
+    "brand-id": "test-snapd",
+    "model": "ubuntu-core-24-pc-amd64",
+    "architecture": "amd64",
+    "timestamp": "2024-07-10T12:00:00.0Z",
+    "base": "core24",
+    "grade": "dangerous",
+    "serial-authority": [ "generic" ],
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "24/beta",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "test-snap-with-components",
+            "id": "o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK",
+            "type": "app",
+            "components": {
+                "one": {
+                    "presence": "required"
+                },
+                "two": "optional"
+            }
+        }
+    ]
+}

--- a/tests/lib/assertions/pc24-with-comps-dangerous.model
+++ b/tests/lib/assertions/pc24-with-comps-dangerous.model
@@ -1,0 +1,52 @@
+type: model
+authority-id: test-snapd
+series: 16
+brand-id: test-snapd
+model: ubuntu-core-24-pc-amd64
+architecture: amd64
+base: core24
+grade: dangerous
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 24/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 24/beta
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    components:
+      one:
+        presence: required
+      two: optional
+    id: o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK
+    name: test-snap-with-components
+    type: app
+timestamp: 2024-07-10T12:00:00.0Z
+sign-key-sha3-384: rrP2xy5LOU-OjnYtfHm7h8QSOkySgyrZoJKT_YqlTKJrWMA8j-0SoClorTN6XR9Z
+
+AcLBcwQAAQoAHRYhBMEAb2Q1SgOrrGcnJ4b6Yn/LKbBXBQJmkZG3AAoJEIb6Yn/LKbBXg10P/1GK
+H8oAj19OLBJZDIXHcl1bZ0IQ0WquOZAH6IUGUxI4nSsYfnxA+EZpRovZcXFECEltOJWqUGBDfWOE
+rN3pVGXhzICHE1tDbt9lbbYfv8XaFkH6DS3K/dyDUyeY/QBa/o5UmDSUuLDcL3PVS1jRvsm6Lw/T
+ErZl7Zy761/FHkMIt+z370AqeP8/4NABz64SCgLNcWIMyY7kWrskktS2pjz46P+cIu3hF/wZZm7h
+0zayZ3PrGh9WLPXsxmWm9wFUi4iJoo9+ElD3G3g3KweEZ7idPcLCrpljE1OnNplAXYnOgWx7E7Na
+1MBflBO1SaTEN78hd2DV/QpNUMdU2+twUwwHkedrZtGjlYycH+P8/Z1KO/XgDRbGDahwqAZSn2Jo
+aigdX3k4FaJoqTtTyDO8viJR3W6+nR5dHT+yEj8fhc7VQRObGOVscCJ/W6G1+5o5kpCNUUIHI4Ng
+JG1Ym3Wy2ncz1UbhZrFexLnF1Hsi1x9ZsXE7AGKs/dxrx9NUBIVyvuxYq1AG4QhnFrU+QYCdyM/r
+hn7TvoM+T0oWeHhHsUO2lD4+gXr16RpcWzaAnOdSoHwWEIvbaU2v/GyX6TJK719QnzTu7l3d4YaU
+HZqbMqrRJm9sv9xo64i6n8m0ybW8yPzApN+iXbMFZJ3jY/KIA8nLxRpnLgUZT/4hIGDfQ5ZT

--- a/tests/lib/assertions/pc24-with-comps-signed.json
+++ b/tests/lib/assertions/pc24-with-comps-signed.json
@@ -1,0 +1,49 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "test-snapd",
+    "brand-id": "test-snapd",
+    "model": "ubuntu-core-24-pc-amd64",
+    "architecture": "amd64",
+    "timestamp": "2024-07-10T12:00:00.0Z",
+    "base": "core24",
+    "grade": "signed",
+    "serial-authority": [ "generic" ],
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "24/beta",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "test-snap-with-components",
+            "id": "o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK",
+            "type": "app",
+            "components": {
+                "one": {
+                    "presence": "required"
+                },
+                "two": "optional"
+            }
+        }
+    ]
+}

--- a/tests/lib/assertions/pc24-with-comps-signed.model
+++ b/tests/lib/assertions/pc24-with-comps-signed.model
@@ -1,0 +1,52 @@
+type: model
+authority-id: test-snapd
+series: 16
+brand-id: test-snapd
+model: ubuntu-core-24-pc-amd64
+architecture: amd64
+base: core24
+grade: signed
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 24/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 24/beta
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    components:
+      one:
+        presence: required
+      two: optional
+    id: o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK
+    name: test-snap-with-components
+    type: app
+timestamp: 2024-07-10T12:00:00.0Z
+sign-key-sha3-384: rrP2xy5LOU-OjnYtfHm7h8QSOkySgyrZoJKT_YqlTKJrWMA8j-0SoClorTN6XR9Z
+
+AcLBcwQAAQoAHRYhBMEAb2Q1SgOrrGcnJ4b6Yn/LKbBXBQJmkZGqAAoJEIb6Yn/LKbBXId0P/2nc
+UfELaVvaJIhNAayppWXM8oKIdIMpKI9xNotO2mOuueOBXpoaQaIR5T59QoBSMYmwk1ZYHEWxsROg
+Z2yuYdSjaw/dW9EQIkWTznxavibWzK1HWTgfN24JSRbM9FJQKWXy/AL69IQe1MRTsnxD4Wkw4+52
+xFVjuwnmDpDlCViESxiIoupGJvrxBMRkN1ktVT96WhDsPiEebLsWF3+vpPB1QntJGhg1OZcjIzwC
+vpEcseFHzobnOMkd0qnNAyjSGhDzlmEAjyHNHEbJwJdR/I8cgDRZ5CZtcfEi80odhdlDnj14MjTB
+I3pK94+teSLe1CCLQmk+ws20HmNDunMOBaV7Pr1n4mNhZJ52FN6U8sUsshJQajZykiwpDu4iF2hQ
+D1v2ak8xNH8+gD5RQX4SYKL00loMeDuNdjauEdyOZ8GhwAoGVl8taWXvqofp/yjOh+lYrX+q53Y5
+IjE4G4bQgIzvwizUnAbkuxxGEpLSd1wrp6hOgDMuxWngxGqkWMzRE3WKvdA3tcYqMgnZjPOmw9o7
+1Jc34VHuqVmTgtO/EgcCH9439/8n7bFBoY5td0irqM/0/iQ6IrjsEEcdsAL3wkVUDzrCD57AUk1r
+uZQRyIWzJZbn66aY5cRmtYFKwlOWg0I272rKCJMy6eo/B/q2Wu6PmkEykOXv3P2o1Gfz1kIH

--- a/tests/main/prepare-image-components/task.yaml
+++ b/tests/main/prepare-image-components/task.yaml
@@ -1,0 +1,70 @@
+summary: Check that prepare-image works when we have components
+
+details: |
+  The `snap prepare-image` command performs some of the steps necessary for
+  creating device images.
+
+  This test verifies that in classic and Ubuntu Core systems, the
+  prepare-image command prepares properly an image with components. It is
+  checked that the fundamental snaps are present and the snap assertions are
+  retrieved.
+
+backends: [-autopkgtest]
+
+systems: [ubuntu-18*, ubuntu-2*]
+
+execute: |
+  TARGET_D=target
+
+  # Checks for container files and assertions.
+  # $1: number of expected components
+  check_files_and_assertions() {
+      SNAPS_D=$TARGET_D/system-seed/snaps
+      LABEL_D=$(find $TARGET_D/system-seed/systems/ -maxdepth 1 -mindepth 1)
+
+      for f in snapd pc pc-kernel core24 test-snap-with-components; do
+          stat "$SNAPS_D"/"$f"_*.snap
+      done
+      for comp in "$@"; do
+          stat "$SNAPS_D"/test-snap-with-components+"$comp"_*.comp
+          MATCH "resource-name: $comp" < "$LABEL_D"/assertions/snaps
+      done
+      MATCH "type: snap-resource-revision" < "$LABEL_D"/assertions/snaps
+      MATCH "type: snap-resource-pair" < "$LABEL_D"/assertions/snaps
+  }
+
+  ## dangerous model
+
+  # component one is mandatory in model
+  snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-dangerous.model "$TARGET_D"
+  check_files_and_assertions one
+
+  # component one is optional in model
+  rm -rf "$TARGET_D"
+  snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-dangerous.model \
+       --comp test-snap-with-components+two "$TARGET_D"
+  check_files_and_assertions one two
+
+  # component three is not in model
+  rm -rf "$TARGET_D"
+  snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-dangerous.model \
+       --comp test-snap-with-components+two --comp test-snap-with-components+three "$TARGET_D"
+  check_files_and_assertions one two three
+
+  ## signed model
+
+  # component one is mandatory in model
+  rm -rf "$TARGET_D"
+  snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-signed.model "$TARGET_D"
+  check_files_and_assertions one
+
+  # component one is optional in model
+  rm -rf "$TARGET_D"
+  snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-signed.model \
+       --comp test-snap-with-components+two "$TARGET_D"
+  check_files_and_assertions one two
+
+  # component three is not in model, must fail
+  rm -rf "$TARGET_D"
+  not snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-signed.model \
+       --comp test-snap-with-components+two --comp test-snap-with-components+three "$TARGET_D"


### PR DESCRIPTION
Support creating seeds with components and related assertions that are downloaded from the store.