### PR TITLE
many: move resealing backend from boot to fdestate's backend

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
@@ -52,10 +53,14 @@ var _ = Suite(&assetsSuite{})
 
 func (s *assetsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
+
+	restore := boot.MockResealKeyForBootChains(fdeBackend.ResealKeyForBootChains)
+	s.AddCleanup(restore)
+
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755), IsNil)
 
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
 	s.AddCleanup(restore)
 
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
@@ -780,7 +785,7 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 
 	// everything is set up, trigger a reseal
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -885,7 +890,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 
 	// everything is set up, trigger reseal
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -1641,7 +1646,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"shim":  []string{shimHash},
 	})
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -1801,7 +1806,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -2560,7 +2565,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 		runKernelBf,
 	}
 
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -2697,7 +2702,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	}
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params.ModelParams, HasLen, 1)
 		mp := params.ModelParams[0]
@@ -2808,7 +2813,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 
 	// make sure that no reseal is triggered
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil/kcmdline"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
@@ -136,6 +137,9 @@ type baseBootenv20Suite struct {
 
 func (s *baseBootenv20Suite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
+
+	restore := boot.MockResealKeyForBootChains(fdeBackend.ResealKeyForBootChains)
+	s.AddCleanup(restore)
 
 	var err error
 	s.kern1, err = snap.ParsePlaceInfoFromSnapFileName("pc-kernel_1.snap")
@@ -1118,7 +1122,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -1238,7 +1242,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -1356,7 +1360,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call")
 	})
@@ -1476,7 +1480,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call")
 	})
@@ -1840,7 +1844,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	model := coreDev.Model()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -2230,7 +2234,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	c.Assert(err, IsNil)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -2459,7 +2463,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -2599,7 +2603,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -2764,7 +2768,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -3405,6 +3409,9 @@ var _ = Suite(&bootConfigSuite{})
 func (s *bootConfigSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
+	restore := boot.MockResealKeyForBootChains(fdeBackend.ResealKeyForBootChains)
+	s.AddCleanup(restore)
+
 	s.bootloader = bootloadertest.Mock("trusted", c.MkDir()).WithTrustedAssets()
 	s.bootloader.StaticCommandLine = "this is mocked panic=-1"
 	s.bootloader.CandidateStaticCommandLine = "mocked candidate panic=-1"
@@ -3437,7 +3444,7 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyNoKeysNoReseal(c *C) {
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -3489,7 +3496,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 	newCmdline := strutil.JoinNonEmpty([]string{
 		"snapd_recovery_mode=run mocked candidate panic=-1", cmdlineAppend}, " ")
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -3542,7 +3549,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyNoChange(c *C, cmdlineAppend 
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})
@@ -3707,7 +3714,7 @@ volumes:
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -3767,7 +3774,7 @@ volumes:
 	// reseal does not happen, because the gadget overrides the static
 	// command line which is part of boot config, thus there's no resulting
 	// change in the command lines tracked in modeenv and no need to reseal
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call")
 	})
@@ -3803,6 +3810,9 @@ var _ = Suite(&bootKernelCommandLineSuite{})
 
 func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
+
+	restore := boot.MockResealKeyForBootChains(fdeBackend.ResealKeyForBootChains)
+	s.AddCleanup(restore)
 
 	data := []byte("foobar")
 	// SHA3-384
@@ -3859,7 +3869,7 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 
 	s.resealCommandLines = nil
 	s.resealCalls = 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		s.resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -4131,7 +4141,7 @@ volumes:
 	c.Assert(s.modeenvWithEncryption.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("reseal fails")
 	})
@@ -4275,7 +4285,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
 	resealPanic := false
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		s.resealCalls++
 		c.Logf("reseal call %v", s.resealCalls)
 		c.Assert(params, NotNil)
@@ -4856,7 +4866,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -4970,7 +4980,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
 		c.Assert(params.ModelParams, HasLen, 1)
