### PR TITLE
tests: use curl from snap in when running as another user in snap-session-socket-activation

### DIFF
--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -62,5 +62,5 @@ execute: |
     tests.session -u test exec systemctl --user is-active snapd.session-agent.service
 
     echo "The user running the session agent can also communicate with it"
-    tests.session -u test exec curl --unix-socket /run/user/12345/snapd-session-agent.socket \
+    tests.session -u test exec test-snapd-curl.curl --unix-socket /run/user/12345/snapd-session-agent.socket \
         -D- http://localhost/v1/session-info | MATCH "HTTP/1.1 200 OK"


### PR DESCRIPTION
When running as the test user, their `PATH` has `/usr/bin` before `/snap/bin`, which causes the curl from `/usr/bin` to be used rather than from the snap. The test then fails on ubuntu 25.10 since curl has an apparmor policy that does not allow reading/writing to the socket. Rather than rely on the alias, this explicitly calls the curl from the snap.