### PR TITLE
interfaces: allow invoking systemd-creds

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -631,6 +631,7 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}bin/stty ixr,
   /{,usr/}bin/sync ixr,
   /{,usr/}bin/systemd-cat ixr,
+  /{,usr/}bin/systemd-creds ixr,
   /{,usr/}bin/tac ixr,
   /{,usr/}bin/tail ixr,
   /{,usr/}bin/tar ixr,


### PR DESCRIPTION
Using systemd credentials from shell integration scripts is easier with the systemd-creds binary. The binary handles the protocol described in https://systemd.io/CREDENTIALS/ and does not grant any additional privileges as it inherits the profile of the caller.

The binary exists since core24.