### PR TITLE
 many: move resealing backend from boot to fdestate's backend

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 name: Tests
 on:
   pull_request:
-    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**", "fde-manager-features" ]
   push:
     # we trigger runs on master branch, but we do not run spread on master 
     # branch, the master branch runs are just for unit tests + codecov.io
-    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**", "fde-manager-features" ]
 
   # XXX we suspect that the whenever the labeler workflow executes successfully
   # it will trigger another workflow of tests on master, temporarily disable to

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -36,6 +36,9 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
@@ -52,10 +55,18 @@ var _ = Suite(&assetsSuite{})
 
 func (s *assetsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
+
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	s.AddCleanup(func() {
+		manager.Stop()
+	})
+
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755), IsNil)
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
 	s.AddCleanup(restore)
 
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
@@ -780,7 +791,7 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 
 	// everything is set up, trigger a reseal
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -885,7 +896,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 
 	// everything is set up, trigger reseal
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -1641,7 +1652,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"shim":  []string{shimHash},
 	})
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -1801,7 +1812,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -2560,7 +2571,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 		runKernelBf,
 	}
 
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -2697,7 +2708,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	}
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params.ModelParams, HasLen, 1)
 		mp := params.ModelParams[0]
@@ -2808,7 +2819,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 
 	// make sure that no reseal is triggered
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -182,12 +182,12 @@ func (b byBootChainOrder) Less(i, j int) bool {
 	return false
 }
 
-type predictableBootChains []bootChain
+type PredictableBootChains []bootChain
 
 // hasUnrevisionedKernels returns true if any of the chains have an
 // unrevisioned kernel. Revisions will not be set for unasserted
 // kernels.
