### PR TITLE
interfaces/apparmor: fix incorrect error message

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -327,7 +327,7 @@ func (b *Backend) setupSnapConfineReexec(info *snap.Info) error {
 		return fmt.Errorf("cannot reload snap-confine apparmor profile: %s", errReload)
 	}
 	if errRemoveCached != nil {
-		return fmt.Errorf("cannot remove cached snap-confine apparmor profile: %s", errReload)
+		return fmt.Errorf("cannot remove cached snap-confine apparmor profile: %s", errRemoveCached)
 	}
 	return nil
 }


### PR DESCRIPTION
When backend setup failed to remove cached snap-confine profiles, it would report the error but use the wrong variable for the actual reporting, masking the underlying issue.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
