### PR TITLE
tests/nested/manual/core20-4k-sector-size: do not assume we have xxd

### DIFF
--- a/tests/nested/manual/core20-4k-sector-size/task.yaml
+++ b/tests/nested/manual/core20-4k-sector-size/task.yaml
@@ -50,7 +50,7 @@ execute: |
     remote.exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    remote.exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
+    remote.exec "od -t x1 /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "^0000000 06 00 00 00 01$"
 
     echo "Ensure 'snap recovery show-keys' works as root"
     remote.exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'


### PR DESCRIPTION
xxd is from vim. od from coreutils.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
