### PR TITLE
tests: do not download snap-confine on Debian

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -558,7 +558,16 @@ prepare_project() {
     # of the tested distribution. Download snapd and snap-confine
     # as they exist in the archive for further use.
     if tests.info is-snapd-from-archive; then
-        ( cd "${GOHOME}" && tests.pkgs download snapd snap-confine)
+        case "$SPREAD_SYSTEM" in
+            debian-*)
+                # In Debian 14+, the snap-confine transitional package was removed.
+                # In earlier versions it was just an empty package so it's not worth pulling.
+                ( cd "${GOHOME}" && tests.pkgs download snapd )
+                ;;
+            *)
+                ( cd "${GOHOME}" && tests.pkgs download snapd snap-confine)
+                ;;
+        esac
     else
         case "$SPREAD_SYSTEM" in
             ubuntu-*|debian-*)


### PR DESCRIPTION
The snap-confine Debian package was a transitional package that was removed with snapd 2.71-1.
