### PR TITLE
interfaces/builtin: isolate polkit tests from the host

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -38,6 +38,7 @@ var (
 	GetDesktopFileRules         = getDesktopFileRules
 	StringListAttribute         = stringListAttribute
 	IsPathMountedWritable       = isPathMountedWritable
+	PolkitPoliciesSupported     = polkitPoliciesSupported
 )
 
 func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {
@@ -132,4 +133,20 @@ func MockDirsToEnsure(fn func(paths []string) ([]*interfaces.EnsureDirSpec, erro
 	dirsToEnsure = fn
 
 	return restore
+}
+
+func MockPolkitPaths(procSelfMounts, daemonPath1, daemonPath2 string) (restore func()) {
+	oldProcSelfMounts := polkitProcSelfMounts
+	oldDaemonPath1 := polkitDaemonPath1
+	oldDaemonPath2 := polkitDaemonPath2
+
+	polkitProcSelfMounts = procSelfMounts
+	polkitDaemonPath1 = daemonPath1
+	polkitDaemonPath2 = daemonPath2
+
+	return func() {
+		polkitProcSelfMounts = oldProcSelfMounts
+		polkitDaemonPath1 = oldDaemonPath1
+		polkitDaemonPath2 = oldDaemonPath2
+	}
 }


### PR DESCRIPTION
Polkit unit tests depend on the host /proc/self/mounts and two possible locations of polkitd executable. This is fragile and incorrect for unit tests. Recently we realized that the LoadMountProfile function has fails to parse real entries generated by the kernel, when the mount options field contains spaces.

Isolate polkit tests by mocking the locations read by interface methods and by overriding StaticInfo so that tests can replace the mount profile location to inspect. Separate testing of core-specific conditions to a dedicated test.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-23799