### PR TITLE
interface/builtin: add desktop-files interface

### DIFF
--- a/interfaces/builtin/desktop_files.go
+++ b/interfaces/builtin/desktop_files.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/snap"
+)
+
+// The desktop-legacy and unity7 interfaces denies access to the contents of the .desktop files
+// located at /var/lib/snapd/desktop/applications; only the list of files is readable.
+// The desktop-files interface, instead, gives access to those files contents. But since, in
+// AppArmor, a deny access is "stronger", if the desktop-legacy or the unity7 interfaces are
+// connected, the access to those contents will be forbidden, no matter what the desktop-files
+// interface adds to the AppArmor configuration.
+//
+// To fix this, a prioritized block is defined with `prioritizedSnippetDesktopFileAccess`, where
+// the AppArmor code inserted by desktop-legacy and unity7 to forbid access to those files is
+// given a lower priority than the code inserted by desktop-files to allow it. This way, if
+// only the desktop-legacy or the unity7 interfaces are connected, everything will work as
+// before (no access to the contents of the .desktop files), but if the desktop-info interface
+// is connected too, then access to those .desktop files is granted, because the code from
+// desktop-legacy and unity7 is removed.
+//
+// desktop-files is also placed lower than desktop-launch, as that's a more privileged interface.
+
+const desktopFilesPriority = 80
+
+type desktopFilesInterface struct{}
+
+const desktopFilesSummary = `allows snaps to identify desktop applications in (or from) other snaps`
+
+const desktopFilesBaseDeclarationPlugs = `
+  desktop-files:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const desktopFilesBaseDeclarationSlots = `
+  desktop-files:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const desktopFilesConnectedPlugAppArmor = `
+# Description: Can identify other snaps.
+
+# Access to the desktop and icon files installed by snaps
+/var/lib/snapd/desktop/applications/{,*} r,
+/var/lib/snapd/desktop/icons/{,**} r,
+
+# Allow access to all snap metadata
+/snap/*/*/** r,
+`
+
+func (iface *desktopFilesInterface) Name() string {
+	return "desktop-files"
+}
+
+func (iface *desktopFilesInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              desktopFilesSummary,
+		ImplicitOnCore:       true,
+		ImplicitOnClassic:    true,
+		BaseDeclarationPlugs: desktopFilesBaseDeclarationPlugs,
+		BaseDeclarationSlots: desktopFilesBaseDeclarationSlots,
+	}
+}
+
+func (iface *desktopFilesInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(desktopFilesConnectedPlugAppArmor)
+	// the DesktopFileRules added by other, less privileged, interfaces (like unity7
+	// or desktop-legacy) can conflict with the rules in this, more privileged,
+	// interface, so they are added there with the minimum priority, while in this
+	// one an empty string is added with a bigger privilege value, thus removing
+	// those rules when desktop-files plug is connected.
+	spec.AddPrioritizedSnippet("", prioritizedSnippetDesktopFileAccess, desktopFilesPriority)
+	return nil
+}
+
+func (iface *desktopFilesInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func init() {
+	registerIface(&desktopFilesInterface{})
+}

--- a/interfaces/builtin/desktop_files.go
+++ b/interfaces/builtin/desktop_files.go
@@ -70,7 +70,7 @@ const desktopFilesConnectedPlugAppArmor = `
 /var/lib/snapd/desktop/icons/{,**} r,
 
 # Allow access to all snap metadata
-/snap/*/*/** r,
+/{,var/lib/snapd/}snap/*/*/** r,
 `
 
 func (iface *desktopFilesInterface) Name() string {

--- a/interfaces/builtin/desktop_files_test.go
+++ b/interfaces/builtin/desktop_files_test.go
@@ -1,0 +1,127 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type desktopFilesSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&desktopFilesSuite{
+	iface: builtin.MustInterface("desktop-files"),
+})
+
+const desktopFilesConsumerYaml = `
+name: other
+version: 0
+apps:
+ app:
+    command: foo
+    plugs: [desktop-files]
+`
+
+const desktopFilesCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  desktop-files:
+`
+
+func (s *desktopFilesSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, desktopFilesConsumerYaml, nil, "desktop-files")
+	s.slot, s.slotInfo = MockConnectedSlot(c, desktopFilesCoreYaml, nil, "desktop-files")
+}
+
+func (s *desktopFilesSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "desktop-files")
+}
+
+func (s *desktopFilesSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *desktopFilesSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *desktopFilesSuite) TestConnectedPlugSnippet(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `Can identify other snaps.`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/{,*} r`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/var/lib/snapd/desktop/icons/{,**} r`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/snap/*/*/** r`)
+}
+
+func (s *desktopFilesSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *desktopFilesSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows snaps to identify desktop applications in (or from) other snaps`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "desktop-files")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "desktop-files")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "deny-auto-connection: true")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "allow-installation: false")
+}
+
+func (s *desktopFilesSuite) TestDesktopFilesAndDesktopLegacy(c *C) {
+	const desktopFilesConsumerYamlWithFilesAndLegacy = `
+name: other
+version: 0
+apps:
+ app:
+    command: foo
+    plugs: [desktop-files, desktop-legacy]
+`
+
+	plug, _ := MockConnectedPlug(c, desktopFilesConsumerYamlWithFilesAndLegacy, nil, "desktop-files")
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	err = apparmorSpec.AddConnectedPlug(builtin.MustInterface("desktop-legacy"), plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), "# Explicitly deny access to other snap's desktop files")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "Description: Can access common desktop legacy methods.")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "Description: Can identify other snaps.")
+}

--- a/interfaces/builtin/desktop_files_test.go
+++ b/interfaces/builtin/desktop_files_test.go
@@ -84,7 +84,7 @@ func (s *desktopFilesSuite) TestConnectedPlugSnippet(c *C) {
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `Can identify other snaps.`)
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/{,*} r`)
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/var/lib/snapd/desktop/icons/{,**} r`)
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/snap/*/*/** r`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/{,var/lib/snapd/}snap/*/*/** r`)
 }
 
 func (s *desktopFilesSuite) TestInterfaces(c *C) {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -813,6 +813,7 @@ var (
 		"cups-control":              {"app", "core"},
 		"dbus":                      {"app"},
 		"docker-support":            {"core"},
+		"desktop-files":             {"core"},
 		"desktop-launch":            {"core"},
 		"dsp":                       {"core", "gadget"},
 		"empty":                     {"app"},

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -47,6 +47,9 @@ apps:
   dcdbas-control:
     command: bin/run
     plugs: [ dcdbas-control ]
+  desktop-files:
+    command: bin/run
+    plugs: [ desktop-files ]
   desktop-legacy:
     command: bin/run
     plugs: [ desktop-legacy ]


### PR DESCRIPTION
This is a subset of `desktop-launch`, allowing access only to desktop files and app metadata, without allowing to launch them.

Replaces #14193.