### PR TITLE
tests: simplify tests.session exec

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -270,8 +270,8 @@ main() {
 		# It is needed to have '|| true' to make sure in case systemd-run fails,
 		# the command systemctl reset-failed is called
 		# shellcheck disable=SC2086
- 		systemd-run \
-  		--unit="$unit_name" \
+		systemd-run \
+		--unit="$unit_name" \
 		--description "tests.session running $* as $user" \
 		--quiet \
 		--wait \
@@ -287,13 +287,10 @@ main() {
 			if systemctl is-failed "$unit_name"; then
 				systemctl reset-failed "$unit_name"
 				exit 1
-			else
-				exit 0
 			fi
-		else
-			exit 0
 		fi
-  	fi
+		exit 0
+	fi
 
 	mkfifo -m 0666 "$tmp_dir/result.pipe" "$tmp_dir/stdin.pipe" "$tmp_dir/stdout.pipe" "$tmp_dir/stderr.pipe"
 	# Use busctl to spawn a command. The command is wrapped in shell, runuser -l
@@ -309,8 +306,8 @@ main() {
 	cat <"$tmp_dir/stderr.pipe" >&2 &
 	cat_stderr_pid=$!
 
-  	mkfifo -m 0666 "$tmp_dir/dbus-monitor.pipe" "$tmp_dir/ready.pipe"
-  	monitor_expr="type='signal', sender='org.freedesktop.systemd1', interface='org.freedesktop.systemd1.Manager', path='/org/freedesktop/systemd1', member='JobRemoved'"
+	mkfifo -m 0666 "$tmp_dir/dbus-monitor.pipe" "$tmp_dir/ready.pipe"
+	monitor_expr="type='signal', sender='org.freedesktop.systemd1', interface='org.freedesktop.systemd1.Manager', path='/org/freedesktop/systemd1', member='JobRemoved'"
 	stdbuf -oL dbus-monitor --system --monitor "$monitor_expr" > "$tmp_dir/dbus-monitor.pipe" 2>"$tmp_dir/dbus-monitor.stderr" &
 	dbus_monitor_pid=$!
 


### PR DESCRIPTION
I was digging around looking for the cause of https://github.com/canonical/snapd/pull/15817#discussion_r2270223759 and was confused by the `tests.session exec` flow, I think it can be simplified like this.