### PR TITLE
many: re-re-enable the prompting notice backend

### DIFF
--- a/daemon/api_debug_features_test.go
+++ b/daemon/api_debug_features_test.go
@@ -38,7 +38,7 @@ type featuresDebugSuite struct {
 func (s *featuresDebugSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 	s.daemonWithOverlordMock()
-	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
+	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().NoticeManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
 	c.Assert(err, IsNil)
 	s.d.Overlord().AddManager(ifacemgr)
 }

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -380,7 +380,7 @@ func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	hookMgr, err := hookstate.Manager(st, runner)
 	c.Assert(err, IsNil)
 	overlord.AddManager(hookMgr)
-	ifaceMgr, err := ifacestate.Manager(st, hookMgr, runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(st, hookMgr, nil, runner, nil, nil)
 	c.Assert(err, IsNil)
 	overlord.AddManager(ifaceMgr)
 	overlord.AddManager(runner)

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -434,6 +434,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	// expiration timer when the DB has been closed, since the timer will fire
 	// and do nothing.
 	if pdb.isClosed() {
+		logger.Debug("prompt timeout callback triggered; returning early because prompt DB is closed")
 		pdb.mutex.Unlock()
 		return
 	}
@@ -447,6 +448,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 		// and the lock being released and subsequently acquired by this
 		// function. So reset the timer to activityTimeout, and do not
 		// purge prompts.
+		logger.Debug("prompt timeout callback triggered; returning early because the timeout was reset before the callback acquired the DB lock")
 		udb.activityResetExpiration()
 		pdb.mutex.Unlock()
 		return
@@ -467,9 +469,16 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	// Unlock now so we can record notices without holding the prompt DB lock
 	pdb.mutex.Unlock()
 	data := map[string]string{"resolved": "expired"}
+	expiredPromptIDs := make([]string, 0, len(expiredPrompts))
 	for _, p := range expiredPrompts {
+		expiredPromptIDs = append(expiredPromptIDs, p.ID.String())
 		pdb.notifyPrompt(user, p.ID, data)
 		p.sendReply(prompting.OutcomeDeny) // ignore any error, should not occur
+	}
+	if len(expiredPromptIDs) > 0 {
+		logger.Debugf("prompt timeout callback triggered; prompts expired: %q", expiredPromptIDs)
+	} else {
+		logger.Debug("prompt timeout callback triggered; no prompts expired")
 	}
 }
 
@@ -722,18 +731,32 @@ func (pdb *PromptDB) HandleReadying(keyNamespace string) []string {
 		requestsToPrune[requestKey] = entry
 	}
 
+	// Now collect prompt IDs and user IDs we didn't see so we can record a
+	// single notice for each expired prompt.
+	nonexistentPrompts := make(map[prompting.IDType]uint32)
+
 	requestKeysPruned := make([]string, 0, len(requestsToPrune))
-	data := map[string]string{"resolved": "expired"}
 	for requestKey, entry := range requestsToPrune {
 		requestKeysPruned = append(requestKeysPruned, requestKey)
 		delete(pdb.requestMap, requestKey)
 		delete(pdb.pendingUnreceivedRequests, requestKey)
 		if !existingPrompts[entry.PromptID] {
-			pdb.notifyPrompt(entry.UserID, entry.PromptID, data)
+			nonexistentPrompts[entry.PromptID] = entry.UserID
 		}
 		// No need to send a reply to the request originator, since the request
 		// is gone. Also we can't, since there's no request to call Reply() on.
 	}
+
+	if len(nonexistentPrompts) > 0 {
+		logger.Debugf("prompts were dropped because requests were not re-received before readying with namespace %q: %q", keyNamespace, nonexistentPrompts)
+		data := map[string]string{"resolved": "expired"}
+		for promptID, userID := range nonexistentPrompts {
+			pdb.notifyPrompt(userID, promptID, data)
+		}
+	} else {
+		logger.Debugf("no prompts dropped when readying with namespace %q", keyNamespace)
+	}
+
 	pdb.saveRequestMap()
 
 	pdb.readyIfPendingAllReceived()
@@ -843,6 +866,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		existingPrompt.addRequest(request)
 		// Although the prompt itself has not changed from client POV,
 		// re-record a notice to re-notify clients to respond to this request.
+		logger.Debugf("new request %q matches existing prompt: %q", request.Key, existingPrompt.ID)
 		pdb.notifyPrompt(metadata.User, existingPrompt.ID, nil)
 		return existingPrompt, true, nil
 	}
@@ -885,6 +909,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		requests:    []*prompting.Request{request},
 	}
 	userEntry.add(prompt)
+	logger.Debugf("created new prompt for request %q: %q", request.Key, promptID)
 	pdb.notifyPrompt(metadata.User, promptID, nil)
 	return prompt, false, nil
 }
@@ -1056,6 +1081,7 @@ func (pdb *PromptDB) Reply(user uint32, id prompting.IDType, outcome prompting.O
 	userEntry.remove(id)
 
 	data := map[string]string{"resolved": "replied"}
+	logger.Debugf("received reply for prompt: %q", id)
 	pdb.notifyPrompt(user, id, data)
 	return prompt, nil
 }
@@ -1118,6 +1144,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		if !respond {
 			// No response necessary, though the prompt constraints were
 			// modified, so just record a notice for the prompt.
+			logger.Debugf("prompt partially handled by new rule, but not resolved: %q", prompt.ID)
 			pdb.notifyPrompt(metadata.User, prompt.ID, nil)
 			continue
 		}
@@ -1156,6 +1183,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		needToSave = true
 
 		satisfiedPromptIDs = append(satisfiedPromptIDs, prompt.ID)
