### PR TITLE
core-initrd: support tee-supplicant and tee-based fTPMs

### DIFF
--- a/core-initrd/26.04/bin/ubuntu-core-initramfs
+++ b/core-initrd/26.04/bin/ubuntu-core-initramfs
@@ -839,6 +839,11 @@ def create_initrd(parser, args):
                 "/usr/bin/.kcapi-hasher.hmac",
             ] + glob.glob("/usr/lib/*/.libkcapi.so.*.hmac"), main, rootfs)
 
+        if "tee" in args.features:
+            install_files([
+                    "/usr/sbin/tee-supplicant",
+            ], main, rootfs)
+
         # Update epoch
         pathlib.Path("%s/main/usr/lib/clock-epoch" % d).touch()
         # Should iterate all the .conf drop ins

--- a/core-initrd/latest/tee/usr/lib/modules-load.d/tee.conf
+++ b/core-initrd/latest/tee/usr/lib/modules-load.d/tee.conf
@@ -1,0 +1,3 @@
+tee
+optee
+tpm_ftpm_tee

--- a/core-initrd/latest/tee/usr/lib/systemd/system/run-mnt-tee\x2ddata.mount
+++ b/core-initrd/latest/tee/usr/lib/systemd/system/run-mnt-tee\x2ddata.mount
@@ -1,0 +1,6 @@
+[Unit]
+Before=tee-supplicant.service
+
+[Mount]
+What=/dev/disk/by-partlabel/tee-data
+Where=/run/mnt/tee-data

--- a/core-initrd/latest/tee/usr/lib/systemd/system/sysinit.target.wants/run-mnt-tee\x2ddata.mount
+++ b/core-initrd/latest/tee/usr/lib/systemd/system/sysinit.target.wants/run-mnt-tee\x2ddata.mount
@@ -1,0 +1,1 @@
+../run-mnt-tee\x2ddata.mount

--- a/core-initrd/latest/tee/usr/lib/systemd/system/sysinit.target.wants/tee-supplicant.service
+++ b/core-initrd/latest/tee/usr/lib/systemd/system/sysinit.target.wants/tee-supplicant.service
@@ -1,0 +1,1 @@
+../tee-supplicant.service

--- a/core-initrd/latest/tee/usr/lib/systemd/system/tee-supplicant.service
+++ b/core-initrd/latest/tee/usr/lib/systemd/system/tee-supplicant.service
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Adapted from https://github.com/OP-TEE/optee_client/blob/6486773583b5983af8250a47cf07eca938e0e422/tee-supplicant/tee-supplicant%40.service.in
+[Unit]
+Description=TEE Supplicant
+DefaultDependencies=no
+ConditionKernelCommandLine=snapd_recovery_mode=run
+After=dev-teepriv0.device run-mnt-tee\x2ddata.mount
+Wants=dev-teepriv0.device run-mnt-tee\x2ddata.mount
+Before=sysinit.target
+Before=snap-initramfs-mounts.service
+
+[Service]
+# tee-supplicant v4.3+ (Oracular and newer) has sd_notify support
+Type=notify
+ExecStartPre=-/bin/sh modprobe -v -r tpm_ftpm_tee
+ExecStart=/usr/sbin/tee-supplicant --fs-parent-path /run/mnt/tee-data
+ExecStartPost=/bin/sh modprobe -v tpm_ftpm_tee
+
+# Workaround for fTPM TA: stop kernel module before tee-supplicant
+ExecStop=-/bin/sh -c "/sbin/modprobe -v -r tpm_ftpm_tee ; /bin/kill $MAINPID"

--- a/core-initrd/latest/tee/usr/lib/udev/rules.d/99-optee.rules
+++ b/core-initrd/latest/tee/usr/lib/udev/rules.d/99-optee.rules
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Adapted from https://github.com/OP-TEE/optee_client/blob/6486773583b5983af8250a47cf07eca938e0e422/tee-supplicant/optee-udev.rules.in
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="root", TAG+="systemd"
+KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="root", TAG+="systemd"


### PR DESCRIPTION
Bringing https://github.com/canonical/core-initrd/pull/286 to the correct repo

This adds support for running tee-supplicant out of the initrd, to allow OP-TEE Trusted Applications to access Secure Storage. It assumes that the gadget has declared a partition called tee-data to serve as a backing store for the Secure Storage.

This is NOT relevant for simple TAs, such as those covered by https://github.com/canonical/snapd/pull/15262. Instead, this is to support fTPMs implemented as a TA, which require Secure Storage as backing for the fTPM's NVmem.

This PR by itself is only half the story, covering unlocking the encrypted partitions in run mode. Initial install and subsequent re-sealing on kernel/firmware updates will require tee-supplicant to also be run separately (either from the core snap or the gadget snap, both have been validated to work).

This has been tested on the Nvidia Jetson platforms, using their downstream implementation of [OP-TEE/optee_ftpm](https://github.com/OP-TEE/optee_ftpm). I have not yet been able to find a way to validate this using QEMU (plus OP-TEE/ATF/EDK2), as the reference OP-TEE development stack is u-boot (non-EFI) based, although I would like to figure that out. Additionally, the development for this was done on core22 then forward-ported, as that is the only version of Ubuntu currently available on the Jetson platforms.
