### PR TITLE
tests: increase disk size for 25.10 nested tests

### DIFF
--- a/tests/nested/manual/hybrid-fde-recovery-keys/task.yaml
+++ b/tests/nested/manual/hybrid-fde-recovery-keys/task.yaml
@@ -137,7 +137,7 @@ execute: |
   gojq '.keyslots | length' < container.out | MATCH "^0$"
 
   # system-seed is also not encrypted
-  gojq '.result."by-container-role"."system-seed-null"' < containers.out > container.out
+  gojq '.result."by-container-role"."system-seed"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^false$"
   gojq '.keyslots | length' < container.out | MATCH "^0$"
 

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -142,7 +142,7 @@ execute: |
   gojq '.keyslots | length' < container.out | MATCH "^0$"
 
   # system-seed is also not encrypted
-  gojq '.result."by-container-role"."system-seed-null"' < containers.out > container.out
+  gojq '.result."by-container-role"."system-seed"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^false$"
   gojq '.keyslots | length' < container.out | MATCH "^0$"
 


### PR DESCRIPTION
25.10 gadget require much larger disks because of this commit which was added yesterday https://github.com/canonical/pc-gadget/commit/814d80acbcc0de4ac799b3bcb67f7ec625d6c53a

This is what is causing `tests/nested/manual/passphrase-support-on-hybrid` to fail, I am surprised that `tests/nested/manual/hybrid-fde-recovery-keys` doesn't fail for the 25.10 variant though maybe it lucked out and didn't pickup the latest gadget snap yet from the store.

Failure sample: https://github.com/canonical/snapd/actions/runs/16916171047/job/47969193679?pr=15756#step:21:3844