+		logger.Debugf("new rule satisfied prompt: %q", prompt.ID)
 		data := map[string]string{"resolved": "satisfied"}
 		pdb.notifyPrompt(metadata.User, prompt.ID, data)
 	}

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -306,6 +306,7 @@ func (rdb *RuleDB) load() (retErr error) {
 
 	if errInvalid != nil {
 		// The DB on disk was invalid, so drop every rule and start over
+		logger.Debug("WARNING: rule DB invalid, so dropping every rule")
 		data := map[string]string{"removed": "dropped"}
 		for _, rule := range wrapped.Rules {
 			rdb.notifyRule(rule.User, rule.ID, data)
@@ -749,21 +750,26 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 			continue
 		}
 		if !maybeExpired.expired(at) {
+			// This should not occur during load since expired permissions are
+			// pruned when the rule is unmarshalled. Thus, it should only occur
+			// when adding a new rule which overlaps with another rule which
+			// has partially expired.
+
 			// Previously removed the rule's permission entry from the tree for
 			// this permission, now let's remove it from the rule as well.
 			delete(maybeExpired.Constraints.Permissions, permission)
 
-			// This should not occur during load since it calls rule.validate()
-			// which calls RuleConstraints.ValidateForInterface, which prunes
-			// any expired permissions. Thus, it should only occur when adding
-			// a new rule which overlaps with another rule which has partially
-			// expired.
+			logger.Debugf("expired permission %q was pruned from partially-expired rule because it conflicted with new rule %q: %q", permission, ruleID, maybeExpired.ID)
+			rdb.notifyRule(maybeExpired.User, maybeExpired.ID, nil)
 			continue
 		}
 		_, err = rdb.removeRuleByID(ruleID)
 		// Error shouldn't occur. If it does, the rule was already removed.
 		if err == nil {
+			logger.Debugf("rule was expired when new rule %q was added: %q", ruleID, maybeExpired.ID)
 			rdb.notifyRule(maybeExpired.User, maybeExpired.ID, expiredData)
+		} else {
+			logger.Debugf("WARNING: error occurred when trying to remove expired rule %q: %v", maybeExpired.ID, err)
 		}
 	}
 
@@ -1046,6 +1052,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 		return nil, fmt.Errorf("cannot add rule: %w", err)
 	}
 
+	logger.Debugf("new rule added: %q", newRule.ID)
 	rdb.notifyRule(user, newRule.ID, nil)
 	return newRule, nil
 }
@@ -1291,6 +1298,7 @@ func (rdb *RuleDB) RemoveRule(user uint32, id prompting.IDType) (*Rule, error) {
 	// rule was affected. We want the rule fully removed, so this is fine.
 
 	data := map[string]string{"removed": "removed"}
+	logger.Debugf("rule was removed: %q", id)
 	rdb.notifyRule(user, id, data)
 	return rule, nil
 }
@@ -1323,12 +1331,14 @@ func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) error {
 		return nil
 	}
 
+	removedRuleIDs := make([]string, 0, len(rules))
 	for _, rule := range rules {
 		// Remove rule from the rules list. Caller should ensure that the rule
 		// exists, and thus this should not error. We don't want to return any
 		// error here, because that would leave some of the given rules removed
 		// and others not, and the caller can ensure that this will not happen.
 		rdb.removeRuleByIDFromRulesList(rule.ID)
+		removedRuleIDs = append(removedRuleIDs, rule.ID.String())
 	}
 
 	// Now that rules have been removed from rules list, attempt to save
@@ -1341,6 +1351,7 @@ func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) error {
 	}
 
 	// Save successful, now remove rules' variants from tree
+	logger.Debugf("removed rules: %q", removedRuleIDs)
 	data := map[string]string{"removed": "removed"}
 	for _, rule := range rules {
 		rdb.removeRuleFromTree(rule)
@@ -1474,6 +1485,7 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 		return nil, err
 	}
 
