### PR TITLE
interfaces/opengl: add new DMA heap for imx

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -159,6 +159,9 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /dev/dma_heap/linux,cma rw,
 /dev/dma_heap/system rw,
 
+# IMX specific
+/dev/dma_heap/linux,cma-uncached rw,
+
 # NXP i.MX driver
 # https://github.com/Freescale/kernel-module-imx-gpu-viv
 /dev/galcore rw,


### PR DESCRIPTION
Add /dev/dma_heap/linux,cma-uncached, that is specific to imx (https://github.com/nxp-imx/linux-imx/blob/lf-6.12.y/drivers/dma-buf/heaps/cma_heap.c#L412).