### PR TITLE
interfaces: switch steam to unrestricted seccomp profile

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -218,16 +218,11 @@ capability setpcap,
 `
 
 const steamSupportConnectedPlugSecComp = `
-# Description: additional permissions needed by Steam
+# Description: allow steam to run without a seccomp profile so that
+# steam's internal sandbox can use any features available on the system
+# without having to perpetually update the snapd interface side.
 
-# Allow Steam to set up "pressure-vessel" containers to run games in.
-mount
-umount2
-pivot_root
-
-# Native games using QtWebEngineProcess -
-# https://forum.snapcraft.io/t/autoconnect-request-steam-network-control/34267
-unshare CLONE_NEWNS
+@unrestricted
 `
 
 const steamSupportSteamInputUDevRules = `

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -90,7 +90,7 @@ func (s *SteamSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := seccomp.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow Steam to set up \"pressure-vessel\" containers to run games in.\nmount\numount2\npivot_root\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "@unrestricted\n")
 }
 
 func (s *SteamSupportInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
To match similar changes to apparmor, steam-support will no longer restrict launched games with a seccomp profile. Steam still relies on an internal sandbox system, and the interaction of the two sandboxes has had ill effects historically, with broken features, degraded performance (real-time scheduling) or extensive logging.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-24864