### PR TITLE
many: switch to apparmor 5.x with 5 ABI

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -325,6 +325,7 @@ func setupConfCacheDirs(newrootdir string) {
 	CacheDir = filepath.Join(newrootdir, "/var/cache/apparmor")
 	hostAbi30File = filepath.Join(newrootdir, "/etc/apparmor.d/abi/3.0")
 	hostAbi40File = filepath.Join(newrootdir, "/etc/apparmor.d/abi/4.0")
+	hostAbi50File = filepath.Join(newrootdir, "/etc/apparmor.d/abi/5.0")
 
 	SystemCacheDir = filepath.Join(ConfDir, "cache")
 	exists, isDir, _ := osutil.DirExists(SystemCacheDir)
@@ -562,6 +563,8 @@ var (
 	hostAbi30File = ""
 	// hostAbi40File is like hostAbi30File but for ABI 4.0
 	hostAbi40File = ""
+	// hostAbi50File is like hostAbi30File but for ABI 5.0
+	hostAbi50File = ""
 )
 
 // Each apparmor feature is manifested as a directory entry.
@@ -948,6 +951,14 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 		path := filepath.Join(dir, "apparmor_parser")
 		if _, err := os.Stat(path); err == nil {
 			logger.Debugf("checking distro apparmor_parser at %v", path)
+
+			// Detect bug ignore apparmor 5.0 ABI support.
+			// There's no known, diagnosed issue with ABI 5 yet but given that
+			// we also ignore host ABI 4.0, it's sensible to ignore this one explicitly too.
+			if fi, err := os.Lstat(hostAbi50File); err == nil && !fi.IsDir() {
+				logger.Debugf("apparmor 5.0 ABI detected but ignored")
+			}
+
 			// Detect but ignore apparmor 4.0 ABI support.
 			//
 			// At present this causes some bugs with mqueue mediation that can

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -952,7 +952,7 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 		if _, err := os.Stat(path); err == nil {
 			logger.Debugf("checking distro apparmor_parser at %v", path)
 
-			// Detect bug ignore apparmor 5.0 ABI support.
+			// Detect but ignore apparmor 5.0 ABI support.
 			// There's no known, diagnosed issue with ABI 5 yet but given that
 			// we also ignore host ABI 4.0, it's sensible to ignore this one explicitly too.
 			if fi, err := os.Lstat(hostAbi50File); err == nil && !fi.IsDir() {

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -908,6 +908,7 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 			prefix := strings.TrimSuffix(path, "apparmor_parser")
 			snapdAbi30File := filepath.Join(prefix, "/apparmor.d/abi/3.0")
 			snapdAbi40File := filepath.Join(prefix, "/apparmor.d/abi/4.0")
+			snapdAbi50File := filepath.Join(prefix, "/apparmor.d/abi/5.0")
 
 			// When using the internal apparmor_parser also use its own
 			// configuration and includes etc plus also ensure we use the 4.0
@@ -918,9 +919,12 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 			// older apparmor, use that instead so that things
 			// don't generally fail.
 			abiFile := ""
+			fi50, err50 := os.Lstat(snapdAbi50File)
 			fi40, err40 := os.Lstat(snapdAbi40File)
 			fi30, err30 := os.Lstat(snapdAbi30File)
 			switch {
+			case err50 == nil && !fi50.IsDir():
+				abiFile = snapdAbi50File
 			case err40 == nil && !fi40.IsDir():
 				abiFile = snapdAbi40File
 			case err30 == nil && !fi30.IsDir():

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -78,6 +78,97 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 	c.Check(err, Equals, nil)
 }
 
+func (s *apparmorSuite) TestAppArmorParserDistroAbiIgnored(c *C) {
+	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
+	defer mockParserCmd.Restore()
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	defer restore()
+
+	type abiCase struct {
+		name     string
+		abi30    string
+		abi40    string
+		abi50    string
+		expected []string
+		logMatch string
+	}
+
+	cases := []abiCase{
+		{
+			name:     "no abi files",
+			expected: []string{mockParserCmd.Exe()},
+		},
+		{
+			name:     "only abi 3.0",
+			abi30:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0"),
+			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0")},
+		},
+		{
+			name:     "only abi 5.0 ignored",
+			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
+			expected: []string{mockParserCmd.Exe()},
+			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored`,
+		},
+		{
+			name:     "abi 4.0 and 5.0 ignored",
+			abi40:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/4.0"),
+			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
+			expected: []string{mockParserCmd.Exe()},
+			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored.* DEBUG: apparmor 4.0 ABI detected but ignored`,
+		},
+		{
+			name:     "all three abis - pins to 3.0, ignores 4 and 5",
+			abi30:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0"),
+			abi40:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/4.0"),
+			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
+			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0")},
+			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored.* DEBUG: apparmor 4.0 ABI detected but ignored`,
+		},
+	}
+
+	for _, tc := range cases {
+		c.Logf("case: %s", tc.name)
+
+		if tc.abi30 != "" {
+			c.Assert(os.MkdirAll(filepath.Dir(tc.abi30), 0755), IsNil)
+			c.Assert(os.WriteFile(tc.abi30, nil, 0644), IsNil)
+		}
+		if tc.abi40 != "" {
+			c.Assert(os.MkdirAll(filepath.Dir(tc.abi40), 0755), IsNil)
+			c.Assert(os.WriteFile(tc.abi40, nil, 0644), IsNil)
+		}
+		if tc.abi50 != "" {
+			c.Assert(os.MkdirAll(filepath.Dir(tc.abi50), 0755), IsNil)
+			c.Assert(os.WriteFile(tc.abi50, nil, 0644), IsNil)
+		}
+
+		restore30 := apparmor.MockHostAbi30File(tc.abi30)
+		restore40 := apparmor.MockHostAbi40File(tc.abi40)
+		restore50 := apparmor.MockHostAbi50File(tc.abi50)
+		log, restoreLogger := logger.MockLogger()
+
+		os.Setenv("SNAPD_DEBUG", "1")
+		cmd, internal, err := apparmor.AppArmorParser()
+		c.Assert(err, IsNil)
+		c.Check(cmd.Path, Equals, mockParserCmd.Exe())
+		c.Check(cmd.Args, DeepEquals, tc.expected)
+		c.Check(internal, Equals, false)
+		if tc.logMatch != "" {
+			c.Check(log.String(), Matches, tc.logMatch)
+		} else if tc.name == "no abi files" || tc.name == "only abi 3.0" {
+			// No ABI-5/ABI-4 ignore messages expected; the generic
+			// "checking distro apparmor_parser" message is still present.
+			c.Check(log.String(), Matches, `(?ms).* DEBUG: checking distro apparmor_parser .*\n`)
+		}
+
+		restoreLogger()
+		os.Unsetenv("SNAPD_DEBUG")
+		restore30()
+		restore40()
+		restore50()
+	}
+}
+
 func setupInternalAppArmorParserEnv(c *C, abiVersions ...string) (parser, libSnapdDir string, restore func()) {
 	fakeroot := c.MkDir()
 	dirs.SetRootDir(fakeroot)

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -78,22 +78,32 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 	c.Check(err, Equals, nil)
 }
 
-func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
-	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
-	parser := filepath.Join(libSnapdDir, "apparmor_parser")
+func setupInternalAppArmorParserEnv(c *C, abiVersions ...string) (parser, libSnapdDir string, restore func()) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	libSnapdDir = filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
+	parser = filepath.Join(libSnapdDir, "apparmor_parser")
 	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
 	c.Assert(os.WriteFile(parser, nil, 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(libSnapdDir, "apparmor.d/abi"), 0755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi/3.0"), nil, 0644), IsNil)
+	for _, abiVersion := range abiVersions {
+		c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi", abiVersion), nil, 0644), IsNil)
+	}
 
-	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
+	restoreReadlink := snapdtool.MockOsReadlink(func(path string) (string, error) {
 		c.Assert(path, Equals, "/proc/self/exe")
 		return filepath.Join(libSnapdDir, "snapd"), nil
 	})
-	defer restore()
-	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
-	defer restore()
+	restoreSupportsReexec := apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
 
+	return parser, libSnapdDir, func() {
+		restoreSupportsReexec()
+		restoreReadlink()
+	}
+}
+
+func assertInternalAppArmorParser(c *C, parser, libSnapdDir, expectedAbiVersion string) {
 	cmd, internal, err := apparmor.AppArmorParser()
 	c.Check(err, IsNil)
 	c.Check(cmd.Path, Equals, parser)
@@ -101,39 +111,30 @@ func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
 		parser,
 		"--config-file", filepath.Join(libSnapdDir, "/apparmor/parser.conf"),
 		"--base", filepath.Join(libSnapdDir, "/apparmor.d"),
-		"--policy-features", filepath.Join(libSnapdDir, "/apparmor.d/abi/3.0"),
+		"--policy-features", filepath.Join(libSnapdDir, "/apparmor.d/abi", expectedAbiVersion),
 	})
 	c.Check(internal, Equals, true)
 }
 
+func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
+	parser, libSnapdDir, restore := setupInternalAppArmorParserEnv(c, "3.0")
+	defer restore()
+
+	assertInternalAppArmorParser(c, parser, libSnapdDir, "3.0")
+}
+
 func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi4(c *C) {
-	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
-	parser := filepath.Join(libSnapdDir, "apparmor_parser")
-	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
-	c.Assert(os.WriteFile(parser, nil, 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(libSnapdDir, "apparmor.d/abi"), 0755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi/3.0"), nil, 0644), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi/4.0"), nil, 0644), IsNil)
-
-	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
-		c.Assert(path, Equals, "/proc/self/exe")
-		return filepath.Join(libSnapdDir, "snapd"), nil
-	})
-	defer restore()
-	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+	parser, libSnapdDir, restore := setupInternalAppArmorParserEnv(c, "3.0", "4.0")
 	defer restore()
 
-	cmd, internal, err := apparmor.AppArmorParser()
-	c.Check(err, IsNil)
-	c.Check(cmd.Path, Equals, parser)
-	c.Check(cmd.Args, DeepEquals, []string{
-		parser,
-		"--config-file", filepath.Join(libSnapdDir, "/apparmor/parser.conf"),
-		"--base", filepath.Join(libSnapdDir, "/apparmor.d"),
-		// 4.0 was preferred.
-		"--policy-features", filepath.Join(libSnapdDir, "/apparmor.d/abi/4.0"),
-	})
-	c.Check(internal, Equals, true)
+	assertInternalAppArmorParser(c, parser, libSnapdDir, "4.0")
+}
+
+func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi5(c *C) {
+	parser, libSnapdDir, restore := setupInternalAppArmorParserEnv(c, "3.0", "4.0", "5.0")
+	defer restore()
+
+	assertInternalAppArmorParser(c, parser, libSnapdDir, "5.0")
 }
 
 func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
@@ -569,26 +570,7 @@ func (s *parserFeatureTestSuite) TestNoParser(c *C) {
 }
 
 func (s *parserFeatureTestSuite) TestInternalParser(c *C) {
-	// Put a fake parser at $SNAP_MOUNT_DIR/snapd/42/usr/lib/snapd/apparmor_parser
-	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
-	parser := filepath.Join(libSnapdDir, "apparmor_parser")
-	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
-	c.Assert(os.WriteFile(parser, nil, 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(libSnapdDir, "apparmor.d/abi"), 0755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi/4.0"), nil, 0644), IsNil)
-
-	// Pretend that we are running snapd from that snap location.
-	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
-		if path != "/proc/self/exe" {
-			c.Fatal("Unexpected readlink", path)
-		}
-
-		return filepath.Join(libSnapdDir, "snapd"), nil
-	})
-	s.AddCleanup(restore)
-
-	// Pretend snapd supports re-execution from snapd snap.
-	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+	_, _, restore := setupInternalAppArmorParserEnv(c, "4.0")
 	s.AddCleanup(restore)
 
 	// Did we recognize the internal parser?
@@ -976,18 +958,7 @@ func (s *apparmorSuite) TestSetupConfCacheDirs(c *C) {
 }
 
 func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
-	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
-	parser := filepath.Join(libSnapdDir, "apparmor_parser")
-	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
-	c.Assert(os.WriteFile(parser, nil, 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(libSnapdDir, "apparmor.d/abi"), 0755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(libSnapdDir, "apparmor.d/abi/4.0"), nil, 0644), IsNil)
-	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
-		c.Assert(path, Equals, "/proc/self/exe")
-		return filepath.Join(libSnapdDir, "snapd"), nil
-	})
-	defer restore()
-	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+	_, _, restore := setupInternalAppArmorParserEnv(c, "4.0")
 	defer restore()
 
 	apparmor.SetupConfCacheDirs("/newdir")

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -85,6 +85,24 @@ func MockSnapdAppArmorSupportsReexec(new func() bool) (restore func()) {
 	return restore
 }
 
+func MockHostAbi30File(new string) func() {
+	restore := testutil.Backup(&hostAbi30File)
+	hostAbi30File = new
+	return restore
+}
+
+func MockHostAbi40File(new string) func() {
+	restore := testutil.Backup(&hostAbi40File)
+	hostAbi40File = new
+	return restore
+}
+
+func MockHostAbi50File(new string) func() {
+	restore := testutil.Backup(&hostAbi50File)
+	hostAbi50File = new
+	return restore
+}
+
 var (
 	ProbeKernelFeatures = probeKernelFeatures
 	ProbeParserFeatures = probeParserFeatures

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -74,7 +74,7 @@ execute: |
                 MATCH 'internal: false' < snap-apparmor-default.out
             else
                 MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out
-                MATCH 'apparmor-parser-command: /snap/snapd/.*/apparmor_parser --config-file /snap/snapd/.*/usr/lib/snapd/apparmor/parser.conf --base /snap/snapd/.*/usr/lib/snapd/apparmor\.d --policy-features /snap/snapd/.*/usr/lib/snapd/apparmor\.d/abi/4\.0' < snap-apparmor-default.out
+                MATCH 'apparmor-parser-command: /snap/snapd/.*/apparmor_parser --config-file /snap/snapd/.*/usr/lib/snapd/apparmor/parser.conf --base /snap/snapd/.*/usr/lib/snapd/apparmor\.d --policy-features /snap/snapd/.*/usr/lib/snapd/apparmor\.d/abi/5\.0' < snap-apparmor-default.out
                 MATCH 'internal: true' < snap-apparmor-default.out
             fi
             ;;
@@ -115,7 +115,7 @@ execute: |
                 MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-force-reexec.out
             else
                 MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out
-                MATCH 'apparmor-parser-command: /snap/snapd/.*/apparmor_parser --config-file /snap/snapd/.*/usr/lib/snapd/apparmor/parser.conf --base /snap/snapd/.*/usr/lib/snapd/apparmor\.d --policy-features /snap/snapd/.*/usr/lib/snapd/apparmor\.d/abi/4\.0' < snap-apparmor-default.out
+                MATCH 'apparmor-parser-command: /snap/snapd/.*/apparmor_parser --config-file /snap/snapd/.*/usr/lib/snapd/apparmor/parser.conf --base /snap/snapd/.*/usr/lib/snapd/apparmor\.d --policy-features /snap/snapd/.*/usr/lib/snapd/apparmor\.d/abi/5\.0' < snap-apparmor-default.out
                 MATCH 'internal: true' < snap-apparmor-default.out
             fi
 


### PR DESCRIPTION
This is extremely early work as we need to align some stars before we get to hit the bugs and fix them:

1) ~~we need apparmor 5.0.0 alpha 2 for upstream af_unix features~~
2) ~~we need to actively use abi 5 across our profiles~~
3) interfaces will likely need some changes
4) ~~there's no abi 5.0 file in the release we are using so that part of the code is dormant~~

Then we get to test and see what breaks.

For apparmor master with 5 abi please see: https://github.com/canonical/snapd/pull/16780
For apparmor 5.x with 5 ABI please see: https://github.com/canonical/snapd/pull/15967
For apparmor 5.x with 4 ABI please see: https://github.com/canonical/snapd/pull/16781
