### PR TITLE
o/snapstate: add more aggressive delay for auto-refresh failure after reboot

### DIFF
--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1584,9 +1584,10 @@ func (s *snapsSuite) TestSnapInfoReturnsRefreshFailures(c *check.C) {
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 
 	expectedRefreshFailures := &snap.RefreshFailuresInfo{
-		Revision:        snap.R(6),
-		FailureCount:    4,
-		LastFailureTime: time.Date(2024, time.October, 10, 21, 22, 11, 0, time.UTC),
+		Revision:            snap.R(6),
+		FailureCount:        4,
+		LastFailureTime:     time.Date(2024, time.October, 10, 21, 22, 11, 0, time.UTC),
+		LastFailureSeverity: snap.RefreshFailureSeverityAfterReboot,
 	}
 
 	st := d.Overlord().State()

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -73,6 +73,18 @@ func maybeTaskSetSnapSetup(ts *state.TaskSet) *SnapSetup {
 	return nil
 }
 
+func isEssentialSnap(snapName string, snapType snap.Type, bootBase string) bool {
+	switch snapType {
+	case snap.TypeBase:
+		if snapName == bootBase {
+			return true
+		}
+	case snap.TypeSnapd, snap.TypeOS, snap.TypeGadget, snap.TypeKernel:
+		return true
+	}
+	return false
+}
+
 // taskSetsByTypeForEssentialSnaps returns a map of task-sets by their essential snap type, if
 // a task-set for any of the essential snap exists.
 func taskSetsByTypeForEssentialSnaps(tss []*state.TaskSet, bootBase string) (map[snap.Type]*state.TaskSet, error) {
@@ -83,12 +95,7 @@ func taskSetsByTypeForEssentialSnaps(tss []*state.TaskSet, bootBase string) (map
 			continue
 		}
 
-		switch snapsup.Type {
-		case snap.TypeBase:
-			if snapsup.SnapName() == bootBase {
-				avail[snapsup.Type] = ts
-			}
-		case snap.TypeSnapd, snap.TypeOS, snap.TypeGadget, snap.TypeKernel:
+		if isEssentialSnap(snapsup.InstanceName(), snapsup.Type, bootBase) {
 			avail[snapsup.Type] = ts
 		}
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -2090,6 +2090,13 @@ func RegistryPlugAttrs(plug *PlugInfo) (account, registry, view string, err erro
 	return account, registry, view, nil
 }
 
+type RefreshFailureSeverity string
+
+const (
+	RefreshFailureSeverityNone        RefreshFailureSeverity = ""
+	RefreshFailureSeverityAfterReboot RefreshFailureSeverity = "after-reboot"
+)
+
 // RefreshFailures holds information about snap failed refreshes.
 type RefreshFailuresInfo struct {
 	// Revision is the target revision that caused the refresh failure.
@@ -2098,7 +2105,7 @@ type RefreshFailuresInfo struct {
 	FailureCount int `json:"failure-count"`
 	// LastFailureTime is the time of the last failed refresh attempt for the revision.
 	LastFailureTime time.Time `json:"last-failure-time"`
-
-	// TODO: add RefreshFailureSeverity to allow for more aggressive
-	// delays for snaps that fail after rebooting.
+	// LastFailureSeverity identifies how severe the last failure was.
+	// This allows for more aggressive backoff delay for snaps that fail after a reboot.
+	LastFailureSeverity RefreshFailureSeverity `json:"last-failure-severity,omitempty"`
 }

--- a/tests/core/auto-refresh-backoff-after-reboot/check_auto_refresh_count.sh
+++ b/tests/core/auto-refresh-backoff-after-reboot/check_auto_refresh_count.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+LAST_CHANGE_ID=$1
+CHANGES_COUNT=$2
+
+#shellcheck disable=SC2086,SC2046
+test $(snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT

--- a/tests/core/auto-refresh-backoff-after-reboot/task.yaml
+++ b/tests/core/auto-refresh-backoff-after-reboot/task.yaml
@@ -1,0 +1,185 @@
+summary: Ensures that a failed snap auto-refresh after a reboot will be aggressively delayed in future refreshes.
+
+details: |
+    Test ensures that if a snap auto-refresh failed after a reboot the next auto-refresh
+    attempt for the same revision will be aggressively delayed.
+
+# TODO make the test work with ubuntu-core-20
+systems: [ubuntu-core-18-*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+    SNAP_NAME/kernel: pc-kernel
+    SNAP_ID/kernel: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    # TODO: Add gadget variant
+    # SNAP_NAME/gadget: pc
+    # SNAP_ID/gadget: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # Needed by make-snap-installable, Install before switching to fakestore
+    snap install jq
+    snap install remarshal
+
+    # Prevent refreshes until we have right snap revisions
+    snap set system refresh.hold=forever
+
+    # Record last change id before we start to avoid flakiness due to auto-refreshes in other tests
+    snap debug api /v2/changes?select=all | jq '.result | sort_by(.id) | .[-1].id' > last-change-id
+    # Record current snap revision for reference
+    readlink "/snap/$SNAP_NAME/current" > snap.rev
+
+    mkdir -p "$BLOB_DIR/asserts"
+
+    # Expose the needed assertions through the fakestore
+    cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$BLOB_DIR/asserts"
+
+    # It is not enough to copy the assertions, we must also ack them otherwise we
+    # will get an error about not being able to resolve the account key
+    snap ack "$BLOB_DIR/asserts/testrootorg-store.account-key"
+    snap ack "$BLOB_DIR/asserts/developer1.account"
+    snap ack "$BLOB_DIR/asserts/developer1.account-key"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+    rm -rf "$BLOB_DIR"
+
+    snap set system refresh.hold!
+
+debug: |
+    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id)"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # The daemon is configured to point to the fake store
+    "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+
+    LAST_CHANGE_ID="$(cat last-change-id)"
+
+    GOOD_SNAP_PATH="$PWD/good.snap"
+    BAD_SNAP_PATH="$PWD/bad.snap"
+
+    add_snap_to_fakestore() {
+        SNAP_FILE="$1"
+        SNAP_REV="$2"
+
+        # Rebuild snap with $SNAP_REV written into a file inside it to force a new snap-sha3-384
+        # hash in snap-revision assertion
+        unsquashfs -d /tmp/fake-snap "$SNAP_FILE"
+        # Force new snap-sha3-384 hash for snap
+        echo "$SNAP_REV" > /tmp/fake-snap/rev
+        snap pack --filename="$SNAP_NAME-rev-$SNAP_REV.snap" /tmp/fake-snap .
+        rm -rf /tmp/fake-snap
+
+        "$TESTSTOOLS"/store-state make-snap-installable --revision "$SNAP_REV" "$BLOB_DIR" "$(pwd)/$SNAP_NAME-rev-$SNAP_REV.snap" "$SNAP_ID"
+    }
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        if [[ "$SNAP_NAME" == "pc-kernel" ]]; then
+            # Just copy existing pc-kernel snap as reference for a good snap
+            cp /var/lib/snapd/snaps/pc-kernel_*.snap "$GOOD_SNAP_PATH"
+            # Make a bad pc-kernel snap
+            if os.query is-core18; then
+                unsquashfs -d pc-kernel-snap /var/lib/snapd/snaps/pc-kernel_*.snap
+                truncate -s 0 pc-kernel-snap/initrd.img
+            else
+                echo "unsupported Ubuntu Core system"
+                exit 1
+            fi
+            snap pack --filename="bad.snap" pc-kernel-snap .
+        fi
+
+        # Make snaps refreshable from fakestore
+        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$SNAP_NAME" --snap-blob="$BAD_SNAP_PATH"
+
+        # -------- FIRST AUTO REFRESH --------
+
+        # Clean old snaps in fakestore directory because the fakestore can't distinguish
+        # multiple snaps files for the same snap
+        rm "$BLOB_DIR"/*.snap
+        echo "Make new bad revision of $SNAP_NAME"
+        add_snap_to_fakestore "$BAD_SNAP_PATH" 11
+
+        # Ensure there are no refresh holds, otherwise can't force auto-refresh
+        snap set system refresh.hold!
+
+        echo "Trigger auto-refresh"
+        systemctl stop snapd.{service,socket}
+        "$TESTSTOOLS"/snapd-state force-autorefresh
+        systemctl start snapd.{service,socket}
+
+        # wait for the link tasks to be done
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        # 1st auto-refresh has completed and failed
+        retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 1
+        # More aggressive backoff delay is applied when failure is after reboot (16 hours instead of 8 hours)
+        journalctl -b -u snapd | MATCH "auto-refresh to revision 11 has failed, next auto-refresh attempt will be delayed by 16 hours"
+
+        # Double check we have not refreshed
+        test "$(readlink /snap/$SNAP_NAME/current)" = "$(cat snap.rev)"
+
+        # -------- SECOND AUTO REFRESH --------
+
+        echo "Trigger auto-refresh a second time with the same bad revision"
+        systemctl stop snapd.{service,socket}
+        "$TESTSTOOLS"/snapd-state force-autorefresh
+        systemctl start snapd.{service,socket}
+        # Wait until auto-refresh is triggered and bad refresh was skipped due to backoff delay
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "auto-refresh to revision 11 was skipped due to previous failures, next auto-refresh attempt will be delayed by 16 hours"'
+
+        # -------- THIRD AUTO REFRESH --------
+
+        # Clean old snaps in fakestore directory because the fakestore can't distinguish
+        # multiple snaps files for the same snap
+        rm "$BLOB_DIR"/*.snap
+        echo "Make new good revision of $SNAP_NAME"
+        add_snap_to_fakestore "$GOOD_SNAP_PATH" 22
+
+        echo "Trigger auto-refresh"
+        systemctl stop snapd.{service,socket}
+        "$TESTSTOOLS"/snapd-state force-autorefresh
+        systemctl start snapd.{service,socket}
+
+        # wait for the link tasks to be done
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 2 ]; then
+        # Refreshed to new revision
+        test "$(readlink /snap/$SNAP_NAME/current)" = "22"
+
+        retry -n 50 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 2
+
+        echo "Check auto-refresh behaviour matches expectations for backoff algorithm"
+        snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id)" > changes.json
+
+        # 1st auto-refresh
+        jq '.[0].status' < changes.json | MATCH "Error"
+        jq '.[0].data."snap-names" | length' < changes.json | MATCH "1"
+        jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
+        jq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_NAME"
+
+        # 2nd auto-refresh
+        jq '.[1].status' < changes.json | MATCH "Done"
+        jq '.[1].data."snap-names" | length' < changes.json | MATCH "1"
+        jq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
+        jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_NAME"
+    fi

--- a/tests/main/auto-refresh-backoff/task.yaml
+++ b/tests/main/auto-refresh-backoff/task.yaml
@@ -114,6 +114,8 @@ execute: |
     systemctl start snapd.{service,socket}
     # Wait until auto-refresh is triggered and completed
     retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 1
+    # Check log is emitted about failed auto-refresh for SNAP_ONE
+    retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "auto-refresh to revision 11 has failed, next auto-refresh attempt will be delayed by 8 hours"'
 
     echo "Check we have expected revisions for both snaps"
     readlink "$SNAP_MOUNT_DIR/$SNAP_ONE/current" | NOMATCH 11
@@ -132,6 +134,8 @@ execute: |
     systemctl start snapd.{service,socket}
     # Wait until auto-refresh is triggered and completed
     retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 2
+    # Check log is emitted about skipping auto-refresh of bad revision for SNAP_ONE
+    retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "auto-refresh to revision 11 was skipped due to previous failures, next auto-refresh attempt will be delayed by 8 hours"'
 
     echo "Check we have expected revisions for both snaps"
     readlink "$SNAP_MOUNT_DIR/$SNAP_ONE/current" | NOMATCH 11


### PR DESCRIPTION
This PR builds on top of https://github.com/canonical/snapd/pull/14578 and should be rebased when the other is merged.

This PR adds more aggressive delay penalty if the snap auto-refresh failed after reboot like a bad kernel/gadget snaps.