### PR TITLE
Support for custom snap delta algorithm

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -616,3 +616,31 @@ parts:
       - liblzo2-dev
       - libzstd-dev
       - zlib1g-dev
+
+  hdiff:
+    plugin: dump
+    source: https://api.github.com/repos/sisong/HDiffPatch/releases/latest
+    source-type: zip
+    override-pull: |
+      release="248607914" # v4.12.0
+      if [ "armhf" = "${CRAFT_ARCH_BUILD_FOR}" ]; then
+        linux_flavour="linux_arm32"
+      elif [ "arm64" = "${CRAFT_ARCH_BUILD_FOR}" ]; then
+        linux_flavour="linux_arm64"
+      elif [ "amd64" = "${CRAFT_ARCH_BUILD_FOR}" ]; then
+        linux_flavour="linux64"
+      elif [ "riscv64" = "${CRAFT_ARCH_BUILD_FOR}" ]; then
+        linux_flavour="linux_riscv64"
+      fi
+      if [ -n "${linux_flavour}" ]; then
+        url=$(curl -sL "https://api.github.com/repos/sisong/HDiffPatch/releases/"${release}"" | jq -r '.assets[].browser_download_url' | grep "${linux_flavour}")
+        wget --quiet -O "${CRAFT_PART_SRC}/hdiffpatch_linux.zip" "${url}"
+        unzip -j "${CRAFT_PART_SRC}/hdiffpatch_linux.zip"
+        chmod 755 *
+      fi
+    organize:
+      '*': usr/bin/
+    stage:
+      - usr/bin/hpatchz
+    build-packages:
+      - jq

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -604,12 +604,12 @@ parts:
     plugin: make
     source: https://github.com/plougher/squashfs-tools.git
     source-type: git
-    source-subdir: squashfs-tools
     source-commit: bad1d213ab6df587d6fa0ef7286180fbf7b86167 # 4.7.4
-    make-parameters:
-      - INSTALL_PREFIX=${CRAFT_PART_INSTALL}/usr
-    stage:
-      - usr/bin
+    override-build: |
+      cd squashfs-tools
+      make -j${CRAFT_PARALLEL_BUILD_COUNT}
+      install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/bin" "${CRAFT_PART_BUILD}/squashfs-tools/mksquashfs"
+      install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/bin" "${CRAFT_PART_BUILD}/squashfs-tools/unsquashfs"
     build-packages:
       - liblz4-dev
       - liblzma-dev
@@ -636,11 +636,7 @@ parts:
         url=$(curl -sL "https://api.github.com/repos/sisong/HDiffPatch/releases/"${release}"" | jq -r '.assets[].browser_download_url' | grep "${linux_flavour}")
         wget --quiet -O "${CRAFT_PART_SRC}/hdiffpatch_linux.zip" "${url}"
         unzip -j "${CRAFT_PART_SRC}/hdiffpatch_linux.zip"
-        chmod 755 *
+        install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/bin" hpatchz
       fi
-    organize:
-      '*': usr/bin/
-    stage:
-      - usr/bin/hpatchz
     build-packages:
       - jq

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -618,7 +618,7 @@ parts:
       - zlib1g-dev
 
   hdiff:
-    plugin: dump
+    plugin: nil
     source: https://api.github.com/repos/sisong/HDiffPatch/releases/latest
     source-type: zip
     override-pull: |

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -605,15 +605,9 @@ parts:
     source: https://github.com/plougher/squashfs-tools.git
     source-type: git
     source-subdir: squashfs-tools
+    source-commit: bad1d213ab6df587d6fa0ef7286180fbf7b86167 # 4.7.4
     make-parameters:
       - INSTALL_PREFIX=${CRAFT_PART_INSTALL}/usr
-    override-pull: |
-      # pull the latest tag
-      craftctl default
-      git_url="https://github.com/plougher/squashfs-tools.git"
-      tag=$(git ls-remote --tags --refs  --sort='version:refname' "${git_url}" "refs/tags/4.*" | tail -1 | awk '{print $2}' | cut -c 11-)
-      echo "building tag: ${tag}"
-      git checkout "${tag}"
     stage:
       - usr/bin
     build-packages:

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -110,7 +110,6 @@ parts:
       - libseccomp2
       - libudev1
       - libzstd1
-      - squashfs-tools
       - xdelta3
       - zlib1g
       - on armhf:
@@ -600,3 +599,26 @@ parts:
       craftctl default
       "${CRAFT_PROJECT_DIR}/build-aux/snap/local/verify-dl.py" \
           "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"
+
+  squashfs-tools:
+    plugin: make
+    source: https://github.com/plougher/squashfs-tools.git
+    source-type: git
+    source-subdir: squashfs-tools
+    make-parameters:
+      - INSTALL_PREFIX=${CRAFT_PART_INSTALL}/usr
+    override-pull: |
+      # pull the latest tag
+      craftctl default
+      git_url="https://github.com/plougher/squashfs-tools.git"
+      tag=$(git ls-remote --tags --refs  --sort='version:refname' "${git_url}" "refs/tags/4.*" | tail -1 | awk '{print $2}' | cut -c 11-)
+      echo "building tag: ${tag}"
+      git checkout "${tag}"
+    stage:
+      - usr/bin
+    build-packages:
+      - liblz4-dev
+      - liblzma-dev
+      - liblzo2-dev
+      - libzstd-dev
+      - zlib1g-dev

--- a/cmd/snap/cmd_delta.go
+++ b/cmd/snap/cmd_delta.go
@@ -37,9 +37,14 @@ Operations:
   generate : generate delta between source and target
   apply    : apply delta on the source
 
+  delta tool, for generate operation one of the following tools has to be spefified
+	--hdiff:   use hdiffz(hpatchz) as delta tool to generate and apply delta on squashfs pseudo file definition
+	           As this delta tool does not support streaming, pseudo file definition is processed per file within the stream.
+	--xdelta3: use xdelta3 as delta tool to generate and apply delta on squashfs pseudo file definition
+
 Examples:
