### PR TITLE
cmd/snap-update-ns: cross-check optimizer with the verification pass

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -10,6 +10,9 @@ ignore_files:
   - cmd/snap-confine/snap-confine.c
   - osutil/mount/libmount/libmount_linux.go
   - osutil/mount/libmount/libmount_linux_test.go
+  - osutil/vfs/mount.go
+  - osutil/vfs/propagation.go
+  - osutil/vfs/propagation_test.go
   - osutil/vfs/tests/bind-semantics/task.yaml
   - osutil/vfs/tests/bind-shadow-propagate/task.yaml
   - osutil/vfs/tests/mount-in-slave/expected.txt

--- a/cmd/snap-update-ns/sorting.go
+++ b/cmd/snap-update-ns/sorting.go
@@ -98,6 +98,7 @@ func (c byOriginAndMountPoint) Less(i, j int) bool {
 		}
 	}
 
+	// FIXME: this doesn't know about file bind mounts
 	iDir := c[i].Dir
 	jDir := c[j].Dir
 	if !strings.HasSuffix(iDir, "/") {

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -362,6 +362,11 @@ func (s *updateSuite) TestKeepSyntheticMountsLP2043993(c *C) {
 	c.Check(saved.Entries[1], DeepEquals, desiredMountEntry)
 
 	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
+	c.Log("saved.Entries has length ", len(saved.Entries))
+	c.Log("saved.Entries ")
+	for _, e := range saved.Entries {
+		c.Log("- ", e)
+	}
 	c.Assert(saved.Entries, HasLen, 2)
 	c.Check(saved.Entries[0].Type, Equals, "tmpfs")
 	c.Check(saved.Entries[0].Name, Equals, "tmpfs")

--- a/osutil/vfs/export_test.go
+++ b/osutil/vfs/export_test.go
@@ -19,6 +19,10 @@
 
 package vfs
 
+func (v *VFS) SetLastGroupID(id GroupID) {
+	v.lastGroupID = id
+}
+
 func (v *VFS) FindMount(id MountID) *mount {
 	for _, m := range v.mounts {
 		if m.mountID == id {

--- a/osutil/vfs/propagation.go
+++ b/osutil/vfs/propagation.go
@@ -1,0 +1,274 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package vfs
+
+import (
+	"io/fs"
+	"iter"
+	"strings"
+)
+
+const flagRecurse = 1 << iota
+
+// makeShared makes a non-shared mount an initial member of a new peer group.
+func (v *VFS) makeShared(mountPoint string, flags uint) error {
+	return v.propagationChange(mountPoint, "make-shared", flags&flagRecurse != 0, func(m *mount) {
+		if m.shared == 0 {
+			m.shared = v.allocateGroupID()
+		}
+		m.unbindable = false
+	})
+}
+
+// makeSlave converts a shared mount to a slave mount of the same group.
+//
+// Making a sole member of a shared peer group slave effectively makes
+// it private as there is no other member to retain as master.
+func (v *VFS) makeSlave(mountPoint string, flags uint) error {
+	return v.propagationChange(mountPoint, "make-slave", flags&flagRecurse != 0, func(m *mount) {
+		if m.shared != 0 {
+			if v.unlockedSharedGroupCount(m.shared) >= 1 {
+				m.master = m.shared
+			}
+			m.shared = 0
+		}
+
+		m.unbindable = false
+	})
+}
+
+// makePrivate makes removes a mount from peer group membership.
+func (v *VFS) makePrivate(mountPoint string, flags uint) error {
+	return v.propagationChange(mountPoint, "make-private", flags&flagRecurse != 0, func(m *mount) {
+		m.shared = 0
+		m.master = 0
+		m.unbindable = false
+	})
+}
+
+// makeUnbindable removes a mount from peer group membership, and prevents using it as bind-mount source.
+func (v *VFS) makeUnbindable(mountPoint string, flags uint) error {
+	return v.propagationChange(mountPoint, "make-private", flags&flagRecurse != 0, func(m *mount) {
+		m.shared = 0
+		m.master = 0
+		m.unbindable = true
+	})
+}
+
+// MakeShared makes a mount point a new member of a peer group.
+//
+// The unbindable flag is always cleared.
+// If the mount point is not yet shared, it joins a new peer group as the only member.
+// When a shared mount is used as a bind-mount source, the shared peer group is retained.
+// When a shared mount dominates a mount or unmount operation, the operation is replayed to all the members of the
+// shared peer group as well as to all the slaves that were former members.
+func (v *VFS) MakeShared(mountPoint string) error {
+	return v.makeShared(mountPoint, 0)
+}
+
+// MakeRecursivelyShared is the recursive version of MakeShared.
+func (v *VFS) MakeRecursivelyShared(mountPoint string) error {
+	return v.makeShared(mountPoint, flagRecurse)
+}
+
+// MakeSlave makes a mount point a new member of a slave group.
+//
+// The unbindable flag is always cleared. If the mount is shared then it
+// converts from a peer to a slave of the group. Mounts that are slave to a
+// peer group receive mount and unmount operations from the group, but do not
+// propagate any operations back.
+func (v *VFS) MakeSlave(mountPoint string) error {
+	return v.makeSlave(mountPoint, 0)
+}
+
+// MakeRecursivelySlave is a recursive version of MakeSlave.
+func (v *VFS) MakeRecursivelySlave(mountPoint string) error {
+	return v.makeSlave(mountPoint, flagRecurse)
+}
+
+// MakePrivate removes a mount point from peer groups and makes it bindable again.
+func (v *VFS) MakePrivate(mountPoint string) error {
+	return v.makePrivate(mountPoint, 0)
+}
+
+// MakeRecursivelyPrivate is a recursive version of MakePrivate.
+func (v *VFS) MakeRecursivelyPrivate(mountPoint string) error {
+	return v.makePrivate(mountPoint, flagRecurse)
+}
+
+// MakeUnbindable makes the mount point unbindable.
+//
+// A bind mount operation that uses an unbindable mount as source immediately
+// fails. A recursive bind mount operation ignores any unbindable mounts without
+// failure.
+func (v *VFS) MakeUnbindable(mountPoint string) error {
+	return v.makeUnbindable(mountPoint, 0)
+}
+
+// MakeRecursivelyUnbindable is a recursive version of MakeUnbindable.
+func (v *VFS) MakeRecursivelyUnbindable(mountPoint string) error {
+	return v.makeUnbindable(mountPoint, flagRecurse)
+}
+
+// prpagationChange applies a propagation change function fn at a given mount point.
+//
+// The string [op] is used to construct an error value in case [mountPoint] is
+// not a mount point.  The [recurse] flag causes the function to be called
+// recursively on all the descendants of the mount denoted by [mountPoint]. The
+// descendants are all the mounts whose parentID is that can be traced back to
+// the selected starting mount.
+func (v *VFS) propagationChange(mountPoint, op string, recurse bool, fn func(m *mount)) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	return v.atMountPoint(mountPoint, op, func(pd pathDominator) error {
+		fn(pd.mount)
+
+		if recurse {
+			ancestorID := pd.mount.mountID
+			for _, m := range v.mounts[pd.index+1:] {
+				if m.hasAncestor(ancestorID) {
+					fn(m)
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+// atMountPoint calls [fn] if [mountPoint] is an existing mount point.
+//
+// If [mountPoint] is not a mount point then a [fs.PathError] is returned,
+// encapsulating the given path [mountPoint], and operation [op].
+func (v *VFS) atMountPoint(mountPoint, op string, fn func(pd pathDominator) error) error {
+	// Find the mount dominating the mount point.
+	pd := v.pathDominator(mountPoint)
+
+	// If the VFS suffix is not empty then the given path is _not_ a mount point.
+	if pd.suffix != "" && pd.suffix != "." {
+		return &fs.PathError{Op: op, Path: mountPoint, Err: errNotMounted}
+	}
+
+	return fn(pd)
+}
+
+// sliceContains returns true if the given slice [sl] contains element [elem].
+func sliceContains[T comparable](sl []T, elem T) bool {
+	for i := range sl {
+		if sl[i] == elem {
+			return true
+		}
+	}
+
+	return false
+}
+
+// unlockedSharedGroupCount countns the members of the shared peer group [id].
+func (v *VFS) unlockedSharedGroupCount(id GroupID) (count int) {
+	for _, m := range v.mounts {
+		if m.shared == id {
+			count++
+		}
+	}
+
+	return count
+}
+
+// maybePropagateMount propagates the mount m among the members of the parent's
+// peer group and their slaves. The function does nothing if the parent mount
+// is not shared.
+func (v *VFS) propagateMount(m *mount, skipFn func(m *mount) bool) {
+	if m.parent == nil {
+		panic("m.parent == nil")
+	}
+
+	if m.parent.shared == 0 {
+		panic("m.parent.shared == 0")
+	}
+
+	// TODO: use range syntax once we upgrade to go 1.23
+	v.peersAndSlavesOf(m.parent.shared)(func(peer *mount) bool {
+		if skipFn(peer) {
+			return true
+		}
+
+		// Skip this peer if it doesn't see the part of the file system that
+		// the event originated from. Here m.attachedAt s the place where the
+		// event originated within the parent mount, and peer.rootDir is the
+		// sub-tree of the parent mount that is actually visible in the peer.
+		if !strings.HasPrefix(m.attachedAt, peer.rootDir) {
+			return true
+		}
+
+		// Re-locate the attachment point based on the sub-tree that the peer
+		// is using. Note that we just checked the presence of the prefix in
+		// the test above.
+		attachedAt := strings.TrimPrefix(m.attachedAt, peer.rootDir)
+
+		// Compute how the new propagated mount is shared based on the type of
+		// peer (peer or slave peer) is the target of the propagation.
+		var master, shared GroupID
+		if peer.shared == m.parent.shared {
+			// Propagating into a peer. The shared group is retained.
+			shared = m.shared
+		} else {
+			// Propagating into a slave. The shared group becomes slave.
+			master = m.shared
+			if shared == 0 && peer.shared != 0 {
+				// The slave is also shared (independently of the peer group
+				// that undergoes propagation) so the propagated mount joins a
+				// new peer group.
+				//
+				// FIXME(propagation): Should this propagate again? After all,
+				// we are mounting something here so ... yes?
+				shared = v.allocateGroupID()
+			}
+		}
+
+		newM := &mount{
+			attachedAt: attachedAt,
+			rootDir:    m.rootDir,
+			isDir:      m.isDir,
+			fsFS:       m.fsFS,
+			shared:     shared,
+			master:     master,
+		}
+		v.attachMount(peer, newM)
+
+		return true
+	})
+}
+
+func (v *VFS) peersAndSlavesOf(id GroupID) iter.Seq[*mount] {
+	if id == 0 {
+		panic("cannot call peersAndSlavesOf(0)")
+	}
+
+	return func(yield func(*mount) bool) {
+		for _, m := range v.mounts[:] {
+			if m.shared == id || m.master == id {
+				if !yield(m) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/osutil/vfs/propagation_test.go
+++ b/osutil/vfs/propagation_test.go
@@ -1,0 +1,172 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package vfs_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/snapcore/snapd/osutil/vfs"
+)
+
+func TestVFS_PropagationToShared(t *testing.T) {
+	v := vfs.NewVFS(fstest.MapFS{
+		"a": &fstest.MapFile{Mode: fs.ModeDir},
+		"b": &fstest.MapFile{Mode: fs.ModeDir},
+		"c": &fstest.MapFile{Mode: fs.ModeDir},
+	})
+	must(t, v.Mount(fstest.MapFS{"1": &fstest.MapFile{Mode: fs.ModeDir}}, "a"))
+	must(t, v.MakeShared("a"))
+	must(t, v.BindMount("a", "b"))
+	must(t, v.BindMount("a", "c"))
+	must(t, v.Mount(fstest.MapFS{}, "a/1"))
+	// The mount a/1 is propagated to a, b and c.
+	assertVFS(t, v, `
+-1 -1 0:0 / / rw - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:1 - (fstype) (source) rw
+1  -1 0:0 / /b rw shared:1 - (fstype) (source) rw
+2  -1 0:0 / /c rw shared:1 - (fstype) (source) rw
+3  0 0:0 / /a/1 rw shared:2 - (fstype) (source) rw
+4  1 0:0 / /b/1 rw shared:2 - (fstype) (source) rw
+5  2 0:0 / /c/1 rw shared:2 - (fstype) (source) rw
+`)
+}
+
+func TestVFS_PropagationToSlave(t *testing.T) {
+	v := vfs.NewVFS(fstest.MapFS{
+		"a": &fstest.MapFile{Mode: fs.ModeDir},
+		"b": &fstest.MapFile{Mode: fs.ModeDir},
+		"c": &fstest.MapFile{Mode: fs.ModeDir},
+	})
+	must(t, v.Mount(fstest.MapFS{"1": &fstest.MapFile{Mode: fs.ModeDir}}, "a"))
+	must(t, v.MakeShared("a"))
+	must(t, v.BindMount("a", "b"))
+	must(t, v.MakeSlave("b"))
+	must(t, v.BindMount("a", "c"))
+	must(t, v.MakeSlave("c"))
+	must(t, v.Mount(fstest.MapFS{}, "a/1"))
+	// The mount a/1 is propagated to a, b and c.
+	assertVFS(t, v, `
+-1 -1 0:0 / / rw - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:1 - (fstype) (source) rw
+1  -1 0:0 / /b rw master:1 - (fstype) (source) rw
+2  -1 0:0 / /c rw master:1 - (fstype) (source) rw
+3  0 0:0 / /a/1 rw shared:2 - (fstype) (source) rw
+4  1 0:0 / /b/1 rw master:2 - (fstype) (source) rw
+5  2 0:0 / /c/1 rw master:2 - (fstype) (source) rw
+`)
+}
+
+func TestVFS_PropagationToSharedSlave(t *testing.T) {
+	v := vfs.NewVFS(fstest.MapFS{
+		"a": &fstest.MapFile{Mode: fs.ModeDir},
+		"b": &fstest.MapFile{Mode: fs.ModeDir},
+		"c": &fstest.MapFile{Mode: fs.ModeDir},
+		"d": &fstest.MapFile{Mode: fs.ModeDir},
+	})
+	v.SetLastGroupID(41)
+	must(t, v.Mount(WithSource("tmpfs-a", fstest.MapFS{
+		"1": &fstest.MapFile{Mode: fs.ModeDir},
+	}), "a"))
+	must(t, v.MakeShared("a"))
+	must(t, v.BindMount("a", "b"))
+	must(t, v.MakeSlave("b"))
+	must(t, v.MakeShared("b"))
+	must(t, v.BindMount("a", "c"))
+	must(t, v.MakeSlave("c"))
+	must(t, v.MakeShared("c"))
+	must(t, v.BindMount("c", "d"))
+	must(t, v.Mount(WithSource("tmpfs-a-1", fstest.MapFS{}), "a/1"))
+	// The mount a/1 is propagated to a, b, c and d.
+	// FIXME: This test is subtly different to what the kernel really does
+	assertVFS(t, v, `
+-1 -1 0:0 / / rw - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:42 - (fstype) tmpfs-a rw
+1  -1 0:0 / /b rw shared:43 master:42 - (fstype) tmpfs-a rw
+2  -1 0:0 / /c rw shared:44 master:42 - (fstype) tmpfs-a rw
+3  -1 0:0 / /d rw shared:44 master:42 - (fstype) tmpfs-a rw
+4  0 0:0 / /a/1 rw shared:45 - (fstype) tmpfs-a-1 rw
+5  1 0:0 / /b/1 rw shared:46 master:45 - (fstype) tmpfs-a-1 rw
+6  2 0:0 / /c/1 rw shared:47 master:45 - (fstype) tmpfs-a-1 rw
+7  3 0:0 / /d/1 rw shared:48 master:45 - (fstype) tmpfs-a-1 rw
+`)
+}
+
+func TestVFS_PropagationAndSubDirectories(t *testing.T) {
+	v := vfs.NewVFS(fstest.MapFS{
+		"a": &fstest.MapFile{Mode: fs.ModeDir},
+		"b": &fstest.MapFile{Mode: fs.ModeDir},
+	})
+	must(t, v.MakeShared(""))
+	must(t, v.Mount(WithSource("tmpfs-a", fstest.MapFS{
+		"1": &fstest.MapFile{Mode: fs.ModeDir},
+		"2": &fstest.MapFile{Mode: fs.ModeDir},
+	}), "a"))
+	must(t, v.BindMount("a/1", "b"))
+	must(t, v.Mount(WithSource("tmpfs-a-1", fstest.MapFS{}), "a/1"))
+	must(t, v.Mount(WithSource("tmpfs-a-2", fstest.MapFS{}), "a/2"))
+	assertVFS(t, v, `
+-1 -1 0:0 / / rw shared:1 - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:2 - (fstype) tmpfs-a rw
+1  -1 0:0 /1 /b rw shared:2 - (fstype) tmpfs-a rw
+2  0 0:0 / /a/1 rw shared:3 - (fstype) tmpfs-a-1 rw
+3  1 0:0 / /b rw shared:3 - (fstype) tmpfs-a-1 rw
+4  0 0:0 / /a/2 rw shared:4 - (fstype) tmpfs-a-2 rw
+`)
+}
+
+func TestVFS_MakeShared(t *testing.T) {
+	t.Run("bind-keeps-sharing", func(t *testing.T) {
+		v := vfs.NewVFS(fstest.MapFS{
+			"a":       &fstest.MapFile{Mode: fs.ModeDir},
+			"a_prime": &fstest.MapFile{Mode: fs.ModeDir},
+		})
+		must(t, v.Mount(fstest.MapFS{"b": &fstest.MapFile{Mode: fs.ModeDir}}, "a"))
+		must(t, v.MakeShared("a"))
+		must(t, v.Mount(fstest.MapFS{}, "a/b"))
+		must(t, v.RecursiveBindMount("a", "a_prime"))
+		assertVFS(t, v, `
+-1 -1 0:0 / / rw - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:1 - (fstype) (source) rw
+1  0 0:0 / /a/b rw shared:2 - (fstype) (source) rw
+2  -1 0:0 / /a_prime rw shared:1 - (fstype) (source) rw
+3  2 0:0 / /a_prime/b rw shared:2 - (fstype) (source) rw
+`)
+	})
+
+	t.Run("share-propagates", func(t *testing.T) {
+		v := vfs.NewVFS(fstest.MapFS{
+			"a":       &fstest.MapFile{Mode: fs.ModeDir},
+			"a_prime": &fstest.MapFile{Mode: fs.ModeDir},
+		})
+		must(t, v.Mount(fstest.MapFS{"b": &fstest.MapFile{Mode: fs.ModeDir}}, "a"))
+		must(t, v.MakeShared("a"))
+		must(t, v.RecursiveBindMount("a", "a_prime"))
+		must(t, v.Mount(fstest.MapFS{}, "a/b"))
+		assertVFS(t, v, `
+-1 -1 0:0 / / rw - (fstype) (source) rw
+0  -1 0:0 / /a rw shared:1 - (fstype) (source) rw
+1  -1 0:0 / /a_prime rw shared:1 - (fstype) (source) rw
+2  0 0:0 / /a/b rw shared:2 - (fstype) (source) rw
+3  1 0:0 / /a_prime/b rw shared:2 - (fstype) (source) rw
+`)
+	})
+}

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -24,36 +24,36 @@ environment:
     # Source and destination are both shared.
     ALTER_A/shared_to_shared: --make-shared
     ALTER_B/shared_to_shared: --make-shared
-    EXPECTED_A/shared_to_shared: "/a shared:42 -"
-    EXPECTED_B/shared_to_shared: "/b shared:42 -"
+    EXPECTED_A/shared_to_shared: "/ /a shared:42 - tmpfs-a"
+    EXPECTED_B/shared_to_shared: "/ /b shared:42 - tmpfs-a"
     # Source is shared, destination is private.
     ALTER_A/shared_to_private: --make-shared
     ALTER_B/shared_to_private: --make-private
-    EXPECTED_A/shared_to_private: "/a shared:42 -"
-    EXPECTED_B/shared_to_private: "/b shared:42 -"
+    EXPECTED_A/shared_to_private: "/ /a shared:42 - tmpfs-a"
+    EXPECTED_B/shared_to_private: "/ /b shared:42 - tmpfs-a"
     # Source is private, destination is shared.
     ALTER_A/private_to_shared: --make-private
     ALTER_B/private_to_shared: --make-shared
-    EXPECTED_A/private_to_shared: "/a -"
+    EXPECTED_A/private_to_shared: "/ /a - tmpfs-a"
     # NOTE: shared:42 is the /b mount that is created by mount --make-shared b.
     # Here we are seeing that /b is another shared mount but the underlying
     # filesystem is tmpfs-a.
-    EXPECTED_B/private_to_shared: "/b shared:43 -"
+    EXPECTED_B/private_to_shared: "/ /b shared:43 - tmpfs-a"
     # Source and destination are both private.
     ALTER_A/private_to_private: --make-private
     ALTER_B/private_to_private: --make-private
-    EXPECTED_A/private_to_private: "/a -"
-    EXPECTED_B/private_to_private: "/b -"
+    EXPECTED_A/private_to_private: "/ /a - tmpfs-a"
+    EXPECTED_B/private_to_private: "/ /b - tmpfs-a"
     # Source is a slave, destination is shared.
     ALTER_A/slave_to_shared: --make-slave
     ALTER_B/slave_to_shared: --make-shared
-    EXPECTED_A/slave_to_shared: "/a master:42 -"
-    EXPECTED_B/slave_to_shared: "/b shared:44 master:42 -"
+    EXPECTED_A/slave_to_shared: "/ /a master:42 - tmpfs-a"
+    EXPECTED_B/slave_to_shared: "/ /b shared:44 master:42 - tmpfs-a"
     # Source is a slave, destination is private.
     ALTER_A/slave_to_private: --make-slave
     ALTER_B/slave_to_private: --make-private
-    EXPECTED_A/slave_to_private: "/a master:42 -"
-    EXPECTED_B/slave_to_private: "/b master:42 -"
+    EXPECTED_A/slave_to_private: "/ /a master:42 - tmpfs-a"
+    EXPECTED_B/slave_to_private: "/ /b master:42 - tmpfs-a"
 prepare: |
     mkdir a
     mount -t tmpfs tmpfs-a a
@@ -81,6 +81,6 @@ restore: |
 debug: |
     cat /proc/self/mountinfo
 execute: |
-    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../mount-point-and-optional-fields.awk | grep -v a-helper >actual.txt
+    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v a-helper >actual.txt
     test "$(head -n 1 actual.txt)" = "$EXPECTED_A"
     test "$(tail -n 1 actual.txt)" = "$EXPECTED_B"

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -24,63 +24,76 @@ environment:
     # Source and destination are both shared.
     ALTER_A/shared_to_shared: --make-shared
     ALTER_B/shared_to_shared: --make-shared
-    EXPECTED_A/shared_to_shared: "/ /a shared:42 - tmpfs-a"
-    EXPECTED_B/shared_to_shared: "/ /b shared:42 - tmpfs-a"
+    EXPECTED_A/shared_to_shared: "/ /A shared:42 - tmpfs-A"
+    EXPECTED_B/shared_to_shared: "/ /B shared:43 - tmpfs-B"
+    EXPECTED_BIND/shared_to_shared: "/a /B/b shared:42 - tmpfs-A"
     # Source is shared, destination is private.
     ALTER_A/shared_to_private: --make-shared
     ALTER_B/shared_to_private: --make-private
-    EXPECTED_A/shared_to_private: "/ /a shared:42 - tmpfs-a"
-    EXPECTED_B/shared_to_private: "/ /b shared:42 - tmpfs-a"
+    EXPECTED_A/shared_to_private: "/ /A shared:42 - tmpfs-A"
+    EXPECTED_B/shared_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/shared_to_private: "/a /B/b shared:42 - tmpfs-A"
     # Source is private, destination is shared.
+    # NOTE: shared:42 is the /B mount that is created by mount --make-shared B.
+    # Here we are seeing that B/b is another shared mount but the underlying
+    # filesystem is tmpfs-A.
     ALTER_A/private_to_shared: --make-private
     ALTER_B/private_to_shared: --make-shared
-    EXPECTED_A/private_to_shared: "/ /a - tmpfs-a"
-    # NOTE: shared:42 is the /b mount that is created by mount --make-shared b.
-    # Here we are seeing that /b is another shared mount but the underlying
-    # filesystem is tmpfs-a.
-    EXPECTED_B/private_to_shared: "/ /b shared:43 - tmpfs-a"
+    EXPECTED_A/private_to_shared: "/ /A - tmpfs-A"
+    EXPECTED_B/private_to_shared: "/ /B shared:42 - tmpfs-B"
+    EXPECTED_BIND/private_to_shared: "/a /B/b shared:43 - tmpfs-A"
     # Source and destination are both private.
     ALTER_A/private_to_private: --make-private
     ALTER_B/private_to_private: --make-private
-    EXPECTED_A/private_to_private: "/ /a - tmpfs-a"
-    EXPECTED_B/private_to_private: "/ /b - tmpfs-a"
+    EXPECTED_A/private_to_private: "/ /A - tmpfs-A"
+    EXPECTED_B/private_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/private_to_private: "/a /B/b - tmpfs-A"
     # Source is a slave, destination is shared.
     ALTER_A/slave_to_shared: --make-slave
     ALTER_B/slave_to_shared: --make-shared
-    EXPECTED_A/slave_to_shared: "/ /a master:42 - tmpfs-a"
-    EXPECTED_B/slave_to_shared: "/ /b shared:44 master:42 - tmpfs-a"
+    EXPECTED_A/slave_to_shared: "/ /A master:42 - tmpfs-A"
+    EXPECTED_B/slave_to_shared: "/ /B shared:43 - tmpfs-B"
+    EXPECTED_BIND/slave_to_shared: "/a /B/b shared:44 master:42 - tmpfs-A"
     # Source is a slave, destination is private.
     ALTER_A/slave_to_private: --make-slave
     ALTER_B/slave_to_private: --make-private
-    EXPECTED_A/slave_to_private: "/ /a master:42 - tmpfs-a"
-    EXPECTED_B/slave_to_private: "/ /b master:42 - tmpfs-a"
+    EXPECTED_A/slave_to_private: "/ /A master:42 - tmpfs-A"
+    EXPECTED_B/slave_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/slave_to_private: "/a /B/b master:42 - tmpfs-A"
 prepare: |
-    mkdir a
-    mount -t tmpfs tmpfs-a a
+    mkdir A
+    mount -t tmpfs tmpfs-A A
+
     # If A needs to be slave then we need some help to allow it to be a slave.
     if [ "$ALTER_A" = --make-slave ]; then
-      mount --make-shared a
-      mkdir a-helper
-      mount --bind a a-helper
+      mount --make-shared A
+      mkdir A-helper
+      mount --bind A A-helper
     fi
-    mount "$ALTER_A" a
-    mkdir b
-    mount -t tmpfs tmpfs-b b
-    mount "$ALTER_B" b
-    mount --bind a b
+    mount "$ALTER_A" A
+
+    mkdir B
+    mount -t tmpfs tmpfs-B B
+    mount "$ALTER_B" B
+    mkdir A/a B/b
+    mount --bind A/a B/b
 restore: |
-    umount -l a
-    rmdir a
-    umount -l b
-    umount -l b || true
-    rmdir b
-    if [ -d a-helper ]; then
-      umount -l a-helper
-      rmdir a-helper
+    umount -l A
+    rmdir A
+    umount -l B/b
+    umount -l B
+    rmdir B
+    if [ -d A-helper ]; then
+      umount -l A-helper
+      rmdir A-helper
     fi
 debug: |
     cat /proc/self/mountinfo
 execute: |
-    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v a-helper >actual.txt
-    test "$(head -n 1 actual.txt)" = "$EXPECTED_A"
-    test "$(tail -n 1 actual.txt)" = "$EXPECTED_B"
+    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v A-helper >actual.txt
+    echo "Expected A mount is..."
+    test "$(tail -n 3 actual.txt | head -n 1)" = "${EXPECTED_A-}"
+    echo "Expected B mount is..."
+    test "$(tail -n 2 actual.txt | head -n 1)" = "${EXPECTED_B-}"
+    echo "Expected A/a -> B/b bind-mount is..."
+    test "$(tail -n 1 actual.txt)" = "${EXPECTED_BIND-}"

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -66,7 +66,7 @@ prepare: |
     mount "$ALTER_A" a
     mkdir b
     mount -t tmpfs tmpfs-b b
-    for op in $ALTER_B; do mount "$op" b; done
+    mount "$ALTER_B" b
     mount --bind a b
 restore: |
     umount -l a

--- a/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
+++ b/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
@@ -1,8 +1,8 @@
-/ /a shared:42 - tmpfs-a
-/ /b shared:43 master:42 - tmpfs-a
-/ /c shared:44 master:42 - tmpfs-a
-/ /d shared:44 master:42 - tmpfs-a
-/ /a/1 shared:45 - tmpfs-a-1
-/ /c/1 shared:46 master:45 - tmpfs-a-1
-/ /d/1 shared:46 master:45 - tmpfs-a-1
-/ /b/1 shared:47 master:45 - tmpfs-a-1
+/ /A shared:42 - tmpfs-a
+/a /b master:42 - tmpfs-a
+/a /c shared:43 master:42 - tmpfs-a
+/a /d shared:43 master:42 - tmpfs-a
+/ /A/a/1 shared:44 - tmpfs-a-1
+/ /c/1 shared:45 master:44 - tmpfs-a-1
+/ /d/1 shared:45 master:44 - tmpfs-a-1
+/ /b/1 master:44 - tmpfs-a-1

--- a/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
+++ b/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
@@ -6,27 +6,27 @@ details: |
     propagation settings of the propagated copies to b/1 and c/1? What
     propagates to d?
 prepare: |
-    mkdir a
+    mkdir A
     mkdir b
     mkdir c
     mkdir d
-    mount -t tmpfs tmpfs-a a
-    mount --make-shared a
-    mount --bind a b
+    mount -t tmpfs tmpfs-a A
+    mkdir A/a
+    mount --make-shared A
+    mount --bind A/a b
     mount --make-slave b
-    mount --make-shared b
-    mount --bind a c
+    mount --bind A/a c
     mount --make-slave c
     mount --make-shared c
     mount --bind c d
-    mkdir a/1
-    mount -t tmpfs tmpfs-a-1 a/1
+    mkdir A/a/1
+    mount -t tmpfs tmpfs-a-1 A/a/1
 restore: |
-    umount -l a
+    umount -l A
     umount -l b
     umount -l c
     umount -l d
-    rmdir a b c d
+    rmdir A b c d
 debug: |
     tail -n 8 /proc/self/mountinfo
 execute: |

--- a/osutil/vfs/vfs_test.go
+++ b/osutil/vfs/vfs_test.go
@@ -34,6 +34,13 @@ func assertVFS(t *testing.T, v *vfs.VFS, expected string) {
 	}
 }
 
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // MetaDataFS allows injecting major:minor pair or source into into any fs.StatFS.
 
 // This allows making VFSes more readable by differentiating each file system.


### PR DESCRIPTION
This is not ready for landing yet. It builds on top of https://github.com/canonical/snapd/pull/15321 and still lacks the `RecursiveBindMount` logic.

The general idea is that after all the $magic that snap-update-ns `neededChanges` computes the reuse set, we add a pass that simulates mounts on top of two separate VFSes, and keep the reuse entry ONLY if they match.