### PR TITLE
wrappers: correctly deal with activated services during service restart

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1223,32 +1223,64 @@ type RestartServicesOptions struct {
 
 func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices []string,
 	opts *RestartServicesOptions, sysd systemd.Systemd, cli *userServiceClient, tm timings.Measurer) error {
+	shouldRestart := func(active, enabled bool, name string) bool {
+		// If the unit was explicitly mentioned in the command line, restart it
+		// even if it is disabled; otherwise, we only restart units which are
+		// currently enabled or running. Reference:
+		// https://forum.snapcraft.io/t/command-line-interface-to-manipulate-services/262/47
+		if !active && !strutil.ListContains(explicitServices, name) {
+			if !opts.AlsoEnabledNonActive {
+				logger.Noticef("not restarting inactive unit %s", name)
+				return false
+			} else if !enabled {
+				logger.Noticef("not restarting disabled and inactive unit %s", name)
+				return false
+			}
+		}
+		return true
+	}
+
 	for _, st := range svcsSts {
 		unitName := st.ServiceUnitStatus().Name
 		unitActive := st.ServiceUnitStatus().Active
-		unitEnabled := st.IsEnabled()
+		unitEnabled := st.ServiceUnitStatus().Enabled
 		unitScope := snap.SystemDaemon
 		if st.IsUserService() {
 			unitScope = snap.UserDaemon
 		}
 
-		// If the unit was explicitly mentioned in the command line, restart it
-		// even if it is disabled; otherwise, we only restart units which are
-		// currently enabled or running. Reference:
-		// https://forum.snapcraft.io/t/command-line-interface-to-manipulate-services/262/47
-		if !unitActive && !strutil.ListContains(explicitServices, unitName) {
-			if !opts.AlsoEnabledNonActive {
-				logger.Noticef("not restarting inactive unit %s", unitName)
-				continue
-			} else if !unitEnabled {
-				logger.Noticef("not restarting disabled and inactive unit %s", unitName)
-				continue
+		var unitsToRestart []string
+
+		// If the service is activated, then we must also consider it's activators
+		if len(st.ActivatorUnitStatuses()) != 0 {
+			// If the primary unit was running then we restart it, for the primary
+			// unit we cannot take enabled into account as that is static for activated
+			// services.
+			if unitActive {
+				unitsToRestart = append(unitsToRestart, unitName)
+			}
+
+			// And restart any activators, but operate normally on these
+			for _, act := range st.ActivatorUnitStatuses() {
+				// Use the primary name here for shouldRestart, as the caller
+				// will never refer directly to the sub-services.
+				if shouldRestart(act.Active, act.Enabled, unitName) {
+					unitsToRestart = append(unitsToRestart, act.Name)
+				}
+			}
+		} else {
+			if shouldRestart(unitActive, unitEnabled, unitName) {
+				unitsToRestart = append(unitsToRestart, unitName)
 			}
 		}
 
+		if len(unitsToRestart) == 0 {
+			continue
+		}
+
 		var err error
-		timings.Run(tm, "restart-service", fmt.Sprintf("restart service %s", unitName), func(nested timings.Measurer) {
-			err = reloadOrRestartServices(sysd, cli, opts.Reload, unitScope, []string{unitName})
+		timings.Run(tm, "restart-service", fmt.Sprintf("restart service(s) %s", unitName), func(nested timings.Measurer) {
+			err = reloadOrRestartServices(sysd, cli, opts.Reload, unitScope, unitsToRestart)
 		})
 		if err != nil {
 			// there is nothing we can do about failed service

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1253,20 +1253,20 @@ func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices
 
 		// If the service is activated, then we must also consider it's activators
 		if len(st.ActivatorUnitStatuses()) != 0 {
-			// If the primary unit was running then we restart it, for the primary
-			// unit we cannot take enabled into account as that is static for activated
-			// services.
-			if unitActive {
-				unitsToRestart = append(unitsToRestart, unitName)
-			}
-
-			// And restart any activators, but operate normally on these
+			// Restart any activators first and operate normally on these
 			for _, act := range st.ActivatorUnitStatuses() {
 				// Use the primary name here for shouldRestart, as the caller
 				// will never refer directly to the sub-services.
 				if shouldRestart(act.Active, act.Enabled, unitName) {
 					unitsToRestart = append(unitsToRestart, act.Name)
 				}
+			}
+
+			// If the primary unit was running then we restart it, for the primary
+			// unit we cannot take enabled into account as that is static for activated
+			// services.
+			if unitActive {
+				unitsToRestart = append(unitsToRestart, unitName)
 			}
 		} else {
 			if shouldRestart(unitActive, unitEnabled, unitName) {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -5427,11 +5427,11 @@ apps:
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
-		{"stop", srvFile2, srvFile2Sock1, srvFile2Sock2},
-		{"show", "--property=ActiveState", srvFile2},
+		{"stop", srvFile2Sock1, srvFile2Sock2, srvFile2},
 		{"show", "--property=ActiveState", srvFile2Sock1},
 		{"show", "--property=ActiveState", srvFile2Sock2},
-		{"start", srvFile2, srvFile2Sock1, srvFile2Sock2},
+		{"show", "--property=ActiveState", srvFile2},
+		{"start", srvFile2Sock1, srvFile2Sock2, srvFile2},
 	})
 }
 


### PR DESCRIPTION
LP bug that triggered this fix: https://bugs.launchpad.net/snapd/+bug/2028141

The issue was that the restart code was not dealing correctly with activated services. Instead of restarting the activator units (i.e sockets, timers) for an activated service, it would just go ahead and restart the primary unit. This would start otherwise unwanted services that previously was not running (but reported enabled to the code as the activator units are enabled).

Cover this case in unit tests and correctly deal with activated services.