### PR TITLE
interfaces/builtin/system_observe: read access to btrfs/ext4/zfs filesystem information

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -76,8 +76,6 @@ ptrace (read),
 @{PROC}/pressure/cpu r,
 @{PROC}/pressure/io r,
 @{PROC}/pressure/memory r,
-# Allow reading ZFS filesystem statistics
-@{PROC}/spl/kstat/zfs/{,**} r,
 @{PROC}/sys/kernel/panic r,
 @{PROC}/sys/kernel/panic_on_oops r,
 @{PROC}/sys/kernel/sched_autogroup_enabled r,


### PR DESCRIPTION
This PR is a continuation of this [previous one](https://github.com/canonical/snapd/pull/15844), and its aim is to reduce the error logs in node-exporter running as a strictly confined snap. 

More info: https://forum.snapcraft.io/t/should-some-snapd-interfaces-be-modified/48242/11?u=abuelodelanada