-  $ snap delta generate --source <source snap file>  --target <output file> --delta <delta file>
-  $ snap delta apply    --source <source snap file>  --target <output file> --delta <delta file>
+  $ snap delta generate --hdiffz --source <SNAP>  --target <SNAP> --delta <DELTA>
+  $ snap delta apply             --source <SNAP>  --target <SNAP> --delta <DELTA>
 `)
 
 type cmdDelta struct {
@@ -48,9 +53,11 @@ type cmdDelta struct {
 		Operation string `positional-args:"yes" choices:"apply|generate"`
 	} `positional-args:"yes" required:"yes"`
 
-	Source string `long:"source" short:"s" required:"yes"`
-	Target string `long:"target" short:"t" required:"yes"`
-	Delta  string `long:"delta" short:"d" required:"yes"`
+	Source      string `long:"source" short:"s" required:"yes"`
+	Target      string `long:"target" short:"t" required:"yes"`
+	Delta       string `long:"delta" short:"d" required:"yes"`
+	Xdelta3Tool bool   `long:"xdelta3" short:"x"`
+	HdiffzTool  bool   `long:"hdiffz" short:"h"`
 }
 
 func init() {
@@ -62,6 +69,10 @@ func init() {
 			"target": i18n.G("Target snap package"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"delta": i18n.G("Delta between source and target snap package"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"xdelta3": i18n.G("Use xdelta3 tool for delta"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"hdiffz": i18n.G("Use hdiffz tool for delta generation"),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to begin with < and end with >
@@ -73,15 +84,26 @@ func init() {
 }
 
 func (x *cmdDelta) Execute(args []string) error {
-	algo, _, _, _, err := squashfs.CheckSupportedDetlaFormats(nil)
+	algo, _, _, _, _, _, err := squashfs.CheckSupportedDeltaFormats(nil)
 	if err != nil {
 		return fmt.Errorf(i18n.G("snap delta not supported: %v"), err)
 	}
 	fmt.Fprintf(Stdout, i18n.G("Using snap delta algorithm '%s'\n"), strings.Split(algo, ";")[0])
 	if "generate" == x.Positional.Operation {
+		var deltaTool uint16
+		if x.HdiffzTool {
+			deltaTool = squashfs.DeltaToolHdiffz
+		} else if x.Xdelta3Tool {
+			deltaTool = squashfs.DeltaToolXdelta3
+		} else {
+			return fmt.Errorf(i18n.G("missing delta tool setting for generate operation"))
+		}
 		fmt.Fprintf(Stdout, i18n.G("Generating delta...\n"))
-		return squashfs.GenerateSnapDelta(x.Source, x.Target, x.Delta)
+		return squashfs.GenerateSnapDelta(x.Source, x.Target, x.Delta, deltaTool)
 	} else if "apply" == x.Positional.Operation {
+		if x.Xdelta3Tool || x.HdiffzTool {
+			return fmt.Errorf(i18n.G("cannot define delta tool (xdelta3/hdiffz) for apply operation"))
+		}
 		fmt.Fprintf(Stdout, i18n.G("Applying delta...\n"))
 		return squashfs.ApplySnapDelta(x.Source, x.Delta, x.Target)
 	}

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -40,6 +40,18 @@ const (
 func (s stat) User() string  { return s.user }
 func (s stat) Group() string { return s.group }
 
+func ParseCompression(id uint16, mksqfsArgs []string) ([]string, error) {
+	return parseCompression(id, mksqfsArgs)
+}
+
+func ParseSuperblockFlags(flags uint16, mksqfsArgs []string) ([]string, error) {
+	return parseSuperblockFlags(flags, mksqfsArgs)
+}
+
+func SetupPipes(pipeNames ...string) (string, []string, error) {
+	return setupPipes(pipeNames...)
+}
+
 func MockLink(newLink func(string, string) error) (restore func()) {
 	oldLink := osLink
 	osLink = newLink

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -1717,7 +1717,7 @@ func setupPipes(pipeNames ...string) (string, []string, error) {
 }
 
 // Check if all the required tools are actually present
-// returns ready to use commands for xdelta3, bsdiff, mksquashfs and unsquashfs
+// returns ready to use commands for xdelta3, mksquashfs and unsquashfs, hdiffz, hpatchz
 func CheckSupportedDetlaFormats(ctx context.Context) (string, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, error) {
 	// check if we have required tools available
 	xdeltaCmd, err := checkForTooling(ctx, xdelta3, "xdelta3", "config")

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -22,6 +22,8 @@ package squashfs
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -29,7 +31,9 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -660,4 +664,575 @@ func BuildDate(path string) time.Time {
 	}
 	t0, _ = time.Parse(time.ANSIC, matches[0][len(prefix):])
 	return t0
+}
+
+// snap delta support
+// Custom Delta header (padded to 'deltaHeaderSize' size)
+// generated delta is using following custom header to capture the delta content
+// |       32b    |   16b   |    32b     |     16b     |        16b        |
+// | magic number | version | time stamp | compression | super block flags |
+// reference squashfs supperblock https://dr-emann.github.io/squashfs
+// Optional compressor options are currently not supported, if target squashfs is detected to
+// use those, we fallback to plain xdelta
+// Delta between two snaps(squashfs) is generated on the squashfs pseudo file definition
+// this represents uncompressed content of the squashfs packages, custom header data is
+// later used as input parameters to mksquashfs when recreated target squashfs from the
+// reconstructed pseudo file definition
+
+const (
+	deltaHeaderSize           = 32 // bytes
+	deltaFormatVersion uint16 = 0x101
+	deltaMagicNumber   uint32 = 0xF989789C
+	xdelta3MagicNumber uint32 = 0x00c4c3d6
+	snapDeltaFormat           = "snapDeltaV1"
+	xdelta3Format             = "xdelta3"
+)
+
+var (
+	// default compression level assumed 3
+	// plain squashfs to squashfs delta size has no measurable gain between  3 and 9 comp level
+	xdelta3PlainTuning = []string{"-3"}
+	// gain in delta pseudo file between 3 and 7 comp level is 10 to 20% size reduction
+	// delta size gain flattens at 7
+	// no noticeable gain from changing source window size(-B) or bytes input window(-W)
+	// or size compression duplicates window (-P)
+	xdelta3Tuning = []string{"-7"}
+)
+
+// SquashFS Superblock Flags
+const (
+	flagCheck             uint16 = 0x0004
+	flagNoFragments       uint16 = 0x0010
+	flagNoDuplicates      uint16 = 0x0040 // Note: logic is inverted (default is duplicates)
+	flagExports           uint16 = 0x0080
+	flagNoXattrs          uint16 = 0x0200
+	flagCompressorOptions uint16 = 0x0400
+)
+
+// Supported version of the snap delta algorythms
+func SupportedDeltaFormats() string {
+	return snapDeltaFormat + ";" + xdelta3Format
+}
+
+type SquashfsCommand func(args ...string) *exec.Cmd
+
+// Check if all the required tools are actually present
+// returns ready to use commands for xdelta3, mksquashfs and unsquashfs
+func CheckSupportedDetlaFormats(ctx context.Context) (string, SquashfsCommand, SquashfsCommand, SquashfsCommand, error) {
+	// check if we have required tools available
+	xdeltaCmd, err := checkForTooling(ctx, "/usr/bin/xdelta3", "xdelta3", "config")
+	if err != nil {
+		return "", nil, nil, nil, fmt.Errorf("missing snapd delta dependencies: %v", err)
+	}
+	// from here we can support plain xdelta3
+	mksquashfsCmd, err := checkForTooling(ctx, "/usr/bin/mksquashfs", "mksquashfs", "-version")
+	if err != nil {
+		return xdelta3Format, xdeltaCmd, nil, nil, fmt.Errorf("missing snapd delta dependencies: %v", err)
+	}
+	// use -help since '-version' does not return 0 error code
+	unsquashfsCmd, err := checkForTooling(ctx, "/usr/bin/unsquashfs", "unsquashfs", "-help")
+	if err != nil {
+		return xdelta3Format, xdeltaCmd, nil, nil, fmt.Errorf("missing snapd delta dependencies: %v", err)
+	}
+	return snapDeltaFormat + ";" + xdelta3Format, xdeltaCmd, mksquashfsCmd, unsquashfsCmd, nil
+}
+
+// helper to check for the presence of the required tools
+func checkForTooling(ctx context.Context, toolPath, tool, option string) (SquashfsCommand, error) {
+	// // check if the 'tool' 'option' command works from the system snap
+	cmd, err := snapdtool.CommandFromSystemSnapWithCtx(ctx, toolPath)
+	if err == nil {
+		// we have tool in the system snap, use it
+		exe := cmd.Path
+		args := cmd.Args[:len(cmd.Args)-1]
+		env := cmd.Env
+		dir := cmd.Dir
+		return func(toolArgs ...string) *exec.Cmd {
+			return &exec.Cmd{
+				Path: exe,
+				Args: append(args, toolArgs...),
+				Env:  env,
+				Dir:  dir,
+			}
+		}, nil
+	}
+
+	// we didn't have one from a system snap or it didn't work, fallback to
+	// trying 'tool' from the system
+	loc, err := exec.LookPath(tool)
+	if err != nil {
+		// no 'tool' in the env, so no deltas
+		return nil, fmt.Errorf("no host system %s available", tool)
+	}
+
+	if err := exec.Command(loc, option).Run(); err != nil {
+		// xdelta3 in the env failed to run, so no deltas
+		return nil, fmt.Errorf("unable to use host system %s, running '%s' command failed: %v", tool, option, err)
+	}
+	// TODO: check minimal required version
+	// the 'tool' in the env worked, so use that one
+	if ctx == nil {
+		return func(toolArgs ...string) *exec.Cmd {
+			return exec.Command(loc, toolArgs...)
+		}, nil
+	} else {
+		return func(toolArgs ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, loc, toolArgs...)
+		}, nil
+	}
+}
+
+// parseCompression converts SquashFS compression ID to a name.
+func parseCompression(id uint16, mksqfsArgs []string) ([]string, error) {
+	switch id {
+	case 1:
+		return append(mksqfsArgs, "-comp", "gzip"), nil
+	case 2:
+		return append(mksqfsArgs, "-comp", "lzma"), nil
+	case 3:
+		return append(mksqfsArgs, "-comp", "lzo"), nil
+	case 4:
+		return append(mksqfsArgs, "-comp", "xz"), nil
+	case 5:
+		return append(mksqfsArgs, "-comp", "lz4"), nil
+	case 6:
+		return append(mksqfsArgs, "-comp", "zstd"), nil
+	default:
+		return nil, fmt.Errorf("unknown compression id: %d", id)
+	}
+}
+
+// parseSuperblockFlags converts SquashFS flags to mksquashfs arguments.
+func parseSuperblockFlags(flags uint16, mksqfsArgs []string) ([]string, error) {
+	if (flags & flagCheck) != 0 {
+		return nil, fmt.Errorf("this does not look like Squashfs 4+ superblock flags")
+	}
+	if (flags & flagNoFragments) != 0 {
+		mksqfsArgs = append(mksqfsArgs, "-no-fragments")
+	}
+	// Note: The flag is "NO_DUPLICATES", so if it's *not* set, we... wait.
+	// The bash script logic is: if 0x0040 is *not* set, add -no-duplicates.
+	if (flags & flagNoDuplicates) == 0 {
+		mksqfsArgs = append(mksqfsArgs, "-no-duplicates")
+	}
+	if (flags & flagExports) != 0 {
+		mksqfsArgs = append(mksqfsArgs, "-exports")
+	}
+	if (flags & flagNoXattrs) != 0 {
+		mksqfsArgs = append(mksqfsArgs, "-no-xattrs")
+	}
+	if (flags & flagCompressorOptions) != 0 {
+		logger.Noticef("warning: Custom compression options detected, created target snap is likely be different from target snap!")
+	}
+
+	return mksqfsArgs, nil
+}
+
+// setupPipes creates a temporary directory and named pipes within it.
+func setupPipes(pipeNames ...string) (string, []string, error) {
+	tempDir, err := os.MkdirTemp("", "snap-delta-")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	var pipePaths []string
+	for _, name := range pipeNames {
+		pipePath := filepath.Join(tempDir, name)
+		if err := syscall.Mkfifo(pipePath, 0600); err != nil {
+			os.RemoveAll(tempDir) // cleanup
+			return "", nil, fmt.Errorf("failed to create fifo %s: %w", pipePath, err)
+		}
+		pipePaths = append(pipePaths, pipePath)
+	}
+
+	return tempDir, pipePaths, nil
+}
+
+func generatePlainXdelta3Delta(sourceSnap, targetSnap, delta string) error {
+	xdelta3Cmd, err := checkForTooling(nil, "/usr/bin/xdelta3", "xdelta3", "config")
+	if err != nil {
+		return fmt.Errorf("missing xdelta3 tooling: %v", err)
+	}
+	xdelta3Args := append(xdelta3PlainTuning, "-f", "-e", "-s", sourceSnap, targetSnap, delta)
+	cmd := xdelta3Cmd(xdelta3Args...)
+	return cmd.Run()
+}
+
+func applyPlainXdelta3Delta(sourceSnap, delta, targetSnap string) error {
+	xdelta3Cmd, err := checkForTooling(nil, "/usr/bin/xdelta3", "xdelta3", "config")
+	if err != nil {
+		return fmt.Errorf("missing xdelta3 tooling: %v", err)
+	}
+	xdelta3Args := []string{
+		"-f", "-d", "-s", sourceSnap, delta, targetSnap,
+	}
+	cmd := xdelta3Cmd(xdelta3Args...)
+	return cmd.Run()
+}
+
+// generate delta file.
+func GenerateSnapDelta(sourceSnap, targetSnap, delta string) error {
+	// Open target snap to read superblock
+	targetFile, err := os.Open(targetSnap)
+	if err != nil {
+		return fmt.Errorf("failed to open target file %s: %w", targetSnap, err)
+	}
+	defer targetFile.Close()
+
+	// Read superblock flags and check for custom compression options (flag flagCompressorOptions)
+	flagsBuf := make([]byte, 2)
+	if _, err := targetFile.ReadAt(flagsBuf, 24); err != nil {
+		return fmt.Errorf("failed to read flags from target: %w", err)
+	}
+	targetFlags := binary.LittleEndian.Uint16(flagsBuf)
+
+	if (targetFlags & flagCompressorOptions) != 0 {
+		logger.Noticef("warning: Custom compression options detected, falling back to plain xdelta3")
+		return generatePlainXdelta3Delta(sourceSnap, targetSnap, delta)
+	}
+
+	// --- Write Custom Header ---
+	headerBuf := new(bytes.Buffer)
+
+	// Magic number (32b)
+	if err := binary.Write(headerBuf, binary.LittleEndian, uint32(deltaMagicNumber)); err != nil {
+		return fmt.Errorf("failed to write snap-delta magic: %w", err)
+	}
+
+	// Version (16b)
+	if err := binary.Write(headerBuf, binary.LittleEndian, uint16(deltaFormatVersion)); err != nil {
+		return fmt.Errorf("failed to write snap-delta version: %w", err)
+	}
+
+	// Read/Write Timestamp (32b at offset 8)
+	tsBuf := make([]byte, 4)
+	if _, err := targetFile.ReadAt(tsBuf, 8); err != nil {
+		return fmt.Errorf("failed to read target snap timestamp: %w", err)
+	}
+	headerBuf.Write(tsBuf)
+
+	// Read/Write Compression (16b at offset 20)
+	compBuf := make([]byte, 2)
+	if _, err := targetFile.ReadAt(compBuf, 20); err != nil {
+		return fmt.Errorf("failed to read target snap compression: %w", err)
+	}
+	headerBuf.Write(compBuf)
+
+	// Super block flags (16b) - read from target (16b at offset 24)
+	headerBuf.Write(flagsBuf) // We already read this
+
+	// Padding to deltaHeaderSize
+	padding := make([]byte, deltaHeaderSize-headerBuf.Len())
+	headerBuf.Write(padding)
+
+	// --- End Header ---
+
+	// Create delta file and write header there
+	deltaFile, err := os.OpenFile(delta, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create delta file %s: %w", delta, err)
+	}
+	defer deltaFile.Close()
+	if _, err := deltaFile.Write(headerBuf.Bytes()); err != nil {
+		return fmt.Errorf("failed to write header to delta file: %w", err)
+	}
+
+	// 1. Setup pipes
+	tempDir, pipePaths, err := setupPipes("source-pipe", "target-pipe")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+	sourcePipe := pipePaths[0]
+	targetPipe := pipePaths[1]
+
+	// Run all as concurrent processes
+	var wg sync.WaitGroup
+	errChan := make(chan error, 3)
+
+	// cancellable context for all tasks
+	ctx, cancel := context.WithCancel(context.Background())
+	// Defer cancel to clean up, though fail() will usually call it first
+	defer cancel()
+
+	// prepare tooling, make sure we have enough for snapDeltaV1 format
+	supportedFormats, xdelta3Cmd, _, unsquashfsCmd, err := CheckSupportedDetlaFormats(ctx)
+	if err != nil || !strings.Contains(supportedFormats, snapDeltaFormat) {
+		return fmt.Errorf("failed to validate required tooling for snap-delta: %v", err)
+	}
+
+	// unsquashfs source -> source-pipe
+	unsquashfsSourceArgs := []string{
+		"-n", "-pf", sourcePipe, sourceSnap,
+	}
+	unsquashSourceCmd := unsquashfsCmd(unsquashfsSourceArgs...)
+
+	// unsquashfs target -> target-pipe
+	unsquashfsTargetArgs := []string{
+		"-n", "-pf", targetPipe, targetSnap,
+	}
+	unsquashfsTargetCmd := unsquashfsCmd(unsquashfsTargetArgs...)
+
+	// xdelta3 source-pipe, target-pipe -> delta-file (append)
+	xdelta3Args := append(xdelta3Tuning, "-e", "-f", "-A", "-s", sourcePipe, targetPipe)
+	xdeltaCmd := xdelta3Cmd(xdelta3Args...)
+	xdeltaCmd.Stdout = deltaFile // Append to the already open delta file
+
+	// handle fail of any task
+	var failOnce sync.Once
+	fail := func(err error) {
+		failOnce.Do(func() {
+			cancel() // <-- This signals all other tasks to stop
+			errChan <- err
+		})
+	}
+
+	// run unsquashfs source
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, unsquashSourceCmd); err != nil {
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("unsquashfs (source) failed: %w", err))
+			}
+		}
+	}()
+
+	// run unsquashfs target
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, unsquashfsTargetCmd); err != nil {
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("unsquashfs (target) failed: %w", err))
+			}
+		}
+	}()
+
+	// run xdelta3 source-pipe, target-pipe -> delta-file, appending
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, xdeltaCmd); err != nil {
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("xdelta3 failed: %w", err))
+			}
+		}
+	}()
+
+	// Wait for all processes and collect errors
+	wg.Wait()
+	close(errChan)
+
+	var allErrors []string
+	for err := range errChan {
+		allErrors = append(allErrors, err.Error())
+	}
+
+	if len(allErrors) > 0 {
+		return fmt.Errorf("delta generation failed:%s", strings.Join(allErrors, "\n"))
+	}
+	return nil
+}
+
+// handleApplyDelta applies the smart delta file.
+func ApplySnapDelta(sourceSnap, delta, targetSnap string) error {
+	// Open delta file to read header
+	deltaFile, err := os.Open(delta)
+	if err != nil {
+		return fmt.Errorf("failed to open delta file %s: %w", delta, err)
+	}
+	defer deltaFile.Close()
+
+	// --- Read Custom Header ---
+	header := make([]byte, deltaHeaderSize)
+	n, err := io.ReadFull(deltaFile, header)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return fmt.Errorf("failed to read delta header: %w", err)
+	}
+	if n < 14 { // Size of magic + version + time + comp + flags
+		return fmt.Errorf("delta file is too small to be valid")
+	}
+
+	headerReader := bytes.NewReader(header)
+	var magicNumber uint32
+	binary.Read(headerReader, binary.LittleEndian, &magicNumber)
+
+	// Check for plain xdelta3
+	if magicNumber == xdelta3MagicNumber {
+		logger.Noticef("This is a plain xdelta3 diff, falling back to plain xdelta3!!")
+		return applyPlainXdelta3Delta(sourceSnap, delta, targetSnap)
+	}
+
+	if magicNumber != deltaMagicNumber {
+		return fmt.Errorf("wrong magic number! (Expected 0x%X, Got 0x%X)", deltaMagicNumber, magicNumber)
+	}
+
+	var versionNumber uint16
+	binary.Read(headerReader, binary.LittleEndian, &versionNumber)
+	if versionNumber != deltaFormatVersion {
+		return fmt.Errorf("mismatch delta version number! (Expected 0x%X, Got 0x%X)", deltaFormatVersion, versionNumber)
+	}
+
+	var fstimeint uint32
+	var targetCompressionID uint16
+	var targetFlags uint16
+	binary.Read(headerReader, binary.LittleEndian, &fstimeint)
+	binary.Read(headerReader, binary.LittleEndian, &targetCompressionID)
+	binary.Read(headerReader, binary.LittleEndian, &targetFlags)
+
+	var mksqfsArgs []string
+	mksqfsArgs, err = parseCompression(targetCompressionID, mksqfsArgs)
+	if err != nil {
+		return fmt.Errorf("failed to parse target compression from snap-delta: %v", err)
+	}
+
+	mksqfsArgs, err = parseSuperblockFlags(targetFlags, mksqfsArgs)
+	if err != nil {
+		return fmt.Errorf("failed to parse target supper block flags from snap-delta:%v", err)
+	}
+
+	// prepare pipes
+	tempDir, pipePaths, err := setupPipes("source-pipe", "delta-pipe")
+	if err != nil {
+		return fmt.Errorf("failed to prepare pipes for snap delta: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	sourceSnapPipe := pipePaths[0]
+	deltaPipe := pipePaths[1]
+
+	// Run concurrent processes
+	var wg sync.WaitGroup
+	errChan := make(chan error, 4) // unsq, dd, xdelta, mksqfs
+	// cancellable context for all tasks
+	ctx, cancel := context.WithCancel(context.Background())
+	// Defer cancel to clean up, though fail() will usually call it first
+	defer cancel()
+
+	// prepare tooling, make sure we have enough for snapDeltaV1 format
+	supportedFormats, xdelta3Cmd, mksquashfsCmd, unsquashfsCmd, err := CheckSupportedDetlaFormats(ctx)
+	if err != nil || !strings.Contains(supportedFormats, snapDeltaFormat) {
+		return fmt.Errorf("failed to validate required tooling for snap-delta: %v", err)
+	}
+
+	// Setup command chains
+	// xdelta3 between two pipes (source and delta pipes)
+	xdelta3Args := []string{
+		"-f", "-d", "-s", sourceSnapPipe, deltaPipe,
+	}
+	xdeltaCmd := xdelta3Cmd(xdelta3Args...)
+
+	// mksquashfs from xdelta3 stream to target snap with correct extra arguments
+	mksqfsFullArgs := []string{
+		"-", // Source from stdin
+		targetSnap,
+		"-pf", "-", // Read patch file list from stdin
+		"-no-progress",
+		"-quiet",
+		"-noappend",
+		"-mkfs-time", strconv.FormatUint(uint64(fstimeint), 10),
+	}
+	mksqfsFullArgs = append(mksqfsFullArgs, mksqfsArgs...)
+	mksqfsCmd := mksquashfsCmd(mksqfsFullArgs...)
+
+	// Connect xdelta3 stdout to mksquashfs stdin
+	mksqfsCmd.Stdin, err = xdeltaCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create pipe between xdelta3 and mksquashfs: %w", err)
+	}
+
+	// unsquash source snap into source pipe
+	unsquashfsArgs := []string{
+		"-n", "-pf", sourceSnapPipe, sourceSnap,
+	}
+	unsquashSourceCmd := unsquashfsCmd(unsquashfsArgs...)
+
+	// handle fail of any task
+	var failOnce sync.Once
+	fail := func(err error) {
+		failOnce.Do(func() {
+			cancel() // <-- This signals all other tasks to stop
+			errChan <- err
+		})
+	}
+
+	// Start target consumers
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, mksqfsCmd); err != nil {
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("mksquashfs (target) failed: %w", err))
+			}
+		}
+	}()
+
+	// start delta consumers: xdelta3
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, xdeltaCmd); err != nil {
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("xdelta3 failed: %w", err))
+			}
+		}
+	}()
+
+	// Start source producers: unsquashfs source -> source-pipe
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := osutil.RunWithContext(ctx, unsquashSourceCmd); err != nil {
+			fail(fmt.Errorf("unsquashfs (source) failed: %w:", err))
+		}
+	}()
+
+	// dd (Go copy) delta-body -> delta-pipe
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pipeF, err := os.OpenFile(deltaPipe, os.O_WRONLY, 0)
+		if err != nil {
+			fail(fmt.Errorf("failed to open delta pipe for writing: %w", err))
+			return
+		}
+		defer pipeF.Close()
+
+		// Make io.Copy cancellable by closing its pipe.
+		go func() {
+			<-ctx.Done()  // Wait for cancellation
+			pipeF.Close() // This will force io.Copy to unblock with an error
+		}()
+
+		// Seek delta file to start of body
+		if _, err := deltaFile.Seek(deltaHeaderSize, io.SeekStart); err != nil {
+			// Check context, as this could fail if pipeF was closed
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("failed to seek delta file: %w", err))
+			}
+			return
+		}
+
+		if _, err := io.Copy(pipeF, deltaFile); err != nil {
+			// If context is cancelled, io.Copy will fail.
+			// We check if this error was an *expected* cancellation.
+			if ctx.Err() == nil {
+				fail(fmt.Errorf("failed to copy delta body to pipe: %w", err))
+			}
+		}
+	}()
+
+	// Wait for all processes and collect errors
+	wg.Wait()
+	close(errChan)
+
+	var allErrors []string
+	for err := range errChan {
+		allErrors = append(allErrors, err.Error())
+	}
+
+	if len(allErrors) > 0 {
+		return fmt.Errorf("applying snap delta failed: %s", strings.Join(allErrors, "\n"))
+	}
+	return nil
 }

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -901,7 +901,7 @@ func ApplySnapDelta(sourceSnap, delta, targetSnap string) error {
 	if mksqfsArgs, err = parseCompression(hdr.Compression, mksqfsArgs); err != nil {
 		return fmt.Errorf("failed to parse compression from delta header:%v", err)
 	}
-	if mksqfsArgs, err = parseSuperblockFlags(hdr.Flags, mksqfsArgs); err != nil {
+	if mksqfsArgs, err = appendSuperBlockFlagArguments(hdr.Flags, mksqfsArgs); err != nil {
 		return fmt.Errorf("failed to parse flags from delta header:%v", err)
 	}
 	// run delta apply for given deta tool
@@ -2119,8 +2119,8 @@ func parseCompression(id uint16, mksqfsArgs []string) ([]string, error) {
 	return nil, fmt.Errorf("unknown compression: %d", id)
 }
 
-// parseSuperblockFlags converts SquashFS flags to mksquashfs arguments.
-func parseSuperblockFlags(flags uint16, mksqfsArgs []string) ([]string, error) {
+// appendSuperBlockFlagArguments converts SquashFS flags to mksquashfs arguments.
+func appendSuperBlockFlagArguments(flags uint16, mksqfsArgs []string) ([]string, error) {
 	if (flags & flagCheck) != 0 {
 		return nil, fmt.Errorf("this does not look like Squashfs 4+ superblock flags")
 	}

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -687,8 +687,8 @@ func BuildDate(path string) time.Time {
 // --- Constants & Configuration ---
 const (
 	// Tool IDs
-	DetlaToolXdelta3 = uint16(0x1)
-	DetlaToolHdiffz  = uint16(0x2)
+	DeltaToolXdelta3 = uint16(0x1)
+	DeltaToolHdiffz  = uint16(0x2)
 )
 
 const (
@@ -731,7 +731,7 @@ var (
 	// unsquashfs tuning
 	// by default unsquashfs would allocated ~2x256 for any size of squashfs image
 	// We need to tame it down use different tuning for:
-	// - generating detla: running server side -> no tuning, we have memory
+	// - generating delta: running server side -> no tuning, we have memory
 	// - apply delta: possibly low spec systems
 	unsquashfsTuningGenerate = []string{"-da", "128", "-fr", "128"}
 	unsquashfsTuningApply    = []string{"-da", "8", "-fr", "8"}
@@ -855,9 +855,9 @@ func GenerateSnapDelta(sourceSnap, targetSnap, delta string, deltaTool uint16) e
 
 	// run delta producer for given deta tool
 	switch deltaTool {
-	case DetlaToolXdelta3:
+	case DeltaToolXdelta3:
 		return generateXdelta3Delta(ctx, deltaFile, sourceSnap, targetSnap)
-	case DetlaToolHdiffz:
+	case DeltaToolHdiffz:
 		return generateHdiffzDelta(ctx, deltaFile, sourceSnap, targetSnap)
 	default:
 		return fmt.Errorf("unsupported delta tool 0x%X", hdr.DeltaTool)
@@ -893,7 +893,7 @@ func ApplySnapDelta(sourceSnap, delta, targetSnap string) error {
 	if hdr.Version != deltaFormatVersion {
 		return fmt.Errorf("version mismatch %d!=%d", hdr.Version, deltaFormatVersion)
 	}
-	if hdr.DeltaTool != DetlaToolXdelta3 && hdr.DeltaTool != DetlaToolHdiffz {
+	if hdr.DeltaTool != DeltaToolXdelta3 && hdr.DeltaTool != DeltaToolHdiffz {
 		return fmt.Errorf("unsupported delta tool %d", hdr.DeltaTool)
 	}
 
@@ -907,9 +907,9 @@ func ApplySnapDelta(sourceSnap, delta, targetSnap string) error {
 	}
 	// run delta apply for given deta tool
 	switch hdr.DeltaTool {
-	case DetlaToolXdelta3:
+	case DeltaToolXdelta3:
 		return applyXdelta3Delta(ctx, sourceSnap, targetSnap, deltaFile, hdr, mksqfsArgs)
-	case DetlaToolHdiffz:
+	case DeltaToolHdiffz:
 		return applyHdiffzDelta(ctx, sourceSnap, targetSnap, deltaFile, hdr, mksqfsArgs)
 	default:
 		return fmt.Errorf("unsupported delta tool 0x%X", hdr.DeltaTool)
@@ -918,7 +918,7 @@ func ApplySnapDelta(sourceSnap, delta, targetSnap string) error {
 
 func generateXdelta3Delta(ctx context.Context, deltaFile *os.File, sourceSnap, targetSnap string) error {
 	// Ensure we have required tooling
-	supportedFormats, xdelta3ToolCmdFn, _, unsquashfsCmdFn, _, _, err := CheckSupportedDetlaFormats(ctx)
+	supportedFormats, xdelta3ToolCmdFn, _, unsquashfsCmdFn, _, _, err := CheckSupportedDeltaFormats(ctx)
 	if err != nil || !strings.Contains(supportedFormats, snapDeltaFormatXdelta3) {
 		return fmt.Errorf("missing delta tooling for xdelta3: %v", err)
 	}
@@ -1004,7 +1004,7 @@ func generateXdelta3Delta(ctx context.Context, deltaFile *os.File, sourceSnap, t
 
 func applyXdelta3Delta(ctx context.Context, sourceSnap, targetSnap string, deltaFile *os.File, hdr *SnapDeltaHeader, mksqfsArgs []string) error {
 	// check if we have required tooling to apply delta
-	supportedFormats, xdelta3CmdFn, mksquashfsCmdFn, unsquashfsCmdFn, _, _, err := CheckSupportedDetlaFormats(ctx)
+	supportedFormats, xdelta3CmdFn, mksquashfsCmdFn, unsquashfsCmdFn, _, _, err := CheckSupportedDeltaFormats(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to validate required tooling for delta format: %v", err)
 	}
@@ -1139,7 +1139,7 @@ func applyXdelta3Delta(ctx context.Context, sourceSnap, targetSnap string, delta
 func generateHdiffzDelta(ctx context.Context, deltaFile *os.File, sourceSnap, targetSnap string) error {
 
 	// Ensure we have required tooling
-	supportedFormats, _, _, unsquashfsCmdFn, hdiffzCmdFn, _, err := CheckSupportedDetlaFormats(ctx)
+	supportedFormats, _, _, unsquashfsCmdFn, hdiffzCmdFn, _, err := CheckSupportedDeltaFormats(ctx)
 	if err != nil || !strings.Contains(supportedFormats, snapDeltaFormatHdiffz) {
 		return fmt.Errorf("failed to validate required tooling for snap-delta: %v", err)
 	}
@@ -1424,7 +1424,7 @@ LOOP:
 
 func applyHdiffzDelta(ctx context.Context, sourceSnap, targetSnap string, deltaFile *os.File, hdr *SnapDeltaHeader, mksqfsArgs []string) error {
 	// check if we have required tooling to apply delta
-	supportedFormats, _, mksquashfsCmdFn, unsquashfsCmdFn, _, hpatchzCmdFn, err := CheckSupportedDetlaFormats(ctx)
+	supportedFormats, _, mksquashfsCmdFn, unsquashfsCmdFn, _, hpatchzCmdFn, err := CheckSupportedDeltaFormats(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to validate required tooling for delta format: %v", err)
 	}
@@ -1908,7 +1908,7 @@ func setupPipes(pipeNames ...string) (string, []string, error) {
 
 // Check if all the required tools are actually present
 // returns ready to use commands for xdelta3, mksquashfs and unsquashfs, hdiffz, hpatchz
-func CheckSupportedDetlaFormats(ctx context.Context) (string, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, error) {
+func CheckSupportedDeltaFormats(ctx context.Context) (string, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, DeltaToolingCmd, error) {
 	// Run checks in parallel to speed up startup
 	type res struct {
 		name string

--- a/snapdtool/cmdutil.go
+++ b/snapdtool/cmdutil.go
@@ -22,6 +22,7 @@ package snapdtool
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"debug/elf"
 	"fmt"
 	"io"
@@ -93,6 +94,15 @@ func parseLdSoConf(root string, confPath string) []string {
 	return out
 }
 
+// helper to create command, with optional context
+func commandWithContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if ctx == nil {
+		return exec.Command(name, args...)
+	} else {
+		return exec.CommandContext(ctx, name, args...)
+	}
+}
+
 // CommandFromSystemSnap runs a command from the snapd/core snap
 // using the proper interpreter and library paths if needed.
 //
@@ -102,6 +112,10 @@ func parseLdSoConf(root string, confPath string) []string {
 // At the moment it can only run ELF files, expects a standard ld.so
 // interpreter, and can't handle RPATH.
 func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
+	return CommandFromSystemSnapWithCtx(nil, name, cmdArgs...)
+}
+
+func CommandFromSystemSnapWithCtx(ctx context.Context, name string, cmdArgs ...string) (*exec.Cmd, error) {
 	from := "snapd"
 	root := filepath.Join(dirs.SnapMountDir, "/snapd/current")
 	if !osutil.FileExists(root) {
@@ -117,7 +131,7 @@ func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
 		// locations are correct, otherwise we need to set up a command to invoke it directly
 		snapdCurrentDir := filepath.Join(dirs.GlobalRootDir, "snap/snapd/current")
 		if match, err := osutil.ComparePathsByDeviceInode(root, snapdCurrentDir); err == nil && match {
-			return exec.Command(cmdPath, cmdArgs...), nil
+			return commandWithContext(ctx, cmdPath, cmdArgs...), nil
 		}
 
 		interp, err := elfInterp(cmdPath)
@@ -132,7 +146,7 @@ func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
 
 		ldSoArgs := []string{"--library-path", ldLibraryPathForSnapd, cmdPath}
 		allArgs := append(ldSoArgs, cmdArgs...)
-		return exec.Command(interp, allArgs...), nil
+		return commandWithContext(ctx, interp, allArgs...), nil
 	}
 
 	// We are trying to execute files from core snap. They need
@@ -167,5 +181,5 @@ func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
 
 	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}
 	allArgs := append(ldSoArgs, cmdArgs...)
-	return exec.Command(coreLdSo, allArgs...), nil
+	return commandWithContext(ctx, coreLdSo, allArgs...), nil
 }

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -674,6 +675,11 @@ func (s *downloadSuite) TestDownloadWithDelta(c *C) {
 		defer restore()
 
 		theStore := store.New(&store.Config{}, nil)
+		squasgfsRestore := store.MockSquashfsApplySnapDelta(func(xdelta3Cmd, mksquashfsCmd, unsquashfsCmd squashfs.SquashfsCommand, sourceSnap, deltaFile, targetSnap string) error {
+			return nil
+		})
+		defer squasgfsRestore()
+
 		path := filepath.Join(c.MkDir(), "subdir", "downloaded-file")
 		err := theStore.Download(context.TODO(), "foo", path, &testCase.info, nil, nil, nil)
 

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -179,6 +180,14 @@ func MockApplyDelta(f func(s *Store, name string, deltaPath string, deltaInfo *s
 	applyDelta = f
 	return func() {
 		applyDelta = origApplyDelta
+	}
+}
+
+func MockSquashfsApplySnapDelta(f func(xdelta3Cmd, mksquashfsCmd, unsquashfsCmd squashfs.SquashfsCommand, sourceSnap, deltaFile, targetSnap string) error) (restore func()) {
+	origSquashfsApplySnapDelta := squashfsApplySnapDelta
+	squashfsApplySnapDelta = f
+	return func() {
+		squashfsApplySnapDelta = origSquashfsApplySnapDelta
 	}
 }
 

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -198,8 +198,8 @@ func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client
 	}
 }
 
-func (sto *Store) SetDeltaFormat(dfmt string) {
-	sto.deltaFormat = dfmt
+func (sto *Store) SetDeltaFormats(dfmt string) {
+	sto.deltaFormats = dfmt
 }
 
 func (sto *Store) DownloadDelta(deltaName string, downloadInfo *snap.DownloadInfo, w io.ReadWriteSeeker, pbar progress.Meter, user *auth.UserState, dlOpts *DownloadOptions) error {

--- a/store/store.go
+++ b/store/store.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -51,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -174,8 +174,6 @@ type Store struct {
 	xdeltaCheckLock sync.Mutex
 	// whether we should use deltas or not
 	shouldUseDeltas *bool
-	// which xdelta3 we picked when we checked the deltas
-	xdelta3CmdFunc func(args ...string) *exec.Cmd
 }
 
 var ErrTooManyRequests = errors.New("too many requests")
@@ -355,9 +353,6 @@ type categoryResults struct {
 	Categories []CategoryDetails `json:"categories"`
 }
 
-// The default delta format if not configured.
-var defaultSupportedDeltaFormat = "xdelta3"
-
 // New creates a new Store with the given access configuration and for given the store id.
 func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 	if cfg == nil {
@@ -391,7 +386,7 @@ func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 
 	deltaFormat := cfg.DeltaFormat
 	if deltaFormat == "" {
-		deltaFormat = defaultSupportedDeltaFormat
+		deltaFormat = squashfs.DeltaFormat()
 	}
 
 	userAgent := snapdenv.UserAgent()

--- a/store/store.go
+++ b/store/store.go
@@ -106,8 +106,8 @@ type Config struct {
 	DetailFields []string
 	InfoFields   []string
 	// search v2 fields
-	FindFields  []string
-	DeltaFormat string
+	FindFields   []string
+	DeltaFormats string
 
 	// CacheDownloads is the number of downloads that should be cached
 	CacheDownloads int
@@ -153,7 +153,7 @@ type Store struct {
 	detailFields []string
 	infoFields   []string
 	findFields   []string
-	deltaFormat  string
+	deltaFormats string
 
 	auth Authorizer
 	// reused http client
@@ -384,9 +384,9 @@ func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 		series = release.Series
 	}
 
-	deltaFormat := cfg.DeltaFormat
-	if deltaFormat == "" {
-		deltaFormat = squashfs.DeltaFormat()
+	deltaFormats := cfg.DeltaFormats
+	if deltaFormats == "" {
+		deltaFormats = squashfs.SupportedDeltaFormats()
 	}
 
 	userAgent := snapdenv.UserAgent()
@@ -402,7 +402,7 @@ func New(cfg *Config, dauthCtx DeviceAndAuthContext) *Store {
 		infoFields:         infoFields,
 		findFields:         findFields,
 		dauthCtx:           dauthCtx,
-		deltaFormat:        deltaFormat,
+		deltaFormats:       deltaFormats,
 		proxy:              cfg.Proxy,
 		proxyConnectHeader: proxyConnectHeader,
 		userAgent:          userAgent,

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -604,8 +604,8 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 	}
 
 	if s.useDeltas() {
-		logger.Debugf("Deltas enabled. Adding header Snap-Accept-Delta-Format: %v", s.deltaFormat)
-		reqOptions.addHeader("Snap-Accept-Delta-Format", s.deltaFormat)
+		logger.Debugf("Deltas enabled. Adding header Snap-Accept-Delta-Format: %v", s.deltaFormats)
+		reqOptions.addHeader("Snap-Accept-Delta-Format", s.deltaFormats)
 	}
 	if opts.RefreshManaged {
 		reqOptions.addHeader("Snap-Refresh-Managed", "true")

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -1265,7 +1266,7 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 		// check device authorization is set, implicitly checking doRequest was used
 		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
 
-		c.Check(r.Header.Get("Snap-Accept-Delta-Format"), Equals, "xdelta3")
+		c.Check(r.Header.Get("Snap-Accept-Delta-Format"), Equals, squashfs.SupportedDeltaFormats())
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -106,7 +106,7 @@ func (s *Store) useDeltas() (use bool) {
 	}
 
 	var err error
-	s.deltaFormat, _, _, _, err = squashfs.CheckSupportedDetlaFormats(nil)
+	s.deltaFormats, _, _, _, err = squashfs.CheckSupportedDetlaFormats(nil)
 	if err != nil {
 		logger.Noticef("snap delta not supported: %v", err)
 		return false
@@ -820,7 +820,7 @@ func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo,
 
 	deltaInfo := downloadInfo.Deltas[0]
 
-	if !strings.Contains(s.deltaFormat, deltaInfo.Format) {
+	if !strings.Contains(s.deltaFormats, deltaInfo.Format) {
 		return fmt.Errorf("store returned unsupported delta format %q (only xdelta3 currently)", deltaInfo.Format)
 	}
 
@@ -844,7 +844,8 @@ func (s *Store) applyDeltaImpl(name string, deltaPath string, deltaInfo *snap.De
 		return fmt.Errorf("snap %q revision %d not found at %s", name, deltaInfo.FromRevision, snapPath)
 	}
 
-	if deltaInfo.Format != s.deltaFormat {
+	// check is store format is among the supported ones
+	if !strings.Contains(s.deltaFormats, deltaInfo.Format) {
 		return fmt.Errorf("cannot apply unsupported delta format %q (only xdelta3 currently)", deltaInfo.Format)
 	}
 

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -106,7 +106,7 @@ func (s *Store) useDeltas() (use bool) {
 	}
 
 	var err error
-	s.deltaFormats, _, _, _, err = squashfs.CheckSupportedDetlaFormats(nil)
+	s.deltaFormats, _, _, _, _, _, err = squashfs.CheckSupportedDeltaFormats(nil)
 	if err != nil {
 		logger.Noticef("snap delta not supported: %v", err)
 		return false

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -602,7 +602,7 @@ func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
 	sto := store.New(nil, dauthCtx)
 
 	for _, testCase := range downloadDeltaTests {
-		sto.SetDeltaFormat(testCase.format)
+		sto.SetDeltaFormats(testCase.format)
 		restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
 			c.Check(dlOpts, DeepEquals, &store.DownloadOptions{Scheduled: true})
 			expectedUser := s.user


### PR DESCRIPTION
# Adding support for a custom snap delta algorithm

SNAPDENG-36094

Updated on 16th December 2025: added hdiffz support

Currently, delta updates are facilitated by **xdelta3** between two snap revisions. While **xdelta3** is an efficient delta tool, it **does not perform** well on compressed packages, such as SquashFS.
Why is that? Ideally, a compressed package should have close to the **maximum theoretical entropy**, so comparing two "ideal" random sets is destined to generate a delta size close to the source or target set.
**xdelta3** acknowledges this, and if it **recognizes** source and targets as compressed packages, it **automatically** unpacks $\rightarrow$ computes delta $\rightarrow$ compresses resulting delta.

However, **xdelta3** does not support SquashFS as a "compressed package," perhaps due to its complexity, or the SquashFS pseudo file definition (**more on that later**) was not supported back then.
As a result, snap delta with **xdelta3** gives results all over the park; it can be very small for snaps with loads of small files (**base snaps**), but can be quickly derailed if more changes are **within** the snap, causing the data to shift, all the way to snaps with few big files (**snapd**) where it fails badly and the resulting delta is often close to the size of the source snap.

So how can we improve, taking into consideration embedded use cases, and the fact that the reassembled snap has to be **bit-identical** to the target so assertions or dm-verity merkle tree are still valid?
**squashfs-tools** **supports** the so-called **pseudo file definition**, which is an uncompressed representation of the SquashFS content. This includes things like file names, owner, mode, time, plus the file's binary content. This is **much** more suitable content to run **xdelta3** on. As a matter of fact, results are usually from **50% to less than 10%** of what we have today.

**But this approach has a few challenges:**

  * **Uncompressed snap content is big**, usually **3x** the snap size, and we would need **3 times** that.
  * The Pseudo file definition has no info about SquashFS's used compression, or time of creation.
  * Luckily, **xdelta3** can use pipes for both input and output, and so can **mksquashfs** and **unsquashfs** when operating with the pseudo file definition. This allows us to run **xdelta3** on the pseudo definition file without actually ever unpacking **the whole thing**.

Another problem can be fixed by the introduction of an **own custom delta superblock** with the required information to restore the target SquashFS with the exact parameters as **the** original. This information can be **lifted** from the target SquashFS superblock. At the same time, the fact that snaps are packed with `snap pack ...` means that supported **use cases** are **relatively** limited. This allows us to omit support for custom compression arguments, e.g., a custom zstd dictionary.

-----

# Custom snap-delta algorithm

## Implementation

Introduction of **an** own delta header file can resolve most of the **limitations** from SquashFS. The proposal is based on the PoC from
[https://github.com/kubiko/squashfs-delta](https://github.com/kubiko/squashfs-delta)
Custom snap-delta header **structure**:

```
# |       32b    |   16b   |     16b    |    32b     |     16b     |        16b        |
# | magic number | version | delta tool | time stamp | compression | super block flags |
```

Magic number and version are to identify the snap-delta and its version.
Delta tool identifies what delta tool was used to generate the delta.
Time stamp, compression, and super block flags are directly copied from the target snap, ensuring the same **mksquashfs** parameters are used when recreating the snap.
The implementation automatically **detects** a plain **xdelta3** delta based on its own magic number and applies **it**, providing clean backwards compatibility.

## Limitations

  * **Conscious** decision to **omit** support for custom SquashFS compression arguments, **as they are** not used by snaps at the moment and added complexity does not justify the effort. This does not mean limited support **for** compression algorithms\! e.g., xz, zstd, lzo, all those are supported.
  * **squashfs-tools** included in the **snapd** snap (Ubuntu 22.04 archive) have a buffer overflow error when working on snaps larger than $\approx$**20MB**. The upstream version of **squashfs-tools** (4.7.4) has this fixed. Therefore **the PR** is vendoring the latest stable version. The version in the Ubuntu 24.04 archive still has the same bug.
  * **CPU heavy**: both delta generation and applying of the delta **are comparatively** heavy on **the** CPU in comparison to **xdelta3**.

-----

# Other options considered

**bsdiff:**

  * **Unsuitable** for anything larger than "few" MB.
  * Very slow encoder (for **500MB** **15 to 30 mins**), slow to medium for decoder.
  * **17x** input size **RAM requirement** (**1GB** snap $\rightarrow$ **10GB** RAM)
  * **The** decoder still requires **4x** input size RAM, but can act under memory pressure with increased time required
  * **bsdiff** does not support streaming, so the RAM requirement cannot be sidestepped.
  * But probably the worst: delta size on snaps is no different to what **xdelta3** produces in **a** fraction of the time.
  * When running bsdiff on the pseudo file definition, the delta for snapd snap is ~ 1/2 to xdelta3 (18MB -> 9MB)

**[projg2-squashdelta](https://github.com/projg2/squashdelta):**

  * **Does** not support other than lzo compression, though support for other compression could be added.
  * Use of large **temporary** files, **2x** uncompressed SquashFS content on **the** encoder, **1x** on **the** decoder side.
  * **A** 3rd party solution without **a** clear **advantage**.
  * Produced sizes comparable to **the** proposed solution, but seems less predictable from sample lzo snaps tests.

**bsdiff size comparison:**

```
delta-core20-2603-2672-bsdiff              16M
delta-core20-2603-2672-xdelta3             16M
delta-core22-2134-2140-bsdiff              6.9M
delta-core22-2134-2140-xdelta3             6.8M
delta-core24-1197-1226-bsdiff              11M
delta-core24-1197-1226-xdelta3             11M
delta-snapd-25585-25839-bsdiff             40M
delta-snapd-25585-25839-xdelta3            40M
```

**projg2 size comparison: (snap-delta refers to the proposed solution)**

```
# delta sizes
delta-chromium-3286-3293-projg2            15M
delta-chromium-3286-3293-snap-delta        19M
delta-chromium-3286-3293-xdelta3           21M

