### PR TITLE
many: reproduce inconsistent common id bug

### DIFF
--- a/tests/main/inconsistent-common-id-reproducer/task.yaml
+++ b/tests/main/inconsistent-common-id-reproducer/task.yaml
@@ -1,0 +1,41 @@
+summary: Reproduce issue with inconsistent common ID
+
+details: |
+    When installing a snap with a `desktop-file-id` defined in the `desktop-file`
+    plug, that common ID is not always respected. One side effect of this is
+    that snap installs of that snap fail periodically when there's a mismatch
+    between the expected ID and the specified common ID. This spread test is a
+    reproducer of this issue.
+
+systems:
+  - ubuntu-2*
+
+prepare: |
+    # Get Marco's demo snap which is known to cause this bug
+    curl -Lo ashpd-demo.snap https://people.ubuntu.com/~3v1n0/snaps/ashpd-demo_0.5.0+desktop-id_amd64.snap
+
+debug: |
+    current_stack_filepath="/tmp/failure-reproducer-current-stack"
+    all_stacks_filepath="/tmp/failure-reproducer-all-stacks"
+    if [ -f "$current_stack_filepath" ] ; then
+        echo
+        echo '%%%%%%%% CURRENT STACK %%%%%%%%'
+        cat "$current_stack_filepath"
+    else
+        echo '%%%%%%%% NO CURRENT STACK FOUND %%%%%%%%'
+    fi
+    if [ -f "$all_stacks_filepath" ] ; then
+        echo
+        echo '%%%%%%%% ALL STACKS %%%%%%%%'
+        cat "$all_stacks_filepath"
+    else
+        echo '%%%%%%%% NO ALL STACKS FOUND %%%%%%%%'
+    fi
+
+execute: |
+    for attempt in $(seq 1 100) ; do
+        echo "Attempt $attempt"
+        # Eventually this should fail
+        snap install ashpd-demo.snap --dangerous
+        snap remove --purge ashpd-demo
+    done


### PR DESCRIPTION
@3v1n0 is seeing the common ID flip between the one defined in the snap `desktop-files` plug and the default `<snap>_...` one. One way this manifests is that snap installs occasionally fail due to a mismatch. This PR adds a spread test to reproduce it and record the stacktraces at time of failure.

Marco said:

> with 2.74.1 we return always the wrong ID, while with 2.73+ubuntu24.04 the dancing behavior happens all the times to me

> in resolute, the desktop file is called: /var/lib/snapd/desktop/applications/ashpd-demo_com.belmoussaoui.ashpd.demo.desktop

In my experience on my local system (25.10 with snapd 2.74.1 from latest/beta) I see the flip-flopping too. So it's host-system dependent.

This PR should not be merged.

This issue is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36476