### PR TITLE
tests: fix debug-execution test when using SNAP_REEXEC=0

### DIFF
--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -96,12 +96,7 @@ execute: |
 
             echo "Checking AppArmor"
             if [ "$SNAP_REEXEC" = 0 ]; then
-                if os.query is-xenial || os.query is-bionic; then
-                    # Ubuntu < 20.04 does not have usr-merge
-                    MATCH 'apparmor-parser: /sbin/apparmor_parser' < snap-apparmor-default.out
-                else
-                    MATCH 'apparmor-parser: /usr/sbin/apparmor_parser' < snap-apparmor-default.out
-                fi
+                MATCH 'apparmor-parser: (/usr)?/sbin/apparmor_parser' < snap-apparmor-default.out
                 MATCH 'internal: false' < snap-apparmor-default.out            
             else
                 MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out


### PR DESCRIPTION
Fix the test for the default scenario when it is not using reexec

test running:
> SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_SNAP_REEXEC=0 spread -debug openstack:debian-sid-64:tests/main/debug-execution