### PR TITLE
tests: add testing support for opensuse 15.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -658,7 +658,7 @@ jobs:
             tests: 'tests/...'
           - group: opensuse
             backend: google-distro-2
-            systems: 'opensuse-15.5-64 opensuse-tumbleweed-64'
+            systems: 'opensuse-15.5-64 opensuse-15.6-64 opensuse-tumbleweed-64'
             tests: 'tests/...'
           - group: ubuntu-trusty
             backend: google

--- a/packaging/opensuse-15.6
+++ b/packaging/opensuse-15.6
@@ -1,0 +1,1 @@
+opensuse

--- a/spread.yaml
+++ b/spread.yaml
@@ -233,6 +233,8 @@ backends:
 
             - opensuse-15.5-64:
                   workers: 6
+            - opensuse-15.6-64:
+                  workers: 6
             - opensuse-tumbleweed-64:
                   workers: 6
 

--- a/tests/main/cgroup-devices-v1/task.yaml
+++ b/tests/main/cgroup-devices-v1/task.yaml
@@ -13,6 +13,7 @@ systems:
     - -fedora-*
     - -debian-*
     - -arch-*
+    - -opensuse-15.6-*
     - -opensuse-tumbleweed-*
     - -centos-9-*
     - -amazon-linux-2023-*

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -9,6 +9,7 @@ systems:
     - -fedora-*
     - -debian-*
     - -arch-*
+    - -opensuse-15.6-*
     - -opensuse-tumbleweed-*
     - -centos-9-*
     - -amazon-linux-2023-*

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -29,6 +29,7 @@ systems:
     - -fedora-39-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
+    - -opensuse-15.6-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old
     - -ubuntu-2*  # test-snapd-eds is incompatible with eds shipped with the distro

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -24,6 +24,7 @@ systems:
     - -fedora-39-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
+    - -opensuse-15.6-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old
     - -ubuntu-2*  # test-snapd-eds is incompatible with eds shipped with the distro


### PR DESCRIPTION
Run tests in opensuse leap 15.6