### PR TITLE
o/snapstate: refresh components from the store

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -488,6 +488,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		revno = r
 	}
 	confinement := snap.StrictConfinement
+	var components map[string]*snap.Component
 	switch cand.channel {
 	case "channel-for-7/stable":
 		revno = snap.R(7)
@@ -495,6 +496,17 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		confinement = snap.ClassicConfinement
 	case "channel-for-devmode/stable":
 		confinement = snap.DevModeConfinement
+	case "channel-for-components":
+		components = map[string]*snap.Component{
+			"test-component": {
+				Type: snap.TestComponent,
+				Name: "test-component",
+			},
+			"kernel-modules-component": {
+				Type: snap.KernelModulesComponent,
+				Name: "kernel-modules-component",
+			},
+		}
 	}
 	if name == "some-snap-now-classic" {
 		confinement = "classic"
@@ -516,6 +528,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		Architectures: []string{"all"},
 		Epoch:         epoch,
 		Base:          base,
+		Components:    components,
 	}
 
 	if strings.HasSuffix(cand.snapID, "-without-version-id") {

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -122,6 +122,7 @@ components:
 	comps, err := snapSt.CurrentComponentInfos()
 	c.Assert(err, IsNil)
 	c.Check(comps, testutil.DeepUnsortedMatches, []*snap.ComponentInfo{foundCi, foundCi2})
+	c.Check(snapSt.CurrentlyHasComponents(), Equals, true)
 
 	snapSt = &snapstate.SnapState{
 		Active: true,
@@ -150,6 +151,7 @@ components:
 	comps, err = snapSt.ComponentInfosForRevision(ssi2.Revision)
 	c.Assert(err, IsNil)
 	c.Check(comps, HasLen, 0)
+	c.Check(snapSt.CurrentlyHasComponents(), Equals, false)
 
 	snapSt = &snapstate.SnapState{
 		Active: true,

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -258,7 +258,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	var readInfoErr error
 	for i := 0; i < 10; i++ {
 		compMntDir := cpi.MountDir()
-		_, readInfoErr = readComponentInfo(compMntDir, nil, nil)
+		_, readInfoErr = readComponentInfo(compMntDir, nil, csi)
 		if readInfoErr == nil {
 			logger.Debugf("component %q (%v) available at %q",
 				csi.Component, compSetup.Revision(), compMntDir)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -561,7 +561,7 @@ func (m *SnapManager) doSetupKernelModules(t *state.Task, finalStatus state.Stat
 	}
 
 	// kernel-modules components already in the system
-	kmodComps := snapSt.Sequence.ComponentsWithTypeForRev(snapsup.Revision(), snap.KernelModulesComponent)
+	kmodComps := snapSt.Sequence.ComponentsWithTypeForRev(snapSt.Current, snap.KernelModulesComponent)
 
 	// Set-up the new kernel modules component - called with unlocked state
 	// as it can take a couple of seconds.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -595,6 +595,18 @@ func (snapst *SnapState) CurrentComponentInfos() ([]*snap.ComponentInfo, error) 
 	return snapst.ComponentInfosForRevision(snapst.Current)
 }
 
+// CurrentlyHasComponents returns true if the current revision of this snap has
+// any components installed with it. Otherwise, false is returned if either the
+// snap isn't installed or the snap has no components installed with it.
+func (snapst *SnapState) CurrentlyHasComponents() bool {
+	index := snapst.LastIndex(snapst.Current)
+	if index == -1 {
+		return false
+	}
+
+	return len(snapst.Sequence.Revisions[index].Components) > 0
+}
+
 // CurrentComponentInfos return a snap.ComponentInfo slice that contains all of
 // the components for the last appearance of the specified revision. Returns an
 // error if the revision is not found in the sequence of snaps.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3644,7 +3644,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		return nil, err
 	}
 
-	snapsup := &SnapSetup{
+	snapsup := SnapSetup{
 		Base:        info.Base,
 		SideInfo:    snapst.Sequence.SideInfos()[i],
 		Flags:       flags.ForSnapSetup(),
@@ -3654,8 +3654,19 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		InstanceKey: snapst.InstanceKey,
 	}
 
-	// TODO:COMPS: we need to handle components here too
-	return doInstall(st, &snapst, *snapsup, nil, 0, fromChange, nil)
+	components := snapst.Sequence.ComponentsForRevision(rev)
+	compsups := make([]ComponentSetup, 0, len(components))
+	for _, comp := range components {
+		compsups = append(compsups, ComponentSetup{
+			CompSideInfo: comp.SideInfo,
+			CompType:     comp.CompType,
+			componentInstallFlags: componentInstallFlags{
+				SkipProfiles: true,
+			},
+		})
+	}
+
+	return doInstall(st, &snapst, snapsup, compsups, 0, fromChange, nil)
 }
 
 // TransitionCore transitions from an old core snap name to a new core

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -469,6 +469,27 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		addTask(preRefreshHook)
 	}
 
+	var tasksAfterLinkSnap []*state.Task
+	var tasksBeforeCurrentUnlink []*state.Task
+	for _, compsup := range compsups {
+		compTaskSet, err := doInstallComponent(st, snapst, &compsup, &snapsup, fromChange)
+		if err != nil {
+			return nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
+		}
+
+		beforeLink, afterLink, err := componentTasksForInstallWithSnap(compTaskSet)
+		if err != nil {
+			return nil, err
+		}
+
+		tasksBeforeCurrentUnlink = append(tasksBeforeCurrentUnlink, beforeLink...)
+		tasksAfterLinkSnap = append(tasksAfterLinkSnap, afterLink...)
+
+		// TODO:COMPS: once component hooks are fully merged, we will need to
+		// take care to correctly order the tasks that are created for running
+		// component and snap hooks
+	}
+
 	if snapst.IsInstalled() {
 		// unlink-current-snap (will stop services for copy-data)
 		stop := st.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap %q services"), snapsup.InstanceName()))
@@ -479,9 +500,21 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		removeAliases.Set("remove-reason", removeAliasesReasonRefresh)
 		addTask(removeAliases)
 
+		// if we're replacing an already installed snaps, make sure that we do
+		// some of the component tasks, up to unlinking the current components,
+		// before we unlink the current snap. this makes sure that undos happen
+		// in the right order
+		for _, t := range tasksBeforeCurrentUnlink {
+			addTask(t)
+		}
+
 		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), snapsup.InstanceName()))
 		unlink.Set("unlink-reason", unlinkReasonRefresh)
 		addTask(unlink)
