### PR TITLE
tests: use ubuntu-image snap from beta channel

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -45,7 +45,7 @@ environment:
     # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
     LXD_SNAP_CHANNEL: "latest/candidate"
     OLD_UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/beta"
     SNAPCRAFT_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod


### PR DESCRIPTION
This is required to fix arm tests which are failing to boot because the error:

failed: cannot install system: gadget and system-boot device /dev/vda partition table not compatible: cannot find disk partition /dev/vda2 (starting at 2097152) in gadget: on disk size 8673820672 (8.08 GiB) is larger than gadget size 1258291200 (1.17 GiB)
