### PR TITLE
interfaces/hostname-control: Allow setting the hostname from install mode

### DIFF
--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -37,6 +37,10 @@ const hostnameControlConnectedPlugAppArmor = `
 # on core /etc/hostname is a link to /etc/writable/hostname
 /etc/writable/hostname w,
 
+# At installation time on core, the hostname can be set here via the install-device hook
+/run/mnt/ubuntu-data/system-data/_writable_defaults/etc/writable/ w,
+/run/mnt/ubuntu-data/system-data/_writable_defaults/etc/writable/hostname w,
+
 #include <abstractions/dbus-strict>
 /{,usr/}{,s}bin/hostnamectl           ixr,
 


### PR DESCRIPTION
Setting the hostname for run mode, during install mode, ensures that a generic hostname, or localhost, will not be used.  This can be important for things such as clear logging, or even ensuring the hostname provided by the dhcpclient is correct [ not the generic "ubuntu" ] when entering run mode for the first time.

The only way to set hostname in the run mode target is to write the `hostname` file under _writable_defaults from a gadgets `install-device` hook. The `_writable_defaults/etc/writable` dir does not seem to exist when the `install-device` hook is run [ at least on uc24 ], and so permission to create the `writable` dir is also required.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

SNAPDENG-36154