+	logger.Debugf("rule was patched: %q", newRule.ID)
 	rdb.notifyRule(newRule.User, newRule.ID, nil)
 	return newRule, nil
 }

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -20,6 +20,7 @@
 package requestrules_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -244,12 +245,22 @@ func (s *requestrulesSuite) testLoadError(c *C, expectedErr string, rules []*req
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
-	logErr := fmt.Errorf("%s", strings.TrimSpace(logbuf.String()))
-	c.Check(logErr, ErrorMatches, fmt.Sprintf(".*cannot load rule database: %s; using new empty rule database", expectedErr))
+	filtered := filterOutDebugLogs(logbuf)
+	c.Check(filtered, Matches, fmt.Sprintf(".*cannot load rule database: %s; using new empty rule database.*", expectedErr))
 	if checkWritten {
 		s.checkWrittenRuleDB(c, nil)
 	}
 	s.checkNewNoticesSimple(c, map[string]string{"removed": "dropped"}, rules...)
+}
+
+func filterOutDebugLogs(logbuf *bytes.Buffer) string {
+	var filteredLines []string
+	for _, logline := range strings.Split(logbuf.String(), "\n") {
+		if !strings.Contains(logline, "DEBUG") {
+			filteredLines = append(filteredLines, logline)
+		}
+	}
+	return strings.TrimSpace(strings.Join(filteredLines, "\n"))
 }
 
 func (s *requestrulesSuite) checkWrittenRuleDB(c *C, expectedRules []*requestrules.Rule) {
@@ -327,7 +338,7 @@ func (s *requestrulesSuite) TestLoadErrorUnmarshal(c *C) {
 	// unmarshal should catch invalid rule and exit before attempting to add.
 	rules := []*requestrules.Rule{good1, bad, good2}
 	s.writeRules(c, dbPath, rules)
-	s.testLoadError(c, `invalid interface: "foo".*`, nil, checkWritten)
+	s.testLoadError(c, `invalid interface: "foo"`, nil, checkWritten)
 }
 
 const ruleTemplatePathPattern = "/home/test/foo"
@@ -403,7 +414,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingID(c *C) {
 	s.writeRules(c, dbPath, rules)
 
 	checkWritten := true
-	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", prompting_errors.ErrRuleIDConflict), rules, checkWritten)
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v", prompting_errors.ErrRuleIDConflict), rules, checkWritten)
 }
 
 func setPermissionsOutcomeLifespanExpirationSession(c *C, rule *requestrules.Rule, permissions []string, outcome prompting.OutcomeType, lifespan prompting.LifespanType, expiration time.Time, userSessionID prompting.IDType) {
@@ -434,7 +445,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingPattern(c *C) {
 	s.writeRules(c, dbPath, rules)
 
 	checkWritten := true
-	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", prompting_errors.ErrRuleConflict), rules, checkWritten)
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v", prompting_errors.ErrRuleConflict), rules, checkWritten)
 }
 
 func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
@@ -469,7 +480,7 @@ func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	expectedWrittenRules := []*requestrules.Rule{good1, good2, good3}
 	s.checkWrittenRuleDB(c, expectedWrittenRules)
@@ -678,7 +689,7 @@ func (s *requestrulesSuite) TestLoadMergedRules(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	expectedWrittenRules := []*requestrules.Rule{expected1, expected2, expected3, expected4}
 	s.checkWrittenRuleDB(c, expectedWrittenRules)
@@ -759,7 +770,7 @@ func (s *requestrulesSuite) TestLoadHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	s.checkWrittenRuleDB(c, rules)
 	s.checkNewNotices(c, nil)
@@ -1854,7 +1865,7 @@ func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rule2, NotNil)
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{rule1, rule2})
-	s.checkNewNoticesSimple(c, nil, rule2)
+	s.checkNewNoticesSimple(c, nil, rule1, rule1, rule2)
 
 	// Check that "read" and "execute" were removed from rule1
 	_, exists := rule1.Constraints.Permissions["read"]

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -716,7 +716,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(err, IsNil)
 	o.AddManager(snapmgr)
 
-	ifacemgr, err := ifacestate.Manager(st, nil, o.TaskRunner(), nil, nil)
+	ifacemgr, err := ifacestate.Manager(st, nil, nil, o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	o.AddManager(ifacemgr)
 	c.Assert(o.StartUp(), IsNil)

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -259,7 +259,7 @@ func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data
 	return nil
 }
 
-// searchExistingNotice looks up the list of existing notices for the given
+// searchExistingNotices looks up the list of existing notices for the given
 // userID and checks whether a notice with the given noticeID already exists.
 //
 // Returns the slice of existing notices for the given userID. If the notice

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -60,13 +60,24 @@ func newNoticeBackends(noticeMgr *notices.NoticeManager) (*noticeBackends, error
 		return nil, fmt.Errorf("cannot create interfaces requests run directory: %w", err)
 	}
 
+	if err := os.MkdirAll(dirs.SnapInterfacesRequestsStateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("cannot create interfaces requests state directory: %w", err)
+	}
+
+	// The prompting notice backend is more tightly coupled to the prompt/rule
+	// state, since they rely on the prompt/rule state providing unique IDs.
+	// Thus, store prompt/rule notice state in the same directory as the
+	// prompts/rules themselves.
+
+	// Store prompt notices alongside the prompt ID mapping, in the run dir.
 	path := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "prompt-notices.json")
 	promptNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsPromptNotice, promptNoticeNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	path = filepath.Join(dirs.SnapInterfacesRequestsRunDir, "rule-notices.json")
