### PR TITLE
testutil: provide a type safe helper for Mocking

### DIFF
--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -44,7 +44,7 @@ func MockEnsureInterval(d time.Duration) (restore func()) {
 
 // MockPruneInterval sets the overlord prune interval for tests.
 func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
-	r := testutil.Backup(&pruneInterval, &pruneWait, &abortWait)
+	r := testutil.BackupMany(&pruneInterval, &pruneWait, &abortWait)
 	pruneInterval = prunei
 	pruneWait = prunew
 	abortWait = abortw

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -62,8 +62,19 @@ func (s *BaseTest) AddCleanup(f func()) {
 	s.cleanupHandlers = append(s.cleanupHandlers, f)
 }
 
+// Backup a single element before further mocking.
+func Backup[T any](mockable *T) (restore func()) {
+	backup := *mockable
+
+	return func() {
+		*mockable = backup
+	}
+}
+
 // Backup the specified list of elements before further mocking.
-func Backup(mockablesByPtr ...interface{}) (restore func()) {
+func BackupMany(mockablesByPtr ...interface{}) (restore func()) {
+	// TODO find a type safe way of doing this when individual elements are
+	// of different type
 	backup := backupMockables(mockablesByPtr)
 
 	return func() {
@@ -89,4 +100,11 @@ func backupMockables(mockablesByPtr []interface{}) (backup []*reflect.Value) {
 		backup[i] = &saved
 	}
 	return backup
+}
+
+// Mock provides a type safe way of mocking a single thing.
+func Mock[T any](mockable *T, newVal T) (restore func()) {
+	restore = Backup(mockable)
+	*mockable = newVal
+	return restore
 }

--- a/testutil/export_test.go
+++ b/testutil/export_test.go
@@ -28,17 +28,9 @@ func UnexpectedIntChecker(relation string) *intChecker {
 }
 
 func MockShellcheckPath(p string) (restore func()) {
-	old := shellcheckPath
-	shellcheckPath = p
-	return func() {
-		shellcheckPath = old
-	}
+	return Mock(&shellcheckPath, p)
 }
 
 func MockRuntimeARCH(new string) (restore func()) {
-	old := runtimeGOARCH
-	runtimeGOARCH = new
-	return func() {
-		runtimeGOARCH = old
-	}
+	return Mock(&runtimeGOARCH, new)
 }

--- a/testutil/mocking_test.go
+++ b/testutil/mocking_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
 )
 
 func ExampleBackup_mockingSimple() {
@@ -41,7 +43,7 @@ func ExampleBackup_mockingMultiple() {
 	}
 
 	// Mock
-	restore := testutil.Backup(&mockableFunc, &mockableNumber, &mockableString, &mockableStruct)
+	restore := testutil.BackupMany(&mockableFunc, &mockableNumber, &mockableString, &mockableStruct)
 	mockableFunc = func() {
 		fmt.Println("Mock")
 	}
@@ -58,4 +60,82 @@ func ExampleBackup_mockingMultiple() {
 	// Output:
 	// Original function
 	// 17.53 Original string {Original struct}
+}
+
+var _ = Suite(&MockingTestSuite{})
+
+type MockingTestSuite struct{}
+
+func (s *MockingTestSuite) TestBackup(c *C) {
+	mockableInt := 2
+	mockableString := "foo"
+	mockableFunc := func() string { return "original" }
+
+	restore := testutil.Backup(&mockableInt)
+	mockableInt = 42
+	restore()
+	c.Check(mockableInt, Equals, 2)
+
+	restore = testutil.Backup(&mockableString)
+	mockableString = "bar"
+	restore()
+	c.Check(mockableString, Equals, "foo")
+
+	restore = testutil.Backup(&mockableFunc)
+	mockableFunc = func() string { return "mock" }
+	restore()
+	c.Check(mockableFunc(), Equals, "original")
+}
+
+func (s *MockingTestSuite) TestBackupMany(c *C) {
+	mockable1 := "foo"
+	mockable2 := 2
+	mockable3 := func() string { return "foo" }
+
+	restore := testutil.BackupMany(&mockable1, &mockable2, &mockable3)
+	mockable1 = "bar"
+	mockable2 = 42
+	mockable3 = func() string { return "bar" }
+
+	restore()
+	c.Check(mockable1, Equals, "foo")
+	c.Check(mockable2, Equals, 2)
+	c.Check(mockable3(), Equals, "foo")
+}
+
+func (s *MockingTestSuite) TestMock(c *C) {
+	mockableInt := 2
+	mockableString := "foo"
+	mockableFunc := func() string { return "foo" }
+
+	type Foo struct {
+		Bar int
+	}
+
+	mockableStruct := Foo{Bar: 9}
+
+	restore := testutil.Mock(&mockableInt, 5)
+	c.Check(mockableInt, Equals, 5)
+	restore()
+	c.Check(mockableInt, Equals, 2)
+
+	restore = testutil.Mock(&mockableString, "bar")
+	c.Check(mockableString, Equals, "bar")
+	restore()
+	c.Check(mockableString, Equals, "foo")
+
+	restore = testutil.Mock(&mockableFunc, func() string { return "bar" })
+	c.Check(mockableFunc(), Equals, "bar")
+	restore()
+	c.Check(mockableFunc(), Equals, "foo")
+
+	restore = testutil.Mock(&mockableStruct, Foo{Bar: 12})
+	c.Check(mockableStruct, Equals, Foo{Bar: 12})
+	restore()
+	c.Check(mockableStruct, Equals, Foo{Bar: 9})
+
+	// XXX does not build because the types don't match
+
+	// restore = testutil.Mock(&mockableFunc, func() int { return 555 })
+	// restore()
 }


### PR DESCRIPTION
Add an explicit `Mock()` helper for mocking single objects. Extend unit tests for exiting `Backup*` code
 