### PR TITLE
daemon: Add support for graphical user daemons

### DIFF
--- a/client/clientutil/service_scope.go
+++ b/client/clientutil/service_scope.go
@@ -94,7 +94,7 @@ func FmtServiceStatus(svc *client.AppInfo, opts FmtServiceStatusOptions) string 
 	// When requesting global service status, we don't have any active
 	// information available for user daemons.
 	current := i18n.G("inactive")
-	if svc.DaemonScope == snap.UserDaemon && opts.IsUserGlobal {
+	if svc.DaemonScope.IsUserDaemon() && opts.IsUserGlobal {
 		current = "-"
 	} else if svc.Active {
 		current = i18n.G("active")

--- a/client/clientutil/service_scope_test.go
+++ b/client/clientutil/service_scope_test.go
@@ -103,7 +103,7 @@ func (s *serviceScopeSuite) TestFmtServiceStatus(c *C) {
 		Name:        "bar",
 		Active:      true,
 		Enabled:     true,
-		DaemonScope: snap.UserDaemon,
+		DaemonScope: snap.UserDaemonScope,
 	}, clientutil.FmtServiceStatusOptions{})
 	c.Check(out, Equals, "test-snap.bar\tenabled\tactive\t-")
 
@@ -112,7 +112,7 @@ func (s *serviceScopeSuite) TestFmtServiceStatus(c *C) {
 		Name:        "bar",
 		Active:      true,
 		Enabled:     true,
-		DaemonScope: snap.UserDaemon,
+		DaemonScope: snap.UserDaemonScope,
 	}, clientutil.FmtServiceStatusOptions{
 		IsUserGlobal: true,
 	})

--- a/client/clientutil/snapinfo.go
+++ b/client/clientutil/snapinfo.go
@@ -98,7 +98,7 @@ func ClientAppInfoNotes(app *client.AppInfo) string {
 	}
 
 	var notes = make([]string, 0, 4)
-	if app.DaemonScope == snap.UserDaemon {
+	if app.DaemonScope.IsUserDaemon() {
 		notes = append(notes, "user")
 	}
 	var seenTimer, seenSocket, seenDbus bool

--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -194,7 +194,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfoAppsInactive(c *C) {
 		},
 	}
 	si.Apps = map[string]*snap.AppInfo{
-		"svc": {Snap: si, Name: "svc", Daemon: "simple", DaemonScope: snap.SystemDaemon},
+		"svc": {Snap: si, Name: "svc", Daemon: "simple", DaemonScope: snap.SystemDaemonScope},
 		"app": {Snap: si, Name: "app", CommonID: "common.id"},
 	}
 	// validity
@@ -222,7 +222,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfoAppsInactive(c *C) {
 			Snap:        "the-snap_insta",
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 	})
 	// not called on inactive snaps
@@ -241,7 +241,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfoAppsActive(c *C) {
 		},
 	}
 	si.Apps = map[string]*snap.AppInfo{
-		"svc": {Snap: si, Name: "svc", Daemon: "simple", DaemonScope: snap.SystemDaemon},
+		"svc": {Snap: si, Name: "svc", Daemon: "simple", DaemonScope: snap.SystemDaemonScope},
 	}
 	// make it active
 	err := os.MkdirAll(si.MountDir(), 0755)
@@ -260,7 +260,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfoAppsActive(c *C) {
 			Snap:        "the-snap_insta",
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 			Enabled:     true,
 			Active:      true,
 		},
@@ -280,7 +280,7 @@ func (*cmdSuite) TestAppStatusNotes(c *C) {
 
 	ai = client.AppInfo{
 		Daemon:      "simple",
-		DaemonScope: snap.UserDaemon,
+		DaemonScope: snap.UserDaemonScope,
 	}
 	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "user")
 
@@ -320,7 +320,7 @@ func (*cmdSuite) TestAppStatusNotes(c *C) {
 	c.Check(clientutil.ClientAppInfoNotes(&ai), Equals, "timer-activated,socket-activated,dbus-activated")
 	ai = client.AppInfo{
 		Daemon:      "oneshot",
-		DaemonScope: snap.UserDaemon,
+		DaemonScope: snap.UserDaemonScope,
 		Activators: []client.AppActivator{
 			{Type: "dbus"},
 			{Type: "socket"},

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -238,7 +238,7 @@ NeedDaemonReload=no
 			Snap:        snapName,
 			Name:        app,
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		if snapName != "snap-b" {
 			// snap-b is not active (all the others are)
@@ -247,7 +247,7 @@ NeedDaemonReload=no
 		}
 		if snapName == "snap-e" {
 			// snap-e contains user services
-			needle.DaemonScope = snap.UserDaemon
+			needle.DaemonScope = snap.UserDaemonScope
 			needle.Active = false
 		}
 		c.Check(apps, testutil.DeepContains, needle)
@@ -343,7 +343,7 @@ func (s *appsSuite) TestGetAppsInfoServices(c *check.C) {
 			Snap:        snapName,
 			Name:        app,
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		if snapName != "snap-b" {
 			// snap-b is not active (all the others are)
@@ -352,7 +352,7 @@ func (s *appsSuite) TestGetAppsInfoServices(c *check.C) {
 		}
 		if snapName == "snap-e" {
 			// snap-e contains user services
-			needle.DaemonScope = snap.UserDaemon
+			needle.DaemonScope = snap.UserDaemonScope
 			needle.Active = false
 		}
 		c.Check(svcs, testutil.DeepContains, needle)
@@ -400,7 +400,7 @@ NeedDaemonReload=no
 			Snap:        snapName,
 			Name:        app,
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		if snapName != "snap-b" {
 			// snap-b is not active (all the others are)
@@ -409,7 +409,7 @@ NeedDaemonReload=no
 		}
 		if snapName == "snap-e" {
 			// snap-e contains user services
-			needle.DaemonScope = snap.UserDaemon
+			needle.DaemonScope = snap.UserDaemonScope
 			needle.Active = false
 		}
 		c.Check(svcs, testutil.DeepContains, needle)
@@ -478,7 +478,7 @@ func (s *appsSuite) TestGetUserAppsInfoServices(c *check.C) {
 			Snap:        snapName,
 			Name:        app,
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		if snapName != "snap-b" {
 			// snap-b is not active (all the others are)
@@ -487,7 +487,7 @@ func (s *appsSuite) TestGetUserAppsInfoServices(c *check.C) {
 		}
 		if snapName == "snap-e" {
 			// snap-e contains user services
-			needle.DaemonScope = snap.UserDaemon
+			needle.DaemonScope = snap.UserDaemonScope
 			needle.Active = true
 		}
 		c.Check(svcs, testutil.DeepContains, needle)

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1256,31 +1256,31 @@ UnitFileState=enabled
 					// services
 					Snap: "foo", Name: "svc1",
 					Daemon:      "simple",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     true,
 					Active:      false,
 				}, {
 					Snap: "foo", Name: "svc2",
 					Daemon:      "forking",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     false,
 					Active:      true,
 				}, {
 					Snap: "foo", Name: "svc3",
 					Daemon:      "oneshot",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     true,
 					Active:      true,
 				}, {
 					Snap: "foo", Name: "svc4",
 					Daemon:      "notify",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     false,
 					Active:      false,
 				}, {
 					Snap: "foo", Name: "svc5",
 					Daemon:      "simple",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     true,
 					Active:      false,
 					Activators: []client.AppActivator{
@@ -1289,7 +1289,7 @@ UnitFileState=enabled
 				}, {
 					Snap: "foo", Name: "svc6",
 					Daemon:      "simple",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     true,
 					Active:      false,
 					Activators: []client.AppActivator{
@@ -1298,7 +1298,7 @@ UnitFileState=enabled
 				}, {
 					Snap: "foo", Name: "svc7",
 					Daemon:      "simple",
-					DaemonScope: snap.SystemDaemon,
+					DaemonScope: snap.SystemDaemonScope,
 					Enabled:     true,
 					Active:      false,
 					Activators: []client.AppActivator{

--- a/interfaces/builtin/snap_interfaces_requests_control.go
+++ b/interfaces/builtin/snap_interfaces_requests_control.go
@@ -88,7 +88,7 @@ func (iface *requestsControlInterface) BeforePreparePlug(plug *snap.PlugInfo) er
 		return fmt.Errorf("declared handler service %q not found in snap", handlerService)
 	}
 
-	if !svc.IsService() || svc.DaemonScope != snap.UserDaemon {
+	if !svc.IsService() || !svc.DaemonScope.IsUserDaemon() {
 		return fmt.Errorf("declared handler service %q is not a user service", handlerService)
 	}
 

--- a/overlord/servicestate/helpers.go
+++ b/overlord/servicestate/helpers.go
@@ -74,7 +74,7 @@ func splitServicesIntoSystemAndUser(apps []*snap.AppInfo) (sys, usr []*snap.AppI
 		if !app.IsService() {
 			continue
 		}
-		if app.DaemonScope == snap.SystemDaemon {
+		if app.DaemonScope.IsSystemDaemon() {
 			sys = append(sys, app)
 		} else {
 			usr = append(usr, app)

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -1313,14 +1313,14 @@ func (s *serviceControlSuite) TestUpdateSnapstateSystemServices(c *C) {
 			enable = append(enable, &snap.AppInfo{
 				Name:        srv,
 				Daemon:      "simple",
-				DaemonScope: snap.SystemDaemon,
+				DaemonScope: snap.SystemDaemonScope,
 			})
 		}
 		for _, srv := range tst.disable {
 			disable = append(disable, &snap.AppInfo{
 				Name:        srv,
 				Daemon:      "simple",
-				DaemonScope: snap.SystemDaemon,
+				DaemonScope: snap.SystemDaemonScope,
 			})
 		}
 		result, err := servicestate.UpdateSnapstateServices(&snapst, enable, disable, wrappers.ScopeOptions{})
@@ -1342,7 +1342,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateServicesIgnoresNonServices(c *C
 		{
 			Name:        "foo",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 		{
 			Name: "baz",
@@ -1352,7 +1352,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateServicesIgnoresNonServices(c *C
 		{
 			Name:        "bar",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 		{
 			Name: "jazz",
@@ -1512,14 +1512,14 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServices(c *C) {
 			enable = append(enable, &snap.AppInfo{
 				Name:        srv,
 				Daemon:      "simple",
-				DaemonScope: snap.UserDaemon,
+				DaemonScope: snap.UserDaemonScope,
 			})
 		}
 		for _, srv := range tst.disable {
 			disable = append(disable, &snap.AppInfo{
 				Name:        srv,
 				Daemon:      "simple",
-				DaemonScope: snap.UserDaemon,
+				DaemonScope: snap.UserDaemonScope,
 			})
 		}
 		result, err := servicestate.UpdateSnapstateServices(&snapst, enable, disable, wrappers.ScopeOptions{Users: tst.users})
@@ -1546,7 +1546,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServicesFailsOnUserError(c 
 		{
 			Name:        "foo",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 	}
 
@@ -1579,7 +1579,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServicesFailsOnInvalidUID(c
 		{
 			Name:        "foo",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 	}
 

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -79,7 +79,7 @@ func (i *Instruction) ServiceScope() wrappers.ServiceScope {
 
 func (i *Instruction) hasUserService(apps []*snap.AppInfo) bool {
 	for _, app := range apps {
-		if app.IsService() && app.DaemonScope == snap.UserDaemon {
+		if app.IsService() && app.DaemonScope.IsUserDaemon() {
 			return true
 		}
 	}
@@ -433,12 +433,12 @@ func (sd *StatusDecorator) queryUserServiceStatus(units []string) ([]*systemd.Un
 func (sd *StatusDecorator) queryServiceStatus(scope snap.DaemonScope, units []string) ([]*systemd.UnitStatus, error) {
 	var sts []*systemd.UnitStatus
 	var err error
-	switch scope {
-	case snap.SystemDaemon:
+	switch {
+	case scope.IsSystemDaemon():
 		// sysd.Status() makes sure that we get only the units we asked
 		// for and raises an error otherwise.
 		sts, err = sd.sysd.Status(units)
-	case snap.UserDaemon:
+	case scope.IsUserDaemon():
 		// Support the previous behavior of retrieving the global enablement
 		// status of user services if no uid is configured for this status
 		// decorator.

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -160,7 +160,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 
 		err = sd.DecorateWithStatus(app, snapApp)
@@ -178,7 +178,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		snapApp.Timer = &snap.TimerInfo{
 			App:   snapApp,
@@ -203,7 +203,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		snapApp.Sockets = map[string]*snap.SocketInfo{
 			"socket1": {
@@ -232,7 +232,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		}
 		snapApp.ActivatesOn = []*snap.SlotInfo{
 			{
@@ -265,7 +265,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		}
 		snapApp.Sockets = map[string]*snap.SocketInfo{
 			"socket1": {
@@ -373,7 +373,7 @@ NeedDaemonReload=no
 			Snap:        snp,
 			Name:        "svc",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		}
 		snapApp.Sockets = map[string]*snap.SocketInfo{
 			"socket1": {
@@ -433,24 +433,24 @@ func (s *instructionSuite) SetUpTest(c *C) {
 		{
 			Name:        "foo",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 		{
 			Name:        "bar",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 	}
 	s.mixServices = []*snap.AppInfo{
 		{
 			Name:        "foo",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		{
 			Name:        "bar",
 			Daemon:      "simple",
-			DaemonScope: snap.SystemDaemon,
+			DaemonScope: snap.SystemDaemonScope,
 		},
 	}
 }
@@ -723,13 +723,13 @@ func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {
 			Snap:        snp,
 			Name:        "svc1",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		{
 			Snap:        snp,
 			Name:        "svc2",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 	}
 
@@ -804,13 +804,13 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 			Snap:        snp,
 			Name:        "svc1",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		{
 			Snap:        snp,
 			Name:        "svc2",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 	}
 
@@ -934,13 +934,13 @@ func (s *snapServiceOptionsSuite) TestLogReader(c *C) {
 			Snap:        snp,
 			Name:        "svc1",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		{
 			Snap:        snp,
 			Name:        "svc2",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 	}
 
@@ -981,7 +981,7 @@ func (s *snapServiceOptionsSuite) TestLogReaderFailsWithNonServices(c *C) {
 			Snap:        snp,
 			Name:        "svc1",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		// Introduce a non-service to make sure we fail on this
 		{
@@ -1012,13 +1012,13 @@ func (s *snapServiceOptionsSuite) TestLogReaderNamespaces(c *C) {
 			Snap:        snp,
 			Name:        "svc1",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 		{
 			Snap:        snp,
 			Name:        "svc2",
 			Daemon:      "simple",
-			DaemonScope: snap.UserDaemon,
+			DaemonScope: snap.UserDaemonScope,
 		},
 	}
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -403,7 +403,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				Snap:        info,
 				Name:        "dbus-daemon",
 				Daemon:      "simple",
-				DaemonScope: snap.SystemDaemon,
+				DaemonScope: snap.SystemDaemonScope,
 				ActivatesOn: []*snap.SlotInfo{slot},
 				Slots: map[string]*snap.SlotInfo{
 					slot.Name: slot,

--- a/overlord/snapstate/dbus.go
+++ b/overlord/snapstate/dbus.go
@@ -37,10 +37,10 @@ func getActivatableDBusServices(info *snap.Info) (session, system map[string]boo
 			if !ok {
 				continue
 			}
-			switch app.DaemonScope {
-			case snap.SystemDaemon:
+			switch {
+			case app.DaemonScope.IsSystemDaemon():
 				system[busName] = true
-			case snap.UserDaemon:
+			case app.DaemonScope.IsUserDaemon():
 				session[busName] = true
 			}
 		}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3153,7 +3153,7 @@ func installModeDisabledSystemServices(snapst *SnapState, currentInfo *snap.Info
 		enabledByHookSvcs[svcName] = true
 	}
 	for _, svc := range currentInfo.Services() {
-		if svc.DaemonScope != snap.SystemDaemon {
+		if !svc.DaemonScope.IsSystemDaemon() {
 			continue
 		}
 
@@ -3188,7 +3188,7 @@ func installModeDisabledUserServices(snapst *SnapState, currentInfo *snap.Info, 
 
 	svcsToDisable := make(map[int][]string)
 	for _, svc := range currentInfo.Services() {
-		if svc.DaemonScope != snap.UserDaemon {
+		if !svc.DaemonScope.IsUserDaemon() {
 			continue
 		}
 

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -258,7 +258,7 @@ func (s *handlersSuite) TestComputeMissingDisabledUserServices(c *C) {
 			map[string]*snap.AppInfo{
 				"app": {
 					Daemon:      "",
-					DaemonScope: snap.UserDaemon,
+					DaemonScope: snap.UserDaemonScope,
 				},
 			},
 			map[int][]string{},
@@ -272,7 +272,7 @@ func (s *handlersSuite) TestComputeMissingDisabledUserServices(c *C) {
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon:      "simple",
-					DaemonScope: snap.UserDaemon,
+					DaemonScope: snap.UserDaemonScope,
 				},
 			},
 			map[int][]string{},
@@ -303,7 +303,7 @@ func (s *handlersSuite) TestComputeMissingDisabledUserServices(c *C) {
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon:      "simple",
-					DaemonScope: snap.UserDaemon,
+					DaemonScope: snap.UserDaemonScope,
 				},
 			},
 			map[int][]string{
@@ -323,7 +323,7 @@ func (s *handlersSuite) TestComputeMissingDisabledUserServices(c *C) {
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon:      "simple",
-					DaemonScope: snap.UserDaemon,
+					DaemonScope: snap.UserDaemonScope,
 				},
 			},
 			map[int][]string{
@@ -343,7 +343,7 @@ func (s *handlersSuite) TestComputeMissingDisabledUserServices(c *C) {
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon:      "",
-					DaemonScope: snap.UserDaemon,
+					DaemonScope: snap.UserDaemonScope,
 				},
 			},
 			map[int][]string{

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1331,7 +1331,7 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 
 	var hasUserService, usesDbusActivation bool
 	for _, app := range info.Apps {
-		if app.IsService() && app.DaemonScope == snap.UserDaemon {
+		if app.IsService() && app.DaemonScope.IsUserDaemon() {
 			hasUserService = true
 		}
 		if len(app.ActivatesOn) != 0 {

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -65,7 +65,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 			Snap:        info,
 			Name:        appname,
 			Daemon:      "simple",
-			DaemonScope: SystemDaemon,
+			DaemonScope: SystemDaemonScope,
 		}
 	}
 	// guess the user services next
@@ -76,7 +76,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 			Snap:        info,
 			Name:        appname,
 			Daemon:      "simple",
-			DaemonScope: UserDaemon,
+			DaemonScope: UserDaemonScope,
 		}
 	}
 

--- a/snap/broken_test.go
+++ b/snap/broken_test.go
@@ -77,14 +77,14 @@ func (s *brokenSuite) TestGuessAppsForBrokenServices(c *C) {
 	info := &snap.Info{SuggestedName: "foo"}
 	apps := snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
-	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.SystemDaemon})
-	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar", Daemon: "simple", DaemonScope: snap.SystemDaemon})
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.SystemDaemonScope})
+	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar", Daemon: "simple", DaemonScope: snap.SystemDaemonScope})
 
 	info = &snap.Info{SuggestedName: "foo", InstanceKey: "instance"}
 	apps = snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
-	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.SystemDaemon})
-	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple", DaemonScope: snap.SystemDaemon})
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.SystemDaemonScope})
+	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple", DaemonScope: snap.SystemDaemonScope})
 }
 
 func (s *brokenSuite) TestGuessAppsForBrokenUserServices(c *C) {
@@ -96,14 +96,14 @@ func (s *brokenSuite) TestGuessAppsForBrokenUserServices(c *C) {
 	info := &snap.Info{SuggestedName: "foo"}
 	apps := snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
-	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.UserDaemon})
-	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar", Daemon: "simple", DaemonScope: snap.UserDaemon})
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.UserDaemonScope})
+	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar", Daemon: "simple", DaemonScope: snap.UserDaemonScope})
 
 	info = &snap.Info{SuggestedName: "foo", InstanceKey: "instance"}
 	apps = snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
-	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.UserDaemon})
-	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple", DaemonScope: snap.UserDaemon})
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple", DaemonScope: snap.UserDaemonScope})
+	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple", DaemonScope: snap.UserDaemonScope})
 }
 
 func (s *brokenSuite) TestForceRenamePlug(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -1347,8 +1347,11 @@ type AppInfo struct {
 
 	// list of other service names that this service will start after or
 	// before
-	After  []string
-	Before []string
+	After     []string
+	Before    []string
+	BindsTo   []string
+	PartOf    []string
+	Requisite []string
 
 	Timer *TimerInfo
 
@@ -1556,10 +1559,10 @@ func (app *AppInfo) ServiceName() string {
 }
 
 func (app *AppInfo) serviceDir() string {
-	switch app.DaemonScope {
-	case SystemDaemon:
+	switch {
+	case app.DaemonScope.IsSystemDaemon():
 		return dirs.SnapServicesDir
-	case UserDaemon:
+	case app.DaemonScope.IsUserDaemon():
 		return dirs.SnapUserServicesDir
 	default:
 		panic("unknown daemon scope")

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -472,7 +472,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 		}
 		// Daemons default to being system daemons
 		if app.Daemon != "" && app.DaemonScope == "" {
-			app.DaemonScope = SystemDaemon
+			app.DaemonScope = SystemDaemonScope
 		}
 
 		snap.Apps[appName] = app

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1592,7 +1592,7 @@ apps:
 		Name:            "svc",
 		Command:         "svc1",
 		Daemon:          "forking",
-		DaemonScope:     snap.SystemDaemon,
+		DaemonScope:     snap.SystemDaemonScope,
 		RestartCond:     snap.RestartOnAbnormal,
 		StopTimeout:     timeout.Timeout(25 * time.Second),
 		StartTimeout:    timeout.Timeout(42 * time.Minute),
@@ -1623,7 +1623,7 @@ apps:
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Check(info.Apps["svc"].DaemonScope, Equals, snap.UserDaemon)
+	c.Check(info.Apps["svc"].DaemonScope, Equals, snap.UserDaemonScope)
 }
 
 func (s *YamlSuite) TestDaemonNoDaemonScope(c *C) {
@@ -1638,7 +1638,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	// If daemon-scope is unset, default to system scope
-	c.Check(info.Apps["svc"].DaemonScope, Equals, snap.SystemDaemon)
+	c.Check(info.Apps["svc"].DaemonScope, Equals, snap.SystemDaemonScope)
 }
 
 func (s *YamlSuite) TestDaemonListenStreamAsInteger(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1534,14 +1534,14 @@ apps:
 
 	svc := info.Apps["svc1"]
 	c.Check(svc.IsService(), Equals, true)
-	c.Check(svc.DaemonScope, Equals, snap.SystemDaemon)
+	c.Check(svc.DaemonScope, Equals, snap.SystemDaemonScope)
 	c.Check(svc.ServiceName(), Equals, "snap.pans.svc1.service")
 	c.Check(svc.ServiceFile(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans.svc1.service")
 
 	c.Check(info.Apps["svc2"].IsService(), Equals, true)
 	userSvc := info.Apps["svc3"]
 	c.Check(userSvc.IsService(), Equals, true)
-	c.Check(userSvc.DaemonScope, Equals, snap.UserDaemon)
+	c.Check(userSvc.DaemonScope, Equals, snap.UserDaemonScope)
 	c.Check(userSvc.ServiceName(), Equals, "snap.pans.svc3.service")
 	c.Check(userSvc.ServiceFile(), Equals, dirs.GlobalRootDir+"/etc/systemd/user/snap.pans.svc3.service")
 	c.Check(info.Apps["app1"].IsService(), Equals, false)

--- a/snap/types.go
+++ b/snap/types.go
@@ -187,9 +187,30 @@ const (
 type DaemonScope string
 
 const (
-	SystemDaemon DaemonScope = "system"
-	UserDaemon   DaemonScope = "user"
+	SystemDaemonScope        DaemonScope = "system"
+	UserDaemonScope          DaemonScope = "user"
+	GraphicalUserDaemonScope DaemonScope = "user-graphical-session"
 )
+
+// Returns if the daemon is a System daemon
+func (daemonScope DaemonScope) IsSystemDaemon() bool {
+	switch daemonScope {
+	case SystemDaemonScope:
+		return true
+	default:
+		return false
+	}
+}
+
+// Returns if the daemon is an User daemon
+func (daemonScope DaemonScope) IsUserDaemon() bool {
+	switch daemonScope {
+	case UserDaemonScope, GraphicalUserDaemonScope:
+		return true
+	default:
+		return false
+	}
+}
 
 // UnmarshalJSON sets *daemonScope to a copy of data, assuming validation passes
 func (daemonScope *DaemonScope) UnmarshalJSON(data []byte) error {
@@ -213,7 +234,7 @@ func (daemonScope *DaemonScope) UnmarshalYAML(unmarshal func(any) error) error {
 
 func (daemonScope *DaemonScope) fromString(str string) error {
 	d := DaemonScope(str)
-	if d != SystemDaemon && d != UserDaemon {
+	if d != SystemDaemonScope && d != UserDaemonScope && d != GraphicalUserDaemonScope {
 		return fmt.Errorf("invalid daemon scope: %q", str)
 	}
 

--- a/snap/types_test.go
+++ b/snap/types_test.go
@@ -228,24 +228,28 @@ func (s *typeSuite) TestJsonUnmarshalInvalidConfinementTypes(c *C) {
 }
 
 func (s *typeSuite) TestYamlMarshalDaemonScopes(c *C) {
-	out, err := yaml.Marshal(SystemDaemon)
+	out, err := yaml.Marshal(SystemDaemonScope)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "system\n")
 
-	out, err = yaml.Marshal(UserDaemon)
+	out, err = yaml.Marshal(UserDaemonScope)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "user\n")
+
+	out, err = yaml.Marshal(GraphicalUserDaemonScope)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "user-graphical-session\n")
 }
 
 func (s *typeSuite) TestYamlUnmarshalDaemonScopes(c *C) {
 	var daemonScope DaemonScope
 	err := yaml.Unmarshal([]byte("system"), &daemonScope)
 	c.Assert(err, IsNil)
-	c.Check(daemonScope, Equals, SystemDaemon)
+	c.Check(daemonScope, Equals, SystemDaemonScope)
 
 	err = yaml.Unmarshal([]byte("user"), &daemonScope)
 	c.Assert(err, IsNil)
-	c.Check(daemonScope, Equals, UserDaemon)
+	c.Check(daemonScope, Equals, UserDaemonScope)
 }
 
 func (s *typeSuite) TestYamlUnmarshalInvalidDaemonScopes(c *C) {
@@ -260,11 +264,11 @@ func (s *typeSuite) TestYamlUnmarshalInvalidDaemonScopes(c *C) {
 }
 
 func (s *typeSuite) TestJsonMarshalDaemonScopes(c *C) {
-	out, err := json.Marshal(SystemDaemon)
+	out, err := json.Marshal(SystemDaemonScope)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"system\"")
 
-	out, err = json.Marshal(UserDaemon)
+	out, err = json.Marshal(UserDaemonScope)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"user\"")
 }
@@ -273,11 +277,11 @@ func (s *typeSuite) TestJsonUnmarshalDaemonScopes(c *C) {
 	var daemonScope DaemonScope
 	err := json.Unmarshal([]byte("\"system\""), &daemonScope)
 	c.Assert(err, IsNil)
-	c.Check(daemonScope, Equals, SystemDaemon)
+	c.Check(daemonScope, Equals, SystemDaemonScope)
 
 	err = json.Unmarshal([]byte("\"user\""), &daemonScope)
 	c.Assert(err, IsNil)
-	c.Check(daemonScope, Equals, UserDaemon)
+	c.Check(daemonScope, Equals, UserDaemonScope)
 }
 
 func (s *typeSuite) TestJsonUnmarshalInvalidDaemonScopes(c *C) {
@@ -306,4 +310,19 @@ func (s *typeSuite) TestComponentTypeFromString(c *C) {
 
 	_, err = ComponentTypeFromString("invalid")
 	c.Assert(err, ErrorMatches, "invalid component type \"invalid\"")
+}
+
+func (s *typeSuite) TestDaemonTypeFromDaemonScope(c *C) {
+	systemScope := DaemonScope("system")
+	c.Assert(systemScope.IsSystemDaemon(), Equals, true)
+	c.Assert(systemScope.IsUserDaemon(), Equals, false)
+	userScope := DaemonScope("user")
+	c.Assert(userScope.IsUserDaemon(), Equals, true)
+	c.Assert(userScope.IsSystemDaemon(), Equals, false)
+	graphicalScope := DaemonScope("user-graphical-session")
+	c.Assert(graphicalScope.IsUserDaemon(), Equals, true)
+	c.Assert(graphicalScope.IsSystemDaemon(), Equals, false)
+	emptyScope := DaemonScope("")
+	c.Assert(emptyScope.IsSystemDaemon(), Equals, false)
+	c.Assert(emptyScope.IsUserDaemon(), Equals, false)
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -253,13 +253,13 @@ func validateSocketAddrPath(socket *SocketInfo, fieldName string, path string) e
 		return fmt.Errorf("invalid %q: %q should be written as %q", fieldName, path, clean)
 	}
 
-	switch socket.App.DaemonScope {
-	case SystemDaemon:
+	switch {
+	case socket.App.DaemonScope.IsSystemDaemon():
 		if !(strings.HasPrefix(path, "$SNAP_DATA/") || strings.HasPrefix(path, "$SNAP_COMMON/") || strings.HasPrefix(path, "$XDG_RUNTIME_DIR/")) {
 			return fmt.Errorf(
 				"invalid %q: system daemon sockets must have a prefix of $SNAP_DATA, $SNAP_COMMON or $XDG_RUNTIME_DIR", fieldName)
 		}
-	case UserDaemon:
+	case socket.App.DaemonScope.IsUserDaemon():
 		if !(strings.HasPrefix(path, "$SNAP_USER_DATA/") || strings.HasPrefix(path, "$SNAP_USER_COMMON/") || strings.HasPrefix(path, "$XDG_RUNTIME_DIR/")) {
 			return fmt.Errorf(
 				"invalid %q: user daemon sockets must have a prefix of $SNAP_USER_DATA, $SNAP_USER_COMMON, or $XDG_RUNTIME_DIR", fieldName)
@@ -830,7 +830,7 @@ func validateAppActivatesOn(app *AppInfo) error {
 
 		// D-Bus slots must match the daemon scope
 		bus := slot.Attrs["bus"]
-		if app.DaemonScope == SystemDaemon && bus != "system" || app.DaemonScope == UserDaemon && bus != "session" {
+		if app.DaemonScope.IsSystemDaemon() && bus != "system" || app.DaemonScope.IsUserDaemon() && bus != "session" {
 			return fmt.Errorf("invalid activates-on value %q: bus %q does not match daemon-scope %q", slot.Name, bus, app.DaemonScope)
 		}
 
@@ -876,7 +876,7 @@ func ValidateApp(app *AppInfo) error {
 		if app.Daemon != "" {
 			return fmt.Errorf(`"daemon-scope" must be set for daemons`)
 		}
-	case SystemDaemon, UserDaemon:
+	case SystemDaemonScope, UserDaemonScope, GraphicalUserDaemonScope:
 		if app.Daemon == "" {
 			return fmt.Errorf(`"daemon-scope" can only be set for daemons`)
 		}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -56,7 +56,7 @@ func createSampleApp() *AppInfo {
 		},
 		Name:        "foo",
 		Daemon:      "simple",
-		DaemonScope: SystemDaemon,
+		DaemonScope: SystemDaemonScope,
 		Plugs:       map[string]*PlugInfo{"network-bind": {}},
 		Sockets: map[string]*SocketInfo{
 			"sock": socket,
@@ -316,7 +316,7 @@ func (s *ValidateSuite) TestValidateAppSocketsInvalidListenStreamAbstractSocket(
 func (s *ValidateSuite) TestValidateAppSocketsInvalidListenStreamAddress(c *C) {
 	app := createSampleApp()
 	app.Daemon = "simple"
-	app.DaemonScope = SystemDaemon
+	app.DaemonScope = SystemDaemonScope
 	invalidListenAddresses := []string{
 		"10.0.1.1:8080",
 		"[fafa::baba]:8080",
@@ -353,7 +353,7 @@ func (s *ValidateSuite) TestValidateAppSocketsInvalidListenStreamPort(c *C) {
 
 func (s *ValidateSuite) TestValidateAppUserSocketsValidListenStreamAddresses(c *C) {
 	app := createSampleApp()
-	app.DaemonScope = UserDaemon
+	app.DaemonScope = UserDaemonScope
 	validListenAddresses := []string{
 		// socket paths using variables as prefix
 		"$SNAP_USER_DATA/my.socket",
@@ -380,7 +380,7 @@ func (s *ValidateSuite) TestValidateAppUserSocketsValidListenStreamAddresses(c *
 
 func (s *ValidateSuite) TestValidateAppUserSocketsInvalidListenStreamPath(c *C) {
 	app := createSampleApp()
-	app.DaemonScope = UserDaemon
+	app.DaemonScope = UserDaemonScope
 	invalidListenAddresses := []string{
 		// socket paths out of the snap dirs
 		"/some/path/my.socket",
@@ -398,7 +398,7 @@ func (s *ValidateSuite) TestValidateAppUserSocketsInvalidListenStreamPath(c *C) 
 
 func (s *ValidateSuite) TestValidateAppUserSocketsInvalidListenStreamAbstractSocket(c *C) {
 	app := createSampleApp()
-	app.DaemonScope = UserDaemon
+	app.DaemonScope = UserDaemonScope
 	invalidListenAddresses := []string{
 		"@snap.mysnap",
 		"@snap.mysnap\000.foo",
@@ -416,7 +416,7 @@ func (s *ValidateSuite) TestValidateAppUserSocketsInvalidListenStreamAbstractSoc
 
 func (s *ValidateSuite) TestValidateAppUserSocketsInvalidListenStreamPort(c *C) {
 	app := createSampleApp()
-	app.DaemonScope = UserDaemon
+	app.DaemonScope = UserDaemonScope
 	invalidListenAddresses := []string{
 		"0",
 		"66536",
@@ -476,7 +476,7 @@ func (s *ValidateSuite) TestAppDaemonValue(c *C) {
 	} {
 		var daemonScope DaemonScope
 		if t.daemon != "" {
-			daemonScope = SystemDaemon
+			daemonScope = SystemDaemonScope
 		}
 		if t.ok {
 			c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: t.daemon, DaemonScope: daemonScope}), IsNil)
@@ -494,12 +494,12 @@ func (s *ValidateSuite) TestAppDaemonScopeValue(c *C) {
 	}{
 		// good
 		{"", "", true},
-		{"simple", SystemDaemon, true},
-		{"simple", UserDaemon, true},
+		{"simple", SystemDaemonScope, true},
+		{"simple", UserDaemonScope, true},
 		// bad
 		{"simple", "", false},
-		{"", SystemDaemon, false},
-		{"", UserDaemon, false},
+		{"", SystemDaemonScope, false},
+		{"", UserDaemonScope, false},
 		{"simple", "invalid-mode", false},
 	} {
 		app := &AppInfo{Name: "foo", Daemon: t.daemon, DaemonScope: t.daemonScope}
@@ -538,9 +538,9 @@ func (s *ValidateSuite) TestAppStopMode(c *C) {
 		{"invalid-thing", false},
 	} {
 		if t.ok {
-			c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemon, StopMode: t.stopMode}), IsNil)
+			c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemonScope, StopMode: t.stopMode}), IsNil)
 		} else {
-			c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemon, StopMode: t.stopMode}), ErrorMatches, fmt.Sprintf(`"stop-mode" field contains invalid value %q`, t.stopMode))
+			c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemonScope, StopMode: t.stopMode}), ErrorMatches, fmt.Sprintf(`"stop-mode" field contains invalid value %q`, t.stopMode))
 		}
 	}
 
@@ -569,7 +569,7 @@ func (s *ValidateSuite) TestAppRefreshMode(c *C) {
 	} {
 		var daemonScope DaemonScope
 		if t.daemon != "" {
-			daemonScope = SystemDaemon
+			daemonScope = SystemDaemonScope
 		}
 
 		err := ValidateApp(&AppInfo{Name: "foo", Daemon: t.daemon, DaemonScope: daemonScope, RefreshMode: t.refreshMode})
@@ -2211,7 +2211,7 @@ func (s *ValidateSuite) TestAppInstallMode(c *C) {
 		// bad
 		{"invalid-thing", false},
 	} {
-		err := ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemon, InstallMode: t.installMode})
+		err := ValidateApp(&AppInfo{Name: "foo", Daemon: "simple", DaemonScope: SystemDaemonScope, InstallMode: t.installMode})
 		if t.ok {
 			c.Check(err, IsNil)
 		} else {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -385,7 +385,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	// validate apps
 	c.Check(info.Apps["user-svc"].Command, Equals, "bin/user-svc")
 	c.Check(info.Apps["user-svc"].Daemon, Equals, "simple")
-	c.Check(info.Apps["user-svc"].DaemonScope, Equals, snap.UserDaemon)
+	c.Check(info.Apps["user-svc"].DaemonScope, Equals, snap.UserDaemonScope)
 
 	// validate components
 	someComponent := *info.Components["some-component"]

--- a/wrappers/dbus.go
+++ b/wrappers/dbus.go
@@ -139,11 +139,11 @@ func AddSnapDBusActivationFiles(s *snap.Info) error {
 				Content: content,
 				Mode:    0644,
 			}
-			switch app.DaemonScope {
-			case snap.SystemDaemon:
+			switch {
+			case app.DaemonScope.IsSystemDaemon():
 				systemContent[filename] = fileState
 				systemServices = append(systemServices, filename)
-			case snap.UserDaemon:
+			case app.DaemonScope.IsUserDaemon():
 				sessionContent[filename] = fileState
 				sessionServices = append(sessionServices, filename)
 			}

--- a/wrappers/internal/service_socket_gen_test.go
+++ b/wrappers/internal/service_socket_gen_test.go
@@ -80,7 +80,7 @@ WantedBy=sockets.target
 		Name:        "app",
 		Command:     "bin/foo start",
 		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
+		DaemonScope: snap.SystemDaemonScope,
 		Plugs:       map[string]*snap.PlugInfo{"network-bind": {Interface: "network-bind"}},
 		Sockets: map[string]*snap.SocketInfo{
 			"sock1": {

--- a/wrappers/internal/service_status.go
+++ b/wrappers/internal/service_status.go
@@ -96,10 +96,10 @@ func appServiceUnitsMany(apps []*snap.AppInfo) (sys, usr []string) {
 			continue
 		}
 		svc, activators := SnapServiceUnits(app)
-		if app.DaemonScope == snap.SystemDaemon {
+		if app.DaemonScope.IsSystemDaemon() {
 			sys = append(sys, svc)
 			sys = append(sys, activators...)
-		} else if app.DaemonScope == snap.UserDaemon {
+		} else if app.DaemonScope.IsUserDaemon() {
 			usr = append(usr, svc)
 			usr = append(usr, activators...)
 		}
@@ -171,7 +171,7 @@ func queryUserServiceStatusMany(apps []*snap.AppInfo, units []string) (map[int][
 			if !app.IsService() {
 				continue
 			}
-			if app.DaemonScope != snap.UserDaemon {
+			if !app.DaemonScope.IsUserDaemon() {
 				continue
 			}
 			svc := constructStatus(app, stsMap)
@@ -214,7 +214,7 @@ func querySystemServiceStatusMany(sysd systemd.Systemd, apps []*snap.AppInfo, un
 		if !app.IsService() {
 			continue
 		}
-		if app.DaemonScope != snap.SystemDaemon {
+		if !app.DaemonScope.IsSystemDaemon() {
 			continue
 		}
 

--- a/wrappers/internal/service_timer_gen.go
+++ b/wrappers/internal/service_timer_gen.go
@@ -292,10 +292,10 @@ WantedBy={{.TimersTarget}}
 		TimerName:       app.Name,
 		Schedules:       schedules,
 	}
-	switch app.DaemonScope {
-	case snap.SystemDaemon:
+	switch {
+	case app.DaemonScope.IsSystemDaemon():
 		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(app.Snap.MountDir()))
-	case snap.UserDaemon:
+	case app.DaemonScope.IsUserDaemon():
 		// nothing
 	default:
 		panic("unknown snap.DaemonScope")

--- a/wrappers/internal/service_timer_gen_test.go
+++ b/wrappers/internal/service_timer_gen_test.go
@@ -67,7 +67,7 @@ WantedBy=timers.target
 		Name:        "app",
 		Command:     "bin/foo start",
 		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
+		DaemonScope: snap.SystemDaemonScope,
 		StopTimeout: timeout.DefaultTimeout,
 		Timer: &snap.TimerInfo{
 			Timer: "10:00-12:00/2",
@@ -92,7 +92,7 @@ func (s *serviceTimerUnitGenSuite) TestServiceTimerUnitBadTimer(c *C) {
 		Name:        "app",
 		Command:     "bin/foo start",
 		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
+		DaemonScope: snap.SystemDaemonScope,
 		StopTimeout: timeout.DefaultTimeout,
 		Timer: &snap.TimerInfo{
 			Timer: "bad-timer",
@@ -134,7 +134,7 @@ Type=%s
 		Name:        "app",
 		Command:     "bin/foo start",
 		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
+		DaemonScope: snap.SystemDaemonScope,
 		StopTimeout: timeout.DefaultTimeout,
 		Timer: &snap.TimerInfo{
 			Timer: "10:00-12:00,,mon,23:00~01:00/2",


### PR DESCRIPTION
Currently, any daemon with an user scope will be added to the user's default target. This is not always what is needed, because some daemons require a graphical desktop environment to run properly, like snapd-desktop-integration.

This patch adds an extra option to the `daemon-scope` parameter, `graphical-user`. When this option is used instead of `user`, the daemon will have the `WantedBy` parameter in the .service file pointing to `graphical-session.target` instead of
`default.target`, and also will include the same target in both the `After` and `BindsTo` parameters, to ensure that it is launched when the desktop is ready, and that is stopped when the desktop session ends.

It still requires a patch to snapcraft to allow it to detect this new option.

Implements the explicit way of the specification SD-230.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
