### PR TITLE
wrappers/internal: Add implicit graphical user daemons (#16326)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 require (
 	github.com/cilium/ebpf v0.9.1
 	go.etcd.io/bbolt v1.3.9
+	gopkg.in/ini.v1 v1.67.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,9 @@ github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHe
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -51,6 +53,7 @@ github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb/go.mod h1
 github.com/pilebones/go-udev v0.9.0 h1:N1uEO/SxUwtIctc0WLU0t69JeBxIYEYnj8lT/Nabl9Q=
 github.com/pilebones/go-udev v0.9.0/go.mod h1:T2eI2tUSK0hA2WS5QLjXJUfQkluZQu+18Cqvem3CaXI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
@@ -63,7 +66,15 @@ github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0E
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19 h1:nVT7EXqb2qUXWG94woDaS5IrWEy87pgj8esfvVFiZx0=
 github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -97,6 +108,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
+gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/macaroon.v1 v1.0.0 h1:BmexIS8QyY02i0uoeXwrtlH8vCS/Rmxq9uzOy4qQvk8=
 gopkg.in/macaroon.v1 v1.0.0/go.mod h1:KeG3in9Jb7Z3RNA/PFngm+mISBo0Q0O9KQeF958zuoQ=
 gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
@@ -105,5 +118,6 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snap/info.go
+++ b/snap/info.go
@@ -1392,9 +1392,18 @@ type AppInfo struct {
 	After  []string
 	Before []string
 
+	PartOf    []string
+	Requisite []string
+
 	Timer *TimerInfo
 
 	Autostart string
+}
+
+// HasPlug returns true if this AppInfo has the requested plug.
+func (app *AppInfo) HasPlug(plug string) bool {
+	_, ok := app.Plugs[plug]
+	return ok
 }
 
 // Runnable returns a Runnable for this app.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2376,6 +2376,16 @@ plugs:
 
 	unscopedApps := info.AppsForPlug(unscoped)
 	c.Assert(unscopedApps, testutil.DeepUnsortedMatches, []*snap.AppInfo{info.Apps["one"], info.Apps["two"]})
+
+	appInfo1 := info.Apps["one"]
+	c.Assert(appInfo1.HasPlug("scoped-plug"), Equals, true)
+	c.Assert(appInfo1.HasPlug("unscoped-plug"), Equals, true)
+	c.Assert(appInfo1.HasPlug("non-existing-plug"), Equals, false)
+
+	appInfo2 := info.Apps["two"]
+	c.Assert(appInfo2.HasPlug("scoped-plug"), Equals, false)
+	c.Assert(appInfo2.HasPlug("unscoped-plug"), Equals, true)
+	c.Assert(appInfo2.HasPlug("non-existing-plug"), Equals, false)
 }
 
 func (s *infoSuite) TestAppsForSlot(c *C) {

--- a/tests/lib/snaps/test-implicit-graphical-user-daemon/meta/snap.yaml
+++ b/tests/lib/snaps/test-implicit-graphical-user-daemon/meta/snap.yaml
@@ -1,0 +1,52 @@
+name: test-implicit-graphical-user-daemon
+version: 1
+summary: test snapd daemon user in graphical desktop
+
+slots:
+  dbus-slot:
+    interface: dbus
+    bus: session
+    name: org.example.implicit-graphical-daemon
+
+apps:
+  graphical:
+    command: usr/bin/ls
+    plugs:
+      - desktop
+    daemon: simple
+    daemon-scope: user
+    restart-condition: on-success
+    restart-delay: 2s
+
+  graphical-dbus:
+    command: usr/bin/ls
+    plugs:
+      - desktop
+    daemon: dbus
+    daemon-scope: user
+    restart-condition: on-success
+    restart-delay: 2s
+    activates-on:
+      - dbus-slot
+
+  graphical-dbus-socket:
+    command: usr/bin/ls
+    plugs:
+      - desktop
+      - network-bind
+    daemon: simple
+    daemon-scope: user
+    restart-condition: on-success
+    restart-delay: 2s
+    sockets:
+      mysocket:
+        listen-stream: $XDG_RUNTIME_DIR/mysocket-0
+        socket-mode: 0644
+
+  normal:
+    command: usr/bin/ls
+    daemon: simple
+    daemon-scope: user
+    restart-condition: on-success
+    restart-delay: 2s
+

--- a/tests/lib/snaps/test-implicit-graphical-user-daemon/usr/bin/ls
+++ b/tests/lib/snaps/test-implicit-graphical-user-daemon/usr/bin/ls
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+/usr/bin/ls -l

--- a/tests/main/implicit-graphical-user-daemon/task.yaml
+++ b/tests/main/implicit-graphical-user-daemon/task.yaml
@@ -1,0 +1,39 @@
+summary: Ensure that the graphical user daemons work as expected
+
+details: |
+    This test ensures that an user daemon with the desktop plug
+    will be launched with the desktop session only.
+
+# Same systems than `interfaces-desktop`, since we require that plug.
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -amazon-*, -centos-*]
+
+prepare: |
+    snap set system experimental.user-daemons=true
+    "$TESTSTOOLS"/snaps-state install-local test-implicit-graphical-user-daemon
+
+execute: |
+    NORMAL_SERVICE=/etc/systemd/user/snap.test-implicit-graphical-user-daemon.normal.service
+    DESKTOP_SERVICE=/etc/systemd/user/snap.test-implicit-graphical-user-daemon.graphical.service
+    DESKTOP_DBUS_SERVICE=/etc/systemd/user/snap.test-implicit-graphical-user-daemon.graphical-dbus.service
+    DESKTOP_DBUS_SOCKET_SERVICE=/etc/systemd/user/snap.test-implicit-graphical-user-daemon.graphical-dbus-socket.service
+
+    echo "Ensure graphical daemon has the right dependencies"
+
+    test -f "${NORMAL_SERVICE}"
+    test -f "${DESKTOP_SERVICE}"
+    test -f "${DESKTOP_DBUS_SERVICE}"
+    test -f "${DESKTOP_DBUS_SOCKET_SERVICE}"
+
+    MATCH "WantedBy=graphical-session\.target" < "${DESKTOP_SERVICE}"
+    MATCH "After=graphical-session\.target" < "${DESKTOP_SERVICE}"
+    MATCH "Requisite=graphical-session\.target" < "${DESKTOP_SERVICE}"
+
+    MATCH "After=graphical-session\.target" < "${DESKTOP_DBUS_SERVICE}"
+    MATCH "Requisite=graphical-session\.target" < "${DESKTOP_DBUS_SERVICE}"
+    MATCH "PartOf=graphical-session\.target" < "${DESKTOP_DBUS_SERVICE}"
+
+    MATCH "After=graphical-session\.target" < "${DESKTOP_DBUS_SOCKET_SERVICE}"
+    MATCH "Requisite=graphical-session\.target" < "${DESKTOP_DBUS_SOCKET_SERVICE}"
+    MATCH "PartOf=graphical-session\.target" < "${DESKTOP_DBUS_SOCKET_SERVICE}"
+
+    MATCH "WantedBy=default\.target" < "${NORMAL_SERVICE}"

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -37,6 +37,8 @@ import (
 	"github.com/snapcore/snapd/timeout"
 )
 
