### PR TITLE
tests: remove "Uploading TICS logs" step from static check

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -93,9 +93,3 @@ jobs:
 
         TICSQServer -project snapd -tmpdir /tmp/tics -branchdir "${{ github.workspace }}/src/github.com/snapcore/snapd"
         tar -cvzf tics-logs.tar.gz /tmp/tics
-
-    - name: Uploading TICS logs
-      uses: actions/upload-artifact@v4
-      with:
-        name: tics-logs.tar.gz
-        path: tics-logs.tar.gz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -92,4 +92,3 @@ jobs:
         . ./install_tics.sh
 
         TICSQServer -project snapd -tmpdir /tmp/tics -branchdir "${{ github.workspace }}/src/github.com/snapcore/snapd"
-        tar -cvzf tics-logs.tar.gz /tmp/tics


### PR DESCRIPTION
This was requested by tiobe.
