### PR TITLE
overlord, snap: reformat for static checks

### DIFF
--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -83,7 +83,7 @@ type SealingParameters struct {
 }
 
 type parametersKey struct {
-	role string
+	role          string
 	containerRole string
 }
 
@@ -112,7 +112,7 @@ func (u *updatedParameters) setTpmPCRProfile(role, containerRole string, tpmPCRP
 }
 
 // find returns the parameters for the first container role it finds
-func (u *updatedParameters) find(role string, containerRoles... string) *SealingParameters {
+func (u *updatedParameters) find(role string, containerRoles ...string) *SealingParameters {
 	for _, cr := range containerRoles {
 		params, ok := u.catalog[parametersKey{role: role, containerRole: cr}]
 		if ok {
@@ -130,7 +130,6 @@ func (u *updatedParameters) apply(manager FDEStateManager) error {
 	}
 	return nil
 }
-
 
 // EncryptedContainer gives information on the role, path and path to
 // extra legacy keys.

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -198,7 +198,6 @@ func (u *unsquashfsStderrWriter) Err() error {
 	}
 }
 
-
 // Unpack unpacks the snap to the given directory.
 //
 // Extended attributes are not preserved. This affects capabilities granted to specific executables.


### PR DESCRIPTION
Static checks on these two files were failing on xenial.

Tested locally:
```
2025-09-23 09:32:02 Project content is packed for delivery (19.82MB).
2025-09-23 09:32:02 If killed, discard servers with: spread -reuse-pid=48001 -discard
2025-09-23 09:32:02 Allocating openstack-dev-ps7:ubuntu-16.04-64...
2025-09-23 09:32:17 Waiting for openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856) to boot at 10.151.54.54...
2025-09-23 09:32:42 Allocated openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856).
2025-09-23 09:32:42 Server connected through proxy ingress-haproxy.ps7.canonical.com:4054
2025-09-23 09:32:42 Connecting to openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856)...
2025-09-23 09:32:42 Connected to openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856) at ingress-haproxy.ps7.canonical.com:4054.
2025-09-23 09:32:42 Sending project content to openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856)...
2025-09-23 09:32:46 Preparing openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856)...
2025-09-23 09:34:53 Preparing openstack-dev-ps7:ubuntu-16.04-64:tests/unit/ (sep230732-156856)...
2025-09-23 09:35:44 Preparing openstack-dev-ps7:ubuntu-16.04-64:tests/unit/go:static (sep230732-156856)...
2025-09-23 09:35:47 Executing openstack-dev-ps7:ubuntu-16.04-64:tests/unit/go:static (sep230732-156856) (1/1)...
2025-09-23 09:36:26 Restoring openstack-dev-ps7:ubuntu-16.04-64:tests/unit/go:static (sep230732-156856)...
2025-09-23 09:36:27 Restoring openstack-dev-ps7:ubuntu-16.04-64:tests/unit/ (sep230732-156856)...
2025-09-23 09:36:30 Restoring openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856)...
2025-09-23 09:36:30 Discarding openstack-dev-ps7:ubuntu-16.04-64 (sep230732-156856)...
2025-09-23 09:36:36 Successful tasks: 1
2025-09-23 09:36:36 Aborted tasks: 0
```