### PR TITLE
interfaces: add new u2f token2 security keys

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -170,7 +170,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "Token2 FIDO2 key",
 		VendorIDPattern:  "349e",
-		ProductIDPattern: "0010|0011|0012|0020|0021|0022|0200|0201|0202",
+		ProductIDPattern: "0010|0011|0012|0013|0014|0015|0016|0020|0021|0022|0023|0024|0025|0026|0200|0201|0202|0203|0204|0205|0206",
 	},
 	{
 		Name:             "Swissbit iShield Key",

--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -168,7 +168,7 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "0e90",
 	},
 	{
-		Name:             "Token2 FIDO2 key",
+		Name:             "Token2 FIDO2 Security Key",
 		VendorIDPattern:  "349e",
 		ProductIDPattern: "0010|0011|0012|0013|0014|0015|0016|0020|0021|0022|0023|0024|0025|0026|0200|0201|0202|0203|0204|0205|0206",
 	},

--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -168,7 +168,7 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "0e90",
 	},
 	{
-		Name:             "Token2 FIDO2 Security Key",
+		Name:             "Token2 FIDO2 Security Keys",
 		VendorIDPattern:  "349e",
 		ProductIDPattern: "0010|0011|0012|0013|0014|0015|0016|0020|0021|0022|0023|0024|0025|0026|0200|0201|0202|0203|0204|0205|0206",
 	},


### PR DESCRIPTION
Token2 is planning the launch of three new security keys, which will feature OpenPGP applets accessible via USB. These keys use a different set of PID (depending on transport combination) that need to be recognized by snapd

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