+	} else {
+		for _, t := range tasksBeforeCurrentUnlink {
+			addTask(t)
+		}
 	}
 
 	// we need to know some of the characteristics of the device - it is
@@ -519,29 +552,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 	if !snapsup.Flags.Revert {
 		copyData := st.NewTask("copy-snap-data", fmt.Sprintf(i18n.G("Copy snap %q data"), snapsup.InstanceName()))
 		addTask(copyData)
-	}
-
-	tasksAfterLinkSnap := make([]*state.Task, 0, len(compsups))
-	for _, compsup := range compsups {
-		compTaskSet, err := doInstallComponent(st, snapst, &compsup, &snapsup, fromChange)
-		if err != nil {
-			return nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
-		}
-
-		beforeLink, afterLink, err := componentTasksForInstallWithSnap(compTaskSet)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO:COMPS: once component hooks are fully, we will need to take care
-		// to correctly order the tasks that are created for running component
-		// and snap hooks
-
-		for _, t := range beforeLink {
-			addTask(t)
-		}
-
-		tasksAfterLinkSnap = append(tasksAfterLinkSnap, afterLink...)
 	}
 
 	// security

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6300,13 +6300,6 @@ func undoOps(instanceName string, snapRevision, prevRev snap.Revision, component
 		containerName := fmt.Sprintf("%s+%s", instanceName, components[i])
 		filename := fmt.Sprintf("%s_%v.comp", containerName, csi.Revision)
 
-		if forRefresh {
-			ops = append(ops, fakeOp{
-				op:   "link-component",
-				path: snap.ComponentMountDir(components[i], snap.R(i+1), instanceName),
-			})
-		}
-
 		if strings.HasPrefix(components[i], string(snap.KernelModulesComponent)) {
 			ops = append(ops, fakeOp{
 				op:            "remove-kernel-modules-components-setup",

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/store/storetest"
 
 	// So it registers Configure.
 	_ "github.com/snapcore/snapd/overlord/configstate"
@@ -6684,6 +6685,9 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyRemovePaths(c *C) {
 func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, snapName, instanceKey string, compNames []string, undo bool, removePaths bool) {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// make sure that the store is never hit
+	snapstate.ReplaceStore(s.state, &storetest.Store{})
 
 	sort.Strings(compNames)
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -106,6 +106,28 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 			"stop-snap-services",
 			"remove-aliases",
 		)
+	}
+
+	afterLinkSnap := make([]string, 0, len(components))
+	for range components {
+		compOpts := compOptSkipSecurity
+		if opts&localSnap != 0 {
+			compOpts |= compOptIsLocal
+		}
+		if opts&unlinkBefore != 0 {
+			compOpts |= compOptIsActive
+		}
+		compTasks := expectedComponentInstallTasks(compOpts)
+		for i, t := range compTasks {
+			if t == "link-component" {
+				afterLinkSnap = append(afterLinkSnap, compTasks[i:]...)
+				break
+			}
+			expected = append(expected, t)
+		}
+	}
+
+	if opts&unlinkBefore != 0 {
 		expected = append(expected, "unlink-current-snap")
 	}
 	if opts&updatesGadgetAssets != 0 && opts&needsKernelSetup != 0 {
@@ -119,22 +141,6 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 	}
 
 	expected = append(expected, "copy-snap-data")
-
-	afterLinkSnap := make([]string, 0, len(components))
-	for range components {
-		compOpts := compOptSkipSecurity
-		if opts&localSnap != 0 {
-			compOpts |= compOptIsLocal
-		}
-		compTasks := expectedComponentInstallTasks(compOpts)
-		for i, t := range compTasks {
-			if t == "link-component" {
-				afterLinkSnap = append(afterLinkSnap, compTasks[i:]...)
-				break
-			}
-			expected = append(expected, t)
-		}
-	}
 
 	expected = append(expected, "setup-profiles", "link-snap")
 	expected = append(expected, afterLinkSnap...)
@@ -6212,7 +6218,9 @@ func (s *snapmgrTestSuite) TestInstallInstanceManyComponentsUndoRunThrough(c *C)
 	s.testInstallComponentsRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo)
 }
 
-func undoInstallOps(snapName, instanceName string, snapRevision snap.Revision, components []string) []fakeOp {
+func undoOps(instanceName string, snapRevision, prevRev snap.Revision, components []string) []fakeOp {
+	snapName, _ := snap.SplitInstanceName(instanceName)
+
 	snapMount := filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String()))
 	ops := []fakeOp{{
 		op: "update-aliases",
@@ -6222,34 +6230,82 @@ func undoInstallOps(snapName, instanceName string, snapRevision snap.Revision, c
 		revno: snapRevision,
 	}}
 
+	forRefresh := !prevRev.Unset()
+
+	compRev := func(i int) snap.Revision {
+		if forRefresh {
+			return snap.R(i + 2)
+		}
+		return snap.R(i + 1)
+	}
+
 	for i := len(components) - 1; i >= 0; i-- {
 		ops = append(ops, fakeOp{
 			op:   "unlink-component",
-			path: snap.ComponentMountDir(components[i], snap.R(i+1), instanceName),
+			path: snap.ComponentMountDir(components[i], compRev(i), instanceName),
 		})
 	}
 
+	if !forRefresh {
+		ops = append(ops, fakeOp{
+			op:   "discard-namespace",
+			name: instanceName,
+		})
+	}
+
+	oldMount := "<no-old>"
+	oldSaveDir := "<no-old>"
+	if forRefresh {
+		oldMount = filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, prevRev.String()))
+		oldSaveDir = filepath.Join(dirs.SnapDataSaveDir, instanceName)
+	}
+
 	ops = append(ops, []fakeOp{{
-		op:   "discard-namespace",
-		name: instanceName,
-	}, {
 		op:                     "unlink-snap",
 		path:                   snapMount,
-		unlinkFirstInstallUndo: true,
+		unlinkFirstInstallUndo: !forRefresh,
 	}, {
 		op:    "setup-profiles:Undoing",
 		name:  instanceName,
 		revno: snapRevision,
+	}, {
+		op:   "undo-copy-snap-data",
+		path: snapMount,
+		old:  oldMount,
+	}, {
+		op:   "undo-setup-snap-save-data",
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+		old:  oldSaveDir,
 	}}...)
