### PR TITLE
tests: move weekly-state-locks from google to openstack-ps7

### DIFF
--- a/.github/workflows/weekly-state-locks.yaml
+++ b/.github/workflows/weekly-state-locks.yaml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         include:
           - group: "ubuntu-24.04"
-            backend: "google"
+            backend: "openstack-ps7"
             systems: "ubuntu-24.04-64"
             tasks: "tests/main/"
             rules: "main"
           - group: "ubuntu-core-24"
-            backend: "google-core"
+            backend: "openstack-ps7"
             systems: "ubuntu-core-24-64"
             tasks: "tests/core/"
             rules: "main"


### PR DESCRIPTION
We are moving the nightly executions to ps7 as well
