### PR TITLE
tests: skip osutil/mkfs tests when running tests as root user

### DIFF
--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -42,12 +42,6 @@ var _ = Suite(&mkfsSuite{})
 
 func (m *mkfsSuite) SetUpTest(c *C) {
 	m.BaseTest.SetUpTest(c)
-	
-	// The tests are set up to test the non-root code paths with fakeroot.
-	// If we are root, just skip.
-	if os.Getuid() == 0 {
-		c.Skip("requires running as non-root user")
-	}
 
 	// fakeroot, mkfs.ext4, mkfs.vfat and mcopy are commonly installed in
 	// the host system, set up some overrides so that we avoid calling the
@@ -66,6 +60,10 @@ func (m *mkfsSuite) SetUpTest(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("test assumes use of fakeroot")
+	}
+
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
@@ -112,6 +110,10 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("test assumes use of fakeroot")
+	}
+
 	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
@@ -177,6 +179,10 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("test assumes use of fakeroot")
+	}
+
 	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()
 

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -60,130 +60,142 @@ func (m *mkfsSuite) SetUpTest(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
-	if os.Getuid() == 0 {
-		c.Skip("test assumes use of fakeroot")
+	useFakeroot := os.Getuid() != 0
+	var cmd *testutil.MockCmd
+	if useFakeroot {
+		cmd = testutil.MockCommand(c, "fakeroot", "")
+	} else {
+		cmd = testutil.MockCommand(c, "mkfs.ext4", "")
 	}
-
-	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
 	err := mkfs.MakeWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-d", "contents",
-			"-L", "my-label",
-			"foo.img",
-		},
-	})
+	expectedCall := []string{
+		"mkfs.ext4",
+		"-d", "contents",
+		"-L", "my-label",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 	// empty label
 	err = mkfs.MakeWithContent("ext4", "foo.img", "", "contents", 0, 0)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-d", "contents",
-			"foo.img",
-		},
-	})
+	expectedCall = []string{
+		"mkfs.ext4",
+		"-d", "contents",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 	// no content
 	err = mkfs.Make("ext4", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-L", "my-label",
-			"foo.img",
-		},
-	})
-
+	expectedCall = []string{
+		"mkfs.ext4",
+		"-L", "my-label",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 }
 
 func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
-	if os.Getuid() == 0 {
-		c.Skip("test assumes use of fakeroot")
+	useFakeroot := os.Getuid() != 0
+	var cmd *testutil.MockCmd
+	if useFakeroot {
+		cmd = testutil.MockCommand(c, "fakeroot", "")
+	} else {
+		cmd = testutil.MockCommand(c, "mkfs.ext4", "")
 	}
-
-	cmd := testutil.MockCommand(c, "fakeroot", "")
 	defer cmd.Restore()
 
 	err := mkfs.MakeWithContent("ext4", "foo.img", "my-label", "contents", 250*1024*1024, 0)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-d", "contents",
-			"-L", "my-label",
-			"foo.img",
-		},
-	})
+	expectedCall := []string{
+		"mkfs.ext4",
+		"-d", "contents",
+		"-L", "my-label",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 	// empty label
 	err = mkfs.MakeWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 0)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-b", "1024",
-			"-d", "contents",
-			"foo.img",
-		},
-	})
+	expectedCall = []string{
+		"mkfs.ext4",
+		"-b", "1024",
+		"-d", "contents",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 	// with sector size of 512
 	err = mkfs.MakeWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 512)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-b", "1024",
-			"-d", "contents",
-			"foo.img",
-		},
-	})
+	expectedCall = []string{
+		"mkfs.ext4",
+		"-b", "1024",
+		"-d", "contents",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 	// with sector size of 4096
 	err = mkfs.MakeWithContent("ext4", "foo.img", "", "contents", 32*1024*1024, 4096)
 	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{
-			"fakeroot",
-			"mkfs.ext4",
-			"-b", "4096",
-			"-d", "contents",
-			"foo.img",
-		},
-	})
+	expectedCall = []string{
+		"mkfs.ext4",
+		"-b", "4096",
+		"-d", "contents",
+		"foo.img",
+	}
+	if useFakeroot {
+		expectedCall = append([]string{"fakeroot"}, expectedCall...)
+	}
+	c.Check(cmd.Calls(), DeepEquals, [][]string{expectedCall})
 
 	cmd.ForgetCalls()
 
 }
 
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
-	if os.Getuid() == 0 {
-		c.Skip("test assumes use of fakeroot")
+	useFakeroot := os.Getuid() != 0
+	var cmd *testutil.MockCmd
+	if useFakeroot {
+		cmd = testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
+	} else {
+		cmd = testutil.MockCommand(c, "mkfs.ext4", "echo 'command failed'; exit 1")
 	}
-
-	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
 	defer cmd.Restore()
 
 	err := mkfs.MakeWithContent("ext4", "foo.img", "my-label", "contents", 0, 0)

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -42,6 +42,12 @@ var _ = Suite(&mkfsSuite{})
 
 func (m *mkfsSuite) SetUpTest(c *C) {
 	m.BaseTest.SetUpTest(c)
+	
+	// The tests are set up to test the non-root code paths with fakeroot.
+	// If we are root, just skip.
+	if os.Getuid() == 0 {
+		c.Skip("requires running as non-root user")
+	}
 
 	// fakeroot, mkfs.ext4, mkfs.vfat and mcopy are commonly installed in
 	// the host system, set up some overrides so that we avoid calling the


### PR DESCRIPTION
Skip tests in osutil/mkfs that use fakeroot when running as root.

https://warthogs.atlassian.net/browse/SNAPDENG-37117