### PR TITLE
osutil/vfs: improve integration tests

### DIFF
--- a/osutil/vfs/tests/bind-shadow-propagate/task.yaml
+++ b/osutil/vfs/tests/bind-shadow-propagate/task.yaml
@@ -28,9 +28,8 @@ restore: |
   umount -l b
   rmdir b
 debug: |
-  cat mountinfo
+  cat /proc/self/mountinfo
 execute: |
-  cat /proc/self/mountinfo >mountinfo
   # Print the fifth (mount point) and second-to-last field (file system source).
-  tail -n 7 mountinfo | awk '{ print substr($5, '"$(pwd | wc -c)"') " " $(NF-1) }' >actual.txt
+  tail -n 7 /proc/self/mountinfo | awk '{ print substr($5, length(ENVIRON["PWD"]) + 1) " " $(NF-1) }' >actual.txt
   diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/bind-stack/task.yaml
+++ b/osutil/vfs/tests/bind-stack/task.yaml
@@ -23,10 +23,9 @@ restore: |
   umount -l b
   rmdir b
 debug: |
-  cat mountinfo
+  cat /proc/self/mountinfo
 execute: |
-  cat /proc/self/mountinfo >mountinfo
   # Second-to-last field is the source device.
   # This shows our custom names for each tmpfs mounted above.
-  tail -n 4 mountinfo | awk '{ print $(NF-1) }' >actual.txt
+  tail -n 4 /proc/self/mountinfo | awk '{ print $(NF-1) }' >actual.txt
   diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/rbind-fragment/task.yaml
+++ b/osutil/vfs/tests/rbind-fragment/task.yaml
@@ -22,9 +22,8 @@ restore: |
   umount -l b-1
   rmdir b-1
 debug: |
-  cat mountinfo
+  cat /proc/self/mountinfo
 execute: |
-  cat /proc/self/mountinfo >mountinfo
   # Field 5 is the mount point path.
-  tail -n 5 mountinfo | cut -d ' ' -f 5 | cut -c "$(pwd | wc -c)"- >actual.txt
+  tail -n 5 /proc/self/mountinfo | awk '{ print substr($5, length(ENVIRON["PWD"]) + 1) }' >actual.txt
   diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/rbind-order/task.yaml
+++ b/osutil/vfs/tests/rbind-order/task.yaml
@@ -27,9 +27,8 @@ restore: |
   umount -l b
   rmdir b
 debug: |
-  cat mountinfo
+  cat /proc/self/mountinfo
 execute: |
-  cat /proc/self/mountinfo >mountinfo
   # Field 5 is the mount point path.
-  tail -n 12 mountinfo | cut -d ' ' -f 5 | cut -c "$(pwd | wc -c)"- >actual.txt
+  tail -n 12 /proc/self/mountinfo | awk '{ print substr($5, length(ENVIRON["PWD"]) + 1) }' >actual.txt
   diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/rbind-unbindable/task.yaml
+++ b/osutil/vfs/tests/rbind-unbindable/task.yaml
@@ -22,9 +22,8 @@ restore: |
   umount -l b
   rmdir b
 debug: |
-  cat mountinfo
+  cat /proc/self/mountinfo
 execute: |
-  cat /proc/self/mountinfo >mountinfo
   # Field 5 is the mount point path.
-  tail -n 6 mountinfo | awk '{ print substr($5, '"$(pwd | wc -c)"') }' >actual.txt
+  tail -n 6 /proc/self/mountinfo | awk '{ print substr($5, length(ENVIRON["PWD"]) + 1) }' >actual.txt
   diff -u actual.txt expected.txt


### PR DESCRIPTION
There are several improvements I've learned since writing this:

- We can look at the current working directory directly from awk by using the ENVIRON array and the PWD environment variable visible there this significantly simplifies quoting.
- We can use awk instead of cut to access numbered fields.
- We don't need to copy the mountinfo file that much.

This brings the old tests in line with the new tests that are landing separately.
