### PR TITLE
i/builtin: remove stale comment about duplicate line detection

### DIFF
--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -35,10 +35,6 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-// TODO: Snapd should validate the correctness of slot declarations
-// (i.e. lines across slots are unique) when installing the gadget
-// snap e.g. when validating snap.yaml
-
 // The interface operates as follows:
 //   - uses snap-gpio-helper to set up a virtual GPIO device exposing specific
 //     lines defined in the slot as character device node at


### PR DESCRIPTION
This was already implemented in https://github.com/canonical/snapd/pull/15307

No need to run spread as it is simply removing a comment