+const graphicalSessionTarget = "graphical-session.target"
+
 // SnapServicesUnitOptions is a struct for controlling the generated service
 // definition for a snap service.
 type SnapServicesUnitOptions struct {
@@ -144,8 +146,14 @@ Wants={{.PrerequisiteTarget}}
 {{- if .After}}
 After={{ stringsJoin .After " " }}
 {{- end}}
+{{- if .Requisite}}
+Requisite={{ stringsJoin .Requisite " " }}
+{{- end}}
 {{- if .Before}}
 Before={{ stringsJoin .Before " "}}
+{{- end}}
+{{- if .PartOf}}
+PartOf={{ stringsJoin .PartOf " " }}
 {{- end}}
 {{- if .CoreMountedSnapdSnapDep}}
 Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
@@ -285,6 +293,8 @@ WantedBy={{.ServicesTarget}}
 		Before                   []string
 		After                    []string
 		Requires                 []string
+		PartOf                   []string
+		Requisite                []string
 		InterfaceServiceSnippets string
 		InterfaceUnitSnippets    string
 		SliceUnit                string
@@ -319,8 +329,10 @@ WantedBy={{.ServicesTarget}}
 		BusName:           busName,
 		SuccessExitStatus: appInfo.SuccessExitStatus,
 
-		Before: generateServiceNames(appInfo.Snap, appInfo.Before),
-		After:  generateServiceNames(appInfo.Snap, appInfo.After),
+		Before:    generateServiceNames(appInfo.Snap, appInfo.Before),
+		After:     generateServiceNames(appInfo.Snap, appInfo.After),
+		PartOf:    generateServiceNames(appInfo.Snap, appInfo.PartOf),
+		Requisite: generateServiceNames(appInfo.Snap, appInfo.Requisite),
 
 		// systemd runs as PID 1 so %h will not work.
 		Home: "/root",
@@ -338,6 +350,12 @@ WantedBy={{.ServicesTarget}}
 		// FIXME: ideally use UserDataDir("%h"), but then the
 		// unit fails if the directory doesn't exist.
 		wrapperData.WorkingDir = appInfo.Snap.DataDir()
+		if appInfo.HasPlug("desktop") {
+			wrapperData.After = append(wrapperData.After, graphicalSessionTarget)
+			wrapperData.PartOf = append(wrapperData.PartOf, graphicalSessionTarget)
+			wrapperData.ServicesTarget = graphicalSessionTarget
+			wrapperData.Requisite = append(wrapperData.Requisite, graphicalSessionTarget)
+		}
 	default:
 		panic("unknown snap.DaemonScope")
 	}

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -97,15 +97,87 @@ Type=%s
 WantedBy=default.target
 `
 
+const expectedGraphicalUserServiceFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application snap.app
+After=graphical-session.target
+Requisite=graphical-session.target
+PartOf=graphical-session.target
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run snap.app
+SyslogIdentifier=snap.app
+Restart=%s
+WorkingDirectory=/var/snap/snap/44
+ExecStop=/usr/bin/snap run --command=stop snap.app
+ExecReload=/usr/bin/snap run --command=reload snap.app
+ExecStopPost=/usr/bin/snap run --command=post-stop snap.app
+TimeoutStopSec=10s
+Type=%s
+
+[Install]
+WantedBy=graphical-session.target
+`
+
+const expectedDBusGraphicalUserServiceFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application snap.app
+After=graphical-session.target
+Requisite=graphical-session.target
+PartOf=graphical-session.target
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run snap.app
+SyslogIdentifier=snap.app
+Restart=%s
+WorkingDirectory=/var/snap/snap/44
+ExecStop=/usr/bin/snap run --command=stop snap.app
+ExecReload=/usr/bin/snap run --command=reload snap.app
+ExecStopPost=/usr/bin/snap run --command=post-stop snap.app
+TimeoutStopSec=10s
+Type=%s
+
+[Install]
+WantedBy=graphical-session.target
+`
+
+const expectedSocketGraphicalUserServiceFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application snap.app
+After=graphical-session.target
+Requisite=graphical-session.target
+PartOf=graphical-session.target
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run snap.app
+SyslogIdentifier=snap.app
+Restart=%s
+WorkingDirectory=/var/snap/snap/44
+ExecStop=/usr/bin/snap run --command=stop snap.app
+ExecReload=/usr/bin/snap run --command=reload snap.app
+ExecStopPost=/usr/bin/snap run --command=post-stop snap.app
+TimeoutStopSec=10s
+Type=%s
+`
+
 var (
 	mountUnitPrefix = strings.Replace(dirs.SnapMountDir[1:], "/", "-", -1)
 )
 
 var (
-	expectedAppService     = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple", expectedInstallSection)
-	expectedDbusService    = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "dbus\nBusName=foo.bar.baz", "")
-	expectedOneshotService = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "no", "oneshot\nRemainAfterExit=yes", expectedInstallSection)
-	expectedUserAppService = fmt.Sprintf(expectedUserServiceFmt, "on-failure", "simple")
+	expectedAppService                    = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple", expectedInstallSection)
+	expectedDbusService                   = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "dbus\nBusName=foo.bar.baz", "")
+	expectedOneshotService                = fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "no", "oneshot\nRemainAfterExit=yes", expectedInstallSection)
+	expectedUserAppService                = fmt.Sprintf(expectedUserServiceFmt, "on-failure", "simple")
+	expectedGraphicalUserAppService       = fmt.Sprintf(expectedGraphicalUserServiceFmt, "on-failure", "simple")
+	expectedDBusGraphicalUserAppService   = fmt.Sprintf(expectedDBusGraphicalUserServiceFmt, "on-failure", "dbus")
+	expectedSocketGraphicalUserAppService = fmt.Sprintf(expectedSocketGraphicalUserServiceFmt, "on-failure", "simple")
 )
 
 var (
@@ -516,6 +588,89 @@ apps:
 	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(app, nil)
 	c.Assert(err, IsNil)
 	c.Check(string(generatedWrapper), Equals, expectedUserAppService)
+}
+
+func (s *serviceUnitGenSuite) TestGenerateSnapGraphicalUserServiceFile(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        stop-command: bin/stop
+        reload-command: bin/reload
+        post-stop-command: bin/stop --post
+        stop-timeout: 10s
+        daemon: simple
+        daemon-scope: user
+        plugs:
+            - desktop
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), Equals, expectedGraphicalUserAppService)
+}
+
+func (s *serviceUnitGenSuite) TestGenerateSnapDBusGraphicalUserServiceFile(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        stop-command: bin/stop
+        reload-command: bin/reload
+        post-stop-command: bin/stop --post
+        stop-timeout: 10s
+        daemon: dbus
+        daemon-scope: user
+        plugs:
+            - desktop
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), Equals, expectedDBusGraphicalUserAppService)
+}
+
+func (s *serviceUnitGenSuite) TestGenerateSnapSocketGraphicalUserServiceFile(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        stop-command: bin/stop
+        reload-command: bin/reload
+        post-stop-command: bin/stop --post
+        stop-timeout: 10s
+        daemon: simple
+        sockets:
+            testsocket:
+                listen-stream: $SNAP_USER_COMMON/unix.socket
+                socket-mode: 0644
+        daemon-scope: user
+        plugs:
+            - network-bind
+            - desktop
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), Equals, expectedSocketGraphicalUserAppService)
 }
 
 func (s *serviceUnitGenSuite) TestServiceAfterBefore(c *C) {


### PR DESCRIPTION
This is the third of three PRs to replace https://github.com/canonical/snapd/pull/16601 It requires https://github.com/canonical/snapd/pull/16685 and https://github.com/canonical/snapd/pull/16686

This is an implicit implementation of graphical user daemons. Here, if an user-scoped daemon has the Desktop plug defined, it is presumed that it requires access to the desktop graphical environment, so it will depend on graphical-session.target instead of the default target.

It implements the implicit way of SD-230.

It also fixes all the problems with Gnome 50.

This PR is an alternative to #16091

* Add "s" (for seconds) in tests

* Added test for desktop daemons

* Fix typo

* Added execute

* Check that the test works

* Update tests/lib/snaps/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update wrappers/internal/service_unit_gen.go

Co-authored-by: Marco Trevisan <mail@3v1n0.net>

* Added test for dbus daemons

* Moved test into tests/main

* Requested changes

* Test to see if this is being run

* Remove error

* Update tests/main/test-user-daemon-in-graphical-environment/test-implicit-graphical-user-daemon/meta/snap.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/test-implicit-graphical-user-daemon/meta/snap.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/test-implicit-graphical-user-daemon/meta/snap.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/test-implicit-graphical-user-daemon/meta/snap.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Added systems

* Moved the snap

* Fix snaps-state

* Fix paths in task.yaml

* Set daemon experimental flag

* Fixed test in dbus services

* Update tests/main/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/test-user-daemon-in-graphical-environment/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Extra required changes

* Update tests/lib/snaps/test-implicit-graphical-user-daemon/meta/snap.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

* Update tests/main/implicit-graphical-user-daemon/task.yaml

Co-authored-by: Oliver Calder <oliver@calder.dev>

---------

Co-authored-by: Oliver Calder <oliver@calder.dev>
Co-authored-by: Marco Trevisan <mail@3v1n0.net>

Always use PartOf instead of BindsTo

Added extra tests

The new Asserts allow to check that both scoped and unscoped plugs are detected.

---

**SNAPD NOTE:**

These 3 PRs are required to fix: https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-535/+bug/2042301

Given it was initially meant for 2.74, it is now moved to 2.76 and requires monitoring by the team to ensure it lands in time. @olivercalder 
