### PR TITLE
ci: Ensure all apt install have -y

### DIFF
--- a/.github/workflows/ci-master-push.yaml
+++ b/.github/workflows/ci-master-push.yaml
@@ -33,7 +33,7 @@ jobs:
           ln -s packaging/ubuntu-16.04 debian
           sudo apt build-dep -d -y ${{ github.workspace }}
           # for indent
-          sudo apt install texinfo autopoint
+          sudo apt install -y texinfo autopoint
 
     - name: Copy dependencies
       run: |

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -173,7 +173,7 @@ jobs:
           ln -s packaging/ubuntu-16.04 debian
           sudo apt build-dep -d -y ${{ github.workspace }}
           # for indent
-          sudo apt install texinfo autopoint
+          sudo apt install -y texinfo autopoint
 
     - name: Copy dependencies
       run: |

--- a/.github/workflows/nightly-firefox-performance.yaml
+++ b/.github/workflows/nightly-firefox-performance.yaml
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo snap install built-snap/snapd_1337.*.snap.keep --dangerous
         sudo snap install firefox
-        sudo apt install xvfb
+        sudo apt install -y xvfb
 
     - name: Run Firefox performance tests
       uses: ./.github/actions/run-firefox-performance-tests
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo snap install firefox
-        sudo apt install xvfb
+        sudo apt install -y xvfb
 
     - name: Run Firefox performance tests
       uses: ./.github/actions/run-firefox-performance-tests

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run codespell tool
       run: |
-          sudo apt install python3-pip
+          sudo apt install -y python3-pip
           pip3 install codespell
           codespell
 

--- a/tests/nested/manual/hybrid-fde-all-key-databases/task.yaml
+++ b/tests/nested/manual/hybrid-fde-all-key-databases/task.yaml
@@ -127,7 +127,7 @@ prepare: |
   esac
 
   remote.push update.auth
-  remote.exec sudo apt install efitools -y
+  remote.exec sudo apt install -y efitools
 
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"


### PR DESCRIPTION
During tests, a lot of .deb packages are installed. In some cases, the -y parameter is missing, which may cause problems in the future if the package to install have new dependencies.

This patch ensures that all apt install calls do have the -y parameter.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
