### PR TITLE
tests: fix errors building ubuntu core

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -156,9 +156,11 @@ backends:
             - ubuntu-core-16-64:
                   image: ubuntu-16.04-64
                   workers: 6
+                  storage: 20G
             - ubuntu-core-18-64:
                   image: ubuntu-18.04-64
                   workers: 6
+                  storage: 20G
             - ubuntu-core-20-64:
                   image: ubuntu-20.04-64
                   workers: 8

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1430,6 +1430,8 @@ EOF
     else
         "${TESTSLIB}/reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"
     fi
+
+    rm -rf "$UNPACK_DIR"
 }
 
 # prepare_ubuntu_core will prepare ubuntu-core 16+


### PR DESCRIPTION
This change fixes 2 errors when ubuntu core tests are executed on master branch.

2024-07-12T15:38:24.0440669Z FATAL ERROR: dir_scan: failed to make directory /tmp/core24-snap/bin.usr-is-merged, because File exists

and also

2024-07-12T15:22:48.6292243Z 2024-07-12 15:22:39.558 :: Write failed because No space left on device
