### PR TITLE
tests/nested/manual/uc-update-assets-secure-add-sbat: remove work-around

### DIFF
--- a/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
@@ -57,13 +57,9 @@ prepare: |
   snap download --basename=pc --channel="${CHANNEL}" pc
   unsquashfs -d pc pc.snap
 
-  # FIXME: find out why the key from test-snapd-ovmf is not accepted
-  # by secboot. It has /O=Snake Oil/ but still it fails.
-  SNAKEOIL_KEY="${PROJECT_PATH}/core-initrd/latest/snakeoil/PkKek-1-snakeoil.key"
-  SNAKEOIL_CERT="${PROJECT_PATH}/core-initrd/latest/snakeoil/PkKek-1-snakeoil.pem"
-  #KEY_NAME=$(tests.nested download snakeoil-key)
-  #SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
-  #SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
   # Remove signatures on grub
   tests.nested secboot-remove-signature pc/grubx64.efi


### PR DESCRIPTION
There was a work-around for secboot not accepting other keys than a fix snakeoil. But now it is broken because of the path of snakeoil key was moved. So we can try to remove it.