### PR TITLE
o/fdestate: tag nosecboot on reseal_sb_test.go

### DIFF
--- a/overlord/fdestate/backend/reseal_sb_test.go
+++ b/overlord/fdestate/backend/reseal_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 
 /*
  * Copyright (C) 2025 Canonical Ltd


### PR DESCRIPTION
This fixes building on Debian, where nosecboot is default.
