### PR TITLE
tests/main/appstream-id: disable on Amazon Linux

### DIFF
--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -5,8 +5,12 @@ details: |
     that the AppStream ID is included in the installed snaps and apps API response.
 
 # TODO we have gojq, so try enabling on ubuntu-core
-# ubuntu-core: no jq
-systems: [-ubuntu-core*]
+systems:
+    # ubuntu-core: no jq
+    - -ubuntu-core*
+    # TODO: test fails on PS7, timeout when making a request from snapd to snap
+    # store, possibly network proxy misconfiguration
+    - -amazon-linux-*
 
 debug: |
     cat response || true


### PR DESCRIPTION
Temporarily disable the test on Amazon Linux.

Related: SNAPDENG-35420

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
