### PR TITLE
tests/main/cgroup-tracking: retry file presence check

### DIFF
--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -65,7 +65,7 @@ execute: |
     echo "$hook_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.hook\.configure-[0-9a-f-]+\.scope'
 
     # The nap service was executed and was tracked as a systemd service.
-    test -f /var/snap/test-snapd-tracking/common/nap.cgroup
+    retry -n 10 test -f /var/snap/test-snapd-tracking/common/nap.cgroup
     service_tracking_cg_path="$(grep -E "^$base_cg_id:" < /var/snap/test-snapd-tracking/common/nap.cgroup | cut -d : -f 3)"
     echo "$service_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.nap\.service'
 


### PR DESCRIPTION
The file is created by a service from test snap, and so is not guaranteed to exist right after the snap is installed.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
