### PR TITLE
interfaces: expand spi interface to relax sysfs access

### DIFF
--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,9 +84,10 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
+
 	// Use parametric snippets to avoid parser slowdown.
 	spec.AddParametricSnippet([]string{
-		"/sys/devices/platform/**/**.spi/**/spidev" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
+		"/sys/devices/platform/**/**.spi/**/{spidev,spi}" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
 	}, strings.TrimPrefix(path, "/dev/spidev"))
 	return nil
 }

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -235,12 +235,12 @@ func (s *spiInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
-		"/sys/devices/platform/**/**.spi/**/spidev0.0/** rw,  # Add any condensed parametric rules")
+		"/sys/devices/platform/**/**.spi/**/{spidev,spi}0.0/** rw,  # Add any condensed parametric rules")
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug1, s.slotGadget2), IsNil)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/spidev0.0 rw,\n"+
 		"/dev/spidev0.1 rw,\n"+
-		"/sys/devices/platform/**/**.spi/**/spidev{0.0,0.1}/** rw,  # Add any condensed parametric rules")
+		"/sys/devices/platform/**/**.spi/**/{spidev,spi}{0.0,0.1}/** rw,  # Add any condensed parametric rules")
 }
 
 func (s *spiInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION

A customer reported to have a DENIAL message when spi interface was used while accessing the following path;
LP#2109617

```
[ 1033.537102] audit: type=1400 audit(1739550356.684:510): apparmor="DENIED" operation="open" profile="snap.my-app.app" name="/sys/devices/platform/soc/2200000.bus/228c000.spi/spi_master/spi4/spi4.0/registers" pid=3644 comm="my-super-app" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```