### PR TITLE
gadget: inject default netplan configuration in gadget configuration

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -2135,16 +2135,35 @@ func flatten(path string, cfg any, out map[string]any) {
 	}
 }
 
-// SystemDefaults returns default system configuration from gadget defaults.
-func SystemDefaults(gadgetDefaults map[string]map[string]any) map[string]any {
-	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
-		if defaults, ok := gadgetDefaults[systemSnap]; ok {
-			coreDefaults := map[string]any{}
-			flatten("", defaults, coreDefaults)
-			return coreDefaults
+func SetFallbackDefaults(values map[string]any) {
+	hasNetplan := false
+	for key := range values {
+		if key == "system.network.netplan" {
+			hasNetplan = true
+		} else if strings.HasPrefix(key, "system.network.netplan.") {
+			hasNetplan = true
 		}
 	}
-	return nil
+	// Also check for the configuration file. If the file exists
+	// already it either was already seeded or the core base contains the configuration.
+	if !hasNetplan && !osutil.FileExists(filepath.Join(dirs.GlobalRootDir, "etc/netplan/00-snapd-config.yaml")) {
+		values["system.network.netplan.network.version"] = 2
+		values["system.network.netplan.network.ethernets.all-en.match.name"] = "en*"
+		values["system.network.netplan.network.ethernets.all-en.dhcp4"] = true
+	}
+}
+
+// SystemDefaults returns default system configuration from gadget defaults.
+func SystemDefaults(gadgetDefaults map[string]map[string]any) map[string]any {
+	coreDefaults := map[string]any{}
+	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
+		if defaults, ok := gadgetDefaults[systemSnap]; ok {
+			flatten("", defaults, coreDefaults)
+			break
+		}
+	}
+	SetFallbackDefaults(coreDefaults)
+	return coreDefaults
 }
 
 // See https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -730,7 +730,14 @@ func (s *gadgetYamlTestSuite) TestFlatten(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
-	err := os.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
+	netPlanConf := filepath.Join(dirs.GlobalRootDir, "etc/netplan/00-snapd-config.yaml")
+	err := os.MkdirAll(filepath.Dir(netPlanConf), 0755)
+	c.Assert(err, IsNil)
+
+	err = os.WriteFile(netPlanConf, []byte{}, 0644)
+	c.Assert(err, IsNil)
+
+	err = os.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
@@ -753,6 +760,21 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	defaults = gadget.SystemDefaults(ginfo.Defaults)
 	c.Check(defaults, DeepEquals, map[string]any{
 		"something": true,
+	})
+}
+
+func (s *gadgetYamlTestSuite) TestCoreConfigDefaultsNoNetplan(c *C) {
+	err := os.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
+	c.Assert(err, IsNil)
+
+	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
+	c.Assert(err, IsNil)
+	defaults := gadget.SystemDefaults(ginfo.Defaults)
+	c.Check(defaults, DeepEquals, map[string]any{
+		"ssh.disable":                            true,
+		"system.network.netplan.network.version": 2,
+		"system.network.netplan.network.ethernets.all-en.match.name": "en*",
+		"system.network.netplan.network.ethernets.all-en.dhcp4":      true,
 	})
 }
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -645,3 +645,7 @@ var ArrangeRebootAndUpdateSeed = arrangeRebootAndUpdateSeed
 func MockProcessDelayedSecurityBackendEffects(f func(st *state.State, lanes []int, joinLane int) (ts *state.TaskSet)) (restore func()) {
 	return testutil.Mock(&ProcessDelayedSecurityBackendEffects, f)
 }
+
+func MockGadgetSetFallbackDefaults(f func(values map[string]any)) (restore func()) {
+	return testutil.Mock(&gadgetSetFallbackDefaults, f)
+}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -95,6 +95,8 @@ var osutilCheckFreeSpace = osutil.CheckFreeSpace
 // See LP:#1940553
 var TestingLeaveOutKernelUpdateGadgetAssets bool = false
 
+var gadgetSetFallbackDefaults = gadget.SetFallbackDefaults
+
 type minimalInstallInfo interface {
 	InstanceName() string
 	Type() snap.Type
@@ -4054,6 +4056,7 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 				logger.Noticef("core snap configuration defaults found under both 'system' key and core-snap-id, preferring 'system'")
 			}
 
+			gadgetSetFallbackDefaults(defaults)
 			return defaults, nil
 		}
 	}

--- a/overlord/snapstate/snapstate_config_defaults_test.go
+++ b/overlord/snapstate/snapstate_config_defaults_test.go
@@ -59,6 +59,8 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]any{"key": "value"})
 
+	snapstate.MockGadgetSetFallbackDefaults(func(values map[string]any) {})
+
 	snapstate.Set(s.state, "local-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
@@ -175,6 +177,8 @@ defaults:
 
 	makeInstalledMockCoreSnap(c)
 
+	snapstate.MockGadgetSetFallbackDefaults(func(values map[string]any) {})
+
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]any{"foo": "bar"})
@@ -222,6 +226,8 @@ defaults:
 		RealName: "snapd",
 		Revision: snap.R(1),
 	})
+
+	snapstate.MockGadgetSetFallbackDefaults(func(values map[string]any) {})
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The plan is to remove the default gadget configuration from core26. But to be able to make netplan work on gadget missing netplan configuration, we should inject the old configuration.
