### PR TITLE
cmd/snapd-apparmor: disable on WSL-1 and 2, fix tests

### DIFF
--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -69,7 +69,15 @@ import (
 // be properly handled by this function.
 func isContainerWithInternalPolicy() bool {
 	if release.OnWSL {
-		return true
+		// WSL-1 is an emulated Windows layer that has no support for AppArmor.
+		// WSL-2 is a virtualised environment with the Linux kernel as
+		// distributed by Microsoft.  In the future, if Microsoft enables
+		// AppArmor in their kernel configuration and adjusts their special
+		// init process, which launches individual distributions in
+		// quasi-containers, to initialize apparmor nesting, we might re-enable
+		// this and treat WSL-2 like a LXD/Incus container, with nested
+		// security.
+		return false
 	}
 
 	var appArmorSecurityFSPath = filepath.Join(dirs.GlobalRootDir, "/sys/kernel/security/apparmor")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -46,6 +46,7 @@ var _ = Suite(&mainSuite{})
 
 func (s *mainSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(mockWSL(0))
 }
 
 func (s *mainSuite) TearDownTest(c *C) {
@@ -235,6 +236,7 @@ type integrationSuite struct {
 var _ = Suite(&integrationSuite{})
 
 func (s *integrationSuite) SetUpTest(c *C) {
+	s.AddCleanup(mockWSL(0))
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -83,10 +83,12 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 
 	// simulate being inside WSL
 	restore := mockWSL(1)
+	// FIXME: This is clearly wrong, WSL-1 doesn't emulate any LSM support.
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
 	restore = mockWSL(2)
+	// FIXME: This is clearly wrong WSL-2 doesn't have LSM support.
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
@@ -269,6 +271,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
+	// FIXME: This is clearly broken, apparmor doesn't exist in WSL-1.
 	defer mockWSL(1)()
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This fixes broken unit tests that don't work on WSL-2 environment due to incorrect assumption about the host environment and also change the non-test code to *disable* attempts to use apparmor on WSL-2.

The reason for this is articulated in 35e15ecdc27a0700108c4c77dbfb7a076b5f5c78 but mainly, because it just doesn't work unless you have a custom kernel and run only one distribution at a time.

Once AppArmor is enabled in the Microsoft distribution of the Linux kernel, and once stacking is enabled in the Microsoft WSL init process, then we can drop most of the special-casing for WSL and just treat WSL-2-with-apparmor-and-apparmor-stacking as a LXD container with internal policy. Before that time comes, this is a more sane approach.

We can consider a follow-up that adds an environment variable like `SNAPD_FORCE_WSL_APPARMOR=1` so that people who do use custom kernels and run only one distribution at a single time, can still use it.