### PR TITLE
interfaces/builtin: set dconf-service as profile for ca.desrt.dconf.Writer

### DIFF
--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -43,7 +43,7 @@ owner @{HOME}/.config/dconf/user w,
 dbus (receive, send)
     bus=session
     interface="ca.desrt.dconf.Writer"
-    peer=(label=unconfined),
+    peer=(label="{dconf-service,unconfined}"),
 `
 
 func init() {


### PR DESCRIPTION
It is the first PR of a series of PRs to set new confined peer_label for dbus services.

[apparmor.d](https://github.com/roddhjav/apparmor.d) introduces apparmor profiles for all dbus services used in snapd. As dbus rules in snapd always use the `unconfined` peer_label, when using apparmor.d, all snap applications (that use dbus extensively) are broken.

The fast solution is to add the confined service (here `dconf-service`) as peer_label in addition to `unconfined`. Later, it could be interesting to have a way of removing the `unconfined` label when the dbus service is confined (by apparmor.d, by the reference policy, a third party project...).

**Side note**

That could be a future PR, but this dbus rule could be restricted a bit. See:

https://github.com/roddhjav/apparmor.d/blob/7cfff26ee273fca78aaea077cf63166d4883e2cb/apparmor.d/abstractions/bus/ca.desrt.dconf.Writer#L7-L15

Used in [abstractions/dconf-write](https://github.com/roddhjav/apparmor.d/blob/main/apparmor.d/abstractions/dconf-write) that is the equivalent of the gsettings interface.
