### PR TITLE
interfaces/builtin: replace failed checkbox-support interface

### DIFF
--- a/interfaces/builtin/checkbox_support.go
+++ b/interfaces/builtin/checkbox_support.go
@@ -19,11 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/udev"
-)
-
 const checkboxSupportSummary = `allows checkbox to execute arbitrary system tests`
 
 const checkboxSupportBaseDeclarationPlugs = `
@@ -40,28 +35,56 @@ const checkboxSupportBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-type checkboxSupportInterface struct {
-	// The checkbox-support interface is exactly the steam-support interface
-	// with the exception that it is also allowed to run on core devices.
-	steamSupportInterface
-}
+const checkboxSupportConnectedPlugAppArmor = `
+include <abstractions/dbus-strict>
 
-func (iface *checkboxSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// we inherit one from steamSupportInterface, but none of the snippets are
-	// useful as the interface can manage device cgroup, giving it unrestricted
-	// access to devices
-	return iface.commonInterface.UDevConnectedPlug(spec, plug, slot)
-}
+# Allow starting transient units in which the tests are run. This is usually
+# carried out using a dedicated helper such as
+# https://gitlab.com/zygoon/plz-run which communicates with systemd over dbus.
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member=StartTransientUnit
+    peer=(name=org.freedesktop.systemd1,label=unconfined),
+
+# No mediation of which unit can be killed.
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member=KillUnit
+    peer=(name=org.freedesktop.systemd1,label=unconfined),
+
+# Allow observing the JobRemoved signal which informs the caller of
+# StartTransientUnit that the job has been dispatched and that the one-shot
+# service has finished.
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member=JobRemoved
+    peer=(name=org.freedesktop.systemd1,label=unconfined),
+
+# Allow observing PropertiesChanged signals from any service. This conveys,
+# among others, completion of the service as well as the exit status of the
+# main process.
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1/unit/*_2eservice
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(name=org.freedesktop.systemd1,label=unconfined),
+`
 
 func init() {
-	registerIface(&checkboxSupportInterface{steamSupportInterface{commonInterface{
-		name:                 "checkbox-support",
-		summary:              checkboxSupportSummary,
-		implicitOnCore:       true,
-		implicitOnClassic:    true,
-		controlsDeviceCgroup: true, // checkbox is exempt from device filtering
-		baseDeclarationSlots: checkboxSupportBaseDeclarationSlots,
-		baseDeclarationPlugs: checkboxSupportBaseDeclarationPlugs,
-		connectedPlugSecComp: steamSupportConnectedPlugSecComp,
-	}}})
+	registerIface(&commonInterface{
+		name:                  "checkbox-support",
+		summary:               checkboxSupportSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		connectedPlugAppArmor: checkboxSupportConnectedPlugAppArmor,
+		baseDeclarationSlots:  checkboxSupportBaseDeclarationSlots,
+		baseDeclarationPlugs:  checkboxSupportBaseDeclarationPlugs,
+	})
 }

--- a/interfaces/builtin/checkbox_support_test.go
+++ b/interfaces/builtin/checkbox_support_test.go
@@ -23,8 +23,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -65,16 +65,16 @@ func (s *CheckboxSupportInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "checkbox-support")
 }
 
-func (s *CheckboxSupportInterfaceSuite) TestSecCompSpec(c *C) {
-	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
-	c.Assert(err, IsNil)
-	spec := seccomp.NewSpecification(appSet)
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "@unrestricted\n")
-}
-
 func (s *CheckboxSupportInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *CheckboxSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "StartTransientUnit")
 }
 
 func (s *CheckboxSupportInterfaceSuite) TestUdevSpec(c *C) {
@@ -82,7 +82,7 @@ func (s *CheckboxSupportInterfaceSuite) TestUdevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.ControlsDeviceCgroup(), Equals, true)
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, false)
 }
 
 func (s *CheckboxSupportInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
The checkbox-support interface was meant to be steam-like, in the sense that the sandbox was largely disabled. What we missed during the original design was that checkbox often runs snap applications, while steam does not. As such, checkbox really needs a full sandbox escape, instead of a "sandbox light" mode like we thought before.

The interface remains super-privileged but the nature of the implementation changed entirely as the former implementation was never productised by checkbox.

During the last couple of weeks we've designed and debugged another approach, where checkbox uses systemd D-Bus APIs to break out of the sandbox. This was both prototyped and developed into a small tool, plz-run - https://gitlab.com/zygoon/plz-run - along with the checkbox developer Massimiliano Girardi.

The new set of permissions allow checkbox to StartTransientUnit, KillUnit and to listen to JobRemoved and PropertiesChanged signals.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35415

