### PR TITLE
tests: move the ps7 environment from stg to prod

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -399,40 +399,7 @@ backends:
             https_proxy: "http://squid.internal:3128"
             no_proxy: '127.0.0.1,127.0.0.53,localhost'
             NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
-        systems: &openstack-systems
-            - ubuntu-16.04-64:
-                image: snapd-spread/ubuntu-16.04-64
-                workers: 8
-            - ubuntu-18.04-64:
-                image: snapd-spread/ubuntu-18.04-64
-                workers: 8
-            - ubuntu-20.04-64:
-                image: snapd-spread/ubuntu-20.04-64
-                workers: 8
-            - ubuntu-22.04-64:
-                image: snapd-spread/ubuntu-22.04-64
-                workers: 8
-            - ubuntu-24.04-64:
-                image: snapd-spread/ubuntu-24.04-64
-                workers: 8
-            - ubuntu-25.04-64:
-                image: snapd-spread/ubuntu-25.04-64
-                workers: 8
-
-
-            - ubuntu-core-18-64:
-                image: snapd-spread/ubuntu-18.04-64
-                workers: 8
-            - ubuntu-core-20-64:
-                image: snapd-spread/ubuntu-20.04-64-uefi
-                workers: 8
-            - ubuntu-core-22-64:
-                image: snapd-spread/ubuntu-22.04-64-uefi
-                workers: 8
-            - ubuntu-core-24-64:
-                image: snapd-spread/ubuntu-24.04-64-uefi
-                workers: 8
-
+        systems:
             - fedora-41-64:
                 image: snapd-spread/fedora-41-64
                 workers: 6
@@ -466,7 +433,7 @@ backends:
         wait-timeout: 5m
         groups: [default]
         proxy: ingress-haproxy.ps7.canonical.com
-        cidr-port-rel: [10.151.54.0/24:4000]
+        cidr-port-rel: [10.151.96.0/21:5000]
         environment:
             SNAPD_USE_PROXY: 'true'
             HTTP_PROXY: 'http://egress.ps7.internal:3128'
@@ -476,7 +443,38 @@ backends:
             no_proxy: '127.0.0.1,127.0.0.53,localhost'
             NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
             NTP_SERVER: 'ntp.ps7.internal'
-        systems: *openstack-systems
+        systems:
+            - ubuntu-16.04-64:
+                image: snapd-spread/ubuntu-16.04-64
+                workers: 8
+            - ubuntu-18.04-64:
+                image: snapd-spread/ubuntu-18.04-64
+                workers: 8
+            - ubuntu-20.04-64:
+                image: snapd-spread/ubuntu-20.04-64
+                workers: 8
+            - ubuntu-22.04-64:
+                image: snapd-spread/ubuntu-22.04-64
+                workers: 8
+            - ubuntu-24.04-64:
+                image: snapd-spread/ubuntu-24.04-64
+                workers: 8
+            - ubuntu-25.04-64:
+                image: snapd-spread/ubuntu-25.04-64
+                workers: 8
+
+            - ubuntu-core-18-64:
+                image: snapd-spread/ubuntu-18.04-64
+                workers: 8
+            - ubuntu-core-20-64:
+                image: snapd-spread/ubuntu-20.04-64-uefi
+                workers: 8
+            - ubuntu-core-22-64:
+                image: snapd-spread/ubuntu-22.04-64-uefi
+                workers: 8
+            - ubuntu-core-24-64:
+                image: snapd-spread/ubuntu-24.04-64-uefi
+                workers: 8
 
     openstack-arm-ps7:
         type: openstack
@@ -486,7 +484,7 @@ backends:
         wait-timeout: 5m
         groups: [default]
         proxy: ingress-haproxy.ps7.canonical.com
-        cidr-port-rel: [10.151.53.0/24:3000]
+        cidr-port-rel: [10.151.89.0/24:8000]
         environment:
             SNAPD_USE_PROXY: 'true'
             HTTP_PROXY: 'http://egress.ps7.internal:3128'


### PR DESCRIPTION
This change is to run the ubuntu systemd in the new prod environment in ps7 using the new cidr 10.151.96.0/2 instead of 10.151.54.0/24

Also the systems are organized in openstack-ps7 backend
