### PR TITLE
wrappers/internal: Sanitize systemd user services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,6 @@ require (
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/term v0.20.0 // indirect
-	gopkg.in/ini.v1 v1.67.1 // indirect
+	gopkg.in/ini.v1 v1.67.1
 	maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -54,5 +54,6 @@ require (
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/term v0.20.0 // indirect
+	gopkg.in/ini.v1 v1.67.1 // indirect
 	maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -65,8 +64,6 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18 h1:A15
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8wPZxFxC3MdOnFiFVAazbOIv1OQNDME=
-github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
 github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19 h1:nVT7EXqb2qUXWG94woDaS5IrWEy87pgj8esfvVFiZx0=
 github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0E
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8wPZxFxC3MdOnFiFVAazbOIv1OQNDME=
 github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
+github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19 h1:nVT7EXqb2qUXWG94woDaS5IrWEy87pgj8esfvVFiZx0=
+github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,13 @@ github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHe
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+<<<<<<< HEAD
+=======
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
+>>>>>>> a78c2adfd6 (Sanitize systemd user services)
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -51,6 +57,7 @@ github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb/go.mod h1
 github.com/pilebones/go-udev v0.9.0 h1:N1uEO/SxUwtIctc0WLU0t69JeBxIYEYnj8lT/Nabl9Q=
 github.com/pilebones/go-udev v0.9.0/go.mod h1:T2eI2tUSK0hA2WS5QLjXJUfQkluZQu+18Cqvem3CaXI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
@@ -61,9 +68,21 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18 h1:A15
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19 h1:nVT7EXqb2qUXWG94woDaS5IrWEy87pgj8esfvVFiZx0=
-github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
+github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8wPZxFxC3MdOnFiFVAazbOIv1OQNDME=
+github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
+github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829 h1:9qeADnUPs/YhO0tty+j2zxi9dUI2Bn96y9Nc9XOKTOk=
+github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829/go.mod h1:BeEYaTJC4cqXVgpjjxajO31p2kVDvXwXJJx3YD7nCaE=
+github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a h1:eKljZN+SzPKM1ua7KG5E2vQdbw9JQn17tbbukHj6hvw=
+github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -97,6 +116,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
+gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/macaroon.v1 v1.0.0 h1:BmexIS8QyY02i0uoeXwrtlH8vCS/Rmxq9uzOy4qQvk8=
 gopkg.in/macaroon.v1 v1.0.0/go.mod h1:KeG3in9Jb7Z3RNA/PFngm+mISBo0Q0O9KQeF958zuoQ=
 gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
@@ -105,5 +126,6 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -21,11 +21,8 @@ github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnx
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-<<<<<<< HEAD
-=======
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
->>>>>>> a78c2adfd6 (Sanitize systemd user services)
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=

--- a/go.sum
+++ b/go.sum
@@ -70,12 +70,6 @@ github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0E
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8wPZxFxC3MdOnFiFVAazbOIv1OQNDME=
 github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
-github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829 h1:9qeADnUPs/YhO0tty+j2zxi9dUI2Bn96y9Nc9XOKTOk=
-github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829/go.mod h1:BeEYaTJC4cqXVgpjjxajO31p2kVDvXwXJJx3YD7nCaE=
-github.com/snapcore/secboot v0.0.0-20260302105957-77bc2457cc76 h1:Vj0VE1XwZTC4YddTYlCYI4X+fukMXkX46d7GRxFbHcg=
-github.com/snapcore/secboot v0.0.0-20260302105957-77bc2457cc76/go.mod h1:BeEYaTJC4cqXVgpjjxajO31p2kVDvXwXJJx3YD7nCaE=
-github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a h1:eKljZN+SzPKM1ua7KG5E2vQdbw9JQn17tbbukHj6hvw=
-github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8w
 github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
 github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829 h1:9qeADnUPs/YhO0tty+j2zxi9dUI2Bn96y9Nc9XOKTOk=
 github.com/snapcore/secboot v0.0.0-20260129175210-e638825ef829/go.mod h1:BeEYaTJC4cqXVgpjjxajO31p2kVDvXwXJJx3YD7nCaE=
+github.com/snapcore/secboot v0.0.0-20260302105957-77bc2457cc76 h1:Vj0VE1XwZTC4YddTYlCYI4X+fukMXkX46d7GRxFbHcg=
+github.com/snapcore/secboot v0.0.0-20260302105957-77bc2457cc76/go.mod h1:BeEYaTJC4cqXVgpjjxajO31p2kVDvXwXJJx3YD7nCaE=
 github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a h1:eKljZN+SzPKM1ua7KG5E2vQdbw9JQn17tbbukHj6hvw=
 github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -54,8 +54,9 @@ func (s *emulation) DaemonReload() error {
 	return nil
 }
 
-func (s *emulation) DaemonReEnable([]string) error {
-	return nil
+func (s *emulation) DaemonReEnable(services []string) error {
+	_, err := systemctlCmd(append([]string{"--root", s.rootDir, "reenable"}, services...)...)
+	return err
 }
 
 func (s *emulation) DaemonReexec() error {

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -54,6 +54,10 @@ func (s *emulation) DaemonReload() error {
 	return nil
 }
 
+func (s *emulation) DaemonReEnable([]string) error {
+	return nil
+}
+
 func (s *emulation) DaemonReexec() error {
 	return &notImplementedError{"DaemonReexec"}
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -403,6 +403,8 @@ type Systemd interface {
 	Backend() Backend
 	// DaemonReload reloads systemd's configuration.
 	DaemonReload() error
+	// DaemonReEnable disables a daemon and re-enables it again
+	DaemonReEnable(services []string) error
 	// DaemonRexec reexecutes systemd's system manager, should be
 	// only necessary to apply manager's configuration like
 	// watchdog.
@@ -695,6 +697,23 @@ func (s *systemd) DisableNoReload(serviceNames []string) error {
 		args = append(args, "--no-reload")
 	}
 	args = append(args, "disable")
+	args = append(args, serviceNames...)
+	_, err := s.systemctl(args...)
+	return err
+}
+
+func (s *systemd) DaemonReEnable(serviceNames []string) error {
+	if len(serviceNames) == 0 {
+		return nil
+	}
+	var args []string
+	if s.rootDir != "" {
+		// passing root already implies no reload
+		args = append(args, "--root", s.rootDir)
+	} else {
+		args = append(args, "--no-reload")
+	}
+	args = append(args, "reenable")
 	args = append(args, serviceNames...)
 	_, err := s.systemctl(args...)
 	return err

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -35,6 +35,9 @@ var (
 	DesktopFileSearchPath     = desktopFileSearchPath
 	DesktopFileIDToFilename   = desktopFileIDToFilename
 	VerifyDesktopFileLocation = verifyDesktopFileLocation
+	CheckServicePlacement     = checkServicePlacement
+	UserHomeDir               = userHomeDir
+	SanitizeUserServices      = sanitizeUserServices
 )
 
 func MockRegularFileExists(f func(string) (bool, bool, error)) func() {
@@ -42,5 +45,21 @@ func MockRegularFileExists(f func(string) (bool, bool, error)) func() {
 	regularFileExists = f
 	return func() {
 		regularFileExists = old
+	}
+}
+
+func MockReenableUserService(f func(string) error) func() {
+	old := reenableUserService
+	reenableUserService = f
+	return func() {
+		reenableUserService = old
+	}
+}
+
+func MockUserHomeDir(f func() (string, error)) func() {
+	old := userHomeDir
+	userHomeDir = f
+	return func() {
+		userHomeDir = old
 	}
 }

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -21,13 +21,20 @@ package userd
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
+	"gopkg.in/ini.v1"
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dbusutil"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/systemd"
 )
 
 type dbusInterface interface {
@@ -48,6 +55,92 @@ type Userd struct {
 var userdBusNames = []string{
 	"io.snapcraft.Launcher",
 	"io.snapcraft.Settings",
+}
+
+func clearBrokenLink(targetPath string) error {
+	_, err := filepath.EvalSymlinks(targetPath)
+	if err != nil {
+		switch err.(type) {
+		case *fs.PathError:
+			logger.Noticef("deleting broken link in snap service %s", targetPath)
+			// it's a broken link; delete it
+			os.Remove(targetPath)
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func reenableUserService(serviceName string) error {
+	logger.Noticef("re-enabling user service %s", serviceName)
+	sysd := systemd.New(systemd.UserMode, nil)
+	return sysd.DaemonReEnable([]string{serviceName})
+}
+
+func checkServicePlacement(targetName, snapTarget string) error {
+	snapTargetData, err := os.ReadFile(snapTarget)
+	if err != nil {
+		return err
+	}
+	targetIni, err := ini.Load(snapTargetData)
+	if err != nil {
+		return err
+	}
+	wantedBy := ""
+	if section := targetIni.Section("Install"); section != nil {
+		wantedBy = section.Key("WantedBy").String()
+	}
+	if wantedBy != targetName {
+		// the symlink is in the wrong folder. Re-enable the service
+		// to change it.
+		err := reenableUserService(path.Base(snapTarget))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sanitizeUserServices() error {
+	// ensure that the user services enabled in the $HOME folder are
+	// correctly placed in the right .target.wants folder. This placement
+	// will be wrong if a service is moved from default.target to
+	// graphical-session.target or vice-versa, so this clean up is required.
+	//
+	// The change can happen in two cases:
+	//
+	// * when migrating from an old version of snapd without "graphical-session.target"
+	//   support, to a new version that supports it: all the user daemons' WantedBy entry
+	//   will be updated, and so these entries will have to be updated too.
+	// * when a snap adds or removes the `desktop` plug in a daemon
+
+	userSystemdQuery := path.Join(os.Getenv("HOME"), ".config", "systemd", "user", "*.target.wants")
+	entries, err := filepath.Glob(userSystemdQuery)
+	if err != nil {
+		return err
+	}
+	for _, targetWantPath := range entries {
+		snapTargetPaths, err := filepath.Glob(path.Join(targetWantPath, "snap.*"))
+		if err != nil {
+			logger.Noticef("cannot get the user service files at %s: %s", targetWantPath, err.Error())
+			continue
+		}
+		for _, snapTarget := range snapTargetPaths {
+			// Remove any broken link (that's a service that was removed)
+			if err = clearBrokenLink(snapTarget); err != nil {
+				logger.Noticef("cannot remove the broken link %s: %s", snapTarget, err.Error())
+				continue
+			}
+			// Check that any snap service is in the right .target.wants
+			targetName := strings.TrimSuffix(targetWantPath, ".wants")
+			if err := checkServicePlacement(path.Base(targetName), snapTarget); err != nil {
+				logger.Noticef("cannot process user service at %s for %s: %s", snapTarget, targetName, err.Error())
+				continue
+			}
+		}
+	}
+	return nil
 }
 
 func (ud *Userd) Init() error {
@@ -86,6 +179,8 @@ func (ud *Userd) Init() error {
 			return fmt.Errorf("cannot obtain bus name '%s'", name)
 		}
 	}
+
+	sanitizeUserServices()
 	return nil
 }
 

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -49,6 +49,8 @@ type Userd struct {
 	dbusIfaces []dbusInterface
 }
 
+var userHomeDir = os.UserHomeDir
+
 // userdBusNames contains the list of bus names userd will acquire on
 // the session bus.  It is unnecessary (and undesirable) to add more
 // names here when adding new interfaces to the daemon.
@@ -72,7 +74,7 @@ func clearBrokenLink(targetPath string) error {
 	return nil
 }
 
-func reenableUserService(serviceName string) error {
+var reenableUserService = func(serviceName string) error {
 	logger.Noticef("re-enabling user service %s", serviceName)
 	sysd := systemd.New(systemd.UserMode, nil)
 	return sysd.DaemonReEnable([]string{serviceName})
@@ -115,7 +117,7 @@ func sanitizeUserServices() error {
 	//   will be updated, and so these entries will have to be updated too.
 	// * when a snap adds or removes the `desktop` plug in a daemon
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDir()
 	if err != nil || homeDir == "" {
 		logger.Noticef("cannot determine user home directory, skipping user service sanitization: %v", err)
 		return nil

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -115,7 +115,13 @@ func sanitizeUserServices() error {
 	//   will be updated, and so these entries will have to be updated too.
 	// * when a snap adds or removes the `desktop` plug in a daemon
 
-	userSystemdQuery := path.Join(os.Getenv("HOME"), ".config", "systemd", "user", "*.target.wants")
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		logger.Noticef("cannot determine user home directory, skipping user service sanitization: %v", err)
+		return nil
+	}
+
+	userSystemdQuery := path.Join(homeDir, ".config", "systemd", "user", "*.target.wants")
 	entries, err := filepath.Glob(userSystemdQuery)
 	if err != nil {
 		return err

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -89,7 +89,7 @@ func checkServicePlacement(targetName, snapTarget string) error {
 	}
 	wantedBy := ""
 	if section := targetIni.Section("Install"); section != nil {
-		wantedBy = section.Key("WantedBy").String()
+		wantedBy = strings.Trim(section.Key("WantedBy").String(), " ")
 	}
 	if wantedBy != targetName {
 		// the symlink is in the wrong folder. Re-enable the service

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -180,7 +180,9 @@ func (ud *Userd) Init() error {
 		}
 	}
 
-	sanitizeUserServices()
+	if err := sanitizeUserServices(); err != nil {
+		logger.Noticef("cannot sanitize user services: %v", err)
+	}
 	return nil
 }
 

--- a/usersession/userd/userd_test.go
+++ b/usersession/userd/userd_test.go
@@ -90,7 +90,7 @@ func (s *userdSuite) TestSanitizeUserServices(c *C) {
 	err = os.MkdirAll(graphicalWanted, 0755)
 	c.Assert(err, IsNil)
 
-	_, err = createFakeUnitService(defaultWanted, "snap.test1", "default.target")
+	service1Path, err := createFakeUnitService(defaultWanted, "snap.test1", "default.target")
 	c.Assert(err, IsNil)
 	_, err = createFakeUnitService(defaultWanted, "snap.test2", "graphical-session.target")
 	c.Assert(err, IsNil)
@@ -108,8 +108,31 @@ func (s *userdSuite) TestSanitizeUserServices(c *C) {
 	_, err = createFakeUnitService(graphicalWanted, "test8", "graphical-session.target")
 	c.Assert(err, IsNil)
 
+	// soft link to an existing file
+	softlink1 := path.Join(defaultWanted, "snap.test9.service")
+	softlink2 := path.Join(defaultWanted, "snap.test10.service")
+	err = os.Symlink(service1Path, softlink1)
+	c.Assert(err, IsNil)
+	err = os.Symlink(service1Path+".not-exist", softlink2)
+	c.Assert(err, IsNil)
+
+	_, err = os.Lstat(softlink1)
+	c.Assert(err, IsNil)
+	_, err = os.Lstat(softlink2)
+	c.Assert(err, IsNil)
+	_, err = os.Stat(softlink1)
+	c.Assert(err, IsNil)
+	_, err = os.Stat(softlink2)
+	c.Assert(err, NotNil)
+
 	userd.SanitizeUserServices()
 	c.Assert(len(reenabledServices), Equals, 2)
 	c.Assert(slices.Contains(reenabledServices, "snap.test2.service"), Equals, true)
 	c.Assert(slices.Contains(reenabledServices, "snap.test3.service"), Equals, true)
+	_, err = os.Lstat(softlink1)
+	c.Assert(err, IsNil)
+	_, err = os.Stat(softlink1)
+	c.Assert(err, IsNil)
+	_, err = os.Lstat(softlink2)
+	c.Assert(err, NotNil)
 }

--- a/usersession/userd/userd_test.go
+++ b/usersession/userd/userd_test.go
@@ -1,0 +1,115 @@
+package userd_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"slices"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/usersession/userd"
+)
+
+type userdSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&userdSuite{})
+
+func createFakeUnitService(folder, serviceName, wantedBy string) (string, error) {
+	filepath := path.Join(folder, serviceName+".service")
+	err := os.WriteFile(filepath, []byte(fmt.Sprintf(`[Unit]
+Description=%s
+
+[Install]
+WantedBy=%s
+`, serviceName, wantedBy)), 0644)
+	return filepath, err
+}
+
+func (s *userdSuite) TestCheckServicePlacementNoChange(c *C) {
+	folder := c.MkDir()
+	testServicePath, err := createFakeUnitService(folder, "test", "graphical-session.target")
+	c.Assert(err, IsNil)
+
+	reenabledServiceName := ""
+	reenabledService := false
+	oldfunc := userd.MockReenableUserService(func(service string) error {
+		reenabledServiceName = service
+		reenabledService = true
+		return nil
+	})
+	defer oldfunc()
+
+	err = userd.CheckServicePlacement("graphical-session.target", testServicePath)
+	c.Assert(err, IsNil)
+	c.Assert(reenabledService, Equals, false)
+	c.Assert(reenabledServiceName, Equals, "")
+}
+
+func (s *userdSuite) TestCheckServicePlacementWithChange(c *C) {
+	folder := c.MkDir()
+	testServicePath, err := createFakeUnitService(folder, "test", "graphical-session.target")
+	c.Assert(err, IsNil)
+
+	reenabledServiceName := ""
+	reenabledService := false
+	oldfunc := userd.MockReenableUserService(func(service string) error {
+		reenabledServiceName = service
+		reenabledService = true
+		return nil
+	})
+	defer oldfunc()
+
+	err = userd.CheckServicePlacement("default.target", testServicePath)
+	c.Assert(err, IsNil)
+	c.Assert(reenabledService, Equals, true)
+	c.Assert(reenabledServiceName, Equals, "test.service")
+}
+
+func (s *userdSuite) TestSanitizeUserServices(c *C) {
+	fakeHomeFolder := c.MkDir()
+	oldfuncHome := userd.MockUserHomeDir(func() (string, error) {
+		return fakeHomeFolder, nil
+	})
+	reenabledServices := []string{}
+	defer oldfuncHome()
+	oldfuncReenable := userd.MockReenableUserService(func(service string) error {
+		reenabledServices = append(reenabledServices, service)
+		return nil
+	})
+	defer oldfuncReenable()
+
+	userSystemdPath := path.Join(fakeHomeFolder, ".config", "systemd", "user")
+	defaultWanted := path.Join(userSystemdPath, "default.target.wants")
+	graphicalWanted := path.Join(userSystemdPath, "graphical-session.target.wants")
+	err := os.MkdirAll(defaultWanted, 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(graphicalWanted, 0755)
+	c.Assert(err, IsNil)
+
+	_, err = createFakeUnitService(defaultWanted, "snap.test1", "default.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(defaultWanted, "snap.test2", "graphical-session.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(graphicalWanted, "snap.test3", "default.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(graphicalWanted, "snap.test4", "graphical-session.target")
+	c.Assert(err, IsNil)
+
+	_, err = createFakeUnitService(defaultWanted, "test5", "default.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(defaultWanted, "test6", "graphical-session.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(graphicalWanted, "test7", "default.target")
+	c.Assert(err, IsNil)
+	_, err = createFakeUnitService(graphicalWanted, "test8", "graphical-session.target")
+	c.Assert(err, IsNil)
+
+	userd.SanitizeUserServices()
+	c.Assert(len(reenabledServices), Equals, 2)
+	c.Assert(slices.Contains(reenabledServices, "snap.test2.service"), Equals, true)
+	c.Assert(slices.Contains(reenabledServices, "snap.test3.service"), Equals, true)
+}


### PR DESCRIPTION
This is the second of three PRs to replace https://github.com/canonical/snapd/pull/16601 It requires #16685

In some cases, snapd insists on enabling user services not only globally, as expected (thus, adding a symlink at `/etc/systemd/user/XXXXX.target.wants`), but also locally (thus, at $HOME/.config/systemd/user/XXXX.target.wants`).

This means that if an user service is migrated from `default.target` to `graphical-session.target` (or vice-versa), the soft link at the user's HOME folder will be in the wrong subfolder.

Unfortunately, the main snapd service seems to not have the capability of accessing and managing the local user services, having to rely on the user's local daemon (`snap userd`), which runs as an user's service. So a change in that daemon (which has its source code at `usersession/userd` folder) is required to check the locally enabled user services and ensure that their soft link is in the right place.

This commit does this by checking the links in the user folder every time user session daemon is launched, and runs as the user a `systemctl --user reenable SNAP-SERVICE-NAME` to rebuild the wrong softlink.

---

**SNAPD NOTE:**

These 3 PRs are required to fix: https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-535/+bug/2042301

Given it was initially meant for 2.74, it is now moved to 2.76 and requires monitoring by the team to ensure it lands in time. @olivercalder