delta-chromium-3293-3287-projg2            89M
delta-chromium-3293-3287-snap-delta        89M
delta-chromium-3293-3287-xdelta3          134M

delta-firefox-7177-7250-projg2           239M   <- outlier +30%
delta-firefox-7177-7250-snap-delta       188M
delta-firefox-7177-7250-xdelta3          156M   <- outlier (xdelta3 the best)

delta-firefox-7177-7259-projg2            42M
delta-firefox-7177-7259-snap-delta        42M
delta-firefox-7177-7259-xdelta3           73M

# source, target sizes
chromium_3286.snap                        184M
chromium_3287.snap                        176M
chromium_3293.snap                        184M
firefox_7177.snap                         250M
firefox_7250.snap                         285M
firefox_7259.snap                         251M
```

-----

# Comparison to plain xdelta3

In general, **the** improvement is **to achieve 50% to less than 10%** of comparable **xdelta3** results. Observations from various tests:

  * Snap with many small files (**core{20,22,24...}**): around **10%** of the reference **xdelta3** delta.
  * Snap with few large files (**go binaries**, e.g., **snapd**): under **50%** of the reference **xdelta3** delta.
  * Snap with already compressed files (**pc-kernel, kernel container, modules, firmware all compressed**): negligible gain.
  * Kernel snap: uncompressed kernel image and modules: $\approx$**50%** of the reference **xdelta3** delta.
  * Kernel snap: no initrd, uncompressed kernel image and modules: **\<25%** of **the** reference **xdelta3** delta.
  * Gadget snap: **\<25%** of **the** reference **xdelta3** delta.
  * **Example size comparison: (snap-delta refers to the proposed solution)**

<!-- end list -->

```
# delta sizes
delta-core20-2603-2672-snap-delta              1.5M
delta-core20-2603-2672-xdelta3                 16M
delta-core22-2134-2140-snap-delta              986K
delta-core22-2134-2140-xdelta3                 6.8M
delta-core24-1197-1226-snap-delta              541K
delta-core24-1197-1226-xdelta3                 11M
delta-arm-gadget-4-5-snap-delta                238K
delta-arm-gadget-4-5-xdelta3                   1.1M
delta-arm-kernel-1006-1008-snap-delta          13M
delta-arm-kernel-1006-1008-xdelta3             35M
delta-arm-kernel-no-initrd-1006-1008-snap-delta  2.5M
delta-arm-kernel-no-initrd-1006-1008-xdelta3   12M
delta-snapd-25585-25839-snap-delta             18M
delta-snapd-25585-25839-xdelta3                40M

