### PR TITLE
snapdtool, sandbox/apparmor: fix apparmor_parser lookup

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -206,6 +206,8 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 		// the user or what do we do if we know snapd is down for maintenance?
 		if _, err := cli.SysInfo(); err == nil {
 			return nil
+		} else {
+			logger.Debugf("cannot obtain system info: %v", err)
 		}
 		// sleep a little bit for good measure
 		time.Sleep(1 * time.Second)

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -395,6 +395,8 @@ func ParserMtime() int64 {
 		if fi, err := os.Stat(cmd.Path); err == nil {
 			mtime = fi.ModTime().Unix()
 		}
+	} else {
+		logger.Debugf("apparmor parser err: %v", err)
 	}
 	return mtime
 }
@@ -790,6 +792,7 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	// installed snapd-apparmor support re-exec
 	if path, err := snapdtool.InternalToolPath("apparmor_parser"); err == nil {
 		if osutil.IsExecutable(path) && snapdAppArmorSupportsReexec() && !systemAppArmorLoadsSnapPolicy() {
+			logger.Debugf("checking internal apparmor_parser candidate at %v", path)
 			prefix := strings.TrimSuffix(path, "apparmor_parser")
 			snapdAbi30File := filepath.Join(prefix, "/apparmor.d/abi/3.0")
 			snapdAbi40File := filepath.Join(prefix, "/apparmor.d/abi/4.0")
@@ -828,6 +831,7 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	for _, dir := range filepath.SplitList(parserSearchPath) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
+			logger.Debugf("checking distro apparmor_parser at %v", path)
 			// Detect but ignore apparmor 4.0 ABI support.
 			//
 			// At present this causes some bugs with mqueue mediation that can

--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -129,13 +129,6 @@ func InternalToolPath(tool string) (string, error) {
 			if osutil.IsExecutable(maybeTool) {
 				return maybeTool, nil
 			}
-		} else {
-			// or perhaps some other random location, make sure the tool
-			// exists there and is an executable
-			maybeTool := filepath.Join(filepath.Dir(exe), tool)
-			if osutil.IsExecutable(maybeTool) {
-				return maybeTool, nil
-			}
 		}
 	}
 

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -286,7 +286,7 @@ func (s *toolSuite) TestInternalToolPathWithDevLocationFallback(c *C) {
 	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
 }
 
-func (s *toolSuite) TestInternalToolPathWithOtherDevLocationWhenExecutable(c *C) {
+func (s *toolSuite) TestInternalToolPathWithOtherDevLocationWhenExecutableFallback(c *C) {
 	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join(dirs.GlobalRootDir, "/tmp/snapd"), nil
 	})
@@ -300,7 +300,7 @@ func (s *toolSuite) TestInternalToolPathWithOtherDevLocationWhenExecutable(c *C)
 
 	path, err := snapdtool.InternalToolPath("potato")
 	c.Check(err, IsNil)
-	c.Check(path, Equals, filepath.Join(dirs.GlobalRootDir, "/tmp/potato"))
+	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
 }
 
 func (s *toolSuite) TestInternalToolPathWithOtherDevLocationNonExecutable(c *C) {


### PR DESCRIPTION
Back in 2019 in https://github.com/snapcore/snapd/commit/216890f6352339d3e732c2fba1b2c7f74cd529ea I have introduced a change which allowed snapdtool.InternalToolPath() to fall back to use an executable from the same directory as currently executing process with the idea of facilitating the local development. However, this has proved to be problematic as it introduces ambiguity about the tool location. Specifically, when called in the context of /usr/bin/snap, a lookup an internal tool called apparmor_parser may return /usr/bin/apparmor_parser, which is obviously incorrect, as that path isn't an internal snapd tool. With https://github.com/snapcore/snapd/pull/13321 landing, the nfs-support tool broke on Arch. The test attempts to set up a known failure scenario, which now did not take place, since instead the snap command ended up waiting for profile regeneration, as a result of /usr/bin/snap detecting /usr/bin/apparmor_parser as the internal tool and with SNAPD_APPARMOR_REEXEC=1 by default, the system key computed by `/usr/lib/snapd/snapd` and `/usr/bin/snap` ended up being different.

Since the intention of the InternalToolPath() function to return only the internal tools, the code has been updated to not break that assumption in any scenario.

Related: SNAPDENG-25498