### PR TITLE
o/fdestate/backend/seal.go: do not save the primary key when using tokens

### DIFF
--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -106,9 +106,12 @@ func sealRunObjectKeys(key secboot.BootstrappedContainer, pbc boot.PredictableBo
 		ModelParams:            modelParams,
 		PrimaryKey:             maybePrimaryKey,
 		VolumesAuth:            volumesAuth,
-		TPMPolicyAuthKeyFile:   filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"),
 		PCRPolicyCounterHandle: pcrHandle,
 		KeyRole:                keyRole,
+	}
+
+	if !useTokens {
+		sealKeyParams.TPMPolicyAuthKeyFile = filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key")
 	}
 
 	logger.Debugf("sealing run key with PCR handle: %#x", sealKeyParams.PCRPolicyCounterHandle)
@@ -152,8 +155,11 @@ func sealFallbackObjectKeys(key, saveKey secboot.BootstrappedContainer, pbc boot
 
 func sealKeyForBootChainsHook(key, saveKey secboot.BootstrappedContainer, params *boot.SealKeyForBootChainsParams) error {
 	sealingParams := secboot.SealKeysWithFDESetupHookParams{
-		AuxKeyFile: filepath.Join(boot.InstallHostFDESaveDir, "aux-key"),
 		PrimaryKey: params.PrimaryKey,
+	}
+
+	if !params.UseTokens {
+		sealingParams.AuxKeyFile = filepath.Join(boot.InstallHostFDESaveDir, "aux-key")
 	}
 
 	for _, runChain := range params.RunModeBootChains {

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -168,7 +168,11 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 			switch sealKeysCalls {
 			case 1:
 				// the run object seals only the ubuntu-data key
-				c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"))
+				if tc.disableTokens {
+					c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"))
+				} else {
+					c.Check(params.TPMPolicyAuthKeyFile, Equals, "")
+				}
 
 				expectedSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default", BootModes: []string{"run", "recover"}}
 				if tc.disableTokens {
@@ -453,7 +457,11 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 	restore = fdeBackend.MockSecbootSealKeysWithFDESetupHook(func(runHook fde.RunSetupHookFunc, skrs []secboot.SealKeyRequest, params *secboot.SealKeysWithFDESetupHookParams) error {
 		c.Check(params.Model.Model(), Equals, model.Model())
 		c.Check(params.Model.Model(), Equals, model.Model())
-		c.Check(params.AuxKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "aux-key"))
+		if useTokens {
+			c.Check(params.AuxKeyFile, Equals, "")
+		} else {
+			c.Check(params.AuxKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "aux-key"))
+		}
 		c.Check(params.PrimaryKey, DeepEquals, []byte{1, 2, 3, 4})
 		for _, skr := range skrs {
 			var expectedBootstrappedContainer secboot.BootstrappedContainer


### PR DESCRIPTION
When using tokens to save keydata we also use the protector key for the save disk. This will contain the primary key, and even when using a recovery key, we will still for sure have the primary key in the keyring.

This is a safe first step before https://github.com/canonical/snapd/pull/15164