### PR TITLE
o/devicemgmtstate: add task to queue response messages

### DIFF
--- a/overlord/devicemgmtstate/devicemgmtmgr.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr.go
@@ -88,9 +88,9 @@ type RequestMessage struct {
 	ValidUntil  time.Time `json:"valid-until"`
 	Body        string    `json:"body"`
 
-	ReceiveTime    time.Time             `json:"receive-time"`
-	ResponseStatus asserts.MessageStatus `json:"status,omitempty"`
-	ResponseReason string                `json:"error,omitempty"`
+	ReceiveTime time.Time             `json:"receive-time"`
+	Status      asserts.MessageStatus `json:"status,omitempty"`
+	Error       string                `json:"error,omitempty"`
 	// Subsystem change applying this message.
 	ChangeID string `json:"change-id,omitempty"`
 }
@@ -396,8 +396,8 @@ func (m *DeviceMgmtManager) doQueueResponse(t *state.Task, _ *tomb.Tomb) error {
 
 		body, status = handler.BuildResponse(change)
 	} else {
-		body = map[string]any{"message": msg.ResponseReason}
-		status = msg.ResponseStatus
+		status = msg.Status
+		body = map[string]any{"message": msg.Error}
 	}
 
 	bodyBytes, err := json.Marshal(body)

--- a/overlord/devicemgmtstate/devicemgmtmgr.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr.go
@@ -25,6 +25,7 @@
 package devicemgmtstate
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -45,6 +46,8 @@ const (
 
 	defaultExchangeLimit    = 10
 	defaultExchangeInterval = 6 * time.Hour
+
+	awaitSubsystemRetryInterval = 30 * time.Second
 )
 
 var (
@@ -85,7 +88,11 @@ type RequestMessage struct {
 	ValidUntil  time.Time `json:"valid-until"`
 	Body        string    `json:"body"`
 
-	ReceiveTime time.Time `json:"receive-time"`
+	ReceiveTime    time.Time             `json:"receive-time"`
+	ResponseStatus asserts.MessageStatus `json:"status,omitempty"`
+	ResponseReason string                `json:"error,omitempty"`
+	// Subsystem change applying this message.
+	ChangeID string `json:"change-id,omitempty"`
 }
 
 // ID returns the full message identifier `BaseID[-SeqNum]`.
@@ -95,6 +102,16 @@ func (msg *RequestMessage) ID() string {
 	}
 
 	return msg.BaseID
+}
+
+// sequenceCache is the LRU-bounded cache of tracked message sequences.
+type sequenceCache struct {
+	// Applied tracks how far each sequence has progressed. A sequenced
+	// message can only be applied once its predecessor has been applied.
+	Applied map[string]int `json:"applied,omitempty"`
+
+	// LRU determines eviction order when the cache is full.
+	LRU []string `json:"lru,omitempty"`
 }
 
 // deviceMgmtState holds the persistent state for device management operations.
@@ -108,12 +125,31 @@ type deviceMgmtState struct {
 	// up to this point.
 	LastReceivedToken string `json:"last-received-token"`
 
+	// Sequences is the LRU-bounded cache of tracked message sequences.
+	Sequences *sequenceCache `json:"sequences"`
+
 	// ReadyResponses are response messages ready to send in the next exchange.
 	// Cleared after successful transmission.
 	ReadyResponses map[string]store.Message `json:"ready-responses"`
 
 	// LastExchangeTime is the timestamp of the last message exchange.
 	LastExchangeTime time.Time `json:"last-exchange-time"`
+}
+
+// getMessage retrieves a request message from pending requests.
+func (ms *deviceMgmtState) getMessage(t *state.Task) (*RequestMessage, error) {
+	var id string
+	err := t.Get("id", &id)
+	if err != nil {
+		return nil, err
+	}
+
+	msg, ok := ms.PendingRequests[id]
+	if !ok {
+		return nil, fmt.Errorf("cannot find message with id %q", id)
+	}
+
+	return msg, nil
 }
 
 // enqueueRequests queues incoming request messages for processing
