### PR TITLE
tests: fix nested setup for xenial in openstack

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1471,10 +1471,10 @@ nested_setup_vm(){
             nameservers="$(resolvectl status "$net_interface" | grep "DNS Servers:" | cut -d: -f2)"
             if [ -n "$nameservers" ]; then
                 remote.exec "grep -v '^nameserver' /etc/resolv.conf > /tmp/resolv.conf"
-                remote.exec "sudo cp /tmp/resolv.conf /etc/resolv.conf"
                 for nameserver in $nameservers; do
-                    remote.exec "echo nameserver $nameserver | sudo tee -a /etc/resolv.conf"
+                    remote.exec "echo nameserver $nameserver >> /tmp/resolv.conf"
                 done
+                remote.exec "sudo cp /tmp/resolv.conf /etc/resolv.conf"
             fi
         else
             remote.push /etc/resolv.conf
@@ -1504,10 +1504,10 @@ nested_setup_vm(){
     if [ -n "${NTP_SERVER:-}" ]; then
         # Configure systemd-timesyncd to use the predefined ntp server
         CONF_FILE="/etc/systemd/timesyncd.conf"
-        remote.exec "sudo cp \"$CONF_FILE\" /tmp/timesyncd.conf"
-        remote.exec "sudo sed -i -e '/^NTP=/d' -e '/^FallbackNTP=/d' /tmp/timesyncd.conf"
-        remote.exec "sudo sed -i '/^\[Time\]/a NTP='\"$NTP_SERVER\" /tmp/timesyncd.conf"
-        remote.exec "sudo sed -i '/^\[Time\]/a FallbackNTP=' /tmp/timesyncd.conf"
+        remote.exec "cp \"$CONF_FILE\" /tmp/timesyncd.conf"
+        remote.exec "sed -i -e '/^NTP=/d' -e '/^FallbackNTP=/d' /tmp/timesyncd.conf"
+        remote.exec "sed -i '/^\[Time\]/a NTP='\"$NTP_SERVER\" /tmp/timesyncd.conf"
+        remote.exec "sed -i '/^\[Time\]/a FallbackNTP=' /tmp/timesyncd.conf"
         remote.exec "sudo cp /tmp/timesyncd.conf \"$CONF_FILE\""
         remote.exec "sudo systemctl restart systemd-timesyncd"
         remote.exec "sudo sync"


### PR DESCRIPTION
This change is to make core tests work needed for edge validation in openstack

We can't use resolvectl in xenial, so we copy the resolv.conf file used in the host machine
sed fails to update /etc/systemd/timesyncd.conf, the alternative is to use a tmp file