# source, target sizes
core20_2603.snap                               60M
core20_2672.snap                               60M
core22_2134.snap                               69M
core22_2140.snap                               69M
core24_1197.snap                               62M
core24_1226.snap                               62M
arm-gadget_4.snap                              1.2M
arm-gadget_5.snap                              1.2M
arm-kernel-no-initrd_1006.snap                 22M
arm-kernel-no-initrd_1008.snap                 22M
arm-kernel_1006.snap                           48M
arm-kernel_1008.snap                           48M
snapd_25585.snap                               45M
snapd_25839.snap                               45M
```

-----

# Tuning of direct xdelta3 on two snaps

No noticeable improvement was observed for various options: source window size, input window size, secondary compression **algorithm**, compression level.

```
# -9: compression level, -Sdjw/-Slzma: secondary compression alg, -Bxxxx: source window size, -Wxxxx: input window size
delta-arm-kernel-1006-1008-xdelta3                      36560987
delta-arm-kernel-1006-1008-xdelta3-9                    36559138
delta-arm-kernel-1006-1008-xdelta3-9-B67108864          36559067
delta-arm-kernel-1006-1008-xdelta3-9-B67108864-W16777216  36558866
delta-arm-kernel-1006-1008-xdelta3-9-Sdjw               36559391
delta-arm-kernel-1006-1008-xdelta3-9-Slzma              36559067
delta-arm-kernel-1006-1008-xdelta3-9-W16777216          36558866
```

-----

# Tuning of xdelta3 on proposed solution

  * Only compression level seems to have **meaningful** improvement ($\approx$**10%** down). From default 3 to 7, going beyond 7 does not provide additional gain.
  * Source window size or input window size do not seem to have a **meaningful** effect.
  * On Ubuntu, default **lzma** secondary compression is **superior** to alternative **djw**.

<!-- end list -->

```
# -{3,5,6,7,9}: compression level, -Sdjw/-Slzma: secondary compression alg
# -Bxxxx: source window size, -Wxxxx: input window size, -Pxxxx: compression duplicates window
delta-snapd-25585-25839-snap-delta-3                    20M
delta-snapd-25585-25839-snap-delta-5                    20M
delta-snapd-25585-25839-snap-delta-6                    18M
delta-snapd-25585-25839-snap-delta-7                    18M
delta-snapd-25585-25839-snap-delta-7-P67108864          18M
delta-snapd-25585-25839-snap-delta-9                    18M
delta-snapd-25585-25839-snap-delta-9-B67108864          18M
delta-snapd-25585-25839-snap-delta-9-B67108864-W16777216  18M
delta-snapd-25585-25839-snap-delta-9-Sdjw               20M
delta-snapd-25585-25839-snap-delta-9-Slzma              18M
delta-snapd-25585-25839-snap-delta-9-Snone              24M
delta-snapd-25585-25839-snap-delta-9-W16777216          18M
```

-----

# Time requirements

## Delta Generation

Time to generate delta can vary, but **is generally** slower **than** **xdelta3**, depending on the nature of the input snap.

```
# xdelta3 vs snap-delta
pc-kernel:                     40.7s vs 41.3s
snapd:                          9s vs 16s
core24:                         2.7s vs 2.4s
arm-kernel:                     8.3s vs 6.4s
```

## Applying Delta

Time to apply delta can vary significantly, mostly because of the diversity of the target **hardware** (hw), from **single/dual-core** low-power arm systems to typical x86 **systems**.

```
# xdelta3 vs snap-delta
# typical x86 system
pc-kernel:                     0.6s vs 8.6s
snapd:                         0.2s vs 3.7s
core24:                        0.1s vs 4.4s
arm-kernel:                    0.1s vs 2.4s

