### PR TITLE
o/snapstate: remove components on snap removal

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -264,7 +264,7 @@ func RemoveComponents(st *state.State, snapName string, compName []string, opts 
 				CompRev:   snap.R(0),
 			}
 		}
-		ts, err := removeComponentTasks(st, compst, info, setupSecurity)
+		ts, err := removeComponentTasks(st, &snapst, compst, info, setupSecurity)
 		if err != nil {
 			return nil, err
 		}
@@ -278,7 +278,7 @@ func RemoveComponents(st *state.State, snapName string, compName []string, opts 
 	return tss, nil
 }
 
-func removeComponentTasks(st *state.State, compst *sequence.ComponentState, info *snap.Info, setupSecurity *state.Task) (*state.TaskSet, error) {
+func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.ComponentState, info *snap.Info, setupSecurity *state.Task) (*state.TaskSet, error) {
 	instName := info.InstanceName()
 
 	// For the moment we consider the same conflicts as if the component
@@ -345,14 +345,13 @@ func removeComponentTasks(st *state.State, compst *sequence.ComponentState, info
 		prev = setupSecurity
 	}
 
-	// Discard component
-	// TODO:COMPS: this removes the component file and when the full
-	// removal of snap+components is implemented it needs to be done as one
-	// of the last tasks in the change.
-	discardComp := st.NewTask("discard-component", fmt.Sprintf(i18n.G(
-		"Discard previous revision for component %q"),
-		compst.SideInfo.Component))
-	addTask(discardComp)
+	// Discard component if not used in other sequence points
+	if !snapst.IsCurrentComponentRevInAnyNonCurrentSeq(compSetup.CompSideInfo.Component) {
+		discardComp := st.NewTask("discard-component", fmt.Sprintf(i18n.G(
+			"Discard previous revision for component %q"),
+			compst.SideInfo.Component))
+		addTask(discardComp)
+	}
 
 	return state.NewTaskSet(tasks...), nil
 }

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/timings"
@@ -458,7 +459,7 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 	defer st.Unlock()
 
 	// snapSt is a copy of the current state
-	compSetup, snapsup, snapSt, err := compSetupAndState(t)
+	compSetup, _, snapSt, err := compSetupAndState(t)
 	if err != nil {
 		return err
 	}
@@ -471,7 +472,48 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 	}
 
 	// Remove current component for the current snap
-	unlinkedComp := snapSt.Sequence.RemoveComponentForRevision(snapInfo.Revision, cref)
+	if err := m.unlinkComponent(
+		t, snapSt, snapInfo.InstanceName(), snapInfo.Revision, cref); err != nil {
+		return err
+	}
+
+	// Finally, write the state
+	Set(st, snapInfo.InstanceName(), snapSt)
+	// Make sure we won't be rerun
+	t.SetStatus(state.DoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) doUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err error) {
+	// invariant: the snap revision in snapSup has this component installed
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	// snapSt is a copy of the current state
+	compSetup, snapSup, snapSt, err := compSetupAndState(t)
+	if err != nil {
+		return err
+	}
+	cref := compSetup.CompSideInfo.Component
+
+	// Remove component for the specified revision
+	if err := m.unlinkComponent(
+		t, snapSt, snapSup.InstanceName(), snapSup.Revision(), cref); err != nil {
+		return err
+	}
+
+	// Finally, write the state
+	Set(st, snapSup.InstanceName(), snapSt)
+	// Make sure we won't be rerun
+	t.SetStatus(state.DoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) unlinkComponent(t *state.Task, snapSt *SnapState, instanceName string, snapRev snap.Revision, cref naming.ComponentRef) (err error) {
+	unlinkedComp := snapSt.Sequence.RemoveComponentForRevision(snapRev, cref)
 	if unlinkedComp == nil {
 		return fmt.Errorf("internal error while unlinking: %s expected but not found", cref)
 	}
@@ -479,8 +521,8 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 	// Remove symlink
 	csi := unlinkedComp.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName())
-	if err := m.backend.UnlinkComponent(cpi, snapInfo.Revision); err != nil {
+		csi.Revision, instanceName)
+	if err := m.backend.UnlinkComponent(cpi, snapRev); err != nil {
 		return err
 	}
 
@@ -491,11 +533,6 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 		return err
 	}
 	setupTask.Set("unlinked-component", *unlinkedComp)
