### PR TITLE
cmd/Makefile: fix out of tree use of 'make hack'

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -74,7 +74,7 @@ fmt-check:: $(wildcard $(addsuffix /*.[ch],$(addprefix $(srcdir)/,$(subdirs))))
 .PHONY: hack
 hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns snap-device-helper/snap-device-helper snapd-apparmor/snapd-apparmor
 	sudo install -D -m 755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
-	sudo setcap "$$(cat snap-confine/snap-confine.caps)" $(DESTDIR)$(libexecdir)/snap-confine
+	sudo setcap "$$(cat $(top_srcdir)/snap-confine/snap-confine.caps)" $(DESTDIR)$(libexecdir)/snap-confine
 	if [ -d $(DESTDIR)$(APPARMOR_SYSCONFIG) ]; then sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real; fi
 	sudo install -d -m 755 $(DESTDIR)$(snapdstatedir)/apparmor/snap-confine/
 	if [ "$$(command -v apparmor_parser)" != "" ]; then sudo apparmor_parser -r snap-confine/snap-confine.apparmor; fi
@@ -86,12 +86,16 @@ hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-up
 	if [ "$$(command -v restorecon)" != "" ]; then sudo restorecon -R -v $(DESTDIR)$(libexecdir)/; fi
 
 # for the hack target also:
-snap-update-ns/snap-update-ns: snap-update-ns/*.go snap-update-ns/*.[ch]
-	cd snap-update-ns && go build -buildmode=$(STATIC_GO_BUILDMODE) -ldflags='-extldflags=$(STATIC_LDFLAGS) -linkmode=external' -v
-snap-seccomp/snap-seccomp: snap-seccomp/*.go
-	cd snap-seccomp && go build -v
-snapd-apparmor/snapd-apparmor: snapd-apparmor/*.go
-	cd snapd-apparmor && go build -v
+snap-update-ns/snap-update-ns: $(top_srcdir)/snap-update-ns/*.go $(top_srcdir)/snap-update-ns/*.[ch]
+	mkdir -p snap-update-ns
+	cd $(top_srcdir)/snap-update-ns && go build -o $(abs_top_builddir)/$@ \
+	     -buildmode=$(STATIC_GO_BUILDMODE) -ldflags='-extldflags=$(STATIC_LDFLAGS) -linkmode=external' -v
+snap-seccomp/snap-seccomp: $(top_srcdir)/snap-seccomp/*.go
+	mkdir -p snap-seccomp
+	cd $(top_srcdir)/snap-seccomp && go build -v -o $(abs_top_builddir)/$@
+snapd-apparmor/snapd-apparmor: $(top_srcdir)/snapd-apparmor/*.go
+	mkdir -p snapd-apparmor
+	cd $(top_srcdir)/snapd-apparmor && go build -v -o $(abs_top_builddir)/$@
 
 ##
 ## libsnap-confine-private.a


### PR DESCRIPTION
Fix use of 'make hack' with out of tree builds, such that this sequence works as expected:
```
BUILD_DIR=$PWD/build-dir ./autogen.sh
cd build-dir
make -j hack
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