@@ -5082,7 +5092,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call to mocked secbootResealKeys")
 	})
@@ -5202,7 +5212,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call")
 	})
@@ -5380,7 +5390,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	model := coreDev.Model()
 
 	resealCalls := 0
-	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore := fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 		return nil
 	})

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -182,12 +182,12 @@ func (b byBootChainOrder) Less(i, j int) bool {
 	return false
 }
 
-type predictableBootChains []bootChain
+type PredictableBootChains []bootChain
 
 // hasUnrevisionedKernels returns true if any of the chains have an
 // unrevisioned kernel. Revisions will not be set for unasserted
 // kernels.
-func (pbc predictableBootChains) hasUnrevisionedKernels() bool {
+func (pbc PredictableBootChains) hasUnrevisionedKernels() bool {
 	for i := range pbc {
 		if pbc[i].KernelRevision == "" {
 			return true
@@ -196,7 +196,7 @@ func (pbc predictableBootChains) hasUnrevisionedKernels() bool {
 	return false
 }
 
-func toPredictableBootChains(chains []bootChain) predictableBootChains {
+func ToPredictableBootChains(chains []bootChain) PredictableBootChains {
 	if chains == nil {
 		return nil
 	}
@@ -221,7 +221,7 @@ const (
 // are clearly different it returns bootChainDifferent.
 // If it would return bootChainEquivalent but the chains contain
 // unrevisioned kernels it will return bootChainUnrevisioned.
-func predictableBootChainsEqualForReseal(pb1, pb2 predictableBootChains) bootChainEquivalence {
+func predictableBootChainsEqualForReseal(pb1, pb2 PredictableBootChains) bootChainEquivalence {
 	pb1JSON, err := json.Marshal(pb1)
 	if err != nil {
 		return bootChainDifferent
@@ -308,10 +308,10 @@ func bootAssetsToLoadChains(assets []bootAsset, kernelBootFile bootloader.BootFi
 // other information
 type predictableBootChainsWrapperForStorage struct {
 	ResealCount int                   `json:"reseal-count"`
-	BootChains  predictableBootChains `json:"boot-chains"`
+	BootChains  PredictableBootChains `json:"boot-chains"`
 }
 
-func readBootChains(path string) (pbc predictableBootChains, resealCount int, err error) {
+func readBootChains(path string) (pbc PredictableBootChains, resealCount int, err error) {
 	inf, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -327,7 +327,7 @@ func readBootChains(path string) (pbc predictableBootChains, resealCount int, er
 	return wrapped.BootChains, wrapped.ResealCount, nil
 }
 
-func writeBootChains(pbc predictableBootChains, path string, resealCount int) error {
+func WriteBootChains(pbc PredictableBootChains, path string, resealCount int) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("cannot create device fde state directory: %v", err)
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -69,7 +70,6 @@ var (
 	ResealKeyToModeenv              = resealKeyToModeenv
 	RecoveryBootChainsForSystems    = recoveryBootChainsForSystems
 	RunModeBootChains               = runModeBootChains
-	SealKeyModelParams              = sealKeyModelParams
 
 	BootVarsForTrustedCommandLineFromGadget = bootVarsForTrustedCommandLineFromGadget
 
@@ -169,8 +169,6 @@ func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash
 
 type BootAsset = bootAsset
 type BootChain = bootChain
-type PredictableBootChains = predictableBootChains
-type ResealKeyForBootChainsParams = resealKeyForBootChainsParams
 
 const (
 	BootChainEquivalent   = bootChainEquivalent
@@ -180,13 +178,10 @@ const (
 
 var (
 	ToPredictableBootChain              = toPredictableBootChain
-	ToPredictableBootChains             = toPredictableBootChains
 	PredictableBootChainsEqualForReseal = predictableBootChainsEqualForReseal
 	BootAssetsToLoadChains              = bootAssetsToLoadChains
 	BootAssetLess                       = bootAssetLess
-	WriteBootChains                     = writeBootChains
 	ReadBootChains                      = readBootChains
-	IsResealNeeded                      = isResealNeeded
 
 	SetImageBootFlags = setImageBootFlags
 	NextBootFlags     = nextBootFlags
@@ -279,4 +274,12 @@ func MockWriteModelToUbuntuBoot(mock func(*asserts.Model) error) (restore func()
 func EnableTestingRebootFunction() (restore func()) {
 	testingRebootItself = true
 	return func() { testingRebootItself = false }
+}
+
+func MockResealKeyForBootChains(f func(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
+	old := ResealKeyForBootChains
+	ResealKeyForBootChains = f
+	return func() {
+		ResealKeyForBootChains = old
+	}
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
@@ -57,6 +58,9 @@ var _ = Suite(&sealSuite{})
 
 func (s *sealSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+
+	restore := boot.MockResealKeyForBootChains(fdeBackend.ResealKeyForBootChains)
+	s.AddCleanup(restore)
 
 	rootdir := c.MkDir()
 	dirs.SetRootDir(rootdir)
@@ -666,7 +670,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 
 		// set mock key resealing
 		resealKeysCalls := 0
-		restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 			c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 
 			resealKeysCalls++
@@ -1130,7 +1134,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 
 		resealKeysCalls++
@@ -1406,7 +1410,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealKeysCalls++
 		c.Assert(params.ModelParams, HasLen, 1)
 		c.Logf("reseal: %+v", params)
@@ -2395,7 +2399,7 @@ func (s *sealSuite) testResealKeyToModeenvWithTryModel(c *C, shimId, grubId stri
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
 		c.Logf("got:")
 		for _, mp := range params.ModelParams {

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -1,0 +1,162 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot"
+)
+
+var (
+	secbootResealKeys = secboot.ResealKeys
+)
+
+// MockSecbootResealKeys is only useful in testing. Note that this is a very low
+// level call and may need significant environment setup.
+func MockSecbootResealKeys(f func(params *secboot.ResealKeysParams) error) (restore func()) {
+	osutil.MustBeTestBinary("secbootResealKeys only can be mocked in tests")
+	old := secbootResealKeys
+	secbootResealKeys = f
+	return func() {
+		secbootResealKeys = old
+	}
+}
+
+// ResealKeyForBootChains reseals disk encryption keys with the given bootchains.
+func ResealKeyForBootChains(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	switch method {
+	case device.SealingMethodFDESetupHook:
+		// FIXME: do something
+		return nil
+	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
+	default:
+		return fmt.Errorf("unknown key sealing method: %q", method)
+	}
+
+	saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
+	authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
+
+	// reseal the run object
+	pbc := boot.ToPredictableBootChains(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
+
+	needed, nextCount, err := boot.IsResealNeeded(pbc, boot.BootChainsFileUnder(rootdir), expectReseal)
+	if err != nil {
+		return err
+	}
+	if needed {
+		pbcJSON, _ := json.Marshal(pbc)
+		logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
+
+		if err := resealRunObjectKeys(pbc, authKeyFile, params.RoleToBlName); err != nil {
+			return err
+		}
+		logger.Debugf("resealing (%d) succeeded", nextCount)
+
+		bootChainsPath := boot.BootChainsFileUnder(rootdir)
+		if err := boot.WriteBootChains(pbc, bootChainsPath, nextCount); err != nil {
+			return err
+		}
+	} else {
+		logger.Debugf("reseal not necessary")
+	}
+
+	// reseal the fallback object
+	rpbc := boot.ToPredictableBootChains(params.RecoveryBootChains)
+
+	var nextFallbackCount int
+	needed, nextFallbackCount, err = boot.IsResealNeeded(rpbc, boot.RecoveryBootChainsFileUnder(rootdir), expectReseal)
+	if err != nil {
+		return err
+	}
+	if needed {
+		rpbcJSON, _ := json.Marshal(rpbc)
+		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
+
+		if err := resealFallbackObjectKeys(rpbc, authKeyFile, params.RoleToBlName); err != nil {
+			return err
+		}
+		logger.Debugf("fallback resealing (%d) succeeded", nextFallbackCount)
+
+		recoveryBootChainsPath := boot.RecoveryBootChainsFileUnder(rootdir)
+		if err := boot.WriteBootChains(rpbc, recoveryBootChainsPath, nextFallbackCount); err != nil {
+			return err
+		}
+	} else {
+		logger.Debugf("fallback reseal not necessary")
+	}
+
+	return nil
+}
+
+func resealRunObjectKeys(pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+	// get model parameters from bootchains
+	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
+	if err != nil {
+		return fmt.Errorf("cannot prepare for key resealing: %v", err)
+	}
+
+	// list all the key files to reseal
+	keyFiles := []string{device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir)}
+
+	resealKeyParams := &secboot.ResealKeysParams{
+		ModelParams:          modelParams,
+		KeyFiles:             keyFiles,
+		TPMPolicyAuthKeyFile: authKeyFile,
+	}
+	if err := secbootResealKeys(resealKeyParams); err != nil {
+		return fmt.Errorf("cannot reseal the encryption key: %v", err)
+	}
+
+	return nil
+}
+
+func resealFallbackObjectKeys(pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+	// get model parameters from bootchains
+	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
+	if err != nil {
+		return fmt.Errorf("cannot prepare for fallback key resealing: %v", err)
+	}
+
+	// list all the key files to reseal
+	keyFiles := []string{
+		device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
+		device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
+	}
+
+	resealKeyParams := &secboot.ResealKeysParams{
+		ModelParams:          modelParams,
+		KeyFiles:             keyFiles,
+		TPMPolicyAuthKeyFile: authKeyFile,
+	}
+	if err := secbootResealKeys(resealKeyParams); err != nil {
+		return fmt.Errorf("cannot reseal the fallback encryption keys: %v", err)
+	}
+
+	return nil
+}

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -22,6 +22,9 @@
 package fdestate
 
 import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -37,6 +40,8 @@ func Manager(st *state.State, runner *state.TaskRunner) *FDEManager {
 		state: st,
 	}
 
+	boot.ResealKeyForBootChains = m.resealKeyForBootChains
+
 	st.Lock()
 	defer st.Unlock()
 	st.Cache(fdeMgrKey{}, m)
@@ -46,6 +51,10 @@ func Manager(st *state.State, runner *state.TaskRunner) *FDEManager {
 
 func (m *FDEManager) Ensure() error {
 	return nil
+}
+
+func (m *FDEManager) resealKeyForBootChains(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	return backend.ResealKeyForBootChains(method, rootdir, params, expectReseal)
 }
 
 func fdeMgr(st *state.State) *FDEManager {

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -39,6 +39,7 @@ func (s *fdeMgrSuite) TestGetManagerFromState(c *C) {
 
 	runner := state.NewTaskRunner(st)
 	manager := fdestate.Manager(st, runner)
+	c.Assert(manager.Ensure(), IsNil)
 	st.Lock()
 	defer st.Unlock()
 	foundManager := fdestate.FdeMgr(st)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -74,6 +74,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -7563,7 +7564,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	c.Assert(err, IsNil)
 
 	secbootResealCalls := 0
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+	restore = fdeBackend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		secbootResealCalls++
 		if !encrypted {
 			return fmt.Errorf("unexpected call")
@@ -7910,11 +7911,6 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C, model
 		"snap_kernel": "pc-kernel_2.snap",
 	})
 	c.Assert(err, IsNil)
-
-	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
-		return fmt.Errorf("unexpected call")
-	})
-	s.AddCleanup(restore)
 }
 
 func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {


### PR DESCRIPTION
We also make the FDE state manager install the the backend function to be associated with the state.
