### PR TITLE
release: 2.70

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,69 @@
+# New in snapd 2.70
+* FDE: Fix reseal with v1 hook key format
+* FDE: set role in TPM keys
+* AppArmor prompting (experimental): add handling for expired requests or listener in the kernel
+* AppArmor prompting: log the notification protocol version negotiated with the kernel
+* AppArmor prompting: implement notification protocol v5 (manually disabled for now)
+* AppArmor prompting: register listener ID with the kernel and resend notifications after snapd restart (requires protocol v5+)
+* AppArmor prompting: select interface from metadata tags and set request interface accordingly (requires protocol v5+)
+* AppArmor prompting: include request PID in prompt
+* AppArmor prompting: move the max prompt ID file to a subdirectory of the snap run directory
+* AppArmor prompting: avoid race between closing/reading socket fd
+* Confdb (experimental): make save/load hooks mandatory if affecting ephemeral
+* Confdb: clear tx state on failed load
+* Confdb: modify 'snap sign' formats JSON in assertion bodies (e.g. confdb-schema)
+* Confdb: add NestedEphemeral to confdb schemas
+* Confdb: add early concurrency checks
+* Simplify building Arch package
+* Enable snapd.apparmor on Fedora
+* Build snapd snap with libselinux
+* Emit snapd.apparmor warning only when using apparmor backend
+* When running snap, on system key mismatch e.g. due to network attached HOME, trigger and wait for a security profiles regeneration
+* Avoid requiring state lock to get user, warnings, or pending restarts when handling API requests
+* Start/stop ssh.socket for core24+ when enabling/disabling the ssh service
+* Allow providing a different base when overriding snap
+* Modify snap-bootstrap to mount snapd snap directly to /snap
+* Modify snap-bootstrap to mount /lib/{modules,firmware} from snap as fallback
+* Modify core-initrd to use systemctl reboot instead of /sbin/reboot
+* Copy the initramfs 'manifest-initramfs.yaml' to initramfs file creation directory so it can be copied to the kernel snap
+* Build the early initrd from installed ucode packages
+* Create drivers tree when remodeling from UC20/22 to UC24
+* Load gpio-aggregator module before the helper-service needs it
+* Run 'systemctl start' for mount units to ensure they are run also when unchanged
+* Update godbus version to 'v5 v5.1.0'
+* Add support for POST to /v2/system-info with system-key-mismatch indication from the client
+* Add 'snap sign --update-timestamp' flag to update timestamp before signing
+* Add vfs support for snap-update-ns to use to simulate and evaluate mount sequences
+* Add refresh app awareness debug logging
+* Add snap-bootstrap scan-disk subcommand to be called from udev
+* Add feature to inject proxy store assertions in build image
+* Add OP-TEE bindings, enable by default in ARM and ARM64 builds
+* Fix systemd dependency options target to go under 'unit' section
+* Fix snap-bootstrap reading kernel snap instead of base resulting in bad modeenv
+* Fix a regression during seeding when using early-config
+* LP: #2107443 reset SHELL to /bin/bash in non-classic snaps
+* Make Azure kernels reboot upon panic
+* Fix snap-confine to not drop capabilities if the original user is already root
+* Fix data race when stopping services
+* Fix task dependency issue by temporarily disable re-refresh on prerequisite updates
+* Fix compiling against op-tee on armhf
+* Fix dbx update when not using FDE
+* Fix potential validation set deadlock due to bases waiting on snaps
+* LP: #2104066 Only cancel notices requests on stop/shutdown
+* Interfaces: bool-file | fix gpio glob pattern as required for '[XXXX]*' format
+* Interfaces: system-packages-doc | allow access to /usr/local/share/doc
+* Interfaces: ros-snapd-support interface | added new interface
+* Interfaces: udisks2 | allow chown capability
+* Interfaces: system-observe | allow reading cpu.max
+* Interfaces: serial-port | add ttyMAXX to allowed list
+* Interfaces: modified seccomp template to disallow 'O_NOTIFICATION_PIPE'
+* Interfaces: fwupd | add support for modem-manager plugin
+* Interfaces: gpio-chardev | make unsupported and remove experimental flag to hide this feature until gpio-aggregator is available
+* Interfaces: hardware-random | fix udev match rule
+* Interfaces: timeserver-control | extend to allow timedatectl timesync commands
+* Interfaces: add symlinks backend
+* Interfaces: system key mismatch handling
+
 # New in snapd 2.69
 * FDE: re-factor listing of the disks based on run mode model and model to correctly resolve paths
 * FDE: run snapd from snap-failure with the correct keyring mode

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'libcap' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.69
+pkgver=2.70
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,101 @@
+snapd (2.70-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2112209
+    - FDE: Fix reseal with v1 hook key format
+    - FDE: set role in TPM keys
+    - AppArmor prompting (experimental): add handling for expired
+      requests or listener in the kernel
+    - AppArmor prompting: log the notification protocol version
+      negotiated with the kernel
+    - AppArmor prompting: implement notification protocol v5 (manually
+      disabled for now)
+    - AppArmor prompting: register listener ID with the kernel and
+      resend notifications after snapd restart (requires protocol v5+)
+    - AppArmor prompting: select interface from metadata tags and set
+      request interface accordingly (requires protocol v5+)
+    - AppArmor prompting: include request PID in prompt
+    - AppArmor prompting: move the max prompt ID file to a subdirectory
+      of the snap run directory
+    - AppArmor prompting: avoid race between closing/reading socket fd
+    - Confdb (experimental): make save/load hooks mandatory if affecting
+      ephemeral
+    - Confdb: clear tx state on failed load
+    - Confdb: modify 'snap sign' formats JSON in assertion bodies (e.g.
+      confdb-schema)
+    - Confdb: add NestedEphemeral to confdb schemas
+    - Confdb: add early concurrency checks
+    - Simplify building Arch package
+    - Enable snapd.apparmor on Fedora
+    - Build snapd snap with libselinux
+    - Emit snapd.apparmor warning only when using apparmor backend
+    - When running snap, on system key mismatch e.g. due to network
+      attached HOME, trigger and wait for a security profiles
+      regeneration
+    - Avoid requiring state lock to get user, warnings, or pending
+      restarts when handling API requests
+    - Start/stop ssh.socket for core24+ when enabling/disabling the ssh
+      service
+    - Allow providing a different base when overriding snap
+    - Modify snap-bootstrap to mount snapd snap directly to /snap
+    - Modify snap-bootstrap to mount /lib/{modules,firmware} from snap
+      as fallback
+    - Modify core-initrd to use systemctl reboot instead of /sbin/reboot
+    - Copy the initramfs 'manifest-initramfs.yaml' to initramfs file
+      creation directory so it can be copied to the kernel snap
+    - Build the early initrd from installed ucode packages
+    - Create drivers tree when remodeling from UC20/22 to UC24
+    - Load gpio-aggregator module before the helper-service needs it
+    - Run 'systemctl start' for mount units to ensure they are run also
+      when unchanged
+    - Update godbus version to 'v5 v5.1.0'
+    - Add support for POST to /v2/system-info with system-key-mismatch
+      indication from the client
+    - Add 'snap sign --update-timestamp' flag to update timestamp before
+      signing
+    - Add vfs support for snap-update-ns to use to simulate and evaluate
+      mount sequences
+    - Add refresh app awareness debug logging
+    - Add snap-bootstrap scan-disk subcommand to be called from udev
+    - Add feature to inject proxy store assertions in build image
+    - Add OP-TEE bindings, enable by default in ARM and ARM64 builds
+    - Fix systemd dependency options target to go under 'unit' section
+    - Fix snap-bootstrap reading kernel snap instead of base resulting
+      in bad modeenv
+    - Fix a regression during seeding when using early-config
+    - LP: #2107443 reset SHELL to /bin/bash in non-classic snaps
+    - Make Azure kernels reboot upon panic
+    - Fix snap-confine to not drop capabilities if the original user is
+      already root
+    - Fix data race when stopping services
+    - Fix task dependency issue by temporarily disable re-refresh on
+      prerequisite updates
+    - Fix compiling against op-tee on armhf
+    - Fix dbx update when not using FDE
+    - Fix potential validation set deadlock due to bases waiting on
+      snaps
+    - LP: #2104066 Only cancel notices requests on stop/shutdown
+    - Interfaces: bool-file | fix gpio glob pattern as required for
+      '[XXXX]*' format
+    - Interfaces: system-packages-doc | allow access to
+      /usr/local/share/doc
+    - Interfaces: ros-snapd-support interface | added new interface
+    - Interfaces: udisks2 | allow chown capability
+    - Interfaces: system-observe | allow reading cpu.max
+    - Interfaces: serial-port | add ttyMAXX to allowed list
+    - Interfaces: modified seccomp template to disallow
+      'O_NOTIFICATION_PIPE'
+    - Interfaces: fwupd | add support for modem-manager plugin
+    - Interfaces: gpio-chardev | make unsupported and remove
+      experimental flag to hide this feature until gpio-aggregator is
+      available
+    - Interfaces: hardware-random | fix udev match rule
+    - Interfaces: timeserver-control | extend to allow timedatectl
+      timesync commands
+    - Interfaces: add symlinks backend
+    - Interfaces: system key mismatch handling
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Tue, 03 Jun 2025 11:46:44 +0200
+
 snapd (2.69-1) unstable; urgency=medium
 
   * New upstream release, LP: #2105854

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.69
+Version:        2.70
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1009,6 +1009,101 @@ fi
 %endif
 
 %changelog
+* Tue Jun 03 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.70
+ - FDE: Fix reseal with v1 hook key format
+ - FDE: set role in TPM keys
+ - AppArmor prompting (experimental): add handling for expired
+   requests or listener in the kernel
+ - AppArmor prompting: log the notification protocol version
+   negotiated with the kernel
+ - AppArmor prompting: implement notification protocol v5 (manually
+   disabled for now)
+ - AppArmor prompting: register listener ID with the kernel and
+   resend notifications after snapd restart (requires protocol v5+)
+ - AppArmor prompting: select interface from metadata tags and set
+   request interface accordingly (requires protocol v5+)
+ - AppArmor prompting: include request PID in prompt
+ - AppArmor prompting: move the max prompt ID file to a subdirectory
+   of the snap run directory
+ - AppArmor prompting: avoid race between closing/reading socket fd
+ - Confdb (experimental): make save/load hooks mandatory if affecting
+   ephemeral
+ - Confdb: clear tx state on failed load
+ - Confdb: modify 'snap sign' formats JSON in assertion bodies (e.g.
+   confdb-schema)
+ - Confdb: add NestedEphemeral to confdb schemas
+ - Confdb: add early concurrency checks
+ - Simplify building Arch package
+ - Enable snapd.apparmor on Fedora
+ - Build snapd snap with libselinux
+ - Emit snapd.apparmor warning only when using apparmor backend
+ - When running snap, on system key mismatch e.g. due to network
+   attached HOME, trigger and wait for a security profiles
+   regeneration
+ - Avoid requiring state lock to get user, warnings, or pending
+   restarts when handling API requests
+ - Start/stop ssh.socket for core24+ when enabling/disabling the ssh
+   service
+ - Allow providing a different base when overriding snap
+ - Modify snap-bootstrap to mount snapd snap directly to /snap
+ - Modify snap-bootstrap to mount /lib/{modules,firmware} from snap
+   as fallback
+ - Modify core-initrd to use systemctl reboot instead of /sbin/reboot
+ - Copy the initramfs 'manifest-initramfs.yaml' to initramfs file
+   creation directory so it can be copied to the kernel snap
+ - Build the early initrd from installed ucode packages
+ - Create drivers tree when remodeling from UC20/22 to UC24
+ - Load gpio-aggregator module before the helper-service needs it
+ - Run 'systemctl start' for mount units to ensure they are run also
+   when unchanged
+ - Update godbus version to 'v5 v5.1.0'
+ - Add support for POST to /v2/system-info with system-key-mismatch
+   indication from the client
+ - Add 'snap sign --update-timestamp' flag to update timestamp before
+   signing
+ - Add vfs support for snap-update-ns to use to simulate and evaluate
+   mount sequences
+ - Add refresh app awareness debug logging
+ - Add snap-bootstrap scan-disk subcommand to be called from udev
+ - Add feature to inject proxy store assertions in build image
+ - Add OP-TEE bindings, enable by default in ARM and ARM64 builds
+ - Fix systemd dependency options target to go under 'unit' section
+ - Fix snap-bootstrap reading kernel snap instead of base resulting
+   in bad modeenv
+ - Fix a regression during seeding when using early-config
+ - LP: #2107443 reset SHELL to /bin/bash in non-classic snaps
+ - Make Azure kernels reboot upon panic
+ - Fix snap-confine to not drop capabilities if the original user is
+   already root
+ - Fix data race when stopping services
+ - Fix task dependency issue by temporarily disable re-refresh on
+   prerequisite updates
+ - Fix compiling against op-tee on armhf
+ - Fix dbx update when not using FDE
+ - Fix potential validation set deadlock due to bases waiting on
+   snaps
+ - LP: #2104066 Only cancel notices requests on stop/shutdown
+ - Interfaces: bool-file | fix gpio glob pattern as required for
+   '[XXXX]*' format
+ - Interfaces: system-packages-doc | allow access to
+   /usr/local/share/doc
+ - Interfaces: ros-snapd-support interface | added new interface
+ - Interfaces: udisks2 | allow chown capability
+ - Interfaces: system-observe | allow reading cpu.max
+ - Interfaces: serial-port | add ttyMAXX to allowed list
+ - Interfaces: modified seccomp template to disallow
+   'O_NOTIFICATION_PIPE'
+ - Interfaces: fwupd | add support for modem-manager plugin
+ - Interfaces: gpio-chardev | make unsupported and remove
+   experimental flag to hide this feature until gpio-aggregator is
+   available
+ - Interfaces: hardware-random | fix udev match rule
+ - Interfaces: timeserver-control | extend to allow timedatectl
+   timesync commands
+ - Interfaces: add symlinks backend
+ - Interfaces: system key mismatch handling
+
 * Tue Apr 08 2025 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.69
  - FDE: re-factor listing of the disks based on run mode model and

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 03 09:46:44 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.70
+
+-------------------------------------------------------------------
 Tue Apr 08 10:53:39 UTC 2025 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.69

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -91,7 +91,7 @@
 
 
 Name:           snapd
-Version:        2.69
+Version:        2.70
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,101 @@
+snapd (2.70~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2112209
+    - FDE: Fix reseal with v1 hook key format
+    - FDE: set role in TPM keys
+    - AppArmor prompting (experimental): add handling for expired
+      requests or listener in the kernel
+    - AppArmor prompting: log the notification protocol version
+      negotiated with the kernel
+    - AppArmor prompting: implement notification protocol v5 (manually
+      disabled for now)
+    - AppArmor prompting: register listener ID with the kernel and
+      resend notifications after snapd restart (requires protocol v5+)
+    - AppArmor prompting: select interface from metadata tags and set
+      request interface accordingly (requires protocol v5+)
+    - AppArmor prompting: include request PID in prompt
+    - AppArmor prompting: move the max prompt ID file to a subdirectory
+      of the snap run directory
+    - AppArmor prompting: avoid race between closing/reading socket fd
+    - Confdb (experimental): make save/load hooks mandatory if affecting
+      ephemeral
+    - Confdb: clear tx state on failed load
+    - Confdb: modify 'snap sign' formats JSON in assertion bodies (e.g.
+      confdb-schema)
+    - Confdb: add NestedEphemeral to confdb schemas
+    - Confdb: add early concurrency checks
+    - Simplify building Arch package
+    - Enable snapd.apparmor on Fedora
+    - Build snapd snap with libselinux
+    - Emit snapd.apparmor warning only when using apparmor backend
+    - When running snap, on system key mismatch e.g. due to network
+      attached HOME, trigger and wait for a security profiles
+      regeneration
+    - Avoid requiring state lock to get user, warnings, or pending
+      restarts when handling API requests
+    - Start/stop ssh.socket for core24+ when enabling/disabling the ssh
+      service
+    - Allow providing a different base when overriding snap
+    - Modify snap-bootstrap to mount snapd snap directly to /snap
+    - Modify snap-bootstrap to mount /lib/{modules,firmware} from snap
+      as fallback
+    - Modify core-initrd to use systemctl reboot instead of /sbin/reboot
+    - Copy the initramfs 'manifest-initramfs.yaml' to initramfs file
+      creation directory so it can be copied to the kernel snap
+    - Build the early initrd from installed ucode packages
+    - Create drivers tree when remodeling from UC20/22 to UC24
+    - Load gpio-aggregator module before the helper-service needs it
+    - Run 'systemctl start' for mount units to ensure they are run also
+      when unchanged
+    - Update godbus version to 'v5 v5.1.0'
+    - Add support for POST to /v2/system-info with system-key-mismatch
+      indication from the client
+    - Add 'snap sign --update-timestamp' flag to update timestamp before
+      signing
+    - Add vfs support for snap-update-ns to use to simulate and evaluate
+      mount sequences
+    - Add refresh app awareness debug logging
+    - Add snap-bootstrap scan-disk subcommand to be called from udev
+    - Add feature to inject proxy store assertions in build image
+    - Add OP-TEE bindings, enable by default in ARM and ARM64 builds
+    - Fix systemd dependency options target to go under 'unit' section
+    - Fix snap-bootstrap reading kernel snap instead of base resulting
+      in bad modeenv
+    - Fix a regression during seeding when using early-config
+    - LP: #2107443 reset SHELL to /bin/bash in non-classic snaps
+    - Make Azure kernels reboot upon panic
+    - Fix snap-confine to not drop capabilities if the original user is
+      already root
+    - Fix data race when stopping services
+    - Fix task dependency issue by temporarily disable re-refresh on
+      prerequisite updates
+    - Fix compiling against op-tee on armhf
+    - Fix dbx update when not using FDE
+    - Fix potential validation set deadlock due to bases waiting on
+      snaps
+    - LP: #2104066 Only cancel notices requests on stop/shutdown
+    - Interfaces: bool-file | fix gpio glob pattern as required for
+      '[XXXX]*' format
+    - Interfaces: system-packages-doc | allow access to
+      /usr/local/share/doc
+    - Interfaces: ros-snapd-support interface | added new interface
+    - Interfaces: udisks2 | allow chown capability
+    - Interfaces: system-observe | allow reading cpu.max
+    - Interfaces: serial-port | add ttyMAXX to allowed list
+    - Interfaces: modified seccomp template to disallow
+      'O_NOTIFICATION_PIPE'
+    - Interfaces: fwupd | add support for modem-manager plugin
+    - Interfaces: gpio-chardev | make unsupported and remove
+      experimental flag to hide this feature until gpio-aggregator is
+      available
+    - Interfaces: hardware-random | fix udev match rule
+    - Interfaces: timeserver-control | extend to allow timedatectl
+      timesync commands
+    - Interfaces: add symlinks backend
+    - Interfaces: system key mismatch handling
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Tue, 03 Jun 2025 11:46:44 +0200
+
 snapd (2.69~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2105854

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,101 @@
+snapd (2.70) xenial; urgency=medium
+
+  * New upstream release, LP: #2112209
+    - FDE: Fix reseal with v1 hook key format
+    - FDE: set role in TPM keys
+    - AppArmor prompting (experimental): add handling for expired
+      requests or listener in the kernel
+    - AppArmor prompting: log the notification protocol version
+      negotiated with the kernel
+    - AppArmor prompting: implement notification protocol v5 (manually
+      disabled for now)
+    - AppArmor prompting: register listener ID with the kernel and
+      resend notifications after snapd restart (requires protocol v5+)
+    - AppArmor prompting: select interface from metadata tags and set
+      request interface accordingly (requires protocol v5+)
+    - AppArmor prompting: include request PID in prompt
+    - AppArmor prompting: move the max prompt ID file to a subdirectory
+      of the snap run directory
+    - AppArmor prompting: avoid race between closing/reading socket fd
+    - Confdb (experimental): make save/load hooks mandatory if affecting
+      ephemeral
+    - Confdb: clear tx state on failed load
+    - Confdb: modify 'snap sign' formats JSON in assertion bodies (e.g.
+      confdb-schema)
+    - Confdb: add NestedEphemeral to confdb schemas
+    - Confdb: add early concurrency checks
+    - Simplify building Arch package
+    - Enable snapd.apparmor on Fedora
+    - Build snapd snap with libselinux
+    - Emit snapd.apparmor warning only when using apparmor backend
+    - When running snap, on system key mismatch e.g. due to network
+      attached HOME, trigger and wait for a security profiles
+      regeneration
+    - Avoid requiring state lock to get user, warnings, or pending
+      restarts when handling API requests
+    - Start/stop ssh.socket for core24+ when enabling/disabling the ssh
+      service
+    - Allow providing a different base when overriding snap
+    - Modify snap-bootstrap to mount snapd snap directly to /snap
+    - Modify snap-bootstrap to mount /lib/{modules,firmware} from snap
+      as fallback
+    - Modify core-initrd to use systemctl reboot instead of /sbin/reboot
+    - Copy the initramfs 'manifest-initramfs.yaml' to initramfs file
+      creation directory so it can be copied to the kernel snap
+    - Build the early initrd from installed ucode packages
+    - Create drivers tree when remodeling from UC20/22 to UC24
+    - Load gpio-aggregator module before the helper-service needs it
+    - Run 'systemctl start' for mount units to ensure they are run also
+      when unchanged
+    - Update godbus version to 'v5 v5.1.0'
+    - Add support for POST to /v2/system-info with system-key-mismatch
+      indication from the client
+    - Add 'snap sign --update-timestamp' flag to update timestamp before
+      signing
+    - Add vfs support for snap-update-ns to use to simulate and evaluate
+      mount sequences
+    - Add refresh app awareness debug logging
+    - Add snap-bootstrap scan-disk subcommand to be called from udev
+    - Add feature to inject proxy store assertions in build image
+    - Add OP-TEE bindings, enable by default in ARM and ARM64 builds
+    - Fix systemd dependency options target to go under 'unit' section
+    - Fix snap-bootstrap reading kernel snap instead of base resulting
+      in bad modeenv
+    - Fix a regression during seeding when using early-config
+    - LP: #2107443 reset SHELL to /bin/bash in non-classic snaps
+    - Make Azure kernels reboot upon panic
+    - Fix snap-confine to not drop capabilities if the original user is
+      already root
+    - Fix data race when stopping services
+    - Fix task dependency issue by temporarily disable re-refresh on
+      prerequisite updates
+    - Fix compiling against op-tee on armhf
+    - Fix dbx update when not using FDE
+    - Fix potential validation set deadlock due to bases waiting on
+      snaps
+    - LP: #2104066 Only cancel notices requests on stop/shutdown
+    - Interfaces: bool-file | fix gpio glob pattern as required for
+      '[XXXX]*' format
+    - Interfaces: system-packages-doc | allow access to
+      /usr/local/share/doc
+    - Interfaces: ros-snapd-support interface | added new interface
+    - Interfaces: udisks2 | allow chown capability
+    - Interfaces: system-observe | allow reading cpu.max
+    - Interfaces: serial-port | add ttyMAXX to allowed list
+    - Interfaces: modified seccomp template to disallow
+      'O_NOTIFICATION_PIPE'
+    - Interfaces: fwupd | add support for modem-manager plugin
+    - Interfaces: gpio-chardev | make unsupported and remove
+      experimental flag to hide this feature until gpio-aggregator is
+      available
+    - Interfaces: hardware-random | fix udev match rule
+    - Interfaces: timeserver-control | extend to allow timedatectl
+      timesync commands
+    - Interfaces: add symlinks backend
+    - Interfaces: system key mismatch handling
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Tue, 03 Jun 2025 11:46:44 +0200
+
 snapd (2.69) xenial; urgency=medium
 
   * New upstream release, LP: #2105854


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter <ernest.lotter@canonical.com>" release-tools/changelog.py 2.70 2112209 NEWS.md

This release contains all the content since 2.68.5. This includes the content of candidate releases 2.69, 2.69.1 as well as the new content for 2.70.

SRU Bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2112209
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34821

**Requires rebase merge**