-
-	// Finally, write the state
-	Set(st, snapsup.InstanceName(), snapSt)
-	// Make sure we won't be rerun
-	t.SetStatus(state.DoneStatus)
 
 	return nil
 }
@@ -512,12 +549,51 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 		return err
 	}
 
-	// Expected to be installed
+	// Expected to be installedsnapInfo.InstanceName()
 	snapInfo, err := snapSt.CurrentInfo()
 	if err != nil {
 		return err
 	}
 
+	if err := m.relinkComponent(
+		t, snapSt, snapInfo.InstanceName(), snapInfo.Revision); err != nil {
+		return err
+	}
+
+	// Finally, write the state
+	Set(st, snapsup.InstanceName(), snapSt)
+	// Make sure we won't be rerun
+	t.SetStatus(state.UndoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err error) {
+	// invariant: component is not installed
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	// snapSt is a copy of the current state
+	_, snapSup, snapSt, err := compSetupAndState(t)
+	if err != nil {
+		return err
+	}
+
+	if err := m.relinkComponent(
+		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
+		return err
+	}
+
+	// Finally, write the state
+	Set(st, snapSup.InstanceName(), snapSt)
+	// Make sure we won't be rerun
+	t.SetStatus(state.UndoneStatus)
+
+	return nil
+}
+
+func (m *SnapManager) relinkComponent(t *state.Task, snapSt *SnapState, instanceName string, snapRev snap.Revision) (err error) {
 	setupTask, err := componentSetupTask(t)
 	if err != nil {
 		return err
@@ -528,22 +604,17 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 	}
 
 	if err := snapSt.Sequence.AddComponentForRevision(
-		snapInfo.Revision, &unlinkedComp); err != nil {
+		snapRev, &unlinkedComp); err != nil {
 		return fmt.Errorf("internal error while undo unlink component: %w", err)
 	}
 
 	// Re-create the symlink
 	csi := unlinkedComp.SideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, snapInfo.InstanceName())
-	if err := m.backend.LinkComponent(cpi, snapInfo.Revision); err != nil {
+		csi.Revision, instanceName)
+	if err := m.backend.LinkComponent(cpi, snapRev); err != nil {
 		return err
 	}
-
-	// Finally, write the state
-	Set(st, snapsup.InstanceName(), snapSt)
-	// Make sure we won't be rerun
-	t.SetStatus(state.UndoneStatus)
 
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -814,6 +814,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)
 	runner.AddHandler("link-component", m.doLinkComponent, m.undoLinkComponent)
+	runner.AddHandler("unlink-component", m.doUnlinkComponent, m.undoUnlinkComponent)
 	// We cannot undo much after a component file is removed. And it is the
 	// last task anyway.
 	runner.AddHandler("discard-component", m.doDiscardComponent, nil)

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -20,9 +20,11 @@
 package snapstate_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -34,9 +36,11 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -2058,4 +2062,262 @@ func (s *snapmgrTestSuite) TestRemoveManyWithPurge(c *C) {
 		})
 	}
 
