### PR TITLE
osutil: add support for shell conditional syntax in envs

### DIFF
--- a/osutil/env.go
+++ b/osutil/env.go
@@ -210,7 +210,7 @@ func NewExpandableEnv(pairs ...string) ExpandableEnv {
 	return ExpandableEnv{OrderedMap: strutil.NewOrderedMap(pairs...)}
 }
 
-var envExpandRegExp, _ = regexp.Compile("[a-zA-Z0-9_]+:[+-]")
+var envExpandRegExp = regexp.MustCompile("[a-zA-Z0-9_]+:[+-]")
 
 // Adds support for bash conditional syntax ${VARIABLE:+XXX} and ${VARIABLE:-XXX}
 func (env *Environment) expand(key string) string {

--- a/osutil/env.go
+++ b/osutil/env.go
@@ -213,28 +213,28 @@ func NewExpandableEnv(pairs ...string) ExpandableEnv {
 var envExpandRegExp = regexp.MustCompile("[a-zA-Z0-9_]+:[+-]")
 
 // Adds support for bash conditional syntax ${VARIABLE:+XXX} and ${VARIABLE:-XXX}
-func (env *Environment) expand(key string) string {
-	return os.Expand(key, func(varName string) string {
+func (env *Environment) expand(value string) string {
+	return os.Expand(value, func(varName string) string {
 		loc := envExpandRegExp.FindStringIndex(varName)
 		if loc == nil {
 			return (*env)[varName]
 		}
-		envvar := string(varName[loc[0]:(loc[1] - 2)])
+		envVar := string(varName[loc[0]:(loc[1] - 2)])
 		operation := string(varName[loc[1]-1])
-		newval := string(varName[loc[1]:])
-		envvar_value := (*env)[envvar]
+		newVal := string(varName[loc[1]:])
+		envVarValue := (*env)[envVar]
 		switch operation {
 		case "-":
-			if envvar_value == "" {
-				return env.expand(newval)
+			if envVarValue == "" {
+				return env.expand(newVal)
 			} else {
-				return envvar_value
+				return envVarValue
 			}
 		case "+":
-			if envvar_value == "" {
+			if envVarValue == "" {
 				return ""
 			} else {
-				return env.expand(newval)
+				return env.expand(newVal)
 			}
 		default: // never can really happen, but the compiler complains without it
 			return (*env)[varName]

--- a/osutil/env_test.go
+++ b/osutil/env_test.go
@@ -330,3 +330,22 @@ func (s *envSuite) TestForExecEscapeUnsafeNothingToEscape(c *C) {
 		"XDG_STUFF=xdg-stuff",
 	})
 }
+
+func (s *envSuite) TestExpandEnvVariable(c *C) {
+	env := osutil.Environment{
+		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib",
+		"TMPDIR":          "/var/tmp",
+	}
+
+	env.ExtendWithExpanded(osutil.NewExpandableEnv(
+		"LD_LIBRARY_PATH", "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/x86_64-linux-gnu",
+		"PATH", "${PATH:+$PATH:}/usr/local/bin",
+		"TMPDIR", "${TMPDIR:-this-wont-be}",
+		"NOEXISTS", "${NOEXITS:-a-new-value}",
+	))
+	c.Check(env, DeepEquals, osutil.Environment{
+		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib:/usr/lib/x86_64-linux-gnu",
+		"NOEXISTS":        "a-new-value",
+		"TMPDIR":          "/var/tmp",
+		"PATH":            "/usr/local/bin"})
+}

--- a/osutil/env_test.go
+++ b/osutil/env_test.go
@@ -335,6 +335,9 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 	env := osutil.Environment{
 		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib",
 		"TMPDIR":          "/var/tmp",
+		"A": "foo",
+		"B": "bad-value",
+		"D_default": "default",
 	}
 
 	env.ExtendWithExpanded(osutil.NewExpandableEnv(
@@ -342,6 +345,10 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 		"PATH", "${PATH:+$PATH:}/usr/local/bin",
 		"TMPDIR", "${TMPDIR:-this-wont-be}",
 		"NOEXISTS", "${NOEXITS:-a-new-value}",
+		"A","${A:+}",
+		"B", "${B:+goodvalue}",
+		"C", "${C:-}",
+		"D", "${D:-$D_default}",
 	))
 	c.Check(env, DeepEquals, osutil.Environment{
 		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib:/usr/lib/x86_64-linux-gnu",

--- a/osutil/env_test.go
+++ b/osutil/env_test.go
@@ -335,9 +335,9 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 	env := osutil.Environment{
 		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib",
 		"TMPDIR":          "/var/tmp",
-		"A": "foo",
-		"B": "bad-value",
-		"D_default": "default",
+		"A":               "foo",
+		"B":               "bad-value",
+		"D_default":       "default",
 	}
 
 	env.ExtendWithExpanded(osutil.NewExpandableEnv(
@@ -345,7 +345,7 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 		"PATH", "${PATH:+$PATH:}/usr/local/bin",
 		"TMPDIR", "${TMPDIR:-this-wont-be}",
 		"NOEXISTS", "${NOEXITS:-a-new-value}",
-		"A","${A:+}",
+		"A", "${A:+}",
 		"B", "${B:+goodvalue}",
 		"C", "${C:-}",
 		"D", "${D:-$D_default}",
@@ -354,5 +354,10 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 		"LD_LIBRARY_PATH": "/usr/lib:/usr/local/lib:/usr/lib/x86_64-linux-gnu",
 		"NOEXISTS":        "a-new-value",
 		"TMPDIR":          "/var/tmp",
-		"PATH":            "/usr/local/bin"})
+		"PATH":            "/usr/local/bin",
+		"A":               "",
+		"B":               "goodvalue",
+		"C":               "",
+		"D":               "default",
+		"D_default":       "default"})
 }

--- a/osutil/env_test.go
+++ b/osutil/env_test.go
@@ -344,7 +344,7 @@ func (s *envSuite) TestExpandEnvVariable(c *C) {
 		"LD_LIBRARY_PATH", "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/x86_64-linux-gnu",
 		"PATH", "${PATH:+$PATH:}/usr/local/bin",
 		"TMPDIR", "${TMPDIR:-this-wont-be}",
-		"NOEXISTS", "${NOEXITS:-a-new-value}",
+		"NOEXISTS", "${NOEXISTS:-a-new-value}",
 		"A", "${A:+}",
 		"B", "${B:+goodvalue}",
 		"C", "${C:-}",


### PR DESCRIPTION
Bash has support for some conditionals that allow to append text
to environment variables in a more clever way than just blindly
appending it. This is a must, for example, when appending paths
to PATH or LD_LIBRARY_PATH, because if the original variables
are empty, the new paths must be added "as-is", but if the
original variables have a value, a colon is required between
the old value and the new one.

So, this patch allows to append extra paths to the current defined
ones directly in the 'environment' section of the snapcraft.yaml
file.

The new supported syntaxes are:

    ${VARIABLE:-XXXXXX}

  if VARIABLE is defined, this will return the value of that
  variable; but if it is undefined, it will return the expansion
  of XXXXX (thus, if there are variables there, they will be
  recursively expanded).

    ${VARIABLE:+YYYYY}

  if VARIABLE is undefined, it will return an empty string;
  but if it is defined, it will return the expansion of YYYYY.

Examples:

    ${PATH:+$PATH:}/usr/local/bin

  If PATH is undefined or empty, it will return an empty string,
  to with '/usr/local/bin' will be appended.
  But if PATH contains, for example, /usr/bin:/bin, it will
  return that plus a colon at the end, to which '/usr/local/bin'
  will be appended, thus resulting in the expected value

    /usr/bin:/bin:/usr/local/bin

    /usr/local/bin${PATH:+:$PATH}

  If PATH is undefined or empty, it will return an empty string,
  which will be appended after '/usr/local/bin', thus resulting in only that path.
  But if PATH contains, for example, /usr/bin:/bin, it will
  return a colon plus that at the end, which will be appended after '/usr/local/bin', thus resulting in the expected value

    /usr/local/bin:/usr/bin:/bin


Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
