### PR TITLE
tests/lib: add libaa-query-peek library

### DIFF
--- a/tests/lib/libaa-query-peek/Makefile
+++ b/tests/lib/libaa-query-peek/Makefile
@@ -1,0 +1,24 @@
+prefix ?= /usr/local
+libdir ?= $(prefix)/lib
+DESTDIR ?=
+CFLAGS = -Wall -Werror
+CPPFLAGS ?=
+
+INSTALL ?= install
+RM ?= rm
+
+n = libaa-query-peek.so
+
+.PHONY: all clean install uninstall
+all: $(n)
+clean:
+	$(RM) $(n)
+install: $(DESTDIR)$(libdir)/$(n)
+uninstall:
+	$(RM) $(DESTDIR)$(libdir)/$(n)
+$(DESTDIR)$(libdir)/$(n): $(n)
+	$(INSTALL) -m 755 $< $@
+$(n): CFLAGS += -fPIC -shared
+$(n): LDLIBS += -ldl
+$(n): query.c
+	$(CC) $(OUTPUT_OPTION) $(CFLAGS) $(CPPFLAGS) $^ $(LDLIBS)

--- a/tests/lib/libaa-query-peek/README.md
+++ b/tests/lib/libaa-query-peek/README.md
@@ -1,0 +1,38 @@
+# libapparmor user-space query peeker
+
+This library can be injected into a process to observe queries from user-space
+to the kernel.
+
+## DBus (system session)
+
+It's the same as the user session override below, but you _have to_ reboot the
+system, as dbus.service cannot be restarted.
+
+## DBus (user session)
+
+Create an override file at
+`~/.config/systemd/user/dbus.service.d/override.conf` with the following
+content:
+
+```
+[Service]
+Environment=LD_PRELOAD=/path/to/libaa-query-peek.so
+```
+
+Reload systemd with:
+
+```sh
+systemctl --user daemon-reload
+```
+
+## Logs
+
+The preload library writes messages to standard error. Bytes <= 32 are escaped
+as `\xFF`.
+
+A typical D-Bus query looks like this:
+```
+aa_query_label mask:0x2, query:label\x00snap.mattermost-desktop.mattermost-desktop\x00\x20session\x00org.freedesktop.DBus\x00unconfined\x00/org/freedesktop/DBus\x00org.freedesktop.DBus\x00NameHasOwner, size:145, -> 0, allowed:0x1, audited:0
+```
+
+The `\x20` escape code stands for `AA_CLASS_DBUS`.

--- a/tests/lib/libaa-query-peek/query.c
+++ b/tests/lib/libaa-query-peek/query.c
@@ -1,0 +1,62 @@
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/apparmor.h>
+
+static void *libaa_handle = NULL;
+static int (*real_aa_query_label)(uint32_t mask, char *query, size_t size, int *allowed, int *audited);
+
+__attribute__((constructor)) static void init() {
+    libaa_handle = dlopen("libapparmor.so.1", RTLD_LAZY);
+    if (!libaa_handle) {
+        fprintf(stderr, "cannot open libapparmor.so.1: %s\n", dlerror());
+        exit(EXIT_FAILURE);
+    }
+
+    (void)dlerror(); /* Clear any existing error */
+
+    real_aa_query_label = (int (*)(uint32_t, char *, size_t, int *, int *))dlsym(libaa_handle, "aa_query_label");
+
+    if (real_aa_query_label == NULL) {
+        fprintf(stderr, "cannot lookup symbol for aa_query_label: %s\n", dlerror());
+        exit(EXIT_FAILURE);
+    }
+}
+
+__attribute__((destructor)) static void fini() {
+    if (libaa_handle) {
+        dlclose(libaa_handle);
+    }
+}
+
+int aa_query_label(uint32_t mask, char *query, size_t size, int *allowed, int *audited) {
+    int rc = real_aa_query_label(mask, query, size, allowed, audited);
+    char *query_buf = NULL;
+    size_t query_buf_size = 0;
+    FILE *f = open_memstream(&query_buf, &query_buf_size);
+    if (!f) {
+        fprintf(stderr, "cannot open memstream\n");
+        exit(EXIT_FAILURE);
+    }
+    for (size_t i = 0; i < size; ++i) {
+        int c = query[i];
+        /* Escape control characters and space (32). The last of the mediation
+         * classes, AA_CLASS_DBUS, has the value 32 and is otherwise confusing to
+         * in logs as it comes up just before the string identifying the type of
+         * bus (session or system) being used. */
+        if (c <= 32)
+            fprintf(f, "\\x%02x", c);
+        else
+            fputc(c, f);
+    }
+    fflush(f);
+    fprintf(stderr,
+            "aa_query_label mask:%#x, query:%*s, size:%zd, -> %d, allowed:%#x, "
+            "audited:%#x\n",
+            mask, (int)query_buf_size, query_buf, size, rc, allowed ? *allowed : 0, audited ? *audited : 0);
+    fclose(f);
+    free(query_buf);
+    return rc;
+}


### PR DESCRIPTION
This library can be preloaded into a process to observe how user-space performs profile queries with the help of the /sys/kernel/security/apparmor/.access file.

At present nothing uses this library. I used it as a development aid. In the future I think it could be pre-loaded into dbus.service upon request, by running spread with an environment variable.