+}
+
+func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
+	const snapName = "snap1"
+	const comp1name = "comp1"
+	const comp2name = "comp2"
+
+	cref1 := naming.NewComponentRef(snapName, comp1name)
+	cref2 := naming.NewComponentRef(snapName, comp2name)
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(compMntDir string,
+		snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
+		switch csi.Component.ComponentName {
+		case comp1name:
+			return &snap.ComponentInfo{
+				Component:         cref1,
+				Type:              snap.TestComponent,
+				ComponentSideInfo: *csi,
+			}, nil
+		case comp2name:
+			return &snap.ComponentInfo{
+				Component:         cref2,
+				Type:              snap.TestComponent,
+				ComponentSideInfo: *csi,
+			}, nil
+		}
+		return nil, errors.New("unexpected component")
+	}))
+
+	s.AddCleanup(snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		info := &snap.Info{
+			SuggestedName: name,
+			SideInfo:      *si,
+			SnapType:      snap.TypeApp,
+			Components: map[string]*snap.Component{
+				comp1name: {Name: comp1name, Type: snap.TestComponent},
+				comp2name: {Name: comp2name, Type: snap.TestComponent},
+			},
+		}
+		info.Apps = map[string]*snap.AppInfo{
+			"app": {Snap: info, Name: "app"},
+		}
+		return info, nil
+	}))
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	siRev1 := &snap.SideInfo{RealName: snapName, Revision: snap.R(1)}
+	siRev2 := &snap.SideInfo{RealName: snapName, Revision: snap.R(2)}
+	comp1si := snap.NewComponentSideInfo(cref1, snap.R(11))
+	comp11si := snap.NewComponentSideInfo(cref1, snap.R(111))
+	comp2si := snap.NewComponentSideInfo(cref2, snap.R(22))
+	comp22si := snap.NewComponentSideInfo(cref2, snap.R(222))
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(siRev1,
+				[]*sequence.ComponentState{
+					sequence.NewComponentState(
+						comp1si, snap.TestComponent),
+					sequence.NewComponentState(
+						comp2si, snap.TestComponent),
+				}),
+			sequence.NewRevisionSideState(siRev2,
+				[]*sequence.ComponentState{
+					sequence.NewComponentState(
+						comp11si, snap.TestComponent),
+					sequence.NewComponentState(
+						comp22si, snap.TestComponent),
+				}),
+		})
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:   true,
+		Sequence: seq,
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	ts, err := snapstate.Remove(s.state, snapName, snap.R(0), nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
+	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
+		"stop-snap-services",
+		"run-hook[remove]",
+		"auto-disconnect",
+		"save-snapshot",
+		"remove-aliases",
+		"unlink-snap",
+		"remove-profiles",
+		"clear-snap",
+		"unlink-component",
+		"discard-component",
+		"unlink-component",
+		"discard-component",
+		"discard-snap",
+		"clear-snap",
+		"unlink-component",
+		"discard-component",
+		"unlink-component",
+		"discard-component",
+		"discard-snap",
+	})
+	verifyStopReason(c, ts, "remove")
+
+	// Run the created tasks
+	chg := s.state.NewChange("remove", "remove a snap")
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	expected := fakeOps{
+		{
+			op:    "auto-disconnect:Doing",
+			name:  "snap1",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-aliases",
+			name: "snap1",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/1"),
+		},
+		{
+			op:    "remove-profiles:Doing",
+			name:  "snap1",
+			revno: snap.R(1),
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/2"),
+		},
+		{
+			op:   "unlink-component",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/components/mnt/comp1/111"),
+		},
+		{
+			op:                "undo-setup-component",
+			containerName:     "snap1+comp1",
+			containerFileName: "snap1+comp1_111.comp",
+		},
+		{
+			op:                "remove-component-dir",
+			containerName:     "snap1+comp1",
+			containerFileName: "snap1+comp1_111.comp",
+		},
+		{
+			op:   "unlink-component",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/components/mnt/comp2/222"),
+		},
+		{
+			op:                "undo-setup-component",
+			containerName:     "snap1+comp2",
+			containerFileName: "snap1+comp2_222.comp",
+		},
+		{
+			op:                "remove-component-dir",
+			containerName:     "snap1+comp2",
+			containerFileName: "snap1+comp2_222.comp",
+		},
+		{
+			op:    "remove-snap-files",
+			path:  filepath.Join(dirs.SnapMountDir, "snap1/2"),
+			stype: "app",
+		},
+		{
+			op:   "remove-snap-data",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/1"),
+		},
+		{
+			op:   "remove-snap-common-data",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/1"),
+		},
+		{
+			op:   "remove-snap-save-data",
+			path: filepath.Join(dirs.SnapDataSaveDir, "snap1"),
+		},
+		{
+			op:   "remove-snap-data-dir",
+			name: "snap1",
+			path: filepath.Join(dirs.SnapDataDir, "snap1"),
+		},
+		{
+			op:   "unlink-component",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/components/mnt/comp1/11"),
+		},
+		{
+			op:                "undo-setup-component",
+			containerName:     "snap1+comp1",
+			containerFileName: "snap1+comp1_11.comp",
+		},
+		{
+			containerName:     "snap1+comp1",
+			containerFileName: "snap1+comp1_11.comp",
+			op:                "remove-component-dir",
+		},
+		{
+			op:   "unlink-component",
+			path: filepath.Join(dirs.SnapMountDir, "snap1/components/mnt/comp2/22"),
+		},
+		{
+			op:                "undo-setup-component",
+			containerName:     "snap1+comp2",
+			containerFileName: "snap1+comp2_22.comp",
+		},
+		{
+			op:                "remove-component-dir",
+			containerName:     "snap1+comp2",
+			containerFileName: "snap1+comp2_22.comp",
+		},
+		{
+			op:    "remove-snap-files",
+			path:  filepath.Join(dirs.SnapMountDir, "snap1/1"),
+			stype: "app",
+		},
+		{
+			op:   "remove-snap-mount-units",
+			name: "snap1",
+		},
+		{
+			op:   "discard-namespace",
+			name: "snap1",
+		},
+		{
+			op:   "remove-inhibit-lock",
+			name: "snap1",
+		},
+		{
+			op:   "remove-snap-dir",
+			name: "snap1",
+			path: filepath.Join(dirs.SnapMountDir, "snap1"),
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
+	c.Check(s.fakeBackend.ops[0:5], DeepEquals, expected[0:5])
+	c.Check(s.fakeBackend.ops[11:16], DeepEquals, expected[11:16])
+	c.Check(s.fakeBackend.ops[22:], DeepEquals, expected[22:])
+	// Check component tasks, that can run in parallel so the order is not
+	// deterministic, but still needs to follow an order per component.
+	checkComps := func(ops, exp1, exp2 fakeOps) {
+		var op1idx, op2idx int
+		for _, op := range ops {
+			switch {
+			case op1idx < 3 && reflect.DeepEqual(exp1[op1idx], op):
+				op1idx++
+			case op2idx < 3 && reflect.DeepEqual(exp2[op2idx], op):
+				op2idx++
+			default:
+				c.Error("expected op not found", op)
+			}
+		}
+	}
+	checkComps(s.fakeBackend.ops[5:11], expected[5:8], expected[8:11])
+	checkComps(s.fakeBackend.ops[16:22], expected[16:19], expected[19:22])
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14446,3 +14446,137 @@ func (s *snapmgrTestSuite) TestRefreshCandidates(c *C) {
 	c.Assert(candidates, HasLen, 1)
 	c.Check(candidates[0].InstanceName(), Equals, "some-snap")
 }
+
+func (s *snapmgrTestSuite) TestUpdateTasksWithComponentsRemoved(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	si1 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	si2 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}
+	si3 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)}
+	si4 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)}
+	si5 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5)}
+	cref1 := naming.NewComponentRef("some-snap", "comp1")
+	cref2 := naming.NewComponentRef("some-snap", "comp2")
+	comp1si := snap.NewComponentSideInfo(cref1, snap.R(11))
+	comp2si := snap.NewComponentSideInfo(cref2, snap.R(22))
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(compMntDir string,
+		snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
+		switch csi.Component.ComponentName {
+		case "comp1":
+			return &snap.ComponentInfo{
+				Component:         cref1,
+				Type:              snap.TestComponent,
+				ComponentSideInfo: *csi,
+			}, nil
+		case "comp2":
+			return &snap.ComponentInfo{
+				Component:         cref2,
+				Type:              snap.TestComponent,
+				ComponentSideInfo: *csi,
+			}, nil
+		}
+		return nil, errors.New("unexpected component")
+	}))
+	seq := snapstatetest.NewSequenceFromRevisionSideInfos(
+		[]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(si1,
+				[]*sequence.ComponentState{
+					sequence.NewComponentState(
+						comp1si, snap.TestComponent),
+					sequence.NewComponentState(
+						comp2si, snap.TestComponent),
+				}),
+			sequence.NewRevisionSideState(si2, nil),
+			sequence.NewRevisionSideState(si3, nil),
+			sequence.NewRevisionSideState(si4,
+				[]*sequence.ComponentState{
+					sequence.NewComponentState(
+						comp1si, snap.TestComponent),
+					sequence.NewComponentState(
+						comp2si, snap.TestComponent),
+				}),
+			sequence.NewRevisionSideState(si5, nil),
+		})
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/edge",
+		Sequence:        seq,
+		Current:         snap.R(3),
+		SnapType:        "app",
+	})
+
+	// run the update
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
+		"prerequisites",
+		"download-snap",
+		"validate-snap",
+		"mount-snap",
+		"run-hook[pre-refresh]",
+		"stop-snap-services",
+		"remove-aliases",
+		"unlink-current-snap",
+		"copy-snap-data",
+		"setup-profiles",
+		"link-snap",
+		"auto-connect",
+		"set-auto-aliases",
+		"setup-aliases",
+		"run-hook[post-refresh]",
+		"start-snap-services",
+		"clear-snap",
+		"unlink-component",
+		"discard-component",
+		"unlink-component",
+		"discard-component",
+		"discard-snap",
+		"clear-snap",
+		"discard-snap",
+		"clear-snap",
+		"unlink-component",
+		"discard-component",
+		"unlink-component",
+		"discard-component",
+		"discard-snap",
+		"cleanup",
+		"run-hook[configure]",
+		"run-hook[check-health]",
+		"check-rerefresh",
+	})
+
+	// and ensure that it will remove the components - si1 is cleaned
+	// because of garbage collection and si4 and si5 because they are after
+	// current.
+	var compSup snapstate.ComponentSetup
+	tasks := ts.Tasks()
+
+	i := len(tasks) - 17
+	c.Check(tasks[i].Kind(), Equals, "unlink-component")
+	err = tasks[i].Get("component-setup", &compSup)
+	c.Assert(err, IsNil)
+	c.Check(compSup.CompSideInfo.Component, Equals, cref1)
+
+	i = len(tasks) - 15
+	c.Check(tasks[i].Kind(), Equals, "unlink-component")
+	err = tasks[i].Get("component-setup", &compSup)
+	c.Assert(err, IsNil)
+	c.Check(compSup.CompSideInfo.Component, Equals, cref2)
+
+	i = len(tasks) - 9
+	c.Check(tasks[i].Kind(), Equals, "unlink-component")
+	err = tasks[i].Get("component-setup", &compSup)
+	c.Assert(err, IsNil)
+	c.Check(compSup.CompSideInfo.Component, Equals, cref1)
+
+	i = len(tasks) - 7
+	c.Check(tasks[i].Kind(), Equals, "unlink-component")
+	err = tasks[i].Get("component-setup", &compSup)
+	c.Assert(err, IsNil)
+	c.Check(compSup.CompSideInfo.Component, Equals, cref2)
+}

--- a/tests/main/component/task.yaml
+++ b/tests/main/component/task.yaml
@@ -78,5 +78,13 @@ execute: |
   snap remove snap-with-comps+comp1
   check_removed x3
 
-  # Finally, remove the snap
+  # Remove the snap
   snap remove snap-with-comps
+
+  # Reinstall, install component, remove all in one change and check
+  snap install --dangerous snap-with-comps_1.0_all.snap
+  install_comp x1
+  snap remove snap-with-comps
+  check_removed x1
+  not test -d "$SNAP_MOUNT_DIR"/snap-with-comps/
+  snap list | NOMATCH snap-with-comps


### PR DESCRIPTION
Remove components on snap removal by adding discard-component tasks.
No other task is actually needed as unlinking the snap also removes
components from the state and clean-up of kernel drivers tree is done
by a per-snap task.
