### PR TITLE
pulseaudio: Fix syntax inconsistency

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -72,9 +72,9 @@ owner /{,var/}run/user/*/pulse/pid r,
 `
 
 const pulseaudioConnectedPlugAppArmorCore = `
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/ r,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/native rwk,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/pid r,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/ r,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/native rwk,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/pid r,
 `
 
 const pulseaudioConnectedPlugSecComp = `
@@ -160,7 +160,7 @@ func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		spec.AddSnippet(pulseaudioConnectedPlugAppArmorDesktop)
 	}
 	if !implicitSystemConnectedSlot(slot) {
-		old := "###PLUG_SECURITY_TAGS###"
+		old := "###SLOT_SECURITY_TAGS###"
 		new := "snap." + slot.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
 		snippet := strings.Replace(pulseaudioConnectedPlugAppArmorCore, old, new, -1)
 		spec.AddSnippet(snippet)


### PR DESCRIPTION
Every interface uses the ###SLOT_SECURITY_TAGS### string in the "plug" methods, and the ###PLUG_SECURITY_TAGS### string in the "slot" methods, with the exception of the pulseaudio interface.

This PR fixes this inconsistency.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