-func (pbc predictableBootChains) hasUnrevisionedKernels() bool {
+func (pbc PredictableBootChains) hasUnrevisionedKernels() bool {
 	for i := range pbc {
 		if pbc[i].KernelRevision == "" {
 			return true
@@ -196,7 +196,7 @@ func (pbc predictableBootChains) hasUnrevisionedKernels() bool {
 	return false
 }
 
-func toPredictableBootChains(chains []bootChain) predictableBootChains {
+func ToPredictableBootChains(chains []bootChain) PredictableBootChains {
 	if chains == nil {
 		return nil
 	}
@@ -221,7 +221,7 @@ const (
 // are clearly different it returns bootChainDifferent.
 // If it would return bootChainEquivalent but the chains contain
 // unrevisioned kernels it will return bootChainUnrevisioned.
-func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bootChainEquivalence {
+func predictableBootChainsEqualForReseal(pb1, pb2 PredictableBootChains) bootChainEquivalence {
 	pb1JSON, err := json.Marshal(pb1)
 	if err != nil {
 		return bootChainDifferent
@@ -308,10 +308,10 @@ func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFi
 // other information
 type predictableBootChainsWrapperForStorage struct {
 	ResealCount int                   `json:"reseal-count"`
-	BootChains  predictableBootChains `json:"boot-chains"`
+	BootChains  PredictableBootChains `json:"boot-chains"`
 }
 
-func readBootChains(path string) (pbc predictableBootChains, resealCount int, err error) {
+func readBootChains(path string) (pbc PredictableBootChains, resealCount int, err error) {
 	inf, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -327,7 +327,7 @@ func readBootChains(path string) (pbc predictableBootChains, resealCount int, er
 	return wrapped.BootChains, wrapped.ResealCount, nil
 }
 
-func writeBootChains(pbc predictableBootChains, path string, resealCount int) error {
+func WriteBootChains(pbc PredictableBootChains, path string, resealCount int) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("cannot create device fde state directory: %v", err)
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -170,6 +170,7 @@ func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash
 type BootAsset = bootAsset
 type BootChain = bootChain
 type PredictableBootChains = predictableBootChains
+type ResealKeyForBootChainsParams = resealKeyForBootChainsParams
 
 const (
 	BootChainEquivalent   = bootChainEquivalent
@@ -250,14 +251,6 @@ func MockRunFDESetupHook(f fde.RunSetupHookFunc) (restore func()) {
 	oldRunFDESetupHook := RunFDESetupHook
 	RunFDESetupHook = f
 	return func() { RunFDESetupHook = oldRunFDESetupHook }
-}
-
-func MockResealKeyToModeenvUsingFDESetupHook(f func(string, *Modeenv, bool) error) (restore func()) {
-	old := resealKeyToModeenvUsingFDESetupHook
-	resealKeyToModeenvUsingFDESetupHook = f
-	return func() {
-		resealKeyToModeenvUsingFDESetupHook = old
-	}
 }
 
 func MockModeenvLocked() (restore func()) {

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -69,7 +69,6 @@ var (
 	ResealKeyToModeenv              = resealKeyToModeenv
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 	RunModeBootChains               = runModeBootChains
-	SealKeyModelParams              = sealKeyModelParams
 
 	BootVarsForTrustedCommandLineFromGadget = bootVarsForTrustedCommandLineFromGadget
 
@@ -169,8 +168,6 @@ func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash
 
 type BootAsset = bootAsset
 type BootChain = bootChain
-type PredictableBootChains = predictableBootChains
-type ResealKeyForBootChainsParams = resealKeyForBootChainsParams
 
 const (
 	BootChainEquivalent   = bootChainEquivalent
@@ -180,13 +177,10 @@ const (
 
 var (
 	ToPredictableBootChain              = toPredictableBootChain
-	ToPredictableBootChains             = toPredictableBootChains
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 	BootAssetsToLoadChains              = bootAssetsToLoadChains
 	BootAssetLess                       = bootAssetLess
-	WriteBootChains                     = writeBootChains
 	ReadBootChains                      = readBootChains
-	IsResealNeeded                      = isResealNeeded
 
 	SetImageBootFlags = setImageBootFlags
 	NextBootFlags     = nextBootFlags

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -33,6 +33,9 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
@@ -89,12 +92,19 @@ func makeEncodableModel(signingAccounts *assertstest.SigningAccounts, overrides 
 func (s *modelSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	s.AddCleanup(func() {
+		manager.Stop()
+	})
+
 	store := assertstest.NewStoreStack("canonical", nil)
 	brands := assertstest.NewSigningAccounts(store)
 	brands.Register("my-brand", brandPrivKey, nil)
 	s.keyID = brands.Signing("canonical").KeyID
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
 	s.AddCleanup(restore)
 	s.oldUc20dev = boottest.MockUC20Device("", makeEncodableModel(brands, nil))
 	s.newUc20dev = boottest.MockUC20Device("", makeEncodableModel(brands, map[string]interface{}{
@@ -200,7 +210,7 @@ func (s *modelSuite) TestDeviceChangeHappy(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -285,7 +295,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstReseal(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -343,7 +353,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstSwapModelFile(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -409,7 +419,7 @@ func (s *modelSuite) TestDeviceChangeUnhappySecondReseal(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -503,7 +513,7 @@ func (s *modelSuite) TestDeviceChangeRebootBeforeNewModel(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
@@ -628,7 +638,7 @@ func (s *modelSuite) TestDeviceChangeRebootAfterNewModelFileWrite(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
@@ -751,7 +761,7 @@ func (s *modelSuite) TestDeviceChangeRebootPostSameModel(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
@@ -882,7 +892,7 @@ func (s *modelSuite) testDeviceChangeUnhappyMockedWriteModelToBoot(c *C, tc unha
 
 	writeModelToBootCalls := 0
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -1019,7 +1029,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFailReseaWithSwappedModelMockedWrite
 
 	writeModelToBootCalls := 0
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		if resealKeysCalls == 3 {
 			// we are resealing the run key, the old model has been
@@ -1111,7 +1121,7 @@ func (s *modelSuite) TestDeviceChangeRebootRestoreModelKeyChangeMockedWriteModel
 	}))
 
 	resealKeysCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -23,7 +23,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +46,6 @@ var (
 	secbootProvisionTPM              = secboot.ProvisionTPM
 	secbootSealKeys                  = secboot.SealKeys
 	secbootSealKeysWithFDESetupHook  = secboot.SealKeysWithFDESetupHook
-	secbootResealKeys                = secboot.ResealKeys
 	secbootPCRHandleOfSealedKey      = secboot.PCRHandleOfSealedKey
 	secbootReleasePCRResourceHandles = secboot.ReleasePCRResourceHandles
 
@@ -68,17 +66,6 @@ var (
 		return nil, fmt.Errorf("internal error: RunFDESetupHook not set yet")
 	}
 )
-
-// MockSecbootResealKeys is only useful in testing. Note that this is a very low
-// level call and may need significant environment setup.
-func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
-	osutil.MustBeTestBinary("secbootResealKeys only can be mocked in tests")
-	old := secbootResealKeys
-	secbootResealKeys = f
-	return func() {
-		secbootResealKeys = old
-	}
-}
 
 // MockResealKeyToModeenv is only useful in testing.
 func MockResealKeyToModeenv(f func(rootdir string, modeenv *Modeenv, expectReseal bool, unlocker Unlocker) error) (restore func()) {
@@ -102,11 +89,11 @@ func MockSealKeyToModeenv(f func(key, saveKey keys.EncryptionKey, model *asserts
 	}
 }
 
-func bootChainsFileUnder(rootdir string) string {
+func BootChainsFileUnder(rootdir string) string {
 	return filepath.Join(dirs.SnapFDEDirUnder(rootdir), "boot-chains")
 }
 
-func recoveryBootChainsFileUnder(rootdir string) string {
+func RecoveryBootChainsFileUnder(rootdir string) string {
 	return filepath.Join(dirs.SnapFDEDirUnder(rootdir), "recovery-boot-chains")
 }
 
@@ -264,7 +251,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, model *assert
 	}
 	logger.Debugf("run mode bootchain:\n%+v", runModeBootChains)
 
-	pbc := toPredictableBootChains(append(runModeBootChains, recoveryBootChains...))
+	pbc := ToPredictableBootChains(append(runModeBootChains, recoveryBootChains...))
 
 	roleToBlName := map[bootloader.Role]string{
 		bootloader.RoleRecovery: rbl.Name(),
@@ -272,7 +259,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, model *assert
 	}
 
 	// the boot chains we seal the fallback object to
-	rpbc := toPredictableBootChains(recoveryBootChains)
+	rpbc := ToPredictableBootChains(recoveryBootChains)
 
 	// gets written to a file by sealRunObjectKeys()
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -339,13 +326,13 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, model *assert
 		return err
 	}
 
-	installBootChainsPath := bootChainsFileUnder(InstallHostWritableDir(model))
-	if err := writeBootChains(pbc, installBootChainsPath, 0); err != nil {
+	installBootChainsPath := BootChainsFileUnder(InstallHostWritableDir(model))
+	if err := WriteBootChains(pbc, installBootChainsPath, 0); err != nil {
 		return err
 	}
 
-	installRecoveryBootChainsPath := recoveryBootChainsFileUnder(InstallHostWritableDir(model))
-	if err := writeBootChains(rpbc, installRecoveryBootChainsPath, 0); err != nil {
+	installRecoveryBootChainsPath := RecoveryBootChainsFileUnder(InstallHostWritableDir(model))
+	if err := WriteBootChains(rpbc, installRecoveryBootChainsPath, 0); err != nil {
 		return err
 	}
 
@@ -363,8 +350,8 @@ func usesAltPCRHandles() (bool, error) {
 	return handle == secboot.AltFallbackObjectPCRPolicyCounterHandle, nil
 }
 
-func sealRunObjectKeys(key keys.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string, pcrHandle uint32) error {
-	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
+func sealRunObjectKeys(key keys.EncryptionKey, pbc PredictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string, pcrHandle uint32) error {
+	modelParams, err := SealKeyModelParams(pbc, roleToBlName)
 	if err != nil {
 		return fmt.Errorf("cannot prepare for key sealing: %v", err)
 	}
@@ -389,9 +376,9 @@ func sealRunObjectKeys(key keys.EncryptionKey, pbc predictableBootChains, authKe
 	return nil
 }
 
-func sealFallbackObjectKeys(key, saveKey keys.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string, factoryReset bool, pcrHandle uint32) error {
+func sealFallbackObjectKeys(key, saveKey keys.EncryptionKey, pbc PredictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string, factoryReset bool, pcrHandle uint32) error {
 	// also seal the keys to the recovery bootchains as a fallback
-	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
+	modelParams, err := SealKeyModelParams(pbc, roleToBlName)
 	if err != nil {
 		return fmt.Errorf("cannot prepare for fallback key sealing: %v", err)
 	}
@@ -442,11 +429,11 @@ func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool,
 	return resealKeyToModeenvForMethod(method, rootdir, modeenv, expectReseal)
 }
 
-type resealKeyForBootChainsParams struct {
-	runModeBootChains           []bootChain
-	recoveryBootChainsForRunKey []bootChain
-	recoveryBootChains          []bootChain
-	roleToBlName                map[bootloader.Role]string
+type ResealKeyForBootChainsParams struct {
+	RunModeBootChains           []bootChain
+	RecoveryBootChainsForRunKey []bootChain
+	RecoveryBootChains          []bootChain
+	RoleToBlName                map[bootloader.Role]string
 }
 
 // TODO:UC20: allow more than one model to accommodate the remodel scenario
@@ -458,7 +445,7 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 		requiresBootChains = false
 	}
 
-	params := &resealKeyForBootChainsParams{}
+	params := &ResealKeyForBootChainsParams{}
 
 	if requiresBootChains {
 		// build the recovery mode boot chain
@@ -481,7 +468,7 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 		// a run key, the boot chains are generated for both models to
 		// accommodate the dynamics of a remodel
 		includeTryModel := true
-		params.recoveryBootChainsForRunKey, err = recoveryBootChainsForSystems(modeenv.CurrentRecoverySystems, modes, tbl,
+		params.RecoveryBootChainsForRunKey, err = recoveryBootChainsForSystems(modeenv.CurrentRecoverySystems, modes, tbl,
 			modeenv, includeTryModel, dirs.SnapSeedDir)
 		if err != nil {
 			return fmt.Errorf("cannot compose recovery boot chains for run key: %v", err)
@@ -500,7 +487,7 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 		// use the current model as the recovery keys are not expected to be
 		// used during a remodel
 		includeTryModel = false
-		params.recoveryBootChains, err = recoveryBootChainsForSystems(testedRecoverySystems, modes, tbl, modeenv, includeTryModel, dirs.SnapSeedDir)
+		params.RecoveryBootChains, err = recoveryBootChainsForSystems(testedRecoverySystems, modes, tbl, modeenv, includeTryModel, dirs.SnapSeedDir)
 		if err != nil {
 			return fmt.Errorf("cannot compose recovery boot chains: %v", err)
 		}
@@ -517,12 +504,12 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 		if err != nil {
 			return err
 		}
-		params.runModeBootChains, err = runModeBootChains(rbl, bl, modeenv, cmdlines, "")
+		params.RunModeBootChains, err = runModeBootChains(rbl, bl, modeenv, cmdlines, "")
 		if err != nil {
 			return fmt.Errorf("cannot compose run mode boot chains: %v", err)
 		}
 
-		params.roleToBlName = map[bootloader.Role]string{
+		params.RoleToBlName = map[bootloader.Role]string{
 			bootloader.RoleRecovery: rbl.Name(),
 			bootloader.RoleRunMode:  bl.Name(),
 		}
@@ -531,127 +518,32 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 	return resealKeyForBootChains(method, rootdir, params, expectReseal)
 }
 
-func resealKeyForBootChainsImpl(method device.SealingMethod, rootdir string, params *resealKeyForBootChainsParams, expectReseal bool) error {
-	switch method {
-	case device.SealingMethodFDESetupHook:
-		// FIXME: do something
-		return nil
-	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
-	default:
-		return fmt.Errorf("unknown key sealing method: %q", method)
-	}
-
-	saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
-	authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
-
-	// reseal the run object
-	pbc := toPredictableBootChains(append(params.runModeBootChains, params.recoveryBootChainsForRunKey...))
-
-	needed, nextCount, err := isResealNeeded(pbc, bootChainsFileUnder(rootdir), expectReseal)
-	if err != nil {
-		return err
-	}
-	if needed {
-		pbcJSON, _ := json.Marshal(pbc)
-		logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
-
-		if err := resealRunObjectKeys(pbc, authKeyFile, params.roleToBlName); err != nil {
-			return err
-		}
-		logger.Debugf("resealing (%d) succeeded", nextCount)
-
-		bootChainsPath := bootChainsFileUnder(rootdir)
-		if err := writeBootChains(pbc, bootChainsPath, nextCount); err != nil {
-			return err
-		}
-	} else {
-		logger.Debugf("reseal not necessary")
-	}
-
-	// reseal the fallback object
-	rpbc := toPredictableBootChains(params.recoveryBootChains)
-
-	var nextFallbackCount int
-	needed, nextFallbackCount, err = isResealNeeded(rpbc, recoveryBootChainsFileUnder(rootdir), expectReseal)
-	if err != nil {
-		return err
-	}
-	if needed {
-		rpbcJSON, _ := json.Marshal(rpbc)
-		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
-
-		if err := resealFallbackObjectKeys(rpbc, authKeyFile, params.roleToBlName); err != nil {
-			return err
-		}
-		logger.Debugf("fallback resealing (%d) succeeded", nextFallbackCount)
-
-		recoveryBootChainsPath := recoveryBootChainsFileUnder(rootdir)
-		if err := writeBootChains(rpbc, recoveryBootChainsPath, nextFallbackCount); err != nil {
-			return err
-		}
-	} else {
-		logger.Debugf("fallback reseal not necessary")
-	}
-
-	return nil
+func resealKeyForBootChainsImpl(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error {
+	return fmt.Errorf("FDE manager was not started")
 }
-
+var resealKeyForBootChainsInstalled bool
 var resealKeyForBootChains = resealKeyForBootChainsImpl
 
-func MockResealKeyForBootChains(f func(method device.SealingMethod, rootdir string, params *resealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
+func InstallResealKeyForBootChains(f func(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error) {
+	//if resealKeyForBootChainsInstalled {
+		//panic("internal error: A FDE manager was already started")
+	//}
+	resealKeyForBootChainsInstalled = true
+	resealKeyForBootChains = f
+}
+
+func RemoveResealKeyForBootChains() {
+	resealKeyForBootChainsInstalled = false
+	resealKeyForBootChains = resealKeyForBootChainsImpl
+}
+
+func MockResealKeyForBootChains(f func(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
 	osutil.MustBeTestBinary("resealKeyForBootChains only can be mocked in tests")
 	old := resealKeyForBootChains
 	resealKeyForBootChains = f
 	return func() {
 		resealKeyForBootChains = old
 	}
-}
-
-func resealRunObjectKeys(pbc predictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
-	// get model parameters from bootchains
-	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
-	if err != nil {
-		return fmt.Errorf("cannot prepare for key resealing: %v", err)
-	}
-
-	// list all the key files to reseal
-	keyFiles := []string{device.DataSealedKeyUnder(InitramfsBootEncryptionKeyDir)}
-
-	resealKeyParams := &secboot.ResealKeysParams{
-		ModelParams:          modelParams,
-		KeyFiles:             keyFiles,
-		TPMPolicyAuthKeyFile: authKeyFile,
-	}
-	if err := secbootResealKeys(resealKeyParams); err != nil {
-		return fmt.Errorf("cannot reseal the encryption key: %v", err)
-	}
-
-	return nil
-}
-
-func resealFallbackObjectKeys(pbc predictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
-	// get model parameters from bootchains
-	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
-	if err != nil {
-		return fmt.Errorf("cannot prepare for fallback key resealing: %v", err)
-	}
-
-	// list all the key files to reseal
-	keyFiles := []string{
-		device.FallbackDataSealedKeyUnder(InitramfsSeedEncryptionKeyDir),
-		device.FallbackSaveSealedKeyUnder(InitramfsSeedEncryptionKeyDir),
-	}
-
-	resealKeyParams := &secboot.ResealKeysParams{
-		ModelParams:          modelParams,
-		KeyFiles:             keyFiles,
-		TPMPolicyAuthKeyFile: authKeyFile,
-	}
-	if err := secbootResealKeys(resealKeyParams); err != nil {
-		return fmt.Errorf("cannot reseal the fallback encryption keys: %v", err)
-	}
-
-	return nil
 }
 
 // recoveryModesForSystems returns a map for recovery modes for recovery systems
@@ -919,7 +811,7 @@ func buildBootAssets(bootFiles []bootloader.BootFile, modeenv *Modeenv, trustedA
 	return assets, bootFiles[len(bootFiles)-1], nil
 }
 
-func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.Role]string) ([]*secboot.SealKeyModelParams, error) {
+func SealKeyModelParams(pbc PredictableBootChains, roleToBlName map[bootloader.Role]string) ([]*secboot.SealKeyModelParams, error) {
 	// seal parameters keyed by unique model ID
 	modelToParams := map[string]*secboot.SealKeyModelParams{}
 	modelParams := make([]*secboot.SealKeyModelParams, 0, len(pbc))
@@ -952,13 +844,13 @@ func sealKeyModelParams(pbc predictableBootChains, roleToBlName map[bootloader.R
 	return modelParams, nil
 }
 
-// isResealNeeded returns true when the predictable boot chains provided as
+// IsResealNeeded returns true when the predictable boot chains provided as
 // input do not match the cached boot chains on disk under rootdir.
 // It also returns the next value for the reseal count that is saved
 // together with the boot chains.
 // A hint expectReseal can be provided, it is used when the matching
 // is ambigous because the boot chains contain unrevisioned kernels.
-func isResealNeeded(pbc predictableBootChains, bootChainsFile string, expectReseal bool) (ok bool, nextCount int, err error) {
+func IsResealNeeded(pbc PredictableBootChains, bootChainsFile string, expectReseal bool) (ok bool, nextCount int, err error) {
 	previousPbc, c, err := readBootChains(bootChainsFile)
 	if err != nil {
 		return false, 0, err

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -40,6 +40,9 @@ import (
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
@@ -57,6 +60,13 @@ var _ = Suite(&sealSuite{})
 
 func (s *sealSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	s.AddCleanup(func() {
+		manager.Stop()
+	})
 
 	rootdir := c.MkDir()
 	dirs.SetRootDir(rootdir)
@@ -666,7 +676,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 
 		// set mock key resealing
 		resealKeysCalls := 0
-		restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 			c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 
 			resealKeysCalls++
@@ -1130,7 +1140,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 
 		resealKeysCalls++
@@ -1406,7 +1416,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Assert(params.ModelParams, HasLen, 1)
 		c.Logf("reseal: %+v", params)
@@ -2395,7 +2405,7 @@ func (s *sealSuite) testResealKeyToModeenvWithTryModel(c *C, shimId, grubId stri
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 		c.Logf("got:")
 		for _, mp := range params.ModelParams {

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
@@ -84,7 +87,14 @@ func (s *systemsSuite) mockTrustedBootloaderWithAssetAndChains(c *C, runKernelBf
 func (s *systemsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	s.AddCleanup(func() {
+		manager.Stop()
+	})
+
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
 	s.AddCleanup(restore)
 
 	s.uc20dev = boottest.MockUC20Device("", nil)
@@ -144,7 +154,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		// bootloader variables have already been modified
 		c.Check(mtbl.SetBootVarsCalls, Equals, 1)
@@ -268,7 +278,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemRemodelEncrypted(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		// bootloader variables have already been modified
 		c.Check(mtbl.SetBootVarsCalls, Equals, 1)
@@ -371,7 +381,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemSimple(c *C) {
 	}
 	c.Assert(modeenv.WriteTo(""), IsNil)
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		return fmt.Errorf("unexpected call")
 	})
 	s.AddCleanup(restore)
@@ -412,7 +422,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemSetBootVarsErr(c *C) {
 	}
 	c.Assert(modeenv.WriteTo(""), IsNil)
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		return fmt.Errorf("unexpected call")
 	})
 	s.AddCleanup(restore)
@@ -523,7 +533,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		if cleanupTriggered {
 			return nil
@@ -632,7 +642,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -735,7 +745,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -783,7 +793,7 @@ func (s *systemsSuite) testInspectRecoverySystemOutcomeHappy(c *C, mtbl *bootloa
 	})
 	defer restore()
 
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		return fmt.Errorf("unexpected call")
 	})
 	defer restore()
@@ -979,7 +989,7 @@ func (s *systemsSuite) testClearRecoverySystem(c *C, mtbl *bootloadertest.MockTr
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -1242,7 +1252,7 @@ func (s *systemsSuite) TestClearRecoverySystemReboot(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -1384,7 +1394,7 @@ func (s *systemsSuite) testPromoteTriedRecoverySystem(c *C, systemLabel string, 
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -1655,7 +1665,7 @@ func (s *systemsSuite) testDropRecoverySystem(c *C, systemLabel string, tc recov
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -1,0 +1,161 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/secboot"
+)
+
+var (
+	secbootResealKeys                = secboot.ResealKeys
+)
+
+// MockSecbootResealKeys is only useful in testing. Note that this is a very low
+// level call and may need significant environment setup.
+func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
+	osutil.MustBeTestBinary("secbootResealKeys only can be mocked in tests")
+	old := secbootResealKeys
+	secbootResealKeys = f
+	return func() {
+		secbootResealKeys = old
+	}
+}
+
+func ResealKeyForBootChains(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	switch method {
+	case device.SealingMethodFDESetupHook:
+		// FIXME: do something
+		return nil
+	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
+	default:
+		return fmt.Errorf("unknown key sealing method: %q", method)
+	}
+
+	saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
+	authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
+
+	// reseal the run object
+	pbc := boot.ToPredictableBootChains(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
+
+	needed, nextCount, err := boot.IsResealNeeded(pbc, boot.BootChainsFileUnder(rootdir), expectReseal)
+	if err != nil {
+		return err
+	}
+	if needed {
+		pbcJSON, _ := json.Marshal(pbc)
+		logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
+
+		if err := resealRunObjectKeys(pbc, authKeyFile, params.RoleToBlName); err != nil {
+			return err
+		}
+		logger.Debugf("resealing (%d) succeeded", nextCount)
+
+		bootChainsPath := boot.BootChainsFileUnder(rootdir)
+		if err := boot.WriteBootChains(pbc, bootChainsPath, nextCount); err != nil {
+			return err
+		}
+	} else {
+		logger.Debugf("reseal not necessary")
+	}
+
+	// reseal the fallback object
+	rpbc := boot.ToPredictableBootChains(params.RecoveryBootChains)
+
+	var nextFallbackCount int
+	needed, nextFallbackCount, err = boot.IsResealNeeded(rpbc, boot.RecoveryBootChainsFileUnder(rootdir), expectReseal)
+	if err != nil {
+		return err
+	}
+	if needed {
+		rpbcJSON, _ := json.Marshal(rpbc)
+		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
+
+		if err := resealFallbackObjectKeys(rpbc, authKeyFile, params.RoleToBlName); err != nil {
+			return err
+		}
+		logger.Debugf("fallback resealing (%d) succeeded", nextFallbackCount)
+
+		recoveryBootChainsPath := boot.RecoveryBootChainsFileUnder(rootdir)
+		if err := boot.WriteBootChains(rpbc, recoveryBootChainsPath, nextFallbackCount); err != nil {
+			return err
+		}
+	} else {
+		logger.Debugf("fallback reseal not necessary")
+	}
+
+	return nil
+}
+
+func resealRunObjectKeys(pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+	// get model parameters from bootchains
+	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
+	if err != nil {
+		return fmt.Errorf("cannot prepare for key resealing: %v", err)
+	}
+
+	// list all the key files to reseal
+	keyFiles := []string{device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir)}
+
+	resealKeyParams := &secboot.ResealKeysParams{
+		ModelParams:          modelParams,
+		KeyFiles:             keyFiles,
+		TPMPolicyAuthKeyFile: authKeyFile,
+	}
+	if err := secbootResealKeys(resealKeyParams); err != nil {
+		return fmt.Errorf("cannot reseal the encryption key: %v", err)
+	}
+
+	return nil
+}
+
+func resealFallbackObjectKeys(pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+	// get model parameters from bootchains
+	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
+	if err != nil {
+		return fmt.Errorf("cannot prepare for fallback key resealing: %v", err)
+	}
+
+	// list all the key files to reseal
+	keyFiles := []string{
+		device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
+		device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
+	}
+
+	resealKeyParams := &secboot.ResealKeysParams{
+		ModelParams:          modelParams,
+		KeyFiles:             keyFiles,
+		TPMPolicyAuthKeyFile: authKeyFile,
+	}
+	if err := secbootResealKeys(resealKeyParams); err != nil {
+		return fmt.Errorf("cannot reseal the fallback encryption keys: %v", err)
+	}
+
+	return nil
+}

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate
+
+var FdeMgr = fdeMgr

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package fdestate implements the manager and state responsible for
+// managing full disk encryption keys.
+package fdestate
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// FDEManager is responsible for managing managing full disk
+// encryption keys.
+type FDEManager struct {
+	state *state.State
+}
+
+type fdeMgrKey struct{}
+
+func Manager(st *state.State, runner *state.TaskRunner) *FDEManager {
+	m := &FDEManager{
+		state: st,
+	}
+
+	st.Lock()
+	defer st.Unlock()
+	st.Cache(fdeMgrKey{}, m)
+
+	return m
+}
+
+func (m *FDEManager) Ensure() error {
+	return nil
+}
+
+func fdeMgr(st *state.State) *FDEManager {
+	c := st.Cached(fdeMgrKey{})
+	if c == nil {
+		panic("internal error: FDE manager is not yet associated with state")
+	}
+	return c.(*FDEManager)
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestFDE(t *testing.T) { TestingT(t) }
+
+type fdeMgrSuite struct{}
+
+var _ = Suite(&fdeMgrSuite{})
+
+func (s *fdeMgrSuite) TestGetManagerFromState(c *C) {
+	st := state.New(nil)
+
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	st.Lock()
+	defer st.Unlock()
+	foundManager := fdestate.FdeMgr(st)
+	c.Check(foundManager, Equals, manager)
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -39,6 +39,7 @@ func (s *fdeMgrSuite) TestGetManagerFromState(c *C) {
 
 	runner := state.NewTaskRunner(st)
 	manager := fdestate.Manager(st, runner)
+	defer manager.Stop()
 	st.Lock()
 	defer st.Unlock()
 	foundManager := fdestate.FdeMgr(st)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/interfaces"
@@ -74,6 +75,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -7563,7 +7565,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	c.Assert(err, IsNil)
 
 	secbootResealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		secbootResealCalls++
 		if !encrypted {
 			return fmt.Errorf("unexpected call")
@@ -7911,7 +7913,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C, model
 	})
 	c.Assert(err, IsNil)
 
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return fmt.Errorf("unexpected call")
 	})
 	s.AddCleanup(restore)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -2,7 +2,7 @@
 //go:build !nomanagers
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -111,6 +112,7 @@ type Overlord struct {
 	deviceMgr  *devicestate.DeviceManager
 	cmdMgr     *cmdstate.CommandManager
 	shotMgr    *snapshotstate.SnapshotManager
+	fdeMgr     *fdestate.FDEManager
 	// proxyConf mediates the http proxy config
 	proxyConf func(req *http.Request) (*url.URL, error)
 }
@@ -171,6 +173,8 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 	o.addManager(ifaceMgr)
 
+	o.addManager(fdestate.Manager(s, o.runner))
+
 	deviceMgr, err := devicestate.Manager(s, hookMgr, o.runner, o.newStore)
 	if err != nil {
 		return nil, err
@@ -220,6 +224,8 @@ func (o *Overlord) addManager(mgr StateManager) {
 		o.shotMgr = x
 	case *restart.RestartManager:
 		o.restartMgr = x
+	case *fdestate.FDEManager:
+		o.fdeMgr = x
 	}
 	o.stateEng.AddManager(mgr)
 }
@@ -669,6 +675,11 @@ func (o *Overlord) DeviceManager() *devicestate.DeviceManager {
 // jobs.
 func (o *Overlord) CommandManager() *cmdstate.CommandManager {
 	return o.cmdMgr
+}
+
+// FDEManager returns the manager responsible for FDE
+func (o *Overlord) FDEManager() *fdestate.FDEManager {
+	return o.fdeMgr
 }
 
 // SnapshotManager returns the manager responsible for snapshots.

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -124,6 +124,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(o.DeviceManager(), NotNil)
 	c.Check(o.CommandManager(), NotNil)
 	c.Check(o.SnapshotManager(), NotNil)
+	c.Check(o.FDEManager(), NotNil)
 	c.Check(configstateInitCalled, Equals, true)
 
 	o.InterfaceManager().DisableUDevMonitor()


### PR DESCRIPTION
We also make the FDE state manager install the the backend function to be associated with the state.