### PR TITLE
tests: some minor changes needed to run UC26 tests

### DIFF
--- a/tests/lib/external/snapd-testing-tools/tools/os.query
+++ b/tests/lib/external/snapd-testing-tools/tools/os.query
@@ -36,6 +36,10 @@ is_core24() {
     grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
 }
 
+is_core26() {
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="26"' /etc/os-release
+}
+
 is_core_gt() {
     local VERSION=$1
     if [ -z "$VERSION" ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1717,6 +1717,8 @@ prepare_ubuntu_core() {
             rsync_snap="test-snapd-rsync-core22"
         elif os.query is-core24; then
             rsync_snap="test-snapd-rsync-core24"
+        elif os.query is-core26; then
+            rsync_snap="test-snapd-rsync-core26"
         fi
         snap install --devmode --edge "$rsync_snap"
         snap alias "$rsync_snap".rsync rsync
@@ -1746,6 +1748,9 @@ prepare_ubuntu_core() {
         fi
         if os.query is-core24; then
             cache_snaps test-snapd-sh-core24
+        fi
+        if os.query is-core26; then
+            cache_snaps test-snapd-sh-core26
         fi
     fi
 


### PR DESCRIPTION
So it is possible to run the smoke tests from core-base repo PRs.
