### PR TITLE
feat(overlord): allow waiting on tasks

### DIFF
--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -255,6 +255,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s
+		t.finishUnmarshal()
 	}
 	for _, chg := range s.changes {
 		chg.state = s

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -532,6 +532,11 @@ func (ss *stateSuite) TestNewTaskAndCheckpoint(c *C) {
 
 	c.Check(task0_1.AtTime().IsZero(), Equals, true)
 	c.Check(task0_2.AtTime().Equal(schedule), Equals, true)
+	select {
+	case <-task0_1.Ready():
+	default:
+		c.Errorf("Task didn't preserve Ready channel closed after deserialization")
+	}
 }
 
 func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -198,6 +198,41 @@ func (ts *taskSuite) TestTaskMarshalsWaitStatus(c *C) {
 	c.Assert(string(d), testutil.Contains, needle)
 }
 
+func (ts *taskSuite) TestTaskReady(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("stages", "...")
+
+	select {
+	case <-task.Ready():
+		c.Fatal("Task should not be ready")
+	default:
+	}
+
+	task.SetStatus(state.DoingStatus)
+	select {
+	case <-task.Ready():
+		c.Fatal("Task should not be ready")
+	default:
+	}
+
+	task.SetStatus(state.DoneStatus)
+	select {
+	case <-task.Ready():
+	default:
+		c.Fatal("Task should be ready")
+	}
+
+	task.SetStatus(state.ErrorStatus)
+	select {
+	case <-task.Ready():
+	default:
+		c.Fatal("Task should still be ready")
+	}
+}
+
 func (ts *taskSuite) TestIsCleanAndSetClean(c *C) {
 	st := state.New(nil)
 	st.Lock()


### PR DESCRIPTION
Tasks already have the idea of "ready" - Task.ReadyTime() returns the time when a task becomes ready and this is exposed to users via the CLI. This extends that concept in a way that mirrors the behavior in changes.