### PR TITLE
github/workflows: set up Ubuntu with deb variant

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -119,6 +119,14 @@
         "systems": "ubuntu-fips-22.04-64",
         "tasks": "tests/fips-deb/...",
         "rules": "fips"
+      },
+      {
+        "group": "ubuntu-deb",
+        "backend": "openstack-ps7",
+        "alternative-backend": "google",
+        "systems": "ubuntu-24.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
       }
     ]
   }

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -402,6 +402,14 @@ jobs:
               export NO_DELTA=1
           fi
 
+          case "${{ inputs.group }}" in
+              ubuntu-deb)
+                  echo "Setting up ubuntu with deb execution"
+                  export SPREAD_SNAP_REEXEC=0
+                  export SPREAD_SNAPD_DEB_FROM_REPO=false
+                  ;;
+          esac
+
           if grep -q "nothing matches provider filter" <<< "$spread_list"; then
             echo "No tests to run, exiting..."
             exit 0


### PR DESCRIPTION
Set up a variant of tests which runs on Ubuntu but consumes the deb instead of a snap.

Related: SNAPDENG-35496

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
