### PR TITLE
tests: fix uc-update-assets-secure nested test in uc24

### DIFF
--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -87,7 +87,11 @@ execute: |
     # Wait for snap seeding to be done
     remote.exec "sudo snap wait system seed.loaded"
     # Wait for cloud init to be done
-    remote.exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait" || ret=$?
+    if [ "$ret" -ne 0 ] && [ "$ret" -ne 2 ]; then
+        echo "cloud-init finished with error $ret"
+        exit 1
+    fi
 
     echo "The device is using encrypted ubuntu-data and is in run mode now"
     remote.exec test -L /dev/disk/by-label/ubuntu-data-enc

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -87,6 +87,7 @@ execute: |
     # Wait for snap seeding to be done
     remote.exec "sudo snap wait system seed.loaded"
     # Wait for cloud init to be done
+    ret=0
     remote.exec "cloud-init status --wait" || ret=$?
     if [ "$ret" -ne 0 ] && [ "$ret" -ne 2 ]; then
         echo "cloud-init finished with error $ret"

--- a/tests/nested/manual/uc-update-assets-secure/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure/task.yaml
@@ -74,19 +74,24 @@ prepare: |
 
   snap pack pc --filename=pc_2.snap
 
+  grubx64_dir=boot
+  if os.query is-ubuntu-ge 24.04; then
+    grubx64_dir=ubuntu
+  fi
+
   cat <<EOF >>expected-before
   ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
-  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  ${old_grub_sha} */boot/efi/EFI/${grubx64_dir}/grubx64.efi
   EOF
   if [ "${UPDATE_SEED}" = true ]; then
     cat <<EOF >>expected-after
   ${new_shim_sha} */boot/efi/EFI/boot/bootx64.efi
-  ${new_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  ${new_grub_sha} */boot/efi/EFI/${grubx64_dir}/grubx64.efi
   EOF
   else
     cat <<EOF >>expected-after
   ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
-  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  ${old_grub_sha} */boot/efi/EFI/${grubx64_dir}/grubx64.efi
   EOF
   fi
 


### PR DESCRIPTION
This test failes with the executables are moved to EFI/ubuntu instead of EFI/boot

Also fix core20-install-mode-shutdown-via-hook. I used the code we have in nested.sh to check "cloud-init status --wait"

