### PR TITLE
interfaces: adjust steam to allow all apparmor permissions

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -674,6 +674,11 @@ func probeParserFeatures() ([]string, error) {
 			minVer:  "4.0.1",
 		},
 		{
+			feature: "all",
+			probe:   "allow all,",
+			minVer:  "4.0.2",
+		},
+		{
 			feature: "cap-bpf",
 			probe:   "capability bpf,",
 		},


### PR DESCRIPTION
This is implemented by @jrjohansen but I will garden tests and ensure it can land.

Technically the feature works as is today but can benefit from AppArmor 4.0.2 (unreleased). We will most likely want to add https://github.com/snapcore/snapd/pull/14167 to ensure that we can use apparmor from the host to the full extent and to create a new PR updating bundled apparmor (inside snapd snap) once a release is available upstream.