### PR TITLE
daemon: reject /v2/logs?n=N where N <= 0

### DIFF
--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -231,6 +231,11 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 			return BadRequest(`invalid value for n: %q: %v`, s, err)
 		}
 		n = int(m)
+		// The special value -1 represents "snap logs -n=all".
+		// The backend handles negative values as "all the log" by passing --no-tail to journalctl.
+		if n != -1 && n <= 0 {
+			return BadRequest(`invalid value for n: %v`, n)
+		}
 	}
 	follow := false
 	if s := query.Get("follow"); s != "" {

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -1059,9 +1059,8 @@ func (s *appsSuite) TestLogsN(c *check.C) {
 
 	for _, t := range []T{
 		{in: "", out: 10},
-		{in: "0", out: 0},
 		{in: "-1", out: -1},
-		{in: strconv.Itoa(math.MinInt32), out: math.MinInt32},
+		{in: "42", out: 42},
 		{in: strconv.Itoa(math.MaxInt32), out: math.MaxInt32},
 	} {
 
@@ -1082,6 +1081,16 @@ func (s *appsSuite) TestLogsBadN(c *check.C) {
 	s.expectLogsAccess()
 
 	req, err := http.NewRequest("GET", "/v2/logs?n=hello", nil)
+	c.Assert(err, check.IsNil)
+
+	rspe := s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rspe.Status, check.Equals, 400)
+}
+
+func (s *appsSuite) TestLogsNegativeN(c *check.C) {
+	s.expectLogsAccess()
+	// -1 is allowed and is tested in TestLogsN.
+	req, err := http.NewRequest("GET", "/v2/logs?n=-2", nil)
 	c.Assert(err, check.IsNil)
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)


### PR DESCRIPTION
The value is parsed as a signed decimal and passed through several layers to systemd's journalctl -n argument. There negative values have no meaning.

Note that journalctl does recognize +N as "the last N" vs plain N as "the first N lines". We could repurpose negative numbers to have the alternative meaning if we wanted to.