### PR TITLE
interfaces/desktop: allow receiving org.freedesktop.Notifications.Act…

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -285,7 +285,7 @@ dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member={ActionInvoked,NotificationClosed,NotificationReplied}
+    member={ActivationToken,ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label="{plasmashell,unconfined}"),
 
 # KDE Plasma's Inhibited property indicating "do not disturb" mode


### PR DESCRIPTION
…ivationToken

On my Ubuntu 25.10 system, running firefox snap, I see this denial every time a notification from firefox is activated.

> wrz 11 11:37:02 x13 dbus-daemon[3559]: apparmor="DENIED"
> operation="dbus_signal"  bus="session" path="/org/freedesktop/Notifications"
> interface="org.freedesktop.Notifications" member="ActivationToken"
> name=":1.32" mask="receive" pid=4974 label="snap.firefox.firefox"
> peer_pid=3929 peer_label="unconfined"
