### PR TITLE
tests: fix muinstaller-real test on uc24

### DIFF
--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -231,7 +231,11 @@ execute: |
   refresh_rebooting_snap pc pc.snap.orig ./pc-gadget
 
   # Make sure we installed the new grub
-  remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi'
+  if os.query is-ubuntu-ge 24.04 && [ "$PARTIAL_GADGET" = false ]; then
+    remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi'
+  else
+    remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi'
+  fi
   remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi'
 
   unsquashfs -d pc-kernel pc-kernel.snap


### PR DESCRIPTION
This change is done to fix the muinstaller-real test in uc24.

The pc gadget in 24/edge is copying the executables to /ubuntu-seed/EFI/ubuntu instead of /ubuntu-seed/EFI/boot