### PR TITLE
interfaces/seccomp/template: allow landlock_* in default template

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -402,6 +402,13 @@ sched_yield
 # permissions)
 seccomp
 
+# Allow restricting access with Landlock. This is OK because the kernel
+# enforces that each new restriction only drops accesses for the calling
+# process (i.e., no widening permissions).
+landlock_create_ruleset
+landlock_add_rule
+landlock_restrict_self
+
 select
 _newselect
 pselect


### PR DESCRIPTION
Add the three Landlock syscalls in the default template. They have been available since Linux 5.13 (2021). As for the seccomp syscall, the Landlock syscalls should be allowed to further restrict processes.

This was reported here: https://forum.snapcraft.io/t/polkadot-snap-landlock-syscall-fails-inside-confinement/48359

See similar changes for other runtimes:
- https://github.com/moby/moby/pull/43199
- https://github.com/containers/common/pull/1081
- https://github.com/opencontainers/runtime-tools/pull/751
- https://github.com/systemd/systemd/pull/34552