### PR TITLE
tests/main/install-refresh-remove-hooks: make shellcheck happy again

### DIFF
--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -83,7 +83,7 @@ execute: |
     snap set "$NAME" exitcode=1
     snap remove "$NAME"
     EXITCODE_VALUE=$(cat "$REMOVE_HOOK_FILE")
-    if test "x$EXITCODE_VALUE" != "x1"; then
+    if test "$EXITCODE_VALUE" != "1"; then
         echo "Remove hook was not executed"
         exit 1
     fi


### PR DESCRIPTION
Shellcheck 0.11.0 flags this issue:

ERROR:root:tests/main/install-refresh-remove-hooks/task.yaml: section 'execute':

In - line 72:
if test "x$EXITCODE_VALUE" != "x1"; then
        ^----------------^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if test "$EXITCODE_VALUE" != "1"; then

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
