### PR TITLE
pipewire: Add access to impl.portal.PermissionStore

### DIFF
--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -67,6 +67,28 @@ network netlink raw,
 
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
+
+# Access to xdg-permission-store
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.impl.portal.PermissionStore
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Peer
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Introspectable
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
 `
 
 const pipewirePermanentSlotSecComp = `


### PR DESCRIPTION
Wireplumber requires access to the PermissionStore DBus service, so access to it must be added to the slot side of the pipewire interface to ensure access when it runs confined, like in Core Desktop.

For the moment, the "peer=(label=unconfined)" is used, since the PermissionStore daemon is still running unconfined; in the future, since it will probably require its own interface, an specific peer rule will be added.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
