### PR TITLE
apparmor: allow rust rewritten coreutils to be run in core base

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -740,6 +740,7 @@ var defaultCoreRuntimeTemplateRules = `
 
   # Allow all snaps to chroot
   /{,usr/}sbin/chroot ixr,
+  /usr/lib/cargo/bin/coreutils/chroot ixr,
 
   # Allow pidof (and killall5, as pidof can be a symlink to killall5 in some distros)
   /{,usr/}bin/pidof ixr,


### PR DESCRIPTION
core26 has switched, now it's broken.

Solves [LP: #2123870](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2123870)