+
+	if !forRefresh {
+		ops = append(ops, fakeOp{
+			op:   "remove-snap-data-dir",
+			name: instanceName,
+			path: filepath.Join(dirs.SnapDataDir, instanceName),
+		})
+	} else {
+		ops = append(ops, fakeOp{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevRev.String()),
+		})
+	}
 
 	for i := len(components) - 1; i >= 0; i-- {
 		csi := &snap.ComponentSideInfo{
 			Component: naming.NewComponentRef(snapName, components[i]),
-			Revision:  snap.R(i + 1),
+			Revision:  compRev(i),
 		}
 
 		containerName := fmt.Sprintf("%s+%s", instanceName, components[i])
 		filename := fmt.Sprintf("%s_%v.comp", containerName, csi.Revision)
+
+		if forRefresh {
+			ops = append(ops, fakeOp{
+				op:   "link-component",
+				path: snap.ComponentMountDir(components[i], snap.R(i+1), instanceName),
+			})
+		}
 
 		if strings.HasPrefix(components[i], string(snap.KernelModulesComponent)) {
 			ops = append(ops, fakeOp{
@@ -6271,18 +6327,6 @@ func undoInstallOps(snapName, instanceName string, snapRevision snap.Revision, c
 	}
 
 	ops = append(ops, []fakeOp{{
-		op:   "undo-copy-snap-data",
-		path: snapMount,
-		old:  "<no-old>",
-	}, {
-		op:   "undo-setup-snap-save-data",
-		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
-		old:  "<no-old>",
-	}, {
-		op:   "remove-snap-data-dir",
-		name: instanceName,
-		path: filepath.Join(dirs.SnapDataDir, instanceName),
-	}, {
 		op:    "undo-setup-snap",
 		name:  instanceName,
 		stype: "app",
@@ -6450,13 +6494,6 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 		name:  instanceName,
 		path:  filepath.Join(dirs.SnapBlobDir, snapFileName),
 		revno: snapRevision,
-	}, {
-		op:   "copy-data",
-		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
-		old:  "<no-old>",
-	}, {
-		op:   "setup-snap-save-data",
-		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
 	}}
 
 	// ops for mounting a component (but not yet linking it)
@@ -6499,6 +6536,13 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 	}
 
 	expected = append(expected, []fakeOp{{
+		op:   "copy-data",
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
+		old:  "<no-old>",
+	}, {
+		op:   "setup-snap-save-data",
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+	}, {
 		op:    "setup-profiles:Doing",
 		name:  instanceName,
 		revno: snapRevision,
@@ -6533,7 +6577,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 	}}...)
 
 	if undo {
-		expected = append(expected, undoInstallOps(snapName, instanceName, snapRevision, components)...)
+		expected = append(expected, undoOps(instanceName, snapRevision, snap.Revision{}, components)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -6755,13 +6799,6 @@ components:
 		name:  instanceName,
 		path:  snapPath,
 		revno: snapRevision,
-	}, {
-		op:   "copy-data",
-		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
-		old:  "<no-old>",
-	}, {
-		op:   "setup-snap-save-data",
-		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
 	}}
 
 	for i, compName := range compNames {
@@ -6786,6 +6823,13 @@ components:
 	}
 
 	expected = append(expected, []fakeOp{{
+		op:   "copy-data",
+		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
+		old:  "<no-old>",
+	}, {
+		op:   "setup-snap-save-data",
+		path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+	}, {
 		op:    "setup-profiles:Doing",
 		name:  instanceName,
 		revno: snapRevision,
@@ -6813,7 +6857,7 @@ components:
 	}}...)
 
 	if undo {
-		expected = append(expected, undoInstallOps(snapName, instanceName, snapRevision, compNames)...)
+		expected = append(expected, undoOps(instanceName, snapRevision, snap.Revision{}, compNames)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14479,3 +14479,272 @@ components:
 		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
 	}
 }
+
+func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
+	const (
+		snapName    = "some-snap"
+		instanceKey = "key"
+		snapID      = "some-snap-id"
+		channel     = "channel-for-components"
+	)
+
+	components := []string{"test-component", "kernel-modules-component"}
+
+	currentSnapRev := snap.R(11)
+	prevSnapRev := snap.R(7)
+	instanceName := snap.InstanceName(snapName, instanceKey)
+
+	sort.Strings(components)
+
+	compNameToType := func(name string) snap.ComponentType {
+		typ, ok := strings.CutSuffix(name, "-component")
+		if !ok {
+			c.Fatalf("unexpected component name %q", name)
+		}
+		return snap.ComponentType(typ)
+	}
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Fatalf("unexpected call to snapResourcesFn")
+		return nil
+	}
+
+	// we start without the auxiliary store info (or with an older one)
+	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
+
+	currentSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: currentSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
+
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// right now, we don't expect to hit the store for this case. we might if we
+	// choose to start checking the store for an updated list of compatible
+	// components.
+	snapstate.ReplaceStore(s.state, &storetest.Store{})
+
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
+	prevSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&prevSI, &currentSI})
+
+	for i, comp := range components {
+		err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+			SideInfo: &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 1),
+			},
+			CompType: compNameToType(comp),
+		})
+		c.Assert(err, IsNil)
+
+		err = seq.AddComponentForRevision(currentSnapRev, &sequence.ComponentState{
+			SideInfo: &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 2),
+			},
+			CompType: compNameToType(comp),
+		})
+		c.Assert(err, IsNil)
+	}
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         csi.Component,
+			Type:              compNameToType(csi.Component.ComponentName),
+			Version:           "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        seq,
+		Current:         currentSI.Revision,
+		SnapType:        "app",
+		TrackingChannel: channel,
+		InstanceKey:     instanceKey,
+	})
+
+	ts, err := snapstate.Update(s.state, instanceName, &snapstate.RevisionOptions{
+		Revision: prevSnapRev,
+	}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	chg.AddAll(ts)
+
+	// check unlink-reason
+	unlinkTask := findLastTask(chg, "unlink-current-snap")
+	c.Assert(unlinkTask, NotNil)
+	var unlinkReason string
+	unlinkTask.Get("unlink-reason", &unlinkReason)
+	c.Check(unlinkReason, Equals, "refresh")
+
+	// local modifications, edge must be set
+	te := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(te, NotNil)
+	c.Assert(te.Kind(), Equals, "prepare-snap")
+
+	s.settle(c)
+
+	c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: instanceName,
+		},
+	}
+
+	for i, compName := range components {
+		csi := snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(i + 1),
+		}
+
+		if strings.HasPrefix(compName, string(snap.KernelModulesComponent)) {
+			expected = append(expected, fakeOp{
+				op: "setup-kernel-modules-components",
+				currentComps: []*snap.ComponentSideInfo{{
+					Component: csi.Component,
+					Revision:  snap.R(i + 2),
+				}},
+				compsToInstall: []*snap.ComponentSideInfo{{
+					Component: naming.NewComponentRef(snapName, compName),
+					Revision:  csi.Revision,
+				}},
+			})
+		}
+	}
+
+	expected = append(expected, fakeOps{
+		{
+			op:          "run-inhibit-snap-for-unlink",
+			name:        instanceName,
+			inhibitHint: "refresh",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "copy-data",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "setup-snap-save-data",
+			path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+		},
+	}...)
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "setup-profiles:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "candidate",
+			sinfo: snap.SideInfo{
+				RealName: snapName,
+				SnapID:   snapID,
+				Channel:  channel,
+				Revision: prevSnapRev,
+			},
+		},
+		{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+		},
+	}...)
+
+	for i, compName := range components {
+		expected = append(expected, fakeOp{
+			op:   "link-component",
+			path: snap.ComponentMountDir(compName, snap.R(i+1), instanceName),
+		})
+	}
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "auto-connect:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "update-aliases",
+		},
+		{
+			op:    "cleanup-trash",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+	}...)
+
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	task := ts.Tasks()[1]
+
+	// verify snapSetup info
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel: channel,
+		UserID:  s.user.ID,
+
+		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		Version:   "some-snapVer",
+		PlugsOnly: true,
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+		InstanceKey: instanceKey,
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		Channel:  channel,
+		SnapID:   snapID,
+	})
+
+	// verify snaps in the system state
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, instanceName, &snapst)
+	c.Assert(err, IsNil)
+
+	c.Assert(snapst.LastRefreshTime, NotNil)
+	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+
+	// link-snap should put the revision we refreshed to at the end of the
+	// sequence. in this case, swapping their positions.
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, seq.Revisions[0])
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[1])
+}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -13915,8 +13915,11 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, instanceKey 
 
 		if strings.HasPrefix(compName, string(snap.KernelModulesComponent)) {
 			expected = append(expected, fakeOp{
-				op:           "setup-kernel-modules-components",
-				currentComps: []*snap.ComponentSideInfo{},
+				op: "setup-kernel-modules-components",
+				currentComps: []*snap.ComponentSideInfo{{
+					Component: csi.Component,
+					Revision:  snap.R(i + 1),
+				}},
 				compsToInstall: []*snap.ComponentSideInfo{{
 					Component: naming.NewComponentRef(snapName, compName),
 					Revision:  csi.Revision,
@@ -14317,8 +14320,11 @@ components:
 
 		if strings.HasPrefix(compName, string(snap.KernelModulesComponent)) {
 			expected = append(expected, fakeOp{
-				op:           "setup-kernel-modules-components",
-				currentComps: []*snap.ComponentSideInfo{},
+				op: "setup-kernel-modules-components",
+				currentComps: []*snap.ComponentSideInfo{{
+					Component: csi.Component,
+					Revision:  snap.R(i + 1),
+				}},
 				compsToInstall: []*snap.ComponentSideInfo{{
 					Component: naming.NewComponentRef(snapName, compName),
 					Revision:  csi.Revision,

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -718,7 +718,23 @@ func storeUpdatePlan(
 			return updatePlan{}, err
 		}
 
-		// TODO:COMPS: handle components here
+		// TODO:COMPS: for now, go back to the components that were already
+		// installed with this revision. to be more robust, we'd need to compare
+		// what components are installed with the revision that we are
+		// refreshing from to the components available in the store for the
+		// revision that we are refreshing to.
+		compInfos, err := snapst.ComponentInfosForRevision(si.Revision)
+		if err != nil {
+			return updatePlan{}, err
+		}
+
+		components := make([]ComponentSetup, 0, len(compInfos))
+		for _, compInfo := range compInfos {
+			components = append(components, ComponentSetup{
+				CompSideInfo: &compInfo.ComponentSideInfo,
+				CompType:     compInfo.Type,
+			})
+		}
 
 		// make sure that we switch the current channel of the snap that we're
 		// switching to
@@ -738,7 +754,7 @@ func storeUpdatePlan(
 				// installed
 				AlwaysUpdate: !revOpts.Revision.Unset(),
 			},
-			components: nil,
+			components: components,
 		})
 	}
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -691,12 +691,20 @@ func storeUpdatePlan(
 			return updatePlan{}, fmt.Errorf("cannot extract components from snap resources: %w", err)
 		}
 
+		// if we still have no channel here, this means that we refreshed
+		// by-revision without specifying a channel. make sure we continue to
+		// track the channel that the snap is currently on
+		channel := up.RevOpts.Channel
+		if channel == "" {
+			channel = snapst.TrackingChannel
+		}
+
 		plan.targets = append(plan.targets, target{
 			info:   sar.Info,
 			snapst: *snapst,
 			setup: SnapSetup{
 				DownloadInfo: &sar.DownloadInfo,
-				Channel:      up.RevOpts.Channel,
+				Channel:      channel,
 				CohortKey:    up.RevOpts.CohortKey,
 			},
 			components: compTargets,
@@ -736,15 +744,20 @@ func storeUpdatePlan(
 			})
 		}
 
+		channel := revOpts.Channel
+		if channel == "" {
+			channel = snapst.TrackingChannel
+		}
+
 		// make sure that we switch the current channel of the snap that we're
 		// switching to
-		info.Channel = revOpts.Channel
+		info.Channel = channel
 
 		plan.targets = append(plan.targets, target{
 			info:   info,
 			snapst: *snapst,
 			setup: SnapSetup{
-				Channel:   revOpts.Channel,
+				Channel:   channel,
 				CohortKey: revOpts.CohortKey,
 				SnapPath:  info.MountFile(),
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -241,9 +241,6 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 	}
 
 	enforcedSetsFunc := cachedEnforcedValidationSets(st)
-	if err != nil {
-		return nil, err
-	}
 
 	includeResources := false
 	actions := make([]*store.SnapAction, 0, len(s.snaps))

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1162,10 +1162,6 @@ func (p *pathUpdateGoal) toUpdate(_ context.Context, st *state.State, opts Optio
 			return updatePlan{}, err
 		}
 
-		// TODO:COMPS: remove this once we are ready to handle components during
-		// refresh
-		t.components = nil
-
 		targets = append(targets, t)
 		names = append(names, sn.InstanceName)
 	}

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1098,10 +1098,16 @@ func validateAndInitStoreUpdates(allSnaps map[string]*SnapState, updates map[str
 			sn.RevOpts.CohortKey = snapst.CohortKey
 		}
 
-		var err error
-		sn.RevOpts.Channel, err = resolveChannel(sn.InstanceName, snapst.TrackingChannel, sn.RevOpts.Channel, opts.DeviceCtx)
-		if err != nil {
-			return err
+		// if either the revision is not set (which means this is just a normal
+		// refresh), or the channel is set, then we need to resolve the channel
+		// to something. if the revison is set and the channel is not set, then
+		// we shouldn't do anything with the channel
+		if sn.RevOpts.Revision.Unset() || sn.RevOpts.Channel != "" {
+			var err error
+			sn.RevOpts.Channel, err = resolveChannel(sn.InstanceName, snapst.TrackingChannel, sn.RevOpts.Channel, opts.DeviceCtx)
+			if err != nil {
+				return err
+			}
 		}
 
 		updates[sn.InstanceName] = sn

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -222,7 +222,7 @@ func validateRevisionOpts(opts *RevisionOptions) error {
 	return nil
 }
 
-var ErrExpectedOneSnap = errors.New("expected exactly one snap to install")
+var ErrExpectedOneSnap = errors.New("expected exactly one snap to install/update")
 
 // toInstall returns the data needed to setup the snaps from the store for
 // installation.

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -28,7 +28,7 @@ func (s *targetTestSuite) TestInstallWithComponents(c *C) {
 	defer s.state.Unlock()
 
 	const (
-		snapName = "test-snap"
+		snapName = "some-snap"
 		compName = "test-component"
 		channel  = "channel-for-components"
 	)
@@ -72,7 +72,7 @@ func (s *targetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
 	defer s.state.Unlock()
 
 	const (
-		snapName = "test-snap"
+		snapName = "some-snap"
 		compName = "test-component"
 		channel  = "channel-for-components"
 	)
@@ -110,7 +110,7 @@ func (s *targetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 	defer s.state.Unlock()
 
 	const (
-		snapName = "test-snap"
+		snapName = "some-snap"
 		compName = "test-component"
 		channel  = "channel-for-components"
 	)
@@ -150,7 +150,7 @@ func (s *targetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	defer s.state.Unlock()
 
 	const (
-		snapName = "test-snap"
+		snapName = "some-snap"
 		compName = "test-missing-component"
 		channel  = "channel-for-components"
 	)
@@ -188,10 +188,10 @@ func (s *targetTestSuite) TestInstallWithComponentsFromPath(c *C) {
 	defer s.state.Unlock()
 
 	const (
-		snapName = "test-snap"
-		snapID   = "test-snap-id"
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
 		compName = "test-component"
-		snapYaml = `name: test-snap
+		snapYaml = `name: some-snap
 version: 1.0
 components:
   test-component:
@@ -199,7 +199,7 @@ components:
   kernel-modules-component:
     type: kernel-modules
 `
-		componentYaml = `component: test-snap+test-component
+		componentYaml = `component: some-snap+test-component
 type: test
 version: 1.0
 `

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -3,8 +3,13 @@ package snapstate_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -12,13 +17,13 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type TargetTestSuite struct {
+type targetTestSuite struct {
 	snapmgrBaseTest
 }
 
-var _ = Suite(&TargetTestSuite{})
+var _ = Suite(&targetTestSuite{})
 
-func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
+func (s *targetTestSuite) TestInstallWithComponents(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -62,7 +67,7 @@ func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
 	verifyInstallTasksWithComponents(c, snap.TypeApp, 0, 0, []string{compName}, ts)
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -100,7 +105,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot find component "%s" in snap resources`, compName))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -140,7 +145,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 	))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -178,7 +183,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsFromPath(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsFromPath(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -227,7 +232,7 @@ version: 1.0
 	verifyInstallTasksWithComponents(c, snap.TypeApp, localSnap, 0, []string{compName}, ts)
 }
 
-func (s *TargetTestSuite) TestUpdateSnapNotInstalled(c *C) {
+func (s *targetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -242,7 +247,7 @@ func (s *TargetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" is not installed`)
 }
 
-func (s *TargetTestSuite) TestInvalidPathGoals(c *C) {
+func (s *targetTestSuite) TestInvalidPathGoals(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -300,4 +305,449 @@ func (s *TargetTestSuite) TestInvalidPathGoals(c *C) {
 		_, _, err = snapstate.InstallOne(context.Background(), s.state, install, snapstate.Options{})
 		c.Check(err, ErrorMatches, t.err)
 	}
+}
+
+func (s *targetTestSuite) TestInstallComponentsFromPathInvalidComponentFile(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		snapID        = "some-snap-id"
+		snapName      = "some-snap"
+		componentName = "test-component"
+	)
+	snapRevision := snap.R(11)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, componentName),
+		Revision:  snap.R(1),
+	}
+
+	compPath := filepath.Join(c.MkDir(), "invalid-component")
+	err := os.WriteFile(compPath, []byte("invalid-component"), 0644)
+	c.Assert(err, IsNil)
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: compPath,
+	}
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+	_, _, err = snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
+}
+
+func (s *targetTestSuite) TestInstallComponentsFromPathInvalidComponentName(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		snapID        = "some-snap-id"
+		snapName      = "some-snap"
+		componentName = "Bad-component"
+	)
+	snapRevision := snap.R(11)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, componentName),
+		Revision:  snap.R(1),
+	}
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: "",
+	}
+
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid snap name: "%s"`, componentName))
+}
+
+func (s *targetTestSuite) TestUpdateComponents(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         naming.NewComponentRef(info.SnapName(), compName),
+			Type:              snap.TestComponent,
+			Version:           "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: channel,
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      compName,
+				Revision:  2,
+				Type:      fmt.Sprintf("component/%s", snap.TestComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: snapName,
+	})
+
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	verifyUpdateTasksWithComponents(c, snap.TypeApp, doesReRefresh, 0, []string{compName}, ts)
+}
+
+func (s *targetTestSuite) TestUpdateComponentsFromPath(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "test-component"
+		channel  = "channel-for-components"
+		snapYaml = `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+epoch: 1
+`
+		componentYaml = `component: some-snap+test-component
+type: test
+version: 1.0
+`
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: channel,
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(9),
+	}
+	snapPath := makeTestSnap(c, snapYaml)
+
+	csi := &snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, compName),
+		Revision:  snap.R(2),
+	}
+	components := map[*snap.ComponentSideInfo]string{
+		csi: snaptest.MakeTestComponent(c, componentYaml),
+	}
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+		Components:   components,
+	})
+
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	verifyUpdateTasksWithComponents(c, snap.TypeApp, doesReRefresh|localSnap, 0, []string{compName}, ts)
+}
+
+func (s *targetTestSuite) TestUpdateComponentsFromPathInvalidComponentFile(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "test-component"
+		channel  = "channel-for-components"
+		snapYaml = `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+epoch: 1
+`
+		componentYaml = `component: some-snap+test-component
+type: test
+version: 1.0
+`
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: channel,
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(9),
+	}
+	snapPath := makeTestSnap(c, snapYaml)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, compName),
+		Revision:  snap.R(2),
+	}
+
+	compPath := filepath.Join(c.MkDir(), "invalid-component")
+	err := os.WriteFile(compPath, []byte("invalid-component"), 0644)
+	c.Assert(err, IsNil)
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: compPath,
+	}
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+		Components:   components,
+	})
+
+	_, err = snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
+}
+
+func (s *targetTestSuite) TestUpdateComponentsFromPathInvalidComponentName(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "test-component"
+		snapYaml = `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+epoch: 1
+`
+		componentYaml = `component: some-snap+test-component
+type: test
+version: 1.0
+`
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:   true,
+		Sequence: seq,
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(9),
+	}
+	snapPath := makeTestSnap(c, snapYaml)
+
+	badName := "Bad-component"
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, badName),
+		Revision:  snap.R(2),
+	}
+
+	compPath := filepath.Join(c.MkDir(), "invalid-component")
+	err := os.WriteFile(compPath, []byte("invalid-component"), 0644)
+	c.Assert(err, IsNil)
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: compPath,
+	}
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+		Components:   components,
+	})
+
+	_, err = snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid snap name: "%s"`, badName))
+}
+
+func (s *targetTestSuite) TestUpdateComponentsFromPathInvalidMissingInInfo(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "other-component"
+		snapYaml = `name: some-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+epoch: 1
+`
+		componentYaml = `component: some-snap+other-component
+type: test
+version: 1.0
+`
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:   true,
+		Sequence: seq,
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(9),
+	}
+	snapPath := makeTestSnap(c, snapYaml)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, compName),
+		Revision:  snap.R(2),
+	}
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: snaptest.MakeTestComponent(c, componentYaml),
+	}
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+		Components:   components,
+	})
+
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
 }


### PR DESCRIPTION
This allows us to refresh components and snaps from the store at the same time.