### PR TITLE
cmd/snap: allow normal snap --version on WSL 2

### DIFF
--- a/cmd/snap/cmd_version_linux.go
+++ b/cmd/snap/cmd_version_linux.go
@@ -30,7 +30,7 @@ import (
 )
 
 func serverVersion(cli *client.Client) *client.ServerVersion {
-	if release.OnWSL {
+	if release.OnWSL && release.WSLVersion == 1 {
 		return &client.ServerVersion{
 			Version:       i18n.G("unavailable"),
 			Series:        release.Series,

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -26,7 +26,9 @@ import (
 	. "gopkg.in/check.v1"
 
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
@@ -72,4 +74,45 @@ func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
 	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestVersionCommandOnWSL1(c *C) {
+	defer MockWSL(1)()
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Error("This should not talk to snapd")
+	})
+	defer mockArgs("snap", "version")()
+	defer snapdtool.MockVersion("4.56")()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), testutil.Contains, "unavailable\n")
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestVersionCommandOnWSL2(c *C) {
+	defer MockWSL(2)()
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89","architecture":"ia64"}}`)
+	})
+	defer mockArgs("snap", "version")()
+	defer snapdtool.MockVersion("4.56")()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Not(testutil.Contains), "unavailable\n")
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func MockWSL(version int) (restore func()) {
+	oldVersion := release.WSLVersion
+	oldFlag := release.OnWSL
+
+	release.OnWSL = true
+	release.WSLVersion = version
+
+	return func() {
+		release.WSLVersion = oldVersion
+		release.OnWSL = oldFlag
+	}
 }


### PR DESCRIPTION
Commit 1adae138ee8c489f959a29fc0ee349d697409bfb ("sanity: refuse to try to do things on WSL.") disabled snap version from attempting to talk to snapd whenever WSL was detected, as WSL 1 didn't support enough of the Linux features for snapd to meaningfully operate. Ever since WSL 2 was released, this is now significantly different, with almost all of the features working out of the box.

Adjust the condition to look for WSL 1 specifically and add missing tests checking both WSL 1 and WSL 2 behavior.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-23939
