### PR TITLE
tests: new script used to build snapd and run tests from localhost

### DIFF
--- a/run-spread
+++ b/run-spread
@@ -19,5 +19,4 @@ for snap in built-snap/snapd_1337.*.snap; do
 done
 
 # Run spread
-#shellcheck disable=SC2068
-spread $@
+spread "$@"

--- a/run-spread
+++ b/run-spread
@@ -7,9 +7,10 @@ if ! snap list snapcraft &>/dev/null; then
 fi
 
 # Clean the snaps created in previous runs
+rm -rf built-snap test-build
 touch test-build
-rm -rf built-snap
 mkdir built-snap
+
 rm -f snapd_1337.*.snap 
 rm -f snapd_1337.*.snap.keep
 

--- a/run-spread
+++ b/run-spread
@@ -10,13 +10,16 @@ fi
 touch test-build
 rm -rf built-snap
 mkdir built-snap
-rm -f snapd_1337.*.snap snapd_1337.*.snap.keep
+rm -f snapd_1337.*.snap 
+rm -f snapd_1337.*.snap.keep
 
 # Build snapd snap
 snapcraft --use-lxd
 for snap in built-snap/snapd_1337.*.snap; do
     mv "${snap}" "${snap}.keep"
 done
+
+export TESTS_USE_PREBUILT_SNAPD_SNAP=true
 
 # Run spread
 spread "$@"

--- a/run-spread
+++ b/run-spread
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# check dependencies
+if ! snap list snapcraft &>/dev/null; then
+    echo "snapcraft is not installed"
+    exit 1
+fi
+
+# Clean the snaps created in previous runs
+touch test-build
+rm -rf built-snap
+mkdir built-snap
+rm -f snapd_1337.*.snap snapd_1337.*.snap.keep
+
+# Build snapd snap
+snapcraft --use-lxd
+for snap in built-snap/snapd_1337.*.snap; do
+    mv "${snap}" "${snap}.keep"
+done
+
+# Run spread
+#shellcheck disable=SC2068
+spread $@

--- a/run-spread
+++ b/run-spread
@@ -15,6 +15,7 @@ rm -f snapd_1337.*.snap
 rm -f snapd_1337.*.snap.keep
 
 # Build snapd snap
+snapcraft clean
 snapcraft --use-lxd
 for snap in snapd_1337.*.snap; do
     mv "${snap}" built-snap/"${snap}.keep"

--- a/run-spread
+++ b/run-spread
@@ -16,11 +16,9 @@ rm -f snapd_1337.*.snap.keep
 
 # Build snapd snap
 snapcraft --use-lxd
-for snap in built-snap/snapd_1337.*.snap; do
-    mv "${snap}" "${snap}.keep"
+for snap in snapd_1337.*.snap; do
+    mv "${snap}" built-snap/"${snap}.keep"
 done
 
-export TESTS_USE_PREBUILT_SNAPD_SNAP=true
-
 # Run spread
-spread "$@"
+TESTS_USE_PREBUILT_SNAPD_SNAP=true spread "$@"


### PR DESCRIPTION
This new script builds snapd snap using snapcraft locally previous to run the spread tests. Then this snap is used to prepare the instances in the desired backend as it is done in the CI

When re run spread from localhost it could be very usefull to avoid long waits during prepare stage (while the snapd snap is built)
