### PR TITLE
i/builtin: make registry role optional

### DIFF
--- a/interfaces/builtin/registry.go
+++ b/interfaces/builtin/registry.go
@@ -69,6 +69,8 @@ func (iface *registryInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 		return fmt.Errorf(`registry plug must have a valid "view" attribute: %w`, err)
 	}
 
+	// by default, snaps can read/write registries and be notified of changes. The
+	// manager role allows snaps to change, reject and persist changes made by others
 	role, ok := plug.Attrs["role"].(string)
 	if ok && role != "manager" {
 		return fmt.Errorf(`optional registry plug "role" attribute must be "manager"`)

--- a/interfaces/builtin/registry.go
+++ b/interfaces/builtin/registry.go
@@ -70,8 +70,8 @@ func (iface *registryInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	}
 
 	role, ok := plug.Attrs["role"].(string)
-	if !ok || (role != "observer" && role != "manager") {
-		return fmt.Errorf(`registry plug "role" attribute must be "observer" or "manager"`)
+	if ok && role != "manager" {
+		return fmt.Errorf(`optional registry plug "role" attribute must be "manager"`)
 	}
 
 	return nil

--- a/interfaces/builtin/registry_test.go
+++ b/interfaces/builtin/registry_test.go
@@ -126,7 +126,6 @@ func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
 			view:    "foo/0-bar",
 			err:     `registry plug must have a valid "view" attribute: invalid view name: 0-bar does not match '^[a-z](?:-?[a-z0-9])*$'`,
 		},
-
 		{
 			account: "_my-acc",
 			view:    "foo/bar",

--- a/interfaces/builtin/registry_test.go
+++ b/interfaces/builtin/registry_test.go
@@ -97,7 +97,6 @@ func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
 		{
 			account: "my-acc",
 			view:    "network/wifi",
-			role:    "observer",
 		},
 		{
 			err: `registry plug must have an "account" attribute`,
@@ -109,9 +108,9 @@ func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
 		{
 			account: "my-acc",
 			view:    "reg/view",
-			err:     `registry plug "role" attribute must be "observer" or "manager"`,
+			role:    "observer",
+			err:     `optional registry plug "role" attribute must be "manager"`,
 		},
-
 		{
 			account: "my-acc",
 			view:    "foobar",
@@ -127,12 +126,7 @@ func (s *registrySuite) TestRegistrySanitizePlug(c *C) {
 			view:    "foo/0-bar",
 			err:     `registry plug must have a valid "view" attribute: invalid view name: 0-bar does not match '^[a-z](?:-?[a-z0-9])*$'`,
 		},
-		{
-			account: "my-acc",
-			view:    "foo/bar",
-			role:    "other-role",
-			err:     `registry plug "role" attribute must be "observer" or "manager"`,
-		},
+
 		{
 			account: "_my-acc",
 			view:    "foo/bar",


### PR DESCRIPTION
Roles are not intended to serve the purpose of access control (views can already do that). The role only controls which of the snaps' hooks are invoked when changing registry data. This commit makes the default role "observer" in which case snapd calls a hook when a view changes. The snap can optionally set role to manager to be called during the alteration of the view to be able to modify or veto the changes. This has been changed in the SD133 spec accordingly.