### PR TITLE
many: update install api to support PIN authentication

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -145,6 +145,9 @@ func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEn
 	if encInfo.PassphraseAuthAvailable {
 		storageEnc.Features = append(storageEnc.Features, client.StorageEncryptionFeaturePassphraseAuth)
 	}
+	if encInfo.PINAuthAvailable {
+		storageEnc.Features = append(storageEnc.Features, client.StorageEncryptionFeaturePINAuth)
+	}
 
 	return storageEnc
 }

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2970,7 +2970,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	})
 }
 
-func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c *C, snapdVersionByType map[snap.Type]string, hasPassphraseSupport bool) {
+func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoAuthSupport(c *C, snapdVersionByType map[snap.Type]string, hasPassphraseSupport, hasPINSupport bool) {
 	isClassic := false
 	fakeModel := s.makeMockUC20SeedWithGadgetYaml(c, "some-label", mockGadgetUCYaml, isClassic, snapdVersionByType)
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
@@ -2996,6 +2996,7 @@ func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoPassphraseS
 		Type:                    "cryptsetup",
 		StorageSafety:           asserts.StorageSafetyPreferEncrypted,
 		PassphraseAuthAvailable: hasPassphraseSupport,
+		PINAuthAvailable:        hasPINSupport,
 	})
 }
 
@@ -3005,7 +3006,18 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseS
 		snap.TypeKernel: "2.68",
 	}
 	const hasPassphraseSupport = false
-	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
+	const hasPINSupport = false
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
+}
+
+func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPINSupportOldSnapd(c *C) {
+	snapdVersionByType := map[snap.Type]string{
+		snap.TypeSnapd:  "2.70",
+		snap.TypeKernel: "2.71",
+	}
+	const hasPassphraseSupport = true
+	const hasPINSupport = false
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseSupportOldKernel(c *C) {
@@ -3014,7 +3026,18 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseS
 		snap.TypeKernel: "2.67",
 	}
 	const hasPassphraseSupport = false
-	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
+	const hasPINSupport = false
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
+}
+
+func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPINSupportOldKernel(c *C) {
+	snapdVersionByType := map[snap.Type]string{
+		snap.TypeSnapd:  "2.71",
+		snap.TypeKernel: "2.70",
+	}
+	const hasPassphraseSupport = true
+	const hasPINSupport = false
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseSupportAvailable(c *C) {
@@ -3023,7 +3046,18 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseS
 		snap.TypeKernel: "2.68",
 	}
 	const hasPassphraseSupport = true
-	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
+	const hasPINSupport = false
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
+}
+
+func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPINSupportAvailable(c *C) {
+	snapdVersionByType := map[snap.Type]string{
+		snap.TypeSnapd:  "2.71",
+		snap.TypeKernel: "2.71",
+	}
+	const hasPassphraseSupport = true
+	const hasPINSupport = true
+	s.testSystemAndGadgetAndEncyptionInfoAuthSupport(c, snapdVersionByType, hasPassphraseSupport, hasPINSupport)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidLabel(c *C) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1241,7 +1241,9 @@ func checkVolumesAuth(volumesAuth *device.VolumesAuthOptions, encryptInfo instal
 			return fmt.Errorf("%q authentication mode is not supported by target system", device.AuthModePassphrase)
 		}
 	case device.AuthModePIN:
-		return fmt.Errorf("%q authentication mode is not implemented", device.AuthModePIN)
+		if !encryptInfo.PINAuthAvailable {
+			return fmt.Errorf("%q authentication mode is not supported by target system", device.AuthModePIN)
+		}
 	default:
 		return fmt.Errorf("invalid authentication mode %q, only %q and %q modes are supported", volumesAuth.Mode, device.AuthModePassphrase, device.AuthModePIN)
 	}

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -343,6 +343,27 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 				PassphraseAuthAvailable: true,
 			},
 		},
+		// PINs support requires snapd 2.71+
+		{
+			"secured", "encrypted", "2.71", "2.71", nil,
+			install.EncryptionSupportInfo{
+				Available: true, Disabled: false,
+				StorageSafety:           asserts.StorageSafetyEncrypted,
+				Type:                    device.EncryptionTypeLUKS,
+				PassphraseAuthAvailable: true,
+				PINAuthAvailable:        true,
+			},
+		},
+		{
+			"secured", "encrypted", "2.72", "2.72", nil,
+			install.EncryptionSupportInfo{
+				Available: true, Disabled: false,
+				StorageSafety:           asserts.StorageSafetyEncrypted,
+				Type:                    device.EncryptionTypeLUKS,
+				PassphraseAuthAvailable: true,
+				PINAuthAvailable:        true,
+			},
+		},
 		{
 			"secured", "encrypted", "2.67", "2.68", nil,
 			install.EncryptionSupportInfo{
@@ -350,6 +371,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 				StorageSafety:           asserts.StorageSafetyEncrypted,
 				Type:                    device.EncryptionTypeLUKS,
 				PassphraseAuthAvailable: false,
+				PINAuthAvailable:        false,
 			},
 		},
 		{
@@ -359,6 +381,27 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 				StorageSafety:           asserts.StorageSafetyEncrypted,
 				Type:                    device.EncryptionTypeLUKS,
 				PassphraseAuthAvailable: false,
+				PINAuthAvailable:        false,
+			},
+		},
+		{
+			"secured", "encrypted", "2.71", "2.70", nil,
+			install.EncryptionSupportInfo{
+				Available: true, Disabled: false,
+				StorageSafety:           asserts.StorageSafetyEncrypted,
+				Type:                    device.EncryptionTypeLUKS,
+				PassphraseAuthAvailable: true,
+				PINAuthAvailable:        false,
+			},
+		},
+		{
+			"secured", "encrypted", "2.70", "2.71", nil,
+			install.EncryptionSupportInfo{
+				Available: true, Disabled: false,
+				StorageSafety:           asserts.StorageSafetyEncrypted,
+				Type:                    device.EncryptionTypeLUKS,
+				PassphraseAuthAvailable: true,
+				PINAuthAvailable:        false,
 			},
 		},
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -521,7 +521,7 @@ func newTPMProtectedKey(tpm *sb_tpm2.Connection, creationParams *sb_tpm2.Protect
 			}
 			protectedKey, primaryKey, unlockKey, err = sbNewTPMPassphraseProtectedKey(tpm, passphraseParams, volumesAuth.Passphrase)
 		case device.AuthModePIN:
-			// TODO: Implement PIN authentication mode.
+			// TODO:FDEM:FIX use NewTPMPINProtectedKey from latest secboot
 			return nil, nil, nil, fmt.Errorf("%q authentication mode is not implemented", device.AuthModePIN)
 		default:
 			return nil, nil, nil, fmt.Errorf("internal error: invalid authentication mode %q", volumesAuth.Mode)


### PR DESCRIPTION
This PR adds API skeleton for:
- `GET /v2/systems/{systems-label}`: allow installers to check if PIN authentication is available for target system (requiring snapd 2.71 as planned).
- `POST /v2/systems/{system-label}`: allow installers to pass PIN authentication options.

For reference check the API spec: SD201

Note: PIN support is missing a secboot support. This should be a single line change in follow up PR accompanied by a spread test when secboot support lands https://github.com/canonical/secboot/pull/289:
https://github.com/canonical/snapd/blob/9efc67f7bcf7417b4ab84e9a6a3128cef0d757bd/secboot/secboot_tpm.go#L523-L525