### PR TITLE
tests: add integration test for systemd credentials

### DIFF
--- a/tests/main/systemd-creds/task.yaml
+++ b/tests/main/systemd-creds/task.yaml
@@ -1,0 +1,28 @@
+summary: verify access to systemd credentials
+details: |
+    Systemd has introduced a feature where services can be provisioned with
+    credentials that are stored in manner safer than typical default and where said
+    credentials can be injected into the system (virtual machine, container or even
+    physical machine) during provisioning or first boot.
+
+    Snapd supports this for snaps on ubuntu-core with core24 boot base or where
+    systemd on the host is recent enough and the application snap uses core24 base.
+
+    This test shows how such credentials are provisioned and how they can be
+    accessed. Note that credentials are only available to systemd services.
+systems:
+    - ubuntu-core-24-64
+    - ubuntu-24.04-64
+prepare: |
+    mkdir /etc/systemd/system/snap.test-snapd-credentials.daemon.service.d
+    tests.cleanup defer rm -rf /etc/systemd/system/snap.test-snapd-credentials.daemon.service.d
+    cat <<__CONF__ >/etc/systemd/system/snap.test-snapd-credentials.daemon.service.d/credentials.conf
+    [Service]
+    $(echo top-secret | systemd-creds encrypt -p --name=foo - -)
+    __CONF__
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-credentials
+execute: |
+    MATCH '^CREDENTIALS_DIRECTORY=/run/credentials/snap.test-snapd-credentials.daemon.service$' </var/snap/test-snapd-credentials/common/log
+    MATCH '^top-secret$' </var/snap/test-snapd-credentials/common/log
+    MATCH '^foo  weak    11B /run/credentials/snap.test-snapd-credentials.daemon.service/foo$' < /var/snap/test-snapd-credentials/common/log

--- a/tests/main/systemd-creds/test-snapd-credentials/bin/daemon
+++ b/tests/main/systemd-creds/test-snapd-credentials/bin/daemon
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -xeu
+(
+    # Look for the credentials environment variable
+    echo "CREDENTIALS_DIRECTORY=${CREDENTIALS_DIRECTORY:-}"
+    # Look at individual credentials.
+    if [ -d "${CREDENTIALS_DIRECTORY:-}" ]; then
+        find "$CREDENTIALS_DIRECTORY" -type f -exec cat {} \;
+    fi
+    # See if we can invoke the standard tool.
+    systemd-creds list
+) >"$SNAP_COMMON"/log
+
+exit 0

--- a/tests/main/systemd-creds/test-snapd-credentials/meta/snap.yaml
+++ b/tests/main/systemd-creds/test-snapd-credentials/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: test-snapd-credentials
+summary: Test snap using systemd credentials
+version: "1"
+
+confinement: strict
+base: core24
+
+apps:
+  daemon:
+    command: bin/daemon
+    daemon: oneshot


### PR DESCRIPTION
We've been adding support for using systemd credentials system but there is no
integration test that shows how this works end-to-end. Until now.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>


~~This depends on #15820 and #15821~~