### PR TITLE
tests: remove tests/**/__pycache__/ from debain source

### DIFF
--- a/packaging/ubuntu-16.04/source/options
+++ b/packaging/ubuntu-16.04/source/options
@@ -1,1 +1,1 @@
-tar-ignore = "tests/lib/cache/*,tests/**/__pycache__/*"
+tar-ignore = {"tests/lib/cache/*","tests/**/__pycache__/*"}

--- a/packaging/ubuntu-16.04/source/options
+++ b/packaging/ubuntu-16.04/source/options
@@ -1,1 +1,1 @@
-tar-ignore = "tests/lib/cache/*"
+tar-ignore = "tests/lib/cache/*,tests/**/__pycache__/*"


### PR DESCRIPTION
This is required to avoid errors like the following (mostly on debian-sid)

dpkg-source: error: cannot represent change to
tests/lib/external/snapd-testing-tools/utils/__pycache__/log_helper.cpython-310.pyc: binary file contents changed

Also __pycache__ is not needed in the final tarball