# low end arm system (2 x Cortex A55)
snapd:                         0.4s vs 1m 36s
core24:                        0.4s vs 2m 8s
arm-kernel:                    0.6s vs 1m

# compared sizes
pc-kernel                      208MB
core24                          62M
snapd                           45M
arm-kernel                      48M
```

-----

# Use-case considerations

Considering the significant time to apply delta on the low-end systems, the proposed delta **algorithm** would not always **be** the right answer. On standard desktop systems, the time to apply the **delta** is still significantly higher than **xdelta3**, possibly still impacting user **experience**. Further **tests** should be done to determine the percentage impact on the whole refresh experience.
Taking **the** mentioned **constraints** into account, perhaps **the** following approach could be considered:

  * All automatic background refreshes would use **the** new, more optimised approach, as there is no visible user impact.
  * User invoked **refreshes** (e.g., `snap refresh ..`) would use the existing **xdelta3** for a better user experience.
  * If a very slow network is detected (e.g., **\<1 Mbit/s**), the new approach could still be attempted.
  * **Snapd** would have a setting to choose from 3 options: **xdelta3**, **snap-delta**, or **auto mode**, allowing **users** to lock to a particular algorithm based on **their own** preferences.

-----

# Some other wins

  * **The** new approach generates a tiny **to few bytes** delta if the snap changes **its** compression method (e.g., xz $\rightarrow$ lzo). This is a case where **xdelta3** would fail badly.
  * No new tooling is introduced.

-----

# Possible future improvement

As **the** delta works on the pseudo file definition, and the target snap is essentially recreated with correct arguments, we can consider a future where the target device would choose a compression which is more suitable for the application (e.g., zstd over xz).
As long as **the** snap store generates a **corresponding** snap revision assertion **for a** given compression.


Added on 16th of December 2025
# hdiffz/hpatchz support

`hdiffz` promises further improvement over the xdelta3 tool without the lofty processing and memory demand of the `bsdiff`, while also providing a slew of tuning options, and even a streaming option, though the source has to be still be available as a file.
Streaming support is only provided internally when only a portion of the source file is loaded into the working memory. This limits us with the options for processing of the squashfs pseudo definition stream. The solution is to first parse psedo definition header, which contains the sizes of the offset of each of the file within the stream. Like this, we can compare each file individually and feed it back to the delta or target stream. Using this strategy means we can avoid using a large temp file for the entire pseudo definition, as well as memory usage. Memory required is proportional to the size of the largest file within the squashfs.
This solution still has limitations in detecting candidates for comparison if the library version changes, resulting in two different filenames. Often, the case is with browser snaps. A similar problem is with kernel snap, when the kernel modules path contains the kernel version, while the file name remains the same. To improve delta efficiency *fuzzy matching score* is introduced, building a score from dirname, basename, size and the offset from the current place in the stream. If the resulting score is high enough, files are matched as related, and a delta is calculated between them.
Gained delta improvements over `xdelta3`streamed option.
```
delta-core20-2603-2672-sd-hdiffz               792K
delta-core20-2603-2672-sd-xdelta3              1.5M
delta-core20-2603-2672-xdelta3                 16M

