### PR TITLE
overlord: introduce option for disallowing auto-connection of a specific interface

### DIFF
--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces/builtin"
+)
+
+func isValidInterface(name string) bool {
+	for _, ifr := range builtin.Interfaces() {
+		if ifr.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidInterfaceOption(opt string) bool {
+	switch opt {
+	case "allow-auto-connection":
+		return true
+	}
+	return false
+}
+
+func isInterfaceChange(opt string) bool {
+	return strings.HasPrefix(opt, "core.interface.")
+}
+
+func validateInterfaceChange(opt string) error {
+	// core.interface.<interface>.<option>
+	tokens := strings.SplitN(opt, ".", 4)
+	if tokens[0] != "core" && tokens[1] != "interface" {
+		return fmt.Errorf("unsupported or wrongly formatted interface change: %s", opt)
+	}
+	if !isValidInterface(tokens[2]) {
+		return fmt.Errorf("unsupported interface %q for configuration change", tokens[2])
+	}
+	if !isValidInterfaceOption(tokens[3]) {
+		return fmt.Errorf("unsupported interface option: %q", tokens[3])
+	}
+	return nil
+}
+
+func validateAllowAutoConnectionValue(tr RunTransaction) error {
+	for _, name := range tr.Changes() {
+		if !strings.HasPrefix(name, "core.interface.") {
+			continue
+		}
+		if !strings.HasSuffix(name, ".allow-auto-connection") {
+			continue
+		}
+
+		value, err := coreCfg(tr, name)
+		if err != nil {
+			return fmt.Errorf("internal error: cannot get data for %s: %v", name, err)
+		}
+
+		switch value {
+		case "", "verified", "true", "false":
+			// thats ok
+		default:
+			return fmt.Errorf("%s can only be set to 'true', 'false' or 'verifed'", name)
+		}
+	}
+	return nil
+}

--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -49,11 +49,21 @@ func isInterfaceChange(opt string) bool {
 }
 
 func validateInterfaceChange(opt string) error {
+	// Double check this to make sure, even though we should have this called
+	// prior to validate
+	if !isInterfaceChange(opt) {
+		return fmt.Errorf("wrongly formatted interface option: %q", opt)
+	}
+
 	// core.interface.<interface>.<option>
 	tokens := strings.SplitN(opt, ".", 4)
-	if tokens[0] != "core" && tokens[1] != "interface" {
-		return fmt.Errorf("unsupported or wrongly formatted interface change: %s", opt)
+	if len(tokens) < 3 || tokens[2] == "" {
+		return fmt.Errorf("interface must be specified for %q", opt)
 	}
+	if len(tokens) < 4 || tokens[3] == "" {
+		return fmt.Errorf("interface option must be specified for %q", opt)
+	}
+
 	if !isValidInterface(tokens[2]) {
 		return fmt.Errorf("unsupported interface %q for configuration change", tokens[2])
 	}
@@ -65,7 +75,7 @@ func validateInterfaceChange(opt string) error {
 
 func validateAllowAutoConnectionValue(tr RunTransaction) error {
 	for _, name := range tr.Changes() {
-		if !strings.HasPrefix(name, "core.interface.") {
+		if !isInterfaceChange(name) {
 			continue
 		}
 		if !strings.HasSuffix(name, ".allow-auto-connection") {

--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -2,7 +2,7 @@
 //go:build !nomanagers
 
 /*
- * Copyright (C) 2024 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -23,17 +23,12 @@ package configcore
 import (
 	"fmt"
 	"strings"
-
-	"github.com/snapcore/snapd/interfaces/builtin"
 )
 
 func isValidInterface(name string) bool {
-	for _, ifr := range builtin.Interfaces() {
-		if ifr.Name() == name {
-			return true
-		}
-	}
-	return false
+	// In the future we can check builtin.Interfaces() for the supported
+	// interfaces if we want to support more than just "x11"
+	return name == "x11"
 }
 
 func isValidInterfaceOption(opt string) bool {

--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -82,7 +82,7 @@ func validateAllowAutoConnectionValue(tr RunTransaction) error {
 		case "", "verified", "true", "false":
 			// thats ok
 		default:
-			return fmt.Errorf("%s can only be set to 'true', 'false' or 'verifed'", name)
+			return fmt.Errorf("%s can only be set to 'true', 'false' or 'verified'", name)
 		}
 	}
 	return nil

--- a/overlord/configstate/configcore/interface.go
+++ b/overlord/configstate/configcore/interface.go
@@ -72,7 +72,8 @@ func validateAllowAutoConnectionValue(tr RunTransaction) error {
 			continue
 		}
 
-		value, err := coreCfg(tr, name)
+		nameWithoutSnap := strings.SplitN(name, ".", 2)[1]
+		value, err := coreCfg(tr, nameWithoutSnap)
 		if err != nil {
 			return fmt.Errorf("internal error: cannot get data for %s: %v", name, err)
 		}

--- a/overlord/configstate/configcore/interface_test.go
+++ b/overlord/configstate/configcore/interface_test.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+)
+
+type interfaceSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&interfaceSuite{})
+
+func (s *interfaceSuite) TestConfigureInterfaceUnhappyName(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.invalid.test": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `unsupported interface "invalid" for configuration change`)
+}
+
+func (s *interfaceSuite) TestConfigureInterfaceUnhappyOption(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.x11.test": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `unsupported interface option: "test"`)
+}
+
+func (s *interfaceSuite) TestConfigureInterfaceUnhappyOptionValue(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.x11.allow-auto-connection": "test",
+		},
+	})
+	c.Assert(err, ErrorMatches, `core.interface.x11.allow-auto-connection can only be set to 'true', 'false' or 'verifed'`)
+}
+
+func (s *interfaceSuite) TestConfigureInterfaceHappy(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.x11.allow-auto-connection": "true",
+		},
+	})
+	c.Assert(err, IsNil)
+}

--- a/overlord/configstate/configcore/interface_test.go
+++ b/overlord/configstate/configcore/interface_test.go
@@ -42,6 +42,16 @@ func (s *interfaceSuite) TestConfigureInterfaceUnhappyName(c *C) {
 	c.Assert(err, ErrorMatches, `unsupported interface "invalid" for configuration change`)
 }
 
+func (s *interfaceSuite) TestConfigureInterfaceUnhappyIncompleteName(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `interface must be specified for "core.interface."`)
+}
+
 func (s *interfaceSuite) TestConfigureInterfaceUnhappyOption(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
@@ -50,6 +60,16 @@ func (s *interfaceSuite) TestConfigureInterfaceUnhappyOption(c *C) {
 		},
 	})
 	c.Assert(err, ErrorMatches, `unsupported interface option: "test"`)
+}
+
+func (s *interfaceSuite) TestConfigureInterfaceUnhappyIncompleteOption(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.x11.": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `interface option must be specified for "core.interface.x11."`)
 }
 
 func (s *interfaceSuite) TestConfigureInterfaceUnhappyOptionValue(c *C) {

--- a/overlord/configstate/configcore/interface_test.go
+++ b/overlord/configstate/configcore/interface_test.go
@@ -42,6 +42,16 @@ func (s *interfaceSuite) TestConfigureInterfaceUnhappyName(c *C) {
 	c.Assert(err, ErrorMatches, `unsupported interface "invalid" for configuration change`)
 }
 
+func (s *interfaceSuite) TestConfigureInterfaceUnsupportedBuiltinName(c *C) {
+	err := configcore.Run(classicDev, &mockConf{
+		state: s.state,
+		changes: map[string]any{
+			"interface.network.test": "xxx",
+		},
+	})
+	c.Assert(err, ErrorMatches, `unsupported interface "network" for configuration change`)
+}
+
 func (s *interfaceSuite) TestConfigureInterfaceUnhappyIncompleteName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,

--- a/overlord/configstate/configcore/interface_test.go
+++ b/overlord/configstate/configcore/interface_test.go
@@ -59,7 +59,7 @@ func (s *interfaceSuite) TestConfigureInterfaceUnhappyOptionValue(c *C) {
 			"interface.x11.allow-auto-connection": "test",
 		},
 	})
-	c.Assert(err, ErrorMatches, `core.interface.x11.allow-auto-connection can only be set to 'true', 'false' or 'verifed'`)
+	c.Assert(err, ErrorMatches, `core.interface.x11.allow-auto-connection can only be set to 'true', 'false' or 'verified'`)
 }
 
 func (s *interfaceSuite) TestConfigureInterfaceHappy(c *C) {

--- a/overlord/configstate/configcore/interface_test.go
+++ b/overlord/configstate/configcore/interface_test.go
@@ -2,7 +2,7 @@
 //go:build !nomanagers
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -75,6 +75,9 @@ func init() {
 
 	// experimental.apparmor-prompting
 	addWithStateHandler(nil, doExperimentalApparmorPromptingDaemonRestart, nil)
+
+	// interface.*.allow-auto-connection
+	addWithStateHandler(validateAllowAutoConnectionValue, nil, &flags{validatedOnlyStateConfig: true})
 }
 
 // RunTransaction is an interface describing how to access
@@ -168,6 +171,10 @@ func applyHandlers(dev sysconfig.Device, cfg RunTransaction, handlers []configHa
 		case isNetplanChange(k):
 			if release.OnClassic {
 				return fmt.Errorf("cannot set netplan configuration on classic")
+			}
+		case isInterfaceChange(k):
+			if err := validateInterfaceChange(k); err != nil {
+				return err
 			}
 		case !supportedConfigurations[k]:
 			return fmt.Errorf("cannot set %q: unsupported system option", k)

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -221,6 +221,6 @@ func (m *InterfaceManager) SetupSecurityByBackend(task *state.Task, appSets []*i
 	return m.setupSecurityByBackend(task, appSets, opts, tm)
 }
 
-func MockIsSnapVerified(new func(si *snap.Info) bool) (restore func()) {
+func MockIsSnapVerified(new func(st *state.State, snapID string) bool) (restore func()) {
 	return testutil.Mock(&isSnapVerified, new)
 }

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -220,3 +220,7 @@ func (m *InterfaceManager) TransitionConnectionsCoreMigration(st *state.State, o
 func (m *InterfaceManager) SetupSecurityByBackend(task *state.Task, appSets []*interfaces.SnapAppSet, opts []interfaces.ConfinementOptions, tm timings.Measurer) error {
 	return m.setupSecurityByBackend(task, appSets, opts, tm)
 }
+
+func MockIsSnapVerified(new func(si *snap.Info) bool) (restore func()) {
+	return testutil.Mock(&isSnapVerified, new)
+}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1430,15 +1430,15 @@ func isSnapSlotAllowed(st *state.State, snapID string, slot *snap.SlotInfo, tr *
 		option, slot.Snap.RealName)
 }
 
-func filterAllowedAutoConnectionSlots(st *state.State, snapID string, css []*snap.SlotInfo) ([]*snap.SlotInfo, error) {
+func filterAllowedAutoConnectionSlots(st *state.State, snapID string, ssi []*snap.SlotInfo) ([]*snap.SlotInfo, error) {
 	var filtered []*snap.SlotInfo
 	tr := config.NewTransaction(st)
-	for _, slot := range css {
+	for _, slot := range ssi {
 		if allowed, err := isSnapSlotAllowed(st, snapID, slot, tr); err != nil {
 			// In case there is any error of filtering auto-connections, assume something is horribly
 			// wrong and return to the default behaviour. However make sure we log this error from the
 			// caller.
-			return css, err
+			return ssi, err
 		} else if allowed {
 			filtered = append(filtered, slot)
 		} else {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1413,6 +1413,12 @@ func getAllowOptionAsString(inter string, tr *config.Transaction) (string, error
 }
 
 func isSnapSlotAllowed(st *state.State, snapID string, slot *snap.SlotInfo, tr *config.Transaction) (bool, error) {
+	// Until we decide that we want to support other interfaces, do a
+	// quick allow check for x11 only.
+	if slot.Interface != "x11" {
+		return true, nil
+	}
+
 	option, err := getAllowOptionAsString(slot.Interface, tr)
 	if err != nil {
 		return false, err

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1389,7 +1389,7 @@ func filterForSlot(slot *snap.SlotInfo) func(candSlots []*snap.SlotInfo) []*snap
 var isSnapVerified = func(st *state.State, snapID string) bool {
 	acc, err := assertstate.Publisher(st, snapID)
 	if err != nil {
-		logger.Debugf("cannot retrieve publisher assertion for %q", snapID)
+		logger.Debugf("cannot retrieve publisher assertion for %q: %v", snapID, err)
 		return false
 	}
 	return acc.Validation() == "verified"

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1387,8 +1387,12 @@ func filterForSlot(slot *snap.SlotInfo) func(candSlots []*snap.SlotInfo) []*snap
 
 // Keep this separate to allow mocking
 var isSnapVerified = func(st *state.State, snapID string) bool {
-	_, err := assertstate.SnapDeclaration(st, snapID)
-	return err == nil
+	acc, err := assertstate.Publisher(st, snapID)
+	if err != nil {
+		logger.Debugf("cannot retrieve publisher assertion for %q", snapID)
+		return false
+	}
+	return acc.Validation() == "verified"
 }
 
 func getAllowOptionAsString(inter string, tr *config.Transaction) (string, error) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -11914,7 +11914,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSupportsConfigurableAutoConnectSe
 }
 
 func (s *interfaceManagerSuite) TestAutoConnectSupportsConfigurableAutoConnectSetToVerifiedUnhappy(c *C) {
-	r := ifacestate.MockIsSnapVerified(func(si *snap.Info) bool {
+	r := ifacestate.MockIsSnapVerified(func(_ *state.State, _ string) bool {
 		return false
 	})
 	defer r()
@@ -11937,7 +11937,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSupportsConfigurableAutoConnectSe
 }
 
 func (s *interfaceManagerSuite) TestAutoConnectSupportsConfigurableAutoConnectSetToVerifiedHappy(c *C) {
-	r := ifacestate.MockIsSnapVerified(func(si *snap.Info) bool {
+	r := ifacestate.MockIsSnapVerified(func(_ *state.State, _ string) bool {
 		return true
 	})
 	defer r()

--- a/tests/lib/snaps/x11-consumer/bin/run
+++ b/tests/lib/snaps/x11-consumer/bin/run
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+    echo "PASS"
+    exit 0
+fi
+
+# Also allow calling the shell directly with options
+/bin/bash --norc "$@"

--- a/tests/lib/snaps/x11-consumer/bin/run
+++ b/tests/lib/snaps/x11-consumer/bin/run
@@ -1,10 +1,3 @@
 #!/bin/bash
-set -e
 
-if [ -z "$1" ]; then
-    echo "PASS"
-    exit 0
-fi
-
-# Also allow calling the shell directly with options
-/bin/bash --norc "$@"
+exit 0

--- a/tests/lib/snaps/x11-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/x11-consumer/meta/snap.yaml
@@ -4,7 +4,7 @@ summary: Basic x11 consumer snap
 description: A basic snap declaring a plug on x11
 
 apps:
-  # dummy app to declare the x11 plug
+  # stub app to declare the x11 plug
   x11-consumer:
     command: bin/run
     plugs: [x11]

--- a/tests/lib/snaps/x11-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/x11-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: x11-consumer
+version: 1.0
+summary: Basic x11 consumer snap
+description: A basic snap declaring a plug on x11
+
+apps:
+  x11-consumer:
+    command: bin/run
+    plugs: [x11]

--- a/tests/lib/snaps/x11-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/x11-consumer/meta/snap.yaml
@@ -4,6 +4,7 @@ summary: Basic x11 consumer snap
 description: A basic snap declaring a plug on x11
 
 apps:
+  # dummy app to declare the x11 plug
   x11-consumer:
     command: bin/run
     plugs: [x11]

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -13,16 +13,16 @@ environment:
 
 restore: |
     snap set system interface.network.allow-auto-connection=true
-    snap remove test-snapd-curl || true
+    snap remove vault || true
     snap remove network-consumer || true
 
 execute: |
     # We can install a snap with an interface by default, install an older revision
     # so we can try refreshing it
-    snap install test-snapd-curl --edge --revision=22
+    snap install vault --revision=22
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
     snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
 
     if [ "$SPREAD_VARIANT" != "unset" ]; then
@@ -34,29 +34,29 @@ execute: |
 
     # Changing the state of auto-connections for that interface does not break it
     snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
 
     # Refreshing keeps the connection, and does not break it
-    snap refresh test-snapd-curl --edge
+    snap refresh vault
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
     snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
 
     # Reinstall and make sure it now honors the option set
-    snap remove --purge test-snapd-curl
+    snap remove --purge vault
     snap remove --purge network-consumer
 
-    snap install test-snapd-curl --edge
+    snap install vault
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
     if [ "$SPREAD_VARIANT" = "true" ]; then
         snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-        snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+        snap connections vault | tr -s ' ' | MATCH "vault:network :network"
     elif [ "$SPREAD_VARIANT" = "false" ]; then
         snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
-        snap connections test-snapd-curl | tr -s ' ' | NOMATCH "test-snapd-curl:network :network"
+        snap connections vault | tr -s ' ' | NOMATCH "vault:network :network"
     elif [ "$SPREAD_VARIANT" = "verified" ]; then
         snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
-        snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+        snap connections vault | tr -s ' ' | MATCH "vault:network :network"
     fi

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -1,9 +1,8 @@
-summary: Verify that the interface.allow-auto-connection setting works
+summary: Verify that the interface.x11.allow-auto-connection setting works
 
 details: |
     Using different snaps that require interface connections, check each of the options
-    for interface.<if>.allow-auto-connection works like they are expected. The supported
-    interfaces are the builtin ones in snapd.
+    for interface.x11.allow-auto-connection works like they are expected.
 
 systems:
     # ubuntu-core: no x11
@@ -17,8 +16,6 @@ environment:
 
 restore: |
     snap set system interface.x11.allow-auto-connection=true
-    snap remove gnome-calculator || true
-    snap remove x11-consumer || true
 
 execute: |
     # We can install a snap with an interface by default, install an older revision

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -19,7 +19,7 @@ restore: |
 execute: |
     # We can install a snap with an interface by default, install an older revision
     # so we can try refreshing it
-    snap install vault --revision=22
+    snap install vault --revision=2424
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
     snap connections vault | tr -s ' ' | MATCH "vault:network :network"
@@ -37,7 +37,7 @@ execute: |
     snap connections vault | tr -s ' ' | MATCH "vault:network :network"
 
     # Refreshing keeps the connection, and does not break it
-    snap refresh vault
+    snap refresh vault --edge
     "$TESTSTOOLS"/snaps-state install-local network-consumer
 
     snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -5,6 +5,10 @@ details: |
     for interface.<if>.allow-auto-connection works like they are expected. The supported
     interfaces are the builtin ones in snapd.
 
+systems:
+    # ubuntu-core: no x11
+    - -ubuntu-core*
+
 environment:
   VARIANT/unset: unset
   VARIANT/false: false

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -11,10 +11,6 @@ environment:
   VARIANT/true: true
   VARIANT/verified: verified
 
-prepare: |
-    # install gnome-calculator to get any required content snaps
-    snap install gnome-calculator --revision=972
-
 restore: |
     snap set system interface.x11.allow-auto-connection=true
     snap remove gnome-calculator || true

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -45,3 +45,13 @@ execute: |
     # Installing a verified one connects it
     snap install test-snapd-curl --edge
     snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+
+    # Changing the option to true does not change any existing connection
+    snap set system interface.network.allow-auto-connection=true
+    snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
+
+    # However, removing and reinstalling will
+    snap remove network-consumer
+
+    "$TESTSTOOLS"/snaps-state install-local network-consumer
+    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -5,6 +5,12 @@ details: |
     for interface.<if>.allow-auto-connection works like they are expected. The supported
     interfaces are the builtin ones in snapd.
 
+environment:
+  VARIANT/unset: unset
+  VARIANT/false: false
+  VARIANT/true: true
+  VARIANT/verified: verified
+
 restore: |
     snap set system interface.network.allow-auto-connection=true
     snap remove test-snapd-curl || true
@@ -14,44 +20,43 @@ execute: |
     # We can install a snap with an interface by default, install an older revision
     # so we can try refreshing it
     snap install test-snapd-curl --edge --revision=22
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    "$TESTSTOOLS"/snaps-state install-local network-consumer
 
-    # Disallowing that interface does not break current connection
-    snap set system interface.network.allow-auto-connection=false
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
+
+    if [ "$SPREAD_VARIANT" != "unset" ]; then
+        snap set system interface.network.allow-auto-connection="$VARIANT"
+    else
+        # stop here, just to verify default behaviour
+        exit 0
+    fi
+
+    # Changing the state of auto-connections for that interface does not break it
+    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
     snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
 
     # Refreshing keeps the connection, and does not break it
     snap refresh test-snapd-curl --edge
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
-
-    # Reset before next attempt
-    snap remove test-snapd-curl
-
-    # Trying to reinstall it does not establish the connection, and honors the option we set
-    # above
-    snap install test-snapd-curl --edge
-    snap connections test-snapd-curl | tr -s ' ' | NOMATCH "test-snapd-curl:network :network"
-
-    # Reset before next attempt
-    snap remove test-snapd-curl
-
-    # Switching to verified, which will only allow snaps that carry a valid declaration
-    snap set system interface.network.allow-auto-connection=verified
-
-    # Installing a local snap wont connect it, as it's a local snap
     "$TESTSTOOLS"/snaps-state install-local network-consumer
-    snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
 
-    # Installing a verified one connects it
-    snap install test-snapd-curl --edge
-    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
-
-    # Changing the option to true does not change any existing connection
-    snap set system interface.network.allow-auto-connection=true
-    snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
-
-    # However, removing and reinstalling will
-    snap remove network-consumer
-
-    "$TESTSTOOLS"/snaps-state install-local network-consumer
     snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+
+    # Reinstall and make sure it now honors the option set
+    snap remove --purge test-snapd-curl
+    snap remove --purge network-consumer
+
+    snap install test-snapd-curl --edge
+    "$TESTSTOOLS"/snaps-state install-local network-consumer
+
+    if [ "$SPREAD_VARIANT" = "true" ]; then
+        snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
+        snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    elif [ "$SPREAD_VARIANT" = "false" ]; then
+        snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
+        snap connections test-snapd-curl | tr -s ' ' | NOMATCH "test-snapd-curl:network :network"
+    elif [ "$SPREAD_VARIANT" = "verified" ]; then
+        snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
+        snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+    fi

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -1,0 +1,45 @@
+summary: Verify that the interface.allow-auto-connection setting works
+
+details: |
+    Using different snaps that require interface connections, check each of the options
+    for interface.<if>.allow-auto-connection works like they are expected. The supported
+    interfaces are the builtin ones in snapd.
+
+restore: |
+    snap set system interface.network.allow-auto-connection=true
+    snap remove test-snapd-curl || true
+    snap remove network-consumer || true
+
+execute: |
+    # We can install a snap with an interface by default
+    snap install test-snapd-curl --edge --revision=22
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+
+    # Disallowing that interface does not break current connection
+    snap set system interface.network.allow-auto-connection=false
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+
+    # Refreshing keeps the connection
+    snap refresh test-snapd-curl --edge
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
+
+    # Remove snap
+    snap remove test-snapd-curl
+
+    # Trying to reinstall it does not establish the connection
+    snap install test-snapd-curl --edge
+    snap connections test-snapd-curl | tr -s ' ' | NOMATCH "test-snapd-curl:network :network"
+
+    # Remove snap
+    snap remove test-snapd-curl
+
+    # Switching to verified
+    snap set system interface.network.allow-auto-connection=verified
+
+    # Installing a local snap wont connect it
+    "$TESTSTOOLS"/snaps-state install-local network-consumer
+    snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
+
+    # Installing a verified one connects it
+    snap install test-snapd-curl --edge
+    snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -11,7 +11,8 @@ restore: |
     snap remove network-consumer || true
 
 execute: |
-    # We can install a snap with an interface by default
+    # We can install a snap with an interface by default, install an older revision
+    # so we can try refreshing it
     snap install test-snapd-curl --edge --revision=22
     snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
 
@@ -19,24 +20,25 @@ execute: |
     snap set system interface.network.allow-auto-connection=false
     snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
 
-    # Refreshing keeps the connection
+    # Refreshing keeps the connection, and does not break it
     snap refresh test-snapd-curl --edge
     snap connections test-snapd-curl | tr -s ' ' | MATCH "test-snapd-curl:network :network"
 
-    # Remove snap
+    # Reset before next attempt
     snap remove test-snapd-curl
 
-    # Trying to reinstall it does not establish the connection
+    # Trying to reinstall it does not establish the connection, and honors the option we set
+    # above
     snap install test-snapd-curl --edge
     snap connections test-snapd-curl | tr -s ' ' | NOMATCH "test-snapd-curl:network :network"
 
-    # Remove snap
+    # Reset before next attempt
     snap remove test-snapd-curl
 
-    # Switching to verified
+    # Switching to verified, which will only allow snaps that carry a valid declaration
     snap set system interface.network.allow-auto-connection=verified
 
-    # Installing a local snap wont connect it
+    # Installing a local snap wont connect it, as it's a local snap
     "$TESTSTOOLS"/snaps-state install-local network-consumer
     snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
 

--- a/tests/main/interface-allow-auto-connection/task.yaml
+++ b/tests/main/interface-allow-auto-connection/task.yaml
@@ -11,52 +11,56 @@ environment:
   VARIANT/true: true
   VARIANT/verified: verified
 
+prepare: |
+    # install gnome-calculator to get any required content snaps
+    snap install gnome-calculator --revision=972
+
 restore: |
-    snap set system interface.network.allow-auto-connection=true
-    snap remove vault || true
-    snap remove network-consumer || true
+    snap set system interface.x11.allow-auto-connection=true
+    snap remove gnome-calculator || true
+    snap remove x11-consumer || true
 
 execute: |
     # We can install a snap with an interface by default, install an older revision
     # so we can try refreshing it
-    snap install vault --revision=2424
-    "$TESTSTOOLS"/snaps-state install-local network-consumer
+    snap install gnome-calculator --revision=972
+    "$TESTSTOOLS"/snaps-state install-local x11-consumer
 
-    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
-    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
+    snap connections gnome-calculator | tr -s ' ' | MATCH "gnome-calculator:x11 :x11"
+    snap connections x11-consumer | tr -s ' ' | MATCH "x11-consumer:x11 :x11"
 
     if [ "$SPREAD_VARIANT" != "unset" ]; then
-        snap set system interface.network.allow-auto-connection="$VARIANT"
+        snap set system interface.x11.allow-auto-connection="$VARIANT"
     else
         # stop here, just to verify default behaviour
         exit 0
     fi
 
     # Changing the state of auto-connections for that interface does not break it
-    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
+    snap connections x11-consumer | tr -s ' ' | MATCH "x11-consumer:x11 :x11"
+    snap connections gnome-calculator | tr -s ' ' | MATCH "gnome-calculator:x11 :x11"
 
     # Refreshing keeps the connection, and does not break it
-    snap refresh vault --edge
-    "$TESTSTOOLS"/snaps-state install-local network-consumer
+    snap refresh gnome-calculator --revision=975
+    "$TESTSTOOLS"/snaps-state install-local x11-consumer
 
-    snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-    snap connections vault | tr -s ' ' | MATCH "vault:network :network"
+    snap connections x11-consumer | tr -s ' ' | MATCH "x11-consumer:x11 :x11"
+    snap connections gnome-calculator | tr -s ' ' | MATCH "gnome-calculator:x11 :x11"
 
     # Reinstall and make sure it now honors the option set
-    snap remove --purge vault
-    snap remove --purge network-consumer
+    snap remove --purge gnome-calculator
+    snap remove --purge x11-consumer
 
-    snap install vault
-    "$TESTSTOOLS"/snaps-state install-local network-consumer
+    snap install gnome-calculator
+    "$TESTSTOOLS"/snaps-state install-local x11-consumer
 
     if [ "$SPREAD_VARIANT" = "true" ]; then
-        snap connections network-consumer | tr -s ' ' | MATCH "network-consumer:network :network"
-        snap connections vault | tr -s ' ' | MATCH "vault:network :network"
+        snap connections x11-consumer | tr -s ' ' | MATCH "x11-consumer:x11 :x11"
+        snap connections gnome-calculator | tr -s ' ' | MATCH "gnome-calculator:x11 :x11"
     elif [ "$SPREAD_VARIANT" = "false" ]; then
-        snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
-        snap connections vault | tr -s ' ' | NOMATCH "vault:network :network"
+        snap connections x11-consumer | tr -s ' ' | NOMATCH "x11-consumer:x11 :x11"
+        snap connections gnome-calculator | tr -s ' ' | NOMATCH "gnome-calculator:x11 :x11"
     elif [ "$SPREAD_VARIANT" = "verified" ]; then
-        snap connections network-consumer | tr -s ' ' | NOMATCH "network-consumer:network :network"
-        snap connections vault | tr -s ' ' | MATCH "vault:network :network"
+        snap connections x11-consumer | tr -s ' ' | NOMATCH "x11-consumer:x11 :x11"
+        snap connections gnome-calculator | tr -s ' ' | MATCH "gnome-calculator:x11 :x11"
     fi


### PR DESCRIPTION
Introduces the ability to manually disable / configure specific interface auto-connection rules. This can now be done with the following system option

`snap set system interface.<builtin-if>.allow-auto-connection={false|true|verified}`

* false or true controls whether any auto-connection is allowed at all
* verified means that only snaps carrying a snap declaration can auto-connect this interface

SNAPDENG-35003