### PR TITLE
tests/main/security-group-policy: old libcap compatibility fox

### DIFF
--- a/tests/main/security-group-policy/task.yaml
+++ b/tests/main/security-group-policy/task.yaml
@@ -43,7 +43,9 @@ prepare: |
 
     chown :snap-runners "$LIBEXEC_DIR"/snapd/snap-confine
     # restore caps, depending on whether the host binary had them
-    caps="$(getcap "$LIBEXEC_DIR"/snapd/snap-confine.backup | awk '{ print $2 }')"
+    # note, getcap output varies across versions, but the capabilities are always listed last
+    caps="$(getcap "$LIBEXEC_DIR"/snapd/snap-confine.backup | awk '{ print $NF }')"
+    echo "caps: $caps"
     if [ -n "$caps" ]; then
         echo "$caps" | setcap - "$LIBEXEC_DIR"/snapd/snap-confine
     fi


### PR DESCRIPTION
The output of getcap is different across various versions. Update the test to be compatible with older libcap (e.g. 2.32) found in Ubuntu 20.04.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
