### PR TITLE
interfaces/builtin: fix polkit rw/ro check

### DIFF
--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -160,7 +160,7 @@ func isPathMountedWritable(mntProfile *osutil.MountProfile, fsPath string) bool 
 	currentPath := fsPath
 	for {
 		if mnt, ok := mntMap[currentPath]; ok {
-			return mnt.Options[0] == "rw"
+			return mnt.OptBool("rw")
 		}
 
 		// Make sure we terminate on the last path token


### PR DESCRIPTION
Existing logic was looking only at the first mount option but there is no guarantee that "rw" or "ro" shows up as the first option. Use OptBool to check for the right option reliably.