delta-core22-2134-2140-sd-hdiffz               758K
delta-core22-2134-2140-sd-xdelta3              986K
delta-core22-2134-2140-xdelta3                 6.8M

delta-core24-1197-1226-sd-hdiffz               425K
delta-core24-1197-1226-sd-xdelta3              541K
delta-core24-1197-1226-xdelta3                 11M

delta-core26-72-77-sd-hdiffz                   3.3M
delta-core26-72-77-sd-xdelta3                  4.1M
delta-core26-72-77-xdelta3                     16M

delta-firefox-7421-7474-sd-hdiffz              22M
delta-firefox-7421-7474-sd-xdelta3             35M
delta-firefox-7421-7474-xdelta3                63M

delta-firefox-7421-7503-sd-hdiffz              32M
delta-firefox-7421-7503-sd-xdelta3             43M
delta-firefox-7421-7503-xdelta3                76M

delta-firefox-7421-7504-sd-hdiffz              110M
delta-firefox-7421-7504-sd-xdelta3             202M
delta-firefox-7421-7504-xdelta3                151M

delta-gnome-46-2404-125-145-sd-hdiffz          43M
delta-gnome-46-2404-125-145-sd-xdelta3         422M
delta-gnome-46-2404-125-145-xdelta3            404M

delta-gadget-4-5-sd-new-hdiffz                 161K
delta-gadget-4-5-sd-xdelta3                    238K
delta-gadget-4-5-xdelta3                       1.1M

delta-kernel-1006-1008-sd-hdiffz               16M
delta-kernel-1006-1008-sd-xdelta3              13M
delta-kernel-1006-1008-xdelta3                 35M

# kernel without initrd
delta-kernel-mini-1006-1008-sd-hdiffz          1.8M
delta-kernel-mini-1006-1008-sd-xdelta3         2.5M
delta-kernel-mini-1006-1008-xdelta3            12M

delta-snapd-25585-25839-sd-hdiffz              7.9M
delta-snapd-25585-25839-sd-xdelta3             18M
delta-snapd-25585-25839-xdelta3                40M
```

It is also important to consider an increase in the size of the snapd, snap binaries, as well as snapd snap. For the current draft PR, increases are as follows
```
usr/bin/snap:         21760k -> 21824k -> +64k
usr/lib/snapd/snapd:  28672k -> 28736k -> +64k
snapd snap:           44240k -> 44676k -> +412k
```