### PR TITLE
packaging/ubuntu-16.04/source/options: ignore .git directory

### DIFF
--- a/packaging/ubuntu-16.04/source/options
+++ b/packaging/ubuntu-16.04/source/options
@@ -1,1 +1,2 @@
 tar-ignore = "tests/lib/cache/*"
+tar-ignore = ".git/"


### PR DESCRIPTION
When building a source package from a git clone of the snapd repository using debuild/dpkg-source, skip the .git directory.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
