### PR TITLE
tests: create empty seed dir for images without seed

### DIFF
--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -57,8 +57,17 @@ inject_snap_into_seed() {
     local IMAGE_MOUNTPOINT=$1
     local SNAP_NAME=$2
     local SNAP_FILE="$SNAP_NAME.snap"
-    local SEED_YAML="$IMAGE_MOUNTPOINT/var/lib/snapd/seed/seed.yaml"
-    local SEED_SNAPS_DIR="$IMAGE_MOUNTPOINT/var/lib/snapd/seed/snaps"
+    local SEED_DIR="$IMAGE_MOUNTPOINT/var/lib/snapd/seed"
+    local SEED_YAML="$SEED_DIR/seed.yaml"
+    local SEED_SNAPS_DIR="$SEED_DIR/snaps"
+
+    # Ubuntu 24.04: there is no longer any seeded snaps in base or minimal cloud images
+    # https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051346
+    # https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051572
+    if [ ! -d "$SEED_DIR" ]; then
+        snap known model > /tmp/generic.model
+        snap prepare-image --classic /tmp/generic.model $IMAGE_MOUNTPOINT
+    fi
 
     # need remarshal for going from json to yaml and back for seed manipulation
     if ! command -v json2yaml || ! command -v yaml2json; then

--- a/tests/lib/preseed.sh
+++ b/tests/lib/preseed.sh
@@ -66,7 +66,7 @@ inject_snap_into_seed() {
     # https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051572
     if [ ! -d "$SEED_DIR" ]; then
         snap known model > /tmp/generic.model
-        snap prepare-image --classic /tmp/generic.model $IMAGE_MOUNTPOINT
+        snap prepare-image --classic /tmp/generic.model "$IMAGE_MOUNTPOINT"
     fi
 
     # need remarshal for going from json to yaml and back for seed manipulation

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -90,7 +90,7 @@ execute: |
   # the host VM as the nested VM, currently we are not, and as such there is a 
   # diff between the preseed apparmor-features and the nested VM actual 
   # system-key
-  if not os.query is-focal && not os.query is-jammy; then
+  if not os.query is-focal && not os.query is-jammy && not os.query is-noble; then
     # note, this doesn't actually test the functionality, but acts as a canary:
     # the test is run against a vm image with ubuntu release matching that from spread host;
     # system-key check can fail if the nested vm image differs too much from the spread host system,

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -114,12 +114,16 @@ execute: |
   remote.exec "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
   remote.exec "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
 
-  echo "Checking that lxd snap is operational"
-  remote.exec "snap list" | NOMATCH "broken"
-  remote.exec "snap services" | MATCH "lxd.activate +enabled +inactive"
-  remote.exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
-  remote.exec "sudo lxd init --auto"
-  remote.exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
+  # there is no longer any seeded snaps in base or minimal cloud images
+  # in noble, skip lxd checks for noble
+  if not os.query is-noble; then
+    echo "Checking that lxd snap is operational"
+    remote.exec "snap list" | NOMATCH "broken"
+    remote.exec "snap services" | MATCH "lxd.activate +enabled +inactive"
+    remote.exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
+    remote.exec "sudo lxd init --auto"
+    remote.exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
+  fi
 
   echo "Checking that the test-postgres-system-usernames snap is operational"
   remote.exec "sudo snap start --enable test-postgres-system-usernames.postgres"


### PR DESCRIPTION
Create seed dir if non exists because in Ubuntu 24.04 there is no longer any seeded snaps in base or minimal cloud images.
- https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051346
- https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051572
