### PR TITLE
tests: disable the test microk8s-smoke

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -27,6 +27,9 @@ systems:
   - -ubuntu-25.04-*
   - -ubuntu-25.10-*
 
+# TODO : remove the manual when the test works with the version 1.32-strict which is newer
+manual: true
+
 environment:
     CHANNEL/edge: 1.26-strict/edge
     # apparmor profile of microk8s can make snapd exceed its spread memory limit


### PR DESCRIPTION
Currently it is failing in openstack-ps7 because it is reaching the max amount of downloads from docker.io

Also it needs to be updated to start using a newer version because the 1.26 was updated 2024-07-16
