### PR TITLE
tests/smoke/sandbox: use core24 base snap

### DIFF
--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -8,6 +8,12 @@ details: |
     works for both the main architecture, and for the 32-bit sub-architecture if
     the CPU supports one.
 
+prepare: |
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test prepare
+        tests.cleanup defer tests.session -u test restore
+    fi
+
 restore: |
     tests.exec is-skipped && exit 0
 
@@ -50,15 +56,23 @@ execute: |
     done
 
     echo "Ensure the apparmor sandbox for snaps works for users"
-    not su -l -c 'test-snapd-sandbox -c "touch /home/test/foo"' test 2>stderr.log
+    if tests.session has-session-systemd-and-dbus; then
+        not tests.session -u test exec test-snapd-sandbox -c "touch /home/test/foo" test 2>stderr.log
+    else
+        not su -l -c 'test-snapd-sandbox -c "touch /home/test/foo"' test 2>stderr.log
+    fi
     MATCH <stderr.log '.* Permission denied'
 
-    echo "But with the right plug the user can put files into home"
-    su -l -c  'test-snapd-sandbox.with-home-plug -c "echo good >/home/test/foo"' test
-    test -e /home/test/foo
-    echo "and also read them back"
-    su -l -c  'test-snapd-sandbox.with-home-plug -c "cat /home/test/foo"' test | MATCH good
-
+    echo "But with the right plug the user can put files into home and read them back"
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test exec test-snapd-sandbox.with-home-plug -c "echo good >/home/test/foo"
+        test -e /home/test/foo
+        tests.session -u test exec test-snapd-sandbox.with-home-plug -c "cat /home/test/foo" | MATCH good
+    else
+        su -l -c  'test-snapd-sandbox.with-home-plug -c "echo good >/home/test/foo"' test
+        test -e /home/test/foo
+        su -l -c  'test-snapd-sandbox.with-home-plug -c "cat /home/test/foo"' test | MATCH good
+    fi
 
     ############## SECCOMP
     echo "Ensure seccomp sandbox works"

--- a/tests/smoke/sandbox/test-snapd-sandbox/meta/snap.yaml
+++ b/tests/smoke/sandbox/test-snapd-sandbox/meta/snap.yaml
@@ -1,6 +1,7 @@
 name: test-snapd-sandbox
 summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
+base: core24
 
 apps:
     test-snapd-sandbox:


### PR DESCRIPTION
Use core24 base for the test snap to enable support for riscv64. Note the test runs as part of autopkgtest suite

Fixes: [LP#2112579](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2112579)
Related: [SNAPDENG-35197](https://warthogs.atlassian.net/browse/SNAPDENG-35197)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-35197]: https://warthogs.atlassian.net/browse/SNAPDENG-35197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