### PR TITLE
interfaces/builtin/desktop: Allow Wine to execute files that are accessed via the Document Portal

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -98,6 +98,9 @@ owner /run/user/[0-9]*/doc/{,*/} r,
 # the user guided the access and can specify anything DAC allows.
 /run/user/[0-9]*/doc/*/** rw,
 
+# Permission for Wine to execute files that were accessed via the Document Portal.
+/run/user/[0-9]*/doc/*/** ix,
+
 # Allow access to xdg-desktop-portal and xdg-document-portal
 dbus (receive, send)
     bus=session


### PR DESCRIPTION
I was testing Zordeer and discovered that Snapd currently doesn't allow running .exe files accessed via the XDG Desktop Portal.

This modification is to fix that.

I demonstrate the error that occurs in this video here:
https://youtu.be/4_7x4NJqlRk?si=R4HCQHwNd-Rifq4m