### PR TITLE
interfaces: simplify checks for polkit actions

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -134,17 +134,14 @@ func MockDirsToEnsure(fn func(paths []string) ([]*interfaces.EnsureDirSpec, erro
 	return restore
 }
 
-func MockPolkitPaths(actionsDir, daemonPath1, daemonPath2 string) (restore func()) {
-	oldActionsDir := polkitActionsDir
+func MockPolkitDaemonPaths(path1, path2 string) (restore func()) {
 	oldDaemonPath1 := polkitDaemonPath1
 	oldDaemonPath2 := polkitDaemonPath2
 
-	polkitActionsDir = actionsDir
-	polkitDaemonPath1 = daemonPath1
-	polkitDaemonPath2 = daemonPath2
+	polkitDaemonPath1 = path1
+	polkitDaemonPath2 = path2
 
 	return func() {
-		polkitActionsDir = oldActionsDir
 		polkitDaemonPath1 = oldDaemonPath1
 		polkitDaemonPath2 = oldDaemonPath2
 	}

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -37,7 +37,6 @@ var (
 	AareExclusivePatterns       = aareExclusivePatterns
 	GetDesktopFileRules         = getDesktopFileRules
 	StringListAttribute         = stringListAttribute
-	IsPathMountedWritable       = isPathMountedWritable
 	PolkitPoliciesSupported     = polkitPoliciesSupported
 )
 
@@ -135,17 +134,17 @@ func MockDirsToEnsure(fn func(paths []string) ([]*interfaces.EnsureDirSpec, erro
 	return restore
 }
 
-func MockPolkitPaths(procSelfMounts, daemonPath1, daemonPath2 string) (restore func()) {
-	oldProcSelfMounts := polkitProcSelfMounts
+func MockPolkitPaths(actionsDir, daemonPath1, daemonPath2 string) (restore func()) {
+	oldActionsDir := polkitActionsDir
 	oldDaemonPath1 := polkitDaemonPath1
 	oldDaemonPath2 := polkitDaemonPath2
 
-	polkitProcSelfMounts = procSelfMounts
+	polkitActionsDir = actionsDir
 	polkitDaemonPath1 = daemonPath1
 	polkitDaemonPath2 = daemonPath2
 
 	return func() {
-		polkitProcSelfMounts = oldProcSelfMounts
+		polkitActionsDir = oldActionsDir
 		polkitDaemonPath1 = oldDaemonPath1
 		polkitDaemonPath2 = oldDaemonPath2
 	}

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -23,9 +23,9 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/polkit"
@@ -149,36 +149,13 @@ func (iface *polkitInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	return err
 }
 
-func isPathMountedWritable(mntProfile *osutil.MountProfile, fsPath string) bool {
-	mntMap := make(map[string]*osutil.MountEntry, len(mntProfile.Entries))
-	for i := range mntProfile.Entries {
-		mnt := &mntProfile.Entries[i]
-		mntMap[mnt.Dir] = mnt
-	}
-
-	// go backwards in path until we hit a match
-	currentPath := fsPath
-	for {
-		if mnt, ok := mntMap[currentPath]; ok {
-			return mnt.OptBool("rw")
-		}
-
-		// Make sure we terminate on the last path token
-		if currentPath == "/" || !strings.Contains(currentPath, "/") {
-			break
-		}
-		currentPath = path.Dir(currentPath)
-	}
-	return false
-}
-
 var (
-	// polkitProcSelfMounts is the path of /proc/self/mounts as used by polkit interface.
-	polkitProcSelfMounts = "/proc/self/mounts"
 	// polkitDaemonPath1 is the path of polkitd on core<24.
 	polkitDaemonPath1 = "/usr/libexec/polkitd"
 	// polkitDaemonPath2 is the path of polkid on core>=24.
 	polkitDaemonPath2 = "/usr/lib/polkit-1/polkitd"
+	// polkitActionsDir is the path of polkit action definitions.
+	polkitActionsDir = "/usr/share/polkit-1/actions"
 )
 
 // hasPolkitDaemonExecutable checks known paths on core for the presence of
@@ -188,22 +165,15 @@ func hasPolkitDaemonExecutable() bool {
 	return osutil.IsExecutable(polkitDaemonPath1) || osutil.IsExecutable(polkitDaemonPath2)
 }
 
+func canWriteToPolkitActionsDir() bool {
+	const W_OK = 2
+	return syscall.Access(polkitActionsDir, W_OK) == nil
+}
+
 func polkitPoliciesSupported() bool {
-	// We must have the polkit daemon present on the system
-	if !hasPolkitDaemonExecutable() {
-		return false
-	}
-
-	mntProfile, err := osutil.LoadMountProfile(polkitProcSelfMounts)
-	if err != nil {
-		// XXX: we are called from init() what can we do here?
-		return false
-	}
-
-	// For core22+ polkitd is present, but it's not possible to install
-	// any policy files, as polkit only checks /usr/share/polkit-1/actions,
-	// which is readonly on core.
-	return isPathMountedWritable(mntProfile, "/usr/share/polkit-1/actions")
+	// We must have the polkit daemon present on the system and be able to write
+	// to the polkit actions directory.
+	return hasPolkitDaemonExecutable() && canWriteToPolkitActionsDir()
 }
 
 func (iface *polkitInterface) StaticInfo() interfaces.StaticInfo {

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/polkit"
 	"github.com/snapcore/snapd/osutil"
@@ -154,8 +155,6 @@ var (
 	polkitDaemonPath1 = "/usr/libexec/polkitd"
 	// polkitDaemonPath2 is the path of polkid on core>=24.
 	polkitDaemonPath2 = "/usr/lib/polkit-1/polkitd"
-	// polkitActionsDir is the path of polkit action definitions.
-	polkitActionsDir = "/usr/share/polkit-1/actions"
 )
 
 // hasPolkitDaemonExecutable checks known paths on core for the presence of
@@ -166,7 +165,7 @@ func hasPolkitDaemonExecutable() bool {
 }
 
 func canWriteToPolkitActionsDir() bool {
-	return unix.Access(polkitActionsDir, unix.W_OK) == nil
+	return unix.Access(dirs.SnapPolkitPolicyDir, unix.W_OK) == nil
 }
 
 func polkitPoliciesSupported() bool {

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -25,13 +25,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/polkit"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/polkit/validate"
 	"github.com/snapcore/snapd/snap"
+	"golang.org/x/sys/unix"
 )
 
 const polkitSummary = `allows access to polkitd to check authorisation`
@@ -166,8 +166,7 @@ func hasPolkitDaemonExecutable() bool {
 }
 
 func canWriteToPolkitActionsDir() bool {
-	const W_OK = 2
-	return syscall.Access(polkitActionsDir, W_OK) == nil
+	return unix.Access(polkitActionsDir, unix.W_OK) == nil
 }
 
 func polkitPoliciesSupported() bool {

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/polkit"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -46,10 +45,10 @@ type polkitInterfaceSuite struct {
 	plug     *interfaces.ConnectedPlug
 	plugInfo *snap.PlugInfo
 
-	procSelfMounts string
-	daemonPath1    string
-	daemonPath2    string
-	restorePaths   func()
+	actionsDir   string
+	daemonPath1  string
+	daemonPath2  string
+	restorePaths func()
 }
 
 var _ = Suite(&polkitInterfaceSuite{
@@ -59,10 +58,13 @@ var _ = Suite(&polkitInterfaceSuite{
 func (s *polkitInterfaceSuite) SetUpSuite(c *C) {
 	mockedPolkitBase := c.MkDir()
 
-	s.procSelfMounts = filepath.Join(mockedPolkitBase, "proc-self-mounts")
+	s.actionsDir = filepath.Join(mockedPolkitBase, "actions")
 	s.daemonPath1 = filepath.Join(mockedPolkitBase, "polkitd-1")
 	s.daemonPath2 = filepath.Join(mockedPolkitBase, "polkitd-2")
-	s.restorePaths = builtin.MockPolkitPaths(s.procSelfMounts, s.daemonPath1, s.daemonPath2)
+	s.restorePaths = builtin.MockPolkitPaths(s.actionsDir, s.daemonPath1, s.daemonPath2)
+
+	// We make the directory once and only adjust permissions.
+	c.Assert(os.Mkdir(s.actionsDir, 0o700), IsNil)
 }
 
 func (s *polkitInterfaceSuite) TearDownSuite(c *C) {
@@ -97,7 +99,7 @@ slots:
 	s.slot, s.slotInfo = MockConnectedSlot(c, mockSlotSnapInfoYaml, nil, "polkit")
 	s.plug, s.plugInfo = MockConnectedPlug(c, mockPlugSnapInfoYaml, nil, "polkit")
 
-	c.Assert(os.WriteFile(s.procSelfMounts, nil, 0o600), IsNil)
+	c.Assert(os.Chmod(s.actionsDir, 0o700), IsNil)
 	c.Assert(os.WriteFile(s.daemonPath1, nil, 0o600), IsNil)
 	c.Assert(os.WriteFile(s.daemonPath2, nil, 0o600), IsNil)
 }
@@ -291,15 +293,9 @@ slots:
 	c.Assert(err, ErrorMatches, `snap "other" has interface "polkit" with invalid value type bool for "action-prefix" attribute: \*string`)
 }
 
-func (s *polkitInterfaceSuite) isProfilePathAccessible(c *C) bool {
-	mntProfile, err := osutil.LoadMountProfile("/proc/self/mounts")
-	c.Assert(err, IsNil)
-	return builtin.IsPathMountedWritable(mntProfile, "/usr/share/polkit-1/actions")
-}
-
 func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Check(si.ImplicitOnCore, Equals, false) // This is really tested in TestPolkitPoliciesSupported.
+	// ImplicitOnCore is only tested in TestPolkitPoliciesSupported.
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.Summary, Equals, "allows access to polkitd to check authorisation")
 	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")
@@ -307,13 +303,8 @@ func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *polkitInterfaceSuite) TestPolkitPoliciesSupported(c *C) {
-	const (
-		procSelfMountsRoPolkitActions = `/usr/share/polkit-1/actions /usr/share/polkit-1/actions none ro,bind 0 0`
-		procSelfMountsRwPolkitActions = `/usr/share/polkit-1/actions /usr/share/polkit-1/actions none rw,bind 0 0`
-	)
-
-	// From now on the actions directory is a read-write mount so daemon permissions matter.
-	c.Assert(os.WriteFile(s.procSelfMounts, []byte(procSelfMountsRwPolkitActions), 0o600), IsNil)
+	// From now the actions directory is writable so daemon permissions matter.
+	c.Assert(os.Chmod(s.actionsDir, 0o700), IsNil)
 
 	// Neither daemon is executable so polkit policies are not supported.
 	c.Assert(os.Chmod(s.daemonPath1, 0o600), IsNil)
@@ -334,100 +325,15 @@ func (s *polkitInterfaceSuite) TestPolkitPoliciesSupported(c *C) {
 	c.Assert(os.Chmod(s.daemonPath1, 0o700), IsNil)
 	c.Assert(os.Chmod(s.daemonPath2, 0o700), IsNil)
 
-	// Actions directory is a read-only mount so polkit policies are not supported.
-	c.Assert(os.WriteFile(s.procSelfMounts, []byte(procSelfMountsRoPolkitActions), 0o600), IsNil)
+	// Actions directory is not writable so polkit policies are not supported.
+	c.Assert(os.Chmod(s.actionsDir, 0o500), IsNil)
 	c.Check(builtin.PolkitPoliciesSupported(), Equals, false)
 
-	// Actions directory is a read-write mount so polkit policies are not supported.
-	c.Assert(os.WriteFile(s.procSelfMounts, []byte(procSelfMountsRwPolkitActions), 0o600), IsNil)
+	// Actions directory is writable so polkit policies are not supported.
+	c.Assert(os.Chmod(s.actionsDir, 0o700), IsNil)
 	c.Check(builtin.PolkitPoliciesSupported(), Equals, true)
 }
 
 func (s *polkitInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
-}
-
-func (s *polkitInterfaceSuite) TestIsPathMountedWritable(c *C) {
-
-	tests := []struct {
-		mounts   string
-		path     string
-		expected bool
-	}{
-		// Test a base case where root is ro
-		{
-			`rpool/ROOT/ubuntu / zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			false,
-		},
-
-		// Test a base case where root is rw
-		{
-			`rpool/ROOT/ubuntu / zfs rw,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			true,
-		},
-
-		// Test a case where the root is mounted rw, but /usr/share is ro
-		{
-			`rpool/ROOT/ubuntu / zfs rw,relatime,xattr,posixacl,casesensitive 0 0
-rpool/ROOT/ubuntu/usr/share /usr/share zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			false,
-		},
-
-		// Test a case where the root is mounted ro, but /usr/share is rw
-		{
-			`rpool/ROOT/ubuntu / zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-rpool/ROOT/ubuntu/usr/share /usr/share zfs rw,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			true,
-		},
-
-		// Test a case where the root is mounted rw, but the path specifically being ro
-		{
-			`rpool/ROOT/ubuntu / zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-rpool/ROOT/ubuntu/usr/share/polkit-1/actions /usr/share/polkit-1/actions zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			false,
-		},
-
-		// Test a case where the path string ends on '/', so we know it's handled
-		{
-			`rpool/ROOT/ubuntu / zfs ro,relatime,xattr,posixacl,casesensitive 0 0
-rpool/ROOT/ubuntu/usr/share /usr/share zfs rw,relatime,xattr,posixacl,casesensitive 0 0
-`,
-			"/usr/share/",
-			true,
-		},
-		// Test an more real example
-		{
-			`/dev/sda3 /run/mnt/ubuntu-boot ext4 rw,relatime 0 0
-/dev/sda2 /run/mnt/ubuntu-seed vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro[7m>[27m
-/dev/sda5 /run/mnt/data ext4 rw,nosuid,relatime 0 0
-/dev/sda4 /run/mnt/ubuntu-save ext4 rw,relatime,stripe=4 0 0
-/dev/loop0 /run/mnt/base squashfs ro,relatime,errors=continue 0 0
-/dev/loop1 /run/mnt/gadget squashfs ro,relatime,errors=continue 0 0
-/dev/loop2 /run/mnt/kernel squashfs ro,relatime,errors=continue 0 0
-/dev/loop3 /run/mnt/snapd squashfs ro,relatime,errors=continue 0 0
-/dev/loop0 / squashfs ro,relatime,errors=continue 0 0
-/dev/loop5 /snap/test-snapd-rsync-core22/1 squashfs ro,nodev,relatime,errors=continue 0 0
-/dev/loop6 /snap/jq-core22/1 squashfs ro,nodev,relatime,errors=continue 0 0
-nsfs /run/snapd/ns/jq-core22.mnt nsfs rw 0 0
-`,
-			"/usr/share/polkit-1/actions",
-			false,
-		},
-	}
-
-	for _, t := range tests {
-		mntProfile, err := osutil.LoadMountProfileText(t.mounts)
-		c.Assert(err, IsNil)
-		c.Check(builtin.IsPathMountedWritable(mntProfile, t.path), Equals, t.expected)
-	}
 }


### PR DESCRIPTION
We used to parse the mount table, which is fragile and complex. Instead we can
just use access(2) to ask the kernel for a simple yes-or-no answer.
    
Thanks to James Henstridge (@jhenstridge) for the suggestion.

This is stacked on top of https://github.com/snapcore/snapd/pull/14184 for convenience.