@@ -177,11 +213,19 @@ func (m *DeviceMgmtManager) getState() (*deviceMgmtState, error) {
 		if errors.Is(err, state.ErrNoState) {
 			return &deviceMgmtState{
 				PendingRequests: make(map[string]*RequestMessage),
-				ReadyResponses:  make(map[string]store.Message),
+				Sequences: &sequenceCache{
+					Applied: make(map[string]int),
+					LRU:     make([]string, 0),
+				},
+				ReadyResponses: make(map[string]store.Message),
 			}, nil
 		}
 
 		return nil, err
+	}
+
+	if ms.Sequences.Applied == nil {
+		ms.Sequences.Applied = make(map[string]int)
 	}
 
 	return &ms, nil
@@ -318,9 +362,66 @@ func (m *DeviceMgmtManager) doApplyMessage(t *state.Task, _ *tomb.Tomb) error {
 }
 
 // doQueueResponse builds a response, signs it, and queues it for transmission on the next exchange.
-// Retries until subsystem change completes.
+// For messages with a subsystem change, the task retries until the change completes.
 func (m *DeviceMgmtManager) doQueueResponse(t *state.Task, _ *tomb.Tomb) error {
-	// TODO: implement this task, no-op for now.
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	ms, err := m.getState()
+	if err != nil {
+		return err
+	}
+
+	msg, err := ms.getMessage(t)
+	if err != nil {
+		return err
+	}
+
+	var body map[string]any
+	var status asserts.MessageStatus
+	if msg.ChangeID != "" {
+		handler, ok := m.handlers[msg.Kind]
+		if !ok {
+			return fmt.Errorf("cannot find handler for message kind %q", msg.Kind)
+		}
+
+		change := m.state.Change(msg.ChangeID)
+		if change == nil {
+			return fmt.Errorf("cannot find subsystem change %q", msg.ChangeID)
+		}
+
+		if !change.Status().Ready() {
+			return &state.Retry{After: awaitSubsystemRetryInterval}
+		}
+
+		body, status = handler.BuildResponse(change)
+	} else {
+		body = map[string]any{"message": msg.ResponseReason}
+		status = msg.ResponseStatus
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cannot marshal response body: %w", err)
+	}
+
+	resAs, err := m.signer.SignResponseMessage(msg.AccountID, msg.ID(), status, bodyBytes)
+	if err != nil {
+		return fmt.Errorf("cannot sign response message: %w", err)
+	}
+
+	ms.ReadyResponses[msg.ID()] = store.Message{
+		Format: "assertion",
+		Data:   string(asserts.Encode(resAs)),
+	}
+
+	if msg.SeqNum > 0 {
+		ms.Sequences.Applied[msg.BaseID] = msg.SeqNum
+	}
+	delete(ms.PendingRequests, msg.ID())
+
+	m.setState(ms)
+
 	return nil
 }
 

