### PR TITLE
cmd: unhide sign and export-key

### DIFF
--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -54,7 +54,7 @@ imported by other systems.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to export"),
 		}})
-	cmd.hidden = true
+	cmd.completeHidden = true
 }
 
 func (x *cmdExportKey) Execute(args []string) error {

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -261,8 +261,8 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:           i18n.G("Development"),
 		Description:     i18n.G("developer-oriented features"),
-		Commands:        []string{"download", "pack", "run", "try"},
-		AllOnlyCommands: []string{"prepare-image"},
+		Commands:        []string{"download", "pack", "run", "try", "sign"},
+		AllOnlyCommands: []string{"prepare-image", "export-key"},
 	}, {
 		Label:       i18n.G("Quota Groups"),
 		Description: i18n.G("Manage quota groups for snaps"),

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -50,7 +50,7 @@ type cmdSign struct {
 }
 
 func init() {
-	cmd := addCommand("sign", shortSignHelp, longSignHelp, func() flags.Commander {
+	addCommand("sign", shortSignHelp, longSignHelp, func() flags.Commander {
 		return &cmdSign{}
 	}, map[string]string{
 		// TRANSLATORS: This should not start with a lowercase letter.
@@ -65,8 +65,6 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("File to sign (defaults to stdin)"),
 	}})
-	cmd.hidden = true
-	cmd.completeHidden = true
 }
 
 func (x *cmdSign) Execute(args []string) error {


### PR DESCRIPTION
our UC-related documentation refers to them

This was discussed with @degville. There might be more to disclose but this is a start.
