### PR TITLE
core-initrd: use cloudimg-rootfs mode only for classic Azure CVM kernels

### DIFF
--- a/core-initrd/26.04/postinst.d/ubuntu-core-initramfs
+++ b/core-initrd/26.04/postinst.d/ubuntu-core-initramfs
@@ -22,7 +22,7 @@ ubuntu-core-initramfs create-initrd --kernelver "$version"
 case $(dpkg --print-architecture) in
     amd64|arm64)
 	case $version in
-	    *-azure | *-azure-fde)
+	    *-azure-fde)
 		# Currently nullboot doesn't seal cmdline, thus it must be baked in for azure
 		ubuntu-core-initramfs create-efi --unsigned --kernelver "$version" --cmdline "snapd_recovery_mode=cloudimg-rootfs console=tty1 console=ttyS0 earlyprintk=ttyS0 panic=60"
 		;;


### PR DESCRIPTION
The previous selection logic was incorrectly setting snapd_recovery_mode to "cloudimg-rootfs" even for kernels built for Ubuntu Core. That caused Ubuntu Core to fail to boot in Azure as "snap-bootstrap" booted in "cvm" mode which requires a partition with the "cloudimg-rootfs" label to be present.

All Azure kernels will be officially named "azure-fde" from now on and existing kernels that don't follow this naming convention are being transitioned too, so "*-azure" should not be needed anymore. @john-cabaj helped with testing the change with the classic 6.8 and 6.14 CVM kernels, which showed no regression.