--- a/overlord/devicemgmtstate/devicemgmtmgr_test.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr_test.go
@@ -22,6 +22,7 @@ package devicemgmtstate_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -55,6 +56,32 @@ type mockStore struct {
 
 func (s *mockStore) ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error) {
 	return s.exchangeMessages(ctx, req)
+}
+
+type mockMessageHandler struct {
+	validate      func(st *state.State, msg *devicemgmtstate.RequestMessage) error
+	apply         func(st *state.State, msg *devicemgmtstate.RequestMessage) (string, error)
+	buildResponse func(chg *state.Change) (map[string]any, asserts.MessageStatus)
+}
+
+func (h *mockMessageHandler) Validate(st *state.State, msg *devicemgmtstate.RequestMessage) error {
+	return h.validate(st, msg)
+}
+
+func (h *mockMessageHandler) Apply(st *state.State, msg *devicemgmtstate.RequestMessage) (string, error) {
+	return h.apply(st, msg)
+}
+
+func (h *mockMessageHandler) BuildResponse(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+	return h.buildResponse(chg)
+}
+
+type mockSigner struct {
+	sign func(accountID, messageID string, status asserts.MessageStatus, body []byte) (*asserts.ResponseMessage, error)
+}
+
+func (s *mockSigner) SignResponseMessage(accountID, messageID string, status asserts.MessageStatus, body []byte) (*asserts.ResponseMessage, error) {
+	return s.sign(accountID, messageID, status, body)
 }
 
 func setRemoteMgmtFeatureFlag(c *C, st *state.State, value any) {
@@ -201,8 +228,10 @@ func (s *deviceMgmtMgrSuite) TestShouldExchangeMessages(c *C) {
 		cmt := Commentf("%s test", tt.name)
 
 		ms := &devicemgmtstate.DeviceMgmtState{
-			LastExchangeTime: tt.lastExchangeTime,
+			PendingRequests:  make(map[string]*devicemgmtstate.RequestMessage),
+			Sequences:        devicemgmtstate.NewSequenceCache(),
 			ReadyResponses:   tt.readyResponses,
+			LastExchangeTime: tt.lastExchangeTime,
 		}
 
 		setRemoteMgmtFeatureFlag(c, s.st, tt.flag)
@@ -250,6 +279,9 @@ func (s *deviceMgmtMgrSuite) TestEnsureChangeAlreadyInFlight(c *C) {
 
 	expired := time.Now().Add(-(devicemgmtstate.DefaultExchangeInterval + time.Minute))
 	ms := &devicemgmtstate.DeviceMgmtState{
+		PendingRequests:  make(map[string]*devicemgmtstate.RequestMessage),
+		Sequences:        devicemgmtstate.NewSequenceCache(),
+		ReadyResponses:   make(map[string]store.Message),
 		LastExchangeTime: expired,
 	}
 	s.mgr.SetState(ms)
@@ -364,10 +396,12 @@ func (s *deviceMgmtMgrSuite) TestDoExchangeMessagesReplyOK(c *C) {
 	})
 
 	ms := &devicemgmtstate.DeviceMgmtState{
+		PendingRequests:   make(map[string]*devicemgmtstate.RequestMessage),
+		Sequences:         devicemgmtstate.NewSequenceCache(),
+		LastReceivedToken: "token-123",
 		ReadyResponses: map[string]store.Message{
 			"someId": {Format: "assertion", Data: "response-data"},
 		},
-		LastReceivedToken: "token-123",
 	}
 	s.mgr.SetState(ms)
 
@@ -466,6 +500,242 @@ func (s *deviceMgmtMgrSuite) TestDoExchangeMessagesStoreError(c *C) {
 	c.Assert(err, ErrorMatches, "network timeout")
 }
 
+func (s *deviceMgmtMgrSuite) TestDoQueueResponse(c *C) {
+	type test struct {
+		name           string
+		msg            func() *devicemgmtstate.RequestMessage
+		buildResponse  func(chg *state.Change) (map[string]any, asserts.MessageStatus)
+		expectedStatus asserts.MessageStatus
+		expectedBody   map[string]any
+	}
+
+	tests := []test{
+		{
+			name: "success",
+			msg: func() *devicemgmtstate.RequestMessage {
+				change := s.st.NewChange("subsys-op", "subsystem operation")
+				change.SetStatus(state.DoneStatus)
+
+				return makeRequestMessage("mesg", 1, "test-kind", change.ID())
+			},
+			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+				return map[string]any{"result": "ok"}, asserts.MessageStatusSuccess
+			},
+			expectedStatus: asserts.MessageStatusSuccess,
+			expectedBody:   map[string]any{"result": "ok"},
+		},
+		{
+			name: "error",
+			msg: func() *devicemgmtstate.RequestMessage {
+				change := s.st.NewChange("subsys-op", "subsystem operation")
+				change.SetStatus(state.ErrorStatus)
+
+				return makeRequestMessage("mesg", 1, "test-kind", change.ID())
+			},
+			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+				return map[string]any{"error": "operation failed"}, asserts.MessageStatusError
+			},
+			expectedStatus: asserts.MessageStatusError,
+			expectedBody:   map[string]any{"error": "operation failed"},
+		},
+		{
+			name: "rejected",
+			msg: func() *devicemgmtstate.RequestMessage {
+				msg := makeRequestMessage("mesg", 1, "test-kind", "")
+				msg.ResponseStatus = asserts.MessageStatusRejected
+				msg.ResponseReason = "invalid payload: missing required field"
+				return msg
+			},
+			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+				c.Log("buildResponse call not expected")
+				c.Fail()
+
+				return nil, ""
+			},
+			expectedStatus: asserts.MessageStatusRejected,
+			expectedBody:   map[string]any{"message": "invalid payload: missing required field"},
+		},
+	}
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	for _, tt := range tests {
+		cmt := Commentf("%s status test", tt.name)
+
+		msg := tt.msg()
+
+		ms := &devicemgmtstate.DeviceMgmtState{
+			PendingRequests: map[string]*devicemgmtstate.RequestMessage{"mesg-1": msg},
+			Sequences:       devicemgmtstate.NewSequenceCache(),
+			ReadyResponses:  make(map[string]store.Message),
+		}
+		s.mgr.SetState(ms)
+
+		handler := &mockMessageHandler{
+			buildResponse: tt.buildResponse,
+		}
+		s.mgr.MockHandler("test-kind", handler)
+
+		signer := &mockSigner{
+			sign: func(accountID, messageID string, status asserts.MessageStatus, body []byte) (*asserts.ResponseMessage, error) {
+				c.Check(status, Equals, tt.expectedStatus, cmt)
+				var bodyMap map[string]any
+				c.Assert(json.Unmarshal(body, &bodyMap), IsNil, cmt)
+				c.Check(bodyMap, DeepEquals, tt.expectedBody, cmt)
+
+				return assertstest.FakeAssertionWithBody(
+					body,
+					map[string]any{
+						"type":        "response-message",
+						"account-id":  accountID,
+						"message-id":  messageID,
+						"device":      "serial-1.my-model.my-brand",
+						"status":      string(status),
+						"body-length": fmt.Sprintf("%d", len(body)),
+					},
+				).(*asserts.ResponseMessage), nil
+			},
+		}
+		s.mgr.MockSigner(signer)
+
+		t := s.st.NewTask("queue-mgmt-response", "test queue-mgmt-response task")
+		t.Set("id", "mesg-1")
+
+		s.st.Unlock()
+		err := s.mgr.DoQueueResponse(t, &tomb.Tomb{})
+		s.st.Lock()
+		c.Assert(err, IsNil)
+
+		ms, err = s.mgr.GetState()
+		c.Assert(err, IsNil)
+		c.Check(ms.PendingRequests, HasLen, 0)
+		c.Assert(ms.ReadyResponses, HasLen, 1)
+		c.Check(ms.ReadyResponses["mesg-1"].Format, Equals, "assertion")
+		c.Check(ms.Sequences.Applied["mesg"], Equals, 1)
+	}
+}
+
+func (s *deviceMgmtMgrSuite) TestDoQueueResponseSubsystemChangeNotReady(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	subsysChg := s.st.NewChange("subsys-op", "subsystem operation")
+	subsysChg.SetStatus(state.DoingStatus)
+
+	ms := &devicemgmtstate.DeviceMgmtState{
+		PendingRequests: map[string]*devicemgmtstate.RequestMessage{
+			"mesg-1": makeRequestMessage("mesg", 1, "test-kind", subsysChg.ID()),
+		},
+		Sequences:      devicemgmtstate.NewSequenceCache(),
+		ReadyResponses: make(map[string]store.Message),
+	}
+	s.mgr.SetState(ms)
+
+	handler := &mockMessageHandler{
+		buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+			c.Log("call not expected")
+			c.Fail()
+
+			return nil, ""
+		},
+	}
+	s.mgr.MockHandler("test-kind", handler)
+
+	t := s.st.NewTask("queue-mgmt-response", "test queue-mgmt-response task")
+	t.Set("id", "mesg-1")
+
+	s.st.Unlock()
+	err := s.mgr.DoQueueResponse(t, &tomb.Tomb{})
+	s.st.Lock()
+	c.Assert(err, FitsTypeOf, &state.Retry{})
+}
+
+func (s *deviceMgmtMgrSuite) TestDoQueueResponseSubsystemChangeNotFound(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	ms := &devicemgmtstate.DeviceMgmtState{
+		PendingRequests: map[string]*devicemgmtstate.RequestMessage{
+			"mesg-1": makeRequestMessage("mesg", 1, "test-kind", "16384"),
+		},
+		Sequences:      devicemgmtstate.NewSequenceCache(),
+		ReadyResponses: make(map[string]store.Message),
+	}
+	s.mgr.SetState(ms)
+
+	handler := &mockMessageHandler{
+		buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+			c.Log("call not expected")
+			c.Fail()
+
+			return nil, ""
+		},
+	}
+	s.mgr.MockHandler("test-kind", handler)
+
+	t := s.st.NewTask("queue-mgmt-response", "test queue-mgmt-response task")
+	t.Set("id", "mesg-1")
+
+	s.st.Unlock()
+	err := s.mgr.DoQueueResponse(t, &tomb.Tomb{})
+	s.st.Lock()
+	c.Assert(err, ErrorMatches, `cannot find subsystem change "\d+"`)
+}
+
+func (s *deviceMgmtMgrSuite) TestDoQueueResponseMessageNotFound(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	t := s.st.NewTask("queue-mgmt-response", "test queue-mgmt-response task")
+	t.Set("id", "mesg-1")
+
+	s.st.Unlock()
+	err := s.mgr.DoQueueResponse(t, &tomb.Tomb{})
+	s.st.Lock()
+	c.Assert(err, ErrorMatches, `cannot find message with id "mesg-1"`)
+}
+
+func (s *deviceMgmtMgrSuite) TestDoQueueResponseSigningError(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	handler := &mockMessageHandler{
+		buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
+			c.Log("call not expected")
+			c.Fail()
+
+			return nil, ""
+		},
+	}
+	s.mgr.MockHandler("test-kind", handler)
+
+	signer := &mockSigner{
+		sign: func(accountID, messageID string, status asserts.MessageStatus, body []byte) (*asserts.ResponseMessage, error) {
+			return nil, fmt.Errorf("signing key not available")
+		},
+	}
+	s.mgr.MockSigner(signer)
+
+	msg := makeRequestMessage("mesg", 1, "test-kind", "")
+	msg.ResponseStatus = asserts.MessageStatusRejected
+	msg.ResponseReason = "invalid payload: missing required field"
+	ms := &devicemgmtstate.DeviceMgmtState{
+		PendingRequests: map[string]*devicemgmtstate.RequestMessage{"mesg-1": msg},
+		Sequences:       devicemgmtstate.NewSequenceCache(),
+		ReadyResponses:  make(map[string]store.Message),
+	}
+	s.mgr.SetState(ms)
+
+	t := s.st.NewTask("queue-mgmt-response", "test queue-mgmt-response task")
+	t.Set("id", "mesg-1")
+
+	s.st.Unlock()
+	err := s.mgr.DoQueueResponse(t, &tomb.Tomb{})
+	s.st.Lock()
+	c.Assert(err, ErrorMatches, "cannot sign response message: signing key not available")
+}
+
 func (s *deviceMgmtMgrSuite) TestParseRequestMessageInvalid(c *C) {
 	type test struct {
 		name        string
@@ -506,5 +776,23 @@ func (s *deviceMgmtMgrSuite) TestParseRequestMessageInvalid(c *C) {
 		msg, err := devicemgmtstate.ParseRequestMessage(tt.message)
 		c.Check(err, ErrorMatches, tt.expectedErr, cmt)
 		c.Check(msg, IsNil, cmt)
+	}
+}
+
+func makeRequestMessage(baseID string, seqNum int, kind string, changeID string) *devicemgmtstate.RequestMessage {
+	wayback := time.Date(2025, 7, 29, 12, 0, 0, 0, time.UTC)
+
+	return &devicemgmtstate.RequestMessage{
+		AccountID:   "my-brand",
+		AuthorityID: "my-brand",
+		BaseID:      baseID,
+		SeqNum:      seqNum,
+		Kind:        kind,
+		Devices:     []string{"serial-1.my-model.my-brand"},
+		ValidSince:  wayback,
+		ValidUntil:  wayback.Add(24 * time.Hour),
+		Body:        `{"action": "get", "account": "my-brand", "view": "network/wifi-state"}`,
+		ReceiveTime: wayback.Add(6 * time.Hour),
+		ChangeID:    changeID,
 	}
 }

--- a/overlord/devicemgmtstate/devicemgmtmgr_test.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr_test.go
@@ -542,8 +542,8 @@ func (s *deviceMgmtMgrSuite) TestDoQueueResponse(c *C) {
 			name: "rejected",
 			msg: func() *devicemgmtstate.RequestMessage {
 				msg := makeRequestMessage("mesg", 1, "test-kind", "")
-				msg.ResponseStatus = asserts.MessageStatusRejected
-				msg.ResponseReason = "invalid payload: missing required field"
+				msg.Status = asserts.MessageStatusRejected
+				msg.Error = "invalid payload: missing required field"
 				return msg
 			},
 			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
@@ -718,8 +718,8 @@ func (s *deviceMgmtMgrSuite) TestDoQueueResponseSigningError(c *C) {
 	s.mgr.MockSigner(signer)
 
 	msg := makeRequestMessage("mesg", 1, "test-kind", "")
-	msg.ResponseStatus = asserts.MessageStatusRejected
-	msg.ResponseReason = "invalid payload: missing required field"
+	msg.Status = asserts.MessageStatusRejected
+	msg.Error = "cannot parse payload: missing required field"
 	ms := &devicemgmtstate.DeviceMgmtState{
 		PendingRequests: map[string]*devicemgmtstate.RequestMessage{"mesg-1": msg},
 		Sequences:       devicemgmtstate.NewSequenceCache(),

--- a/overlord/devicemgmtstate/devicemgmtmgr_test.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr_test.go
@@ -519,10 +519,10 @@ func (s *deviceMgmtMgrSuite) TestDoQueueResponse(c *C) {
 				return makeRequestMessage("mesg", 1, "test-kind", change.ID())
 			},
 			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
-				return map[string]any{"result": "ok"}, asserts.MessageStatusSuccess
+				return map[string]any{"values": "ok"}, asserts.MessageStatusSuccess
 			},
 			expectedStatus: asserts.MessageStatusSuccess,
-			expectedBody:   map[string]any{"result": "ok"},
+			expectedBody:   map[string]any{"values": "ok"},
 		},
 		{
 			name: "error",
@@ -533,17 +533,17 @@ func (s *deviceMgmtMgrSuite) TestDoQueueResponse(c *C) {
 				return makeRequestMessage("mesg", 1, "test-kind", change.ID())
 			},
 			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
-				return map[string]any{"error": "operation failed"}, asserts.MessageStatusError
+				return map[string]any{"message": "cannot process message: operation failed"}, asserts.MessageStatusError
 			},
 			expectedStatus: asserts.MessageStatusError,
-			expectedBody:   map[string]any{"error": "operation failed"},
+			expectedBody:   map[string]any{"message": "cannot process message: operation failed"},
 		},
 		{
 			name: "rejected",
 			msg: func() *devicemgmtstate.RequestMessage {
 				msg := makeRequestMessage("mesg", 1, "test-kind", "")
 				msg.Status = asserts.MessageStatusRejected
-				msg.Error = "invalid payload: missing required field"
+				msg.Error = "cannot parse payload: missing required field"
 				return msg
 			},
 			buildResponse: func(chg *state.Change) (map[string]any, asserts.MessageStatus) {
@@ -553,7 +553,7 @@ func (s *deviceMgmtMgrSuite) TestDoQueueResponse(c *C) {
 				return nil, ""
 			},
 			expectedStatus: asserts.MessageStatusRejected,
-			expectedBody:   map[string]any{"message": "invalid payload: missing required field"},
+			expectedBody:   map[string]any{"message": "cannot parse payload: missing required field"},
 		},
 	}
 

--- a/overlord/devicemgmtstate/export_test.go
+++ b/overlord/devicemgmtstate/export_test.go
@@ -35,6 +35,13 @@ var (
 	DefaultExchangeInterval = defaultExchangeInterval
 )
 
+func NewSequenceCache() *sequenceCache {
+	return &sequenceCache{
+		Applied: make(map[string]int),
+		LRU:     make([]string, 0),
+	}
+}
+
 type DeviceMgmtState deviceMgmtState
 
 func (m *DeviceMgmtManager) GetState() (*DeviceMgmtState, error) {


### PR DESCRIPTION
This PR implements the `queue-mgmt-response` task. Once a message has been applied (or rejected before reaching the subsystem), this task builds a signed response-message and queues it for transmission on the next store exchange.

For messages with a subsystem change, the task retries until the change completes, then calls the handler's `ResultFromChange` to produce the response body. For messages that were rejected or not authorized before dispatch, the response is built directly from `ResponseStatus` & `ResponseBody` in the `RequestMessage`.

Split from #16248.