### PR TITLE
interfaces/builtin: remove workaround for slash filtering in ibus address

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -137,14 +137,9 @@ unix (connect, receive, send)
     type=stream
     peer=(addr="@/tmp/ibus/dbus-*"),
 
-# abstract path in ibus >= 1.5.22 uses $XDG_CACHE_HOME (ie, @{HOME}/.cache)
-# This should use this, but due to LP: #1856738 we cannot
-#unix (connect, receive, send)
-#    type=stream
-#    peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
 unix (connect, receive, send)
-     type=stream
-     peer=(addr="@/home/*/.cache/ibus/dbus-*"),
+    type=stream
+    peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
 
 # when running with glib >= 2.75.0, ibus uses a regular socket
 owner @{HOME}/.cache/ibus/dbus-* rw,

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -140,14 +140,9 @@ unix (connect, receive, send)
      type=stream
      peer=(addr="@/tmp/ibus/dbus-*"),
 
-# abstract path in ibus >= 1.5.22 uses $XDG_CACHE_HOME (ie, @{HOME}/.cache)
-# This should use this, but due to LP: #1856738 we cannot
-#unix (connect, receive, send)
-#    type=stream
-#    peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
 unix (connect, receive, send)
      type=stream
-     peer=(addr="@/home/*/.cache/ibus/dbus-*"),
+     peer=(addr="@@{HOME}/.cache/ibus/dbus-*"),
 
 
 # input methods (mozc)


### PR DESCRIPTION
Previously the pattern for the ibus socket address was `@/home/*/.cache/ibus/dbus-*`
instead of `@@{HOME}/.cache/ibus/dbus-*` due to a bug ([LP: #1856738](https://bugs.launchpad.net/apparmor/+bug/1856738)) where double slashes where not filtered in unix socket address.

As a result, snaps have trouble accessing the ibus socket in situations where the user directory is an an unconventional location.

The workaround seems to have been carried over from the upstream ibus abstraction in apparmor. [^1]
The original bug being worked around was fixed upstream ([MR 607](https://gitlab.com/apparmor/apparmor/-/merge_requests/607)), but the workaround was never removed.

If the workaround is removed upstream, in the future the ibus specific code in desktop_legacy.go can be replace with `include <abstractions/ibus>`.

[^1]: https://gitlab.com/apparmor/apparmor/-/blob/ac06a3fe283374280fde227eb17a4002fcdf1c8c/profiles/apparmor.d/abstractions/ibus