+	// Store rule notices alongside the rule state, in the state dir.
+	path = filepath.Join(dirs.SnapInterfacesRequestsStateDir, "rule-notices.json")
 	ruleNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsRuleUpdateNotice, ruleNoticeNamespace)
 	if err != nil {
 		return nil, err
@@ -96,8 +107,25 @@ func (nb *noticeBackends) registerWithManager(noticeMgr *notices.NoticeManager) 
 		// responsible for notices of this type.
 		for _, notice := range drainedNotices {
 			// Re-create each notice in the backend, so no data is lost before
-			// a client can receive it. The ID will be different, but the key
-			// will be the same.
+			// a client can receive it. The notice ID will be different, but
+			// the notice key (prompt/rule ID) will be the same.
+			//
+			// It's possible that notices were already recorded to this backend
+			// during startup of other sub-services (e.g. the rules backend)
+			// prior to registering it with the notice manager. In that case,
+			// those notices are "fresher" than the notices we drained from the
+			// state, so we want to make sure we don't overwrite the data from
+			// those notices with the stale data from state.
+			noticeID := bknd.noticeKeyToID(notice.Key())
+			if bknd.BackendNotice(noticeID) != nil {
+				// The notice has already been re-added with fresher data.
+				// XXX: Technically, it's possible that the existing notice
+				// could have a different user and by skipping re-adding it,
+				// we silently ignore it rather than throwing an error. But
+				// this should not occur in practice, and we would prefer the
+				// fresher notice anyway.
+				continue
+			}
 			userID, _ := notice.UserID() // prompting notices always have UserID
 			promptingID, err := prompting.IDFromString(notice.Key())
 			if err != nil {
@@ -164,6 +192,10 @@ func newNoticeTypeBackend(now time.Time, nextNoticeTimestamp func() time.Time, p
 	return ntb, nil
 }
 
+func (ntb *noticeTypeBackend) noticeKeyToID(key string) string {
+	return fmt.Sprintf("%s-%s", ntb.namespace, key)
+}
+
 // addNotice records an occurrence of a notice with the specified user ID, a
 // key equal to the given prompt/rule ID, and the given data, with notice ID
 // and type derived from the receiver.
@@ -171,7 +203,7 @@ func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data
 	ntb.rwmu.Lock()
 	defer ntb.rwmu.Unlock()
 	key := id.String()
-	noticeID := fmt.Sprintf("%s-%s", ntb.namespace, key)
+	noticeID := ntb.noticeKeyToID(key)
 
 	userNotices, existingNotice, existingIndex, err := ntb.searchExistingNotices(userID, noticeID)
 	if err != nil {

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -76,21 +76,33 @@ func (s *noticebackendSuite) TestRegisterWithManager(c *C) {
 	c.Assert(err, IsNil)
 	id3, err := s.st.AddNotice(&uid2, state.InterfacesRequestsRuleUpdateNotice, prompting.IDType(0x789).String(), &state.AddNoticeOptions{Data: data1})
 	c.Assert(err, IsNil)
-	id4, err := s.st.AddNotice(&uid2, state.WarningNotice, "foo", &state.AddNoticeOptions{Data: data2})
+	// Add some notices for which we'll pre-record notices in the backends
+	// before draining, so we expect not to re-record
+	id4, err := s.st.AddNotice(&uid1, state.InterfacesRequestsPromptNotice, prompting.IDType(0xabc).String(), &state.AddNoticeOptions{Data: nil})
+	c.Assert(err, IsNil)
+	id5, err := s.st.AddNotice(&uid1, state.InterfacesRequestsRuleUpdateNotice, prompting.IDType(0xdef).String(), &state.AddNoticeOptions{Data: data1})
+	c.Assert(err, IsNil)
+	id6, err := s.st.AddNotice(&uid1, state.InterfacesRequestsPromptNotice, prompting.IDType(0x1000).String(), &state.AddNoticeOptions{Data: data2})
+	c.Assert(err, IsNil)
+	// Add warning notice which we won't drain
+	id7, err := s.st.AddNotice(&uid2, state.WarningNotice, "foo", &state.AddNoticeOptions{Data: data2})
 	c.Assert(err, IsNil)
 	// Add one prompting notice with a key which is not an IDType.String(), which will be dropped
-	id5, err := s.st.AddNotice(&uid2, state.InterfacesRequestsRuleUpdateNotice, "bar", &state.AddNoticeOptions{Data: data2})
+	id8, err := s.st.AddNotice(&uid2, state.InterfacesRequestsRuleUpdateNotice, "bar", &state.AddNoticeOptions{Data: data2})
 	c.Assert(err, IsNil)
 	s.st.Unlock()
 
 	// Check that all notices are retrievable from the manager
 	existingNotices := s.noticeMgr.Notices(nil)
-	c.Assert(existingNotices, HasLen, 5)
+	c.Assert(existingNotices, HasLen, 8)
 	c.Check(existingNotices[0].ID(), Equals, id1)
 	c.Check(existingNotices[1].ID(), Equals, id2)
 	c.Check(existingNotices[2].ID(), Equals, id3)
 	c.Check(existingNotices[3].ID(), Equals, id4)
 	c.Check(existingNotices[4].ID(), Equals, id5)
+	c.Check(existingNotices[5].ID(), Equals, id6)
+	c.Check(existingNotices[6].ID(), Equals, id7)
+	c.Check(existingNotices[7].ID(), Equals, id8)
 
 	// Create new prompting notice backends and check that they initially have no notices
 	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
@@ -100,7 +112,16 @@ func (s *noticebackendSuite) TestRegisterWithManager(c *C) {
 
 	// Creating backend has no effect on the notice manager yet
 	existingNotices = s.noticeMgr.Notices(nil)
-	c.Assert(existingNotices, HasLen, 5)
+	c.Assert(existingNotices, HasLen, 8)
+
+	// Pre-create some notices in the prompting notice backends which we expect
+	// to not be overwritten by drained notices
+	c.Check(noticeBackend.PromptBackend().AddNotice(uid1, 0xabc, data1), IsNil)
+	c.Check(noticeBackend.RuleBackend().AddNotice(uid1, 0xdef, data2), IsNil)
+	c.Check(noticeBackend.PromptBackend().AddNotice(uid1, 0x1000, nil), IsNil)
+	// And the notices can be retrieved
+	c.Check(noticeBackend.PromptBackend().BackendNotices(nil), HasLen, 2)
+	c.Check(noticeBackend.RuleBackend().BackendNotices(nil), HasLen, 1)
 
 	// Register the prompting backends with the notice manager
 	err = apparmorprompting.RegisterWithManager(noticeBackend, s.noticeMgr)
@@ -108,39 +129,57 @@ func (s *noticebackendSuite) TestRegisterWithManager(c *C) {
 
 	// Check that the prompting backends have the expected notices now
 	promptNotices := noticeBackend.PromptBackend().BackendNotices(nil)
-	c.Assert(promptNotices, HasLen, 1)
+	c.Assert(promptNotices, HasLen, 3)
 	ruleNotices := noticeBackend.RuleBackend().BackendNotices(nil)
-	c.Assert(ruleNotices, HasLen, 2)
-	// Check that the new notice IDs are namespaced as expected and key and data were preserved
-	c.Check(promptNotices[0].ID(), Equals, "prompt-0000000000000123")
-	c.Check(promptNotices[0].Key(), Equals, "0000000000000123")
-	c.Check(promptNotices[0].LastData(), DeepEquals, data1)
-	c.Check(ruleNotices[0].ID(), Equals, "rule-0000000000000456")
-	c.Check(ruleNotices[0].Key(), Equals, "0000000000000456")
-	c.Check(ruleNotices[0].LastData(), DeepEquals, data2)
-	c.Check(ruleNotices[1].ID(), Equals, "rule-0000000000000789")
-	c.Check(ruleNotices[1].Key(), Equals, "0000000000000789")
-	c.Check(ruleNotices[1].LastData(), DeepEquals, data1)
+	c.Assert(ruleNotices, HasLen, 3)
+	// Check that the new notice IDs are namespaced as expected and key and
+	// data were preserved. When the notices were pre-created in the backend
+	// prior to registering, the data should not have changed, otherwise the
+	// data should match what was drained from state
+	c.Check(promptNotices[0].ID(), Equals, "prompt-0000000000000ABC")
+	c.Check(promptNotices[0].Key(), Equals, "0000000000000ABC")
+	c.Check(promptNotices[0].LastData(), DeepEquals, data1) // from pre-created
+	c.Check(promptNotices[1].ID(), Equals, "prompt-0000000000001000")
+	c.Check(promptNotices[1].Key(), Equals, "0000000000001000")
+	c.Check(promptNotices[1].LastData(), IsNil) // from pre-created
+	c.Check(promptNotices[2].ID(), Equals, "prompt-0000000000000123")
+	c.Check(promptNotices[2].Key(), Equals, "0000000000000123")
+	c.Check(promptNotices[2].LastData(), DeepEquals, data1) // from state
+	c.Check(ruleNotices[0].ID(), Equals, "rule-0000000000000DEF")
+	c.Check(ruleNotices[0].Key(), Equals, "0000000000000DEF")
+	c.Check(ruleNotices[0].LastData(), DeepEquals, data2) // from pre-created
+	c.Check(ruleNotices[1].ID(), Equals, "rule-0000000000000456")
+	c.Check(ruleNotices[1].Key(), Equals, "0000000000000456")
+	c.Check(ruleNotices[1].LastData(), DeepEquals, data2) // from state
+	c.Check(ruleNotices[2].ID(), Equals, "rule-0000000000000789")
+	c.Check(ruleNotices[2].Key(), Equals, "0000000000000789")
+	c.Check(ruleNotices[2].LastData(), DeepEquals, data1) // from state
 
 	// Check that the state no longer has notices with prompting types
 	s.st.Lock()
 	stateNotices := s.st.Notices(nil)
 	s.st.Unlock()
 	c.Check(stateNotices, HasLen, 1)
-	c.Check(stateNotices[0].ID(), Equals, id4)
+	c.Check(stateNotices[0].ID(), Equals, id7)
 	c.Check(stateNotices[0].Key(), Equals, "foo")
 
 	// Check that the notice manager can retrieve all expected notices
 	notices := s.noticeMgr.Notices(nil)
-	c.Check(notices, HasLen, 4)
-	c.Check(notices[0].ID(), Equals, id4)
+	c.Check(notices, HasLen, 7)
+	c.Check(notices[0].ID(), Equals, id7)
 	c.Check(notices[0].Key(), Equals, "foo")
-	c.Check(notices[1].ID(), Equals, "prompt-0000000000000123")
-	c.Check(notices[1].Key(), Equals, "0000000000000123")
-	c.Check(notices[2].ID(), Equals, "rule-0000000000000456")
-	c.Check(notices[2].Key(), Equals, "0000000000000456")
-	c.Check(notices[3].ID(), Equals, "rule-0000000000000789")
-	c.Check(notices[3].Key(), Equals, "0000000000000789")
+	c.Check(notices[1].ID(), Equals, "prompt-0000000000000ABC")
+	c.Check(notices[1].Key(), Equals, "0000000000000ABC")
+	c.Check(notices[2].ID(), Equals, "rule-0000000000000DEF")
+	c.Check(notices[2].Key(), Equals, "0000000000000DEF")
+	c.Check(notices[3].ID(), Equals, "prompt-0000000000001000")
+	c.Check(notices[3].Key(), Equals, "0000000000001000")
+	c.Check(notices[4].ID(), Equals, "prompt-0000000000000123")
+	c.Check(notices[4].Key(), Equals, "0000000000000123")
+	c.Check(notices[5].ID(), Equals, "rule-0000000000000456")
+	c.Check(notices[5].Key(), Equals, "0000000000000456")
+	c.Check(notices[6].ID(), Equals, "rule-0000000000000789")
+	c.Check(notices[6].Key(), Equals, "0000000000000789")
 }
 
 func (s *noticebackendSuite) TestAddNotice(c *C) {

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -86,33 +86,16 @@ type InterfacesRequestsManager struct {
 	listenerAlreadySignalled chan struct{}
 
 	askRequests chan *prompting.Request
-
-	notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error
-	notifyRule   func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 }
 
-func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
-	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyPrompt calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
-			Data: data,
-		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsPromptNotice, promptID.String(), &options)
-		return err
-	}
-	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyRule calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
-			Data: data,
-		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
-		return err
+func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr error) {
+	// First initialize notice backends to load notices from disk and allow
+	// prompting managers to record notices. Don't register the notice backends
+	// with the state until we're sure initialization was successful and
+	// prompting will be enabled.
+	noticeBackends, err := newNoticeBackends(noticeMgr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize prompting notice backend: %w", err)
 	}
 
 	listenerBackend, err := listenerRegister()
@@ -125,7 +108,7 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
-	promptsBackend, err := requestprompts.New(notifyPrompt)
+	promptsBackend, err := requestprompts.New(noticeBackends.promptBackend.addNotice)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request prompts backend: %w", err)
 	}
@@ -135,7 +118,7 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
-	rulesBackend, err := requestrules.New(notifyRule)
+	rulesBackend, err := requestrules.New(noticeBackends.ruleBackend.addNotice)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request rules backend: %w", err)
 	}
@@ -145,14 +128,19 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
+	// Now that all prompting managers were successfully initialized, register
+	// the notice backends with the state as notice providers.
+	if err = noticeBackends.registerWithManager(noticeMgr); err != nil {
+		// This should never occur
+		return nil, fmt.Errorf("cannot register notice backends for prompting manager: %w", err)
+	}
+
 	m = &InterfacesRequestsManager{
 		listener:                 listenerBackend,
 		prompts:                  promptsBackend,
 		rules:                    rulesBackend,
 		listenerAlreadySignalled: make(chan struct{}),
 		askRequests:              make(chan *prompting.Request),
-		notifyPrompt:             notifyPrompt,
-		notifyRule:               notifyRule,
 	}
 
 	m.tomb.Go(m.run)

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -48,7 +49,7 @@ func Test(t *testing.T) { TestingT(t) }
 type apparmorpromptingSuite struct {
 	testutil.BaseTest
 
-	st *state.State
+	noticeMgr *notices.NoticeManager
 
 	defaultUser uint32
 }
@@ -61,7 +62,9 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	s.st = state.New(nil)
+	st := state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(st)
+
 	s.defaultUser = 1000
 
 	currSession := prompting.IDType(0x12345)
@@ -89,7 +92,7 @@ func (s *apparmorpromptingSuite) TestNew(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -110,7 +113,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
@@ -127,7 +130,7 @@ func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -156,7 +159,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -172,7 +175,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	promptDB := mgr.PromptDB()
@@ -221,7 +224,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestDenyRoot(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Send request for root
@@ -245,7 +248,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	clientActivity := true
@@ -271,8 +274,15 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 			},
 		}
 		reqChan <- req
+		// Poke the prompts backend to ensure there's no timeout
+		_, err = mgr.Prompts(s.defaultUser, clientActivity)
+		c.Assert(err, IsNil)
 	}
-	time.Sleep(10 * time.Millisecond)
+	lastPromptID := prompting.IDType(1000).String()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	_, err = s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{lastPromptID}})
+	c.Assert(err, IsNil)
 
 	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
 	c.Assert(err, IsNil)
@@ -309,7 +319,7 @@ func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	req, replyChan := requestWithReplyChan(&prompting.Request{})
@@ -355,7 +365,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *prompting.R
 	// which should generate a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -447,7 +457,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyUnusualPaths(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	const clientActivity = true
@@ -530,7 +540,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	_, prompt := s.simulateRequest(c, reqChan, mgr, &prompting.Request{}, false)
@@ -610,7 +620,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 	defer func() {
 		c.Check(mgr.Stop(), IsNil)
@@ -654,7 +664,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	// Wait for a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -720,7 +730,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeSending(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	const (
@@ -772,7 +782,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	neverClose := make(chan struct{})
@@ -877,7 +887,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownViaChannelBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	snapdShuttingDown := make(chan struct{})
@@ -921,7 +931,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match read permission
@@ -968,22 +978,18 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 }
 
 func (s *apparmorpromptingSuite) checkRecordedPromptNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
 func (s *apparmorpromptingSuite) checkRecordedRuleUpdateNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsRuleUpdateNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
@@ -991,7 +997,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add rule to match read permission
@@ -1020,7 +1026,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -1063,7 +1069,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -1118,7 +1124,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1190,7 +1196,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1256,7 +1262,7 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1351,7 +1357,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1445,7 +1451,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Requests with identical *original* abstract permissions are merged into
@@ -1518,7 +1524,7 @@ func (s *apparmorpromptingSuite) TestRules(c *C) {
 
 func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompting.InterfacesRequestsManager, rules []*requestrules.Rule) {
 	var err error
-	mgr, err = apparmorprompting.New(s.st)
+	mgr, err = apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	whenAdded := time.Now()
@@ -1638,7 +1644,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1723,7 +1729,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsReady(c *C) {
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1764,7 +1770,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsNotReady(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1808,7 +1814,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfN
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1853,7 +1859,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1873,7 +1879,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	// Wait for a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -1924,7 +1930,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -2089,7 +2095,11 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	// Need a new noticeMgr each time so we can re-register backends with the same types
+	st := state.New(nil)
+	noticeMgr := notices.NewNoticeManager(st)
+
+	mgr, err := apparmorprompting.New(noticeMgr)
 	c.Assert(err, IsNil)
 
 	startChan := make(chan time.Time)

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -135,7 +136,7 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	}
 }
 
-func MockCreateInterfacesRequestsManager(new func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+func MockCreateInterfacesRequestsManager(new func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
 	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -431,7 +431,7 @@ apps:
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -504,7 +504,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -557,7 +557,7 @@ func (s *helpersSuite) TestProfileRegenerationDoesNotDelay(c *C) {
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -610,7 +610,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -840,7 +840,7 @@ func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
 	ovld := overlord.Mock()
 	st := ovld.State()
 	// manager
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	// installs the ifacemgr helper
 	err = mgr.StartUp()

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -185,7 +185,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.o.AddManager(hookMgr)
 
-	s.mgr, err = ifacestate.Manager(s.state, hookMgr, s.o.TaskRunner(), nil, nil)
+	s.mgr, err = ifacestate.Manager(s.state, hookMgr, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	s.o.AddManager(s.mgr)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/swfeats"
@@ -50,6 +51,9 @@ type deviceData struct {
 type InterfaceManager struct {
 	state *state.State
 	repo  *interfaces.Repository
+
+	// Notice Manager (because interfacesRequestsManager may be a notice backend)
+	noticeManager *notices.NoticeManager
 
 	udevMonMu           sync.Mutex
 	udevMon             udevmonitor.Interface
@@ -75,7 +79,7 @@ type InterfaceManager struct {
 
 // Manager returns a new InterfaceManager.
 // Extra interfaces can be provided for testing.
-func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
+func Manager(s *state.State, hookManager *hookstate.HookManager, noticeManager *notices.NoticeManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
 	delayedCrossMgrInit()
 
 	// NOTE: hookManager is nil only when testing.
@@ -87,6 +91,8 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	m := &InterfaceManager{
 		state: s,
 		repo:  interfaces.NewRepository(),
+		// noticeManager is stored to register future notice backends
+		noticeManager: noticeManager,
 		// note: enumeratedDeviceKeys is reset to nil when enumeration is done
 		enumeratedDeviceKeys: make(map[string]map[snap.HotplugKey]bool),
 		hotplugDevicePaths:   make(map[string][]deviceData),
@@ -600,16 +606,16 @@ var interfacesRequestsControlHandlerServicePresent = func(m *InterfaceManager) (
 // initInterfacesRequestsManager initializes the prompting backends which make
 // up the interfaces requests manager.
 //
+// Pass the notice manager to the backends so that they can be registered as
+// providers of prompting-related notices.
+//
 // This function should only be called if prompting is supported and enabled,
 // and at least one installed snap has a "snap-interfaces-requests-control"
 // connection with the "handler-service" attribute declared.
-//
-// The state lock must not be held when this function is called, so that
-// notices can be recorded if necessary.
 func (m *InterfaceManager) initInterfacesRequestsManager() error {
 	m.interfacesRequestsManagerMu.Lock()
 	defer m.interfacesRequestsManagerMu.Unlock()
-	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.noticeManager)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
@@ -179,6 +180,7 @@ type interfaceManagerSuite struct {
 	o              *overlord.Overlord
 	state          *state.State
 	se             *overlord.StateEngine
+	noticeMgr      *notices.NoticeManager
 	privateMgr     *ifacestate.InterfaceManager
 	privateHookMgr *hookstate.HookManager
 	extraIfaces    []interfaces.Interface
@@ -244,6 +246,8 @@ func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
+
+	s.noticeMgr = notices.NewNoticeManager(s.state)
 
 	s.SetupAsserts(c, s.state, &s.BaseTest)
 
@@ -312,7 +316,7 @@ slots:
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
 }
 
-var fakeCreateInterfacesRequestsManager = func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+var fakeCreateInterfacesRequestsManager = func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 	return nil, nil
 }
 
@@ -341,7 +345,7 @@ func addForeignTaskHandlers(runner *state.TaskRunner) {
 
 func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 	if s.privateMgr == nil {
-		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
+		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.noticeMgr, s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
 		c.Assert(err, IsNil)
 		addForeignTaskHandlers(s.o.TaskRunner())
 		mgr.DisableUDevMonitor()
@@ -393,12 +397,8 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
-		// InterfacesRequestsManager may record notices during creation, so
-		// simulate it acquiring the state lock to do so.
-		s.Lock()
-		defer s.Unlock()
 		return fakeManager, nil
 	})
 	defer restore()
@@ -443,7 +443,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		c.Errorf("unexpectedly called m.initInterfacesRequestsManager")
 		createCount++
 		return fakeManager, nil
@@ -7760,13 +7760,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7807,13 +7807,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7848,12 +7848,12 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer restore()
 
 	createError := fmt.Errorf("custom error")
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return nil, createError
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7885,7 +7885,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 	})
 	defer restore()
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return fakeManager, nil
 	})
 	defer restore()
@@ -9128,7 +9128,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -9169,7 +9169,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -9205,7 +9205,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -184,7 +184,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 	o.addManager(assertMgr)
 
-	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.noticeMgr, o.runner, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -45,103 +45,10 @@ debug: |
 execute: |
     RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
 
-    echo "Since there is no user 1000 active on the system, write a user session ID"
-    echo "xattr to /run/user/1000/"
+    echo "Since there is no user 1000 active on the system, write a known user session ID xattr to /run/user/1000/"
     USER_SESSION_PATH="/run/user/1000"
     mkdir -p "$USER_SESSION_PATH"
     setfattr -n trusted.snapd_user_session_id -v "0123456789ABCDEF" "$USER_SESSION_PATH"
-
-    echo "Write three rules to disk, one of which is partially expired,"
-    echo "another is fully expired, and the last is not expired whatsoever"
-    mkdir -p "$(dirname $RULES_PATH)"
-    echo '{
-      "rules": [
-        {
-          "id": "0000000000000002",
-          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
-          "user": 1000,
-          "snap": "shellcheck",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Projects/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000003",
-          "timestamp": "2004-10-20T16:47:32.138415627-05:00",
-          "user": 1000,
-          "snap": "firefox",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/**",
-            "permissions": {
-              "read": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "session-id": "F00BA4F00BA40000"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000005",
-          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
-          "user": 1000,
-          "snap": "thunderbird",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "session-id": "0123456789ABCDEF"
-              }
-            }
-          }
-        }
-      ]
-    }' | tee "$RULES_PATH"
-
-    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
-
-    # Wait a second to make sure any notices are recorded after CURRTIME
-    sleep 1
 
     echo "Enable AppArmor prompting experimental feature"
     snap set system experimental.apparmor-prompting=true
@@ -150,154 +57,212 @@ execute: |
     sleep 5
 
     echo "Check that snapd is able to start up"
-    retry --wait 1 -n 60 systemctl is-active snapd
-
-    echo "Check that apparmor prompting is supported and enabled"
-    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
-
-    # Write expected rules after the expired rule has been removed
-    echo '{
-      "rules": [
-        {
-          "id": "0000000000000002",
-          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
-          "user": 1000,
-          "snap": "shellcheck",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Projects/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000005",
-          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
-          "user": 1000,
-          "snap": "thunderbird",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0123456789ABCDEF"
-              }
-            }
-          }
-        }
-      ]
-    }' | gojq | tee expected.json
-    # Parse existing rules through (go)jq so they can be compared
-
-    if ! tests.info is-reexec-in-use && os.query is-ubuntu-ge 25.04; then
-        echo "Expect snapd to be built with go 1.24+, which supports omitzero,"
-        echo "so remove the zero-valued fields from the rules."
-        gojq 'del(.rules.[].constraints.permissions.[]."expiration" | select(. == "0001-01-01T00:00:00Z"))' < expected.json | \
-        gojq 'del(.rules.[].constraints.permissions.[]."session-id" | select(. == "0000000000000000"))' | tee expected-modified.json
-        mv expected-modified.json expected.json
-    fi
-
-    echo "Check that rules on disk match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
-
-    echo "Check that we received two notices, one of which marked a rule as expired"
-    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result' | grep -c '"removed": "expired"' | MATCH '^1$'
-    echo "One notice for rule with ID 0000000000000002, which was modified but not expired"
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000002" | \
-        gojq '.result | length' | MATCH '^1$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000002" | \
-        gojq '.result' | NOMATCH '"last-data"'
-    echo "One notice for rule with ID 0000000000000003, which expired"
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000003" | \
-        gojq '.result | length' | MATCH '^1$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000003" | \
-        gojq '.result[0]."last-data".removed' | MATCH '"expired"'
-
-    echo "Check that only the first and last rules are still valid (must be done with UID 1000)"
-    snap debug api --fail "/v2/interfaces/requests/rules?user-id=1000" | gojq
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
-
-    echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
-
-    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
-
-    echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
-    echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
-    echo "Check that we received no new notices notices, as the non-expired rules did not change on restart"
+    echo "Add first rule (which we'll later modify manually to expire some permissions)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "shellcheck",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Projects/**",
+          "permissions": {
+            "read": {
+              "outcome": "allow",
+              "lifespan": "forever"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "timespan",
+              "duration": "100h"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE1_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE1_ID"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Add second rule (which we'll later modify manually to expire all permissions)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "firefox",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Downloads/**",
+          "permissions": {
+            "read": {
+              "outcome": "deny",
+              "lifespan": "timespan",
+              "duration": "15m"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "session"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api --fail -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE2_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE2_ID"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Add third rule (which we'll leave unchanged on disk)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "thunderbird",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
+          "permissions": {
+            "read": {
+              "outcome": "allow",
+              "lifespan": "forever"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "session"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api --fail -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE3_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE3_ID"
+
+    echo "Stop snapd so we can edit rules on disk, and ensure it is not in failure mode"
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
+
+    echo "Edit the rules on disk to expire some permissions"
+    gojq '(.rules.[] | select(.id == '"$RULE1_ID"')).constraints.permissions.write.expiration = "2005-04-08T00:00:00Z"' < "$RULES_PATH" | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.read.expiration = "2005-04-08T00:00:00Z"' | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.write.expiration = "2005-04-08T00:00:00Z"' | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.execute."session-id" = "F00BA4F00BA40000"' | tee modified.json
+    mv modified.json "$RULES_PATH"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Enable snapd so it will remove the expired permissions and record notices"
+    systemctl enable --now snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that only the first and last rules are still valid (must be done with UID 1000)"
+    snap debug api --fail "/v2/interfaces/requests/rules?user-id=1000" | gojq
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
+
+    echo "Check that the expired permissions of the non-expired rules were removed"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE1_ID"') | .constraints.permissions | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE1_ID"') | .constraints.permissions.write' | MATCH 'null'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE3_ID"') | .constraints.permissions | length' | MATCH '^3$'
+
+    echo "Check that we received two notices, one of which marked a rule as expired"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[].key' | MATCH "$RULE1_ID"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[].key' | MATCH "$RULE2_ID"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result' | grep -c '"removed": "expired"' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[] | select(.key == '"$RULE2_ID"')' | MATCH '"removed": "expired"'
+
+    cp "$RULES_PATH" expected.json
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl enable --now snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk were not changed after snapd restart"
+    diff expected.json "$RULES_PATH"
+
+    echo "Check that only the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
+
+    echo "Check that we received no new notices since the rules were not changed on load"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result | length' | MATCH '^0$'
 
-    echo "Check that only the non-expired rules are still valid (must be done with UID 1000)"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
-
     echo '### Simulate failure to open interfaces requests manager ###'
 
     echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
 
     echo "Corrupt the max prompt ID file (by making it a dir) so it will fail to start up next time"
     # This simulates what would happen on system restart, if e.g. /run/snapd did not yet exist during StartUp
     MAX_ID_FILEPATH="/run/snapd/interfaces-requests/request-prompt-max-id"
-    rm -f "$MAX_ID_FILEPATH"
+    mv "$MAX_ID_FILEPATH" "$MAX_ID_FILEPATH".bak
     mkdir -p "$MAX_ID_FILEPATH"
 
     echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
+    systemctl enable --now snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
@@ -307,8 +272,7 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    diff expected.json "$RULES_PATH"
 
     echo "Check that accessing a prompting endpoint results in an expected error"
     snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '."status-code"' | MATCH '^500$'
@@ -317,18 +281,17 @@ execute: |
     echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
 
     echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
 
     echo "Remove corrupted max prompt ID file"
     rm -rf "$MAX_ID_FILEPATH"
+    mv "$MAX_ID_FILEPATH".bak "$MAX_ID_FILEPATH"
 
     CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
     echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
+    systemctl enable --now snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
@@ -336,15 +299,14 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    diff expected.json "$RULES_PATH"
+
+    echo "Check that the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
 
     echo "Check that we received no new notices, as the non-expired rules did not changed on restart"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result | length' | MATCH '^0$'
-
-    echo "Check that the non-expired rules are still valid (must be done with UID 1000)"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"


### PR DESCRIPTION
Relying on the new `prompting-client` integration tests added in #16289, re-enable the prompting notice backend after fixing whatever is causing problems with those integration tests. The potential regression was not caught by existing prompting spread tests.

The real root cause appears to be that the prompting-client integration tests would hang after the subprocess which triggered the request exited, due to a problem with the output not sending depending on the timing and the tokio scheduler. And enabling the prompting notice backend changed the timing enough to fairly reliably trigger the tests hanging on at least a few test cases per run.

The issue with the test reliability was solved here: https://github.com/canonical/prompting-client/pull/304

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36018

A reproducer and analysis of the timing and the root cause can also be found there. #16879 is can be used to reproduce the issue and easily enable/disable the prompting notice backend.

We may not want to include all the extra debug logging in the final PR. I've split out the changes so it should be easy to drop/squash the parts we want to before merging. I would like to merge spread test improvements and the prompting notice backend enablement as separate PRs, at least.

unskip:

- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-flag-restart
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-integration-tests
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-prompt-restoration
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-smoke
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-snapd-startup
- openstack:ubuntu-26.04-64:tests/main/interfaces-requests-activates-handlers
- openstack:ubuntu-26.04-64:tests/main/snap-interfaces-requests-control