### PR TITLE
tests: show that snap from snapd deb can be bundled

### DIFF
--- a/tests/main/bin-snap-in-snap/task.yaml
+++ b/tests/main/bin-snap-in-snap/task.yaml
@@ -1,0 +1,30 @@
+summary: snaps bundling /bin/snap from snapd.deb can do so
+
+details: |
+  The snap binary may be embedded in a snap for as long as the bases match.
+  The snap binary may be called with LD_PRELOAD=, or other dynamic linker
+  environment variables without ill effects.
+
+  Note that this contract does *not* extend to the snap binary from the snapd
+  snap. That version cannot be embedded in snap applications.
+
+systems:
+  # This test runs only on systems that are ABI-matching the core24 snap.  This
+  # test could be extended to include more bases later. This test cannot run
+  # on ubuntu core, because /usr/bin/snap is the "snapd snap" version which is
+  # linked differently.
+  - ubuntu-24.04-64
+
+
+prepare: |
+  cp "$(command -v snap)" test-snapd-sh-core24/bin
+  snap pack test-snapd-sh-core24
+  snap install --dangerous ./test-snapd-sh-core24_1.0_all.snap
+
+execute: |
+  # We are pre-loading libz simply because it's small and easy to get. The
+  # point is to show, that the copied snap executable does not crash in this
+  # configuration.
+  #
+  # shellcheck disable=SC2016
+  test-snapd-sh-core24.sh -c 'LD_PRELOAD=/lib/x86_64-linux-gnu/libz.so "$SNAP"/bin/snap' | MATCH 'Usage: snap <command> \[<options>...\]'

--- a/tests/main/bin-snap-in-snap/test-snapd-sh-core24/bin/sh
+++ b/tests/main/bin-snap-in-snap/test-snapd-sh-core24/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/bin-snap-in-snap/test-snapd-sh-core24/meta/snap.yaml
+++ b/tests/main/bin-snap-in-snap/test-snapd-sh-core24/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-sh-core24
+version: 1.0
+architectures: ["all"]
+base: core24
+apps:
+    sh:
+        command: bin/sh


### PR DESCRIPTION
Developers may want to bundle the snap executable from the snapd project into their application to get access to the snap APIs in a convenient form.

This test shows that this can be safely done for as long as the snapd deb is used as the source (not snapd snap) and that the ABI of snapd.deb and the application snap's base match.

Relates to changes made here: https://github.com/canonical/snapd/pull/14509

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-32203