### PR TITLE
many: attempt to clean up potentially corrupted files during download undo

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -98,6 +98,10 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	if snapsup.DownloadInfo != nil && snapSize == 0 {
+		return fmt.Errorf("cannot verify snap %q, snap file is unexpected empty and possibly corrupted", snapsup.InstanceName())
+	}
+
 	deviceCtx, err := snapstate.DeviceCtx(st, t, nil)
 	if err != nil {
 		return err

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -77,9 +77,9 @@ type StoreService interface {
 	// busy and the cleanup could not run.
 	CleanDownloadsCache() error
 
-	// CleanDownloadsCacheEntry drops a cached entry associated with
-	// given download info.
-	CleanDownloadsCacheEntry(*snap.DownloadInfo) error
+	// CleanupDownloadArtifacts attempts to remove unused download artifacts of
+	// a given snap.
+	CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error
 
 	ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error)
 }

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -77,6 +77,10 @@ type StoreService interface {
 	// busy and the cleanup could not run.
 	CleanDownloadsCache() error
 
+	// CleanDownloadsCacheEntry drops a cached entry associated with
+	// given download info.
+	CleanDownloadsCacheEntry(*snap.DownloadInfo) error
+
 	ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error)
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -105,6 +105,8 @@ type fakeOp struct {
 
 	snapLocked bool
 	isUndo     bool
+
+	sha3 string
 }
 
 type fakeOps []fakeOp
@@ -215,6 +217,8 @@ type fakeStore struct {
 	idsToNames         map[string]string
 
 	mutateSnapInfo func(*snap.Info) error
+
+	cleanupDownloadArtifactsError map[string]error
 }
 
 func (f *fakeStore) registerID(name, id string) {
@@ -645,6 +649,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		Version: name + "Ver",
 		DownloadInfo: snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 		Confinement:   confinement,
 		Architectures: []string{"all"},
@@ -1022,8 +1027,22 @@ func (f *fakeStore) CleanDownloadsCache() error {
 	return nil
 }
 
-func (f *fakeStore) CleanDownloadsCacheEntry(info *snap.DownloadInfo) error {
-	f.fakeBackend.appendOp(&fakeOp{op: "storesvc-clean-downloads-cache-entry", name: info.Sha3_384})
+func (f *fakeStore) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error {
+	f.pokeStateLock()
+
+	cksum := "<not-provided>"
+	if dl != nil {
+		cksum = dl.Sha3_384
+	}
+
+	f.fakeBackend.appendOp(&fakeOp{op: "storesvc-cleanup-download-artifacts",
+		sha3: cksum,
+		path: targetFn,
+	})
+
+	if f.cleanupDownloadArtifactsError != nil {
+		return f.cleanupDownloadArtifactsError[cksum]
+	}
 	return nil
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1022,6 +1022,11 @@ func (f *fakeStore) CleanDownloadsCache() error {
 	return nil
 }
 
+func (f *fakeStore) CleanDownloadsCacheEntry(info *snap.DownloadInfo) error {
+	f.fakeBackend.appendOp(&fakeOp{op: "storesvc-clean-downloads-cache-entry", name: info.Sha3_384})
+	return nil
+}
+
 type fakeSnappyBackend struct {
 	ops fakeOps
 	mu  sync.Mutex

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1011,6 +1011,9 @@ func (m *SnapManager) undoDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 	err = func() error {
 		st.Unlock()
 		defer st.Lock()
+		// Remove the snap blob from downloads directory but keep the cache
+		// entry for reuse if the download is triggered again in another change
+		// pertaining to the same snap revision.
 		return theStore.CleanupDownloadArtifacts(fname, snapsup.DownloadInfo)
 	}()
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1007,38 +1007,15 @@ func (m *SnapManager) undoDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	fname := snapsup.BlobPath()
-	fi, err := os.Stat(fname)
-	if err != nil {
-		t.Logf("cannot stat download file: %v", err)
-		return nil
-	}
 
 	err = func() error {
 		st.Unlock()
 		defer st.Lock()
-
-		// TODO: better check for file being corrupted, verify the hash?
-		corrupted := fi.Size() == 0
-		if !corrupted {
-			return nil
-		}
-
-		err := fmt.Errorf("found corrupted snap file")
-
-		if rerr := os.Remove(fname); rerr != nil {
-			err = strutil.JoinErrors(err, fmt.Errorf("cannot remove corrupted file: %w", rerr))
-		}
-
-		if snapsup.DownloadInfo != nil {
-			// takes a lock inside, could block
-			if cerr := theStore.CleanDownloadsCacheEntry(snapsup.DownloadInfo); cerr != nil {
-				err = strutil.JoinErrors(err, fmt.Errorf("cannot drop cached download entry: %w", cerr))
-			}
-		}
-		return err
+		return theStore.CleanupDownloadArtifacts(fname, snapsup.DownloadInfo)
 	}()
 	if err != nil {
-		t.Logf("errors during cleanup: %v", err)
+		t.Logf("cannot clean up downloaded snap artifacts: %v", err)
+		return nil
 	}
 
 	return nil

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -995,6 +995,55 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+func (m *SnapManager) undoDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapsup, theStore, _, err := downloadSnapParams(st, t)
+	if err != nil {
+		t.Logf("cannot obtain download info: %v", err)
+		return nil
+	}
+
+	fname := snapsup.BlobPath()
+	fi, err := os.Stat(fname)
+	if err != nil {
+		t.Logf("cannot stat download file: %v", err)
+		return nil
+	}
+
+	err = func() error {
+		st.Unlock()
+		defer st.Lock()
+
+		// TODO: better check for file being corrupted, verify the hash?
+		corrupted := fi.Size() == 0
+		if !corrupted {
+			return nil
+		}
+
+		err := fmt.Errorf("found corrupted snap file")
+
+		if rerr := os.Remove(fname); rerr != nil {
+			err = strutil.JoinErrors(err, fmt.Errorf("cannot remove corrupted file: %w", rerr))
+		}
+
+		if snapsup.DownloadInfo != nil {
+			// takes a lock inside, could block
+			if cerr := theStore.CleanDownloadsCacheEntry(snapsup.DownloadInfo); cerr != nil {
+				err = strutil.JoinErrors(err, fmt.Errorf("cannot drop cached download entry: %w", cerr))
+			}
+		}
+		return err
+	}()
+	if err != nil {
+		t.Logf("errors during cleanup: %v", err)
+	}
+
+	return nil
+}
+
 func waitForPreDownload(task *state.Task, snapsup *SnapSetup) error {
 	st := task.State()
 	st.Lock()

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"os"
 	"path/filepath"
 	"time"
 
@@ -524,4 +525,88 @@ func (s *downloadSnapSuite) TestDoDownloadRateLimitedIntegration(c *C) {
 		},
 	})
 
+}
+
+type testUndoDownloadSnapFileCorruptedScenario int
+
+const (
+	validFile testUndoDownloadSnapFileCorruptedScenario = iota
+	badFile
+	removedFile
+)
+
+func (s *downloadSnapSuite) testUndoDownloadSnapFile(c *C, scenario testUndoDownloadSnapFileCorruptedScenario) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t := s.state.NewTask("download-snap", "test")
+
+	sup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(1),
+		},
+		DownloadInfo: &snap.DownloadInfo{
+			Sha3_384: "some-hash",
+		},
+	}
+	t.Set("snap-setup", sup)
+	t.SetStatus(state.UndoStatus)
+
+	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
+	switch scenario {
+	case badFile:
+		c.Assert(os.WriteFile(sup.BlobPath(), nil, 0644), IsNil)
+	case validFile:
+		c.Assert(os.WriteFile(sup.BlobPath(), []byte("some-content"), 0644), IsNil)
+	case removedFile:
+	// the file is already gone
+	default:
+		panic("unexpected scenario")
+	}
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Assert(chg.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
+	// file was dropped
+	switch scenario {
+	case removedFile:
+		// file was already gone
+		c.Check(sup.BlobPath(), testutil.FileAbsent)
+		// no cleanup was requested
+		c.Check(s.fakeBackend.ops, IsNil)
+	case badFile:
+		// file was removed
+		c.Check(sup.BlobPath(), testutil.FileAbsent)
+		// entry drop was requested
+		c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+			{
+				op:   "storesvc-clean-downloads-cache-entry",
+				name: "some-hash",
+			},
+		})
+	case validFile:
+		// file is kept
+		c.Check(sup.BlobPath(), testutil.FilePresent)
+		// nothing is dropped
+		c.Assert(s.fakeBackend.ops, IsNil)
+	}
+
+}
+
+func (s *downloadSnapSuite) TestUndoDownloadSnapFileCorrupted(c *C) {
+	s.testUndoDownloadSnapFile(c, badFile)
+}
+
+func (s *downloadSnapSuite) TestUndoDownloadSnapFileRemovedNotFatal(c *C) {
+	s.testUndoDownloadSnapFile(c, removedFile)
+}
+
+func (s *downloadSnapSuite) TestUndoDownloadSnapFileOk(c *C) {
+	s.testUndoDownloadSnapFile(c, validFile)
 }

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -20,7 +20,7 @@
 package snapstate_test
 
 import (
-	"os"
+	"errors"
 	"path/filepath"
 	"time"
 
@@ -530,9 +530,8 @@ func (s *downloadSnapSuite) TestDoDownloadRateLimitedIntegration(c *C) {
 type testUndoDownloadSnapFileCorruptedScenario int
 
 const (
-	validFile testUndoDownloadSnapFileCorruptedScenario = iota
-	badFile
-	removedFile
+	cleanupOk = iota
+	cleanupErr
 )
 
 func (s *downloadSnapSuite) testUndoDownloadSnapFile(c *C, scenario testUndoDownloadSnapFileCorruptedScenario) {
@@ -552,14 +551,12 @@ func (s *downloadSnapSuite) testUndoDownloadSnapFile(c *C, scenario testUndoDown
 	t.Set("snap-setup", sup)
 	t.SetStatus(state.UndoStatus)
 
-	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
 	switch scenario {
-	case badFile:
-		c.Assert(os.WriteFile(sup.BlobPath(), nil, 0644), IsNil)
-	case validFile:
-		c.Assert(os.WriteFile(sup.BlobPath(), []byte("some-content"), 0644), IsNil)
-	case removedFile:
-	// the file is already gone
+	case cleanupOk:
+	case cleanupErr:
+		s.fakeStore.cleanupDownloadArtifactsError = map[string]error{
+			"some-hash": errors.New("mock error"),
+		}
 	default:
 		panic("unexpected scenario")
 	}
@@ -573,40 +570,19 @@ func (s *downloadSnapSuite) testUndoDownloadSnapFile(c *C, scenario testUndoDown
 	s.state.Lock()
 
 	c.Assert(chg.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
-	// file was dropped
-	switch scenario {
-	case removedFile:
-		// file was already gone
-		c.Check(sup.BlobPath(), testutil.FileAbsent)
-		// no cleanup was requested
-		c.Check(s.fakeBackend.ops, IsNil)
-	case badFile:
-		// file was removed
-		c.Check(sup.BlobPath(), testutil.FileAbsent)
-		// entry drop was requested
-		c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
-			{
-				op:   "storesvc-clean-downloads-cache-entry",
-				name: "some-hash",
-			},
-		})
-	case validFile:
-		// file is kept
-		c.Check(sup.BlobPath(), testutil.FilePresent)
-		// nothing is dropped
-		c.Assert(s.fakeBackend.ops, IsNil)
-	}
-
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op:   "storesvc-cleanup-download-artifacts",
+			sha3: "some-hash",
+			path: sup.BlobPath(),
+		},
+	})
 }
 
-func (s *downloadSnapSuite) TestUndoDownloadSnapFileCorrupted(c *C) {
-	s.testUndoDownloadSnapFile(c, badFile)
+func (s *downloadSnapSuite) TestUndoDownloadSnapFileDone(c *C) {
+	s.testUndoDownloadSnapFile(c, cleanupOk)
 }
 
-func (s *downloadSnapSuite) TestUndoDownloadSnapFileRemovedNotFatal(c *C) {
-	s.testUndoDownloadSnapFile(c, removedFile)
-}
-
-func (s *downloadSnapSuite) TestUndoDownloadSnapFileOk(c *C) {
-	s.testUndoDownloadSnapFile(c, validFile)
+func (s *downloadSnapSuite) TestUndoDownloadSnapCleanupErrorNotFatal(c *C) {
+	s.testUndoDownloadSnapFile(c, cleanupErr)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -848,7 +848,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	// remove anything that is not referenced anymore
 	runner.AddHandler("prerequisites", m.doPrerequisites, nil)
 	runner.AddHandler("prepare-snap", m.doPrepareSnap, m.undoPrepareSnap)
-	runner.AddHandler("download-snap", m.doDownloadSnap, m.undoPrepareSnap)
+	runner.AddHandler("download-snap", m.doDownloadSnap, m.undoDownloadSnap)
 	runner.AddHandler("mount-snap", m.doMountSnap, m.undoMountSnap)
 	runner.AddHandler("unlink-current-snap", m.doUnlinkCurrentSnap, m.undoUnlinkCurrentSnap)
 	runner.AddHandler("copy-snap-data", m.doCopySnapData, m.undoCopySnapData)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -897,6 +897,9 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 
 	// component tasks
 	runner.AddHandler("prepare-component", m.doPrepareComponent, nil)
+	// TODO: add undo handler for download-component similar to
+	// undoDownloadSnap to clean up potentially corrupted component
+	// blobs (SNAPDENG-36484)
 	runner.AddHandler("download-component", m.doDownloadComponent, nil)
 	runner.AddHandler("mount-component", m.doMountComponent, m.undoMountComponent)
 	runner.AddHandler("unlink-current-component", m.doUnlinkCurrentComponent, m.undoUnlinkCurrentComponent)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2167,6 +2167,11 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 			name: "some-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap"),
 		},
+		{
+			op:   "storesvc-cleanup-download-artifacts",
+			name: "",
+			path: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+		},
 	}
 	// start with an easier-to-read error if this fails:
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
@@ -4625,6 +4630,11 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 			op:   "remove-snap-dir",
 			name: "some-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap"),
+		},
+		{
+			op:   "storesvc-cleanup-download-artifacts",
+			name: "",
+			path: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -7394,6 +7404,11 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, opts testInstal
 
 	if opts.undo {
 		expected = append(expected, undoOps(instanceName, opts.snapType, expectedSeq, nil)...)
+		expected = append(expected, fakeOp{
+			op:   "storesvc-cleanup-download-artifacts",
+			sha3: "",
+			path: snap.MountFile(instanceName, snapRevision),
+		})
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1559,6 +1559,7 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 		SnapPath: filepath.Join(dirs.SnapBlobDir, "services-snap_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeApp,
@@ -1950,6 +1951,7 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 		SnapPath: filepath.Join(dirs.SnapBlobDir, "services-snap_instance_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 		SideInfo:    snapsup.SideInfo,
 		Type:        snap.TypeApp,
@@ -2310,6 +2312,7 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 		SnapPath: filepath.Join(dirs.SnapBlobDir, "kernel_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
@@ -2872,6 +2875,12 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 			name: "some-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap"),
 		},
+		{
+			op:   "storesvc-cleanup-download-artifacts",
+			name: "",
+			path: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+			sha3: "<some-hash>",
+		},
 	}...)
 
 	// ensure all our tasks ran
@@ -3248,6 +3257,11 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 			op:   "remove-snap-dir",
 			name: "some-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap"),
+		},
+		{
+			op:   "storesvc-cleanup-download-artifacts",
+			sha3: "<some-hash>",
+			path: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
 		},
 	}...)
 
@@ -17549,6 +17563,13 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	if opts.undo {
 		expected = append(expected,
 			undoOps(instanceName, opts.snapType, expectedSideState, originalSideState)...)
+		if !opts.useSameSnapRev {
+			expected = append(expected, fakeOp{
+				op:   "storesvc-cleanup-download-artifacts",
+				sha3: "<some-hash>",
+				path: snap.MountFile(instanceName, newSnapRev),
+			})
+		}
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -17616,6 +17637,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	if !opts.useSameSnapRev {
 		expectedSnapsup.DownloadInfo = &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		}
 	}
 
@@ -18053,6 +18075,12 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 
 	if undo {
 		expected = append(expected, undoOps(snapName, snap.TypeKernel, expectedSideState, originalSideState)...)
+		expected = append(expected, fakeOp{
+			op:   "storesvc-cleanup-download-artifacts",
+			sha3: "<some-hash>",
+			path: snap.MountFile(snapName, newSnapRev),
+		})
+
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -18102,6 +18130,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 		PreUpdateKernelModuleComponents: currentKmodComps,
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 	}
 
@@ -19713,12 +19742,14 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	c.Assert(err, IsNil)
 	c.Assert(snapsup.DownloadInfo, DeepEquals, &snap.DownloadInfo{
 		DownloadURL: "https://some-server.com/some/path.snap",
+		Sha3_384:    "<some-hash>",
 	})
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: channel,
 		UserID:  s.user.ID,
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Sha3_384:    "<some-hash>",
 		},
 		SideInfo:  snapsup.SideInfo,
 		Type:      opts.snapType,

--- a/store/cache.go
+++ b/store/cache.go
@@ -22,6 +22,7 @@ package store
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -72,6 +73,8 @@ type downloadCache interface {
 	GetPath(cacheKey string) string
 	// Drop an entry. Ignores errors when entry does not exist.
 	Drop(cacheKey string) error
+	// Open a stream to entry under a given key.
+	Open(cacheKey string) (io.ReadSeekCloser, error)
 	// Best effort cleanup of outstanding cache items. Returns ErrCleanupBusy
 	// when the cache is in use and cleanup should be retried at some later
 	// time.
@@ -90,6 +93,8 @@ func (cm *nullCache) GetPath(cacheKey string) string {
 func (cm *nullCache) Put(cacheKey, sourcePath string) error { return nil }
 
 func (cm *nullCache) Drop(cacheKey string) error { return nil }
+
+func (cm *nullCache) Open(cacheKey string) (io.ReadSeekCloser, error) { return nil, fs.ErrNotExist }
 
 func (cm *nullCache) Cleanup() error { return nil }
 
@@ -214,6 +219,22 @@ func (cm *CacheManager) Drop(cacheKey string) error {
 		}
 		return nil
 	}()
+}
+
+// Open a stream for reading from an entry under a given key.
+func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, error) {
+	if cacheKey == "" {
+		return nil, fs.ErrNotExist
+	}
+
+	// always try to create the cache dir first or the following
+	// osutil.IsWritable will always fail if the dir is missing
+	_ = os.MkdirAll(cm.cacheDir, 0700)
+
+	cm.cleanupLock.RLock()
+	defer cm.cleanupLock.RUnlock()
+
+	return os.Open(cm.path(cacheKey))
 }
 
 // count returns the number of items in the cache

--- a/store/cache.go
+++ b/store/cache.go
@@ -73,8 +73,9 @@ type downloadCache interface {
 	GetPath(cacheKey string) string
 	// Drop an entry. Ignores errors when entry does not exist.
 	Drop(cacheKey string) error
-	// Open a stream to entry under a given key.
-	Open(cacheKey string) (io.ReadSeekCloser, error)
+	// Open a stream to entry under a given key. Returns an
+	// io.ReadSeekCloser and the stream size.
+	Open(cacheKey string) (io.ReadSeekCloser, int64, error)
 	// Best effort cleanup of outstanding cache items. Returns ErrCleanupBusy
 	// when the cache is in use and cleanup should be retried at some later
 	// time.
@@ -94,7 +95,9 @@ func (cm *nullCache) Put(cacheKey, sourcePath string) error { return nil }
 
 func (cm *nullCache) Drop(cacheKey string) error { return nil }
 
-func (cm *nullCache) Open(cacheKey string) (io.ReadSeekCloser, error) { return nil, fs.ErrNotExist }
+func (cm *nullCache) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
+	return nil, 0, fs.ErrNotExist
+}
 
 func (cm *nullCache) Cleanup() error { return nil }
 
@@ -222,9 +225,9 @@ func (cm *CacheManager) Drop(cacheKey string) error {
 }
 
 // Open a stream for reading from an entry under a given key.
-func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, error) {
+func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
 	if cacheKey == "" {
-		return nil, fs.ErrNotExist
+		return nil, 0, fs.ErrNotExist
 	}
 
 	// always try to create the cache dir first or the following
@@ -234,7 +237,16 @@ func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, error) {
 	cm.cleanupLock.RLock()
 	defer cm.cleanupLock.RUnlock()
 
-	return os.Open(cm.path(cacheKey))
+	f, err := os.Open(cm.path(cacheKey))
+	if err != nil {
+		return nil, 0, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return f, fi.Size(), nil
 }
 
 // count returns the number of items in the cache

--- a/store/cache.go
+++ b/store/cache.go
@@ -70,6 +70,8 @@ type downloadCache interface {
 	Put(cacheKey, sourcePath string) error
 	// Get full path of the file in cache
 	GetPath(cacheKey string) string
+	// Drop an entry. Ignores errors when entry does not exist.
+	Drop(cacheKey string) error
 	// Best effort cleanup of outstanding cache items. Returns ErrCleanupBusy
 	// when the cache is in use and cleanup should be retried at some later
 	// time.
@@ -86,6 +88,8 @@ func (cm *nullCache) GetPath(cacheKey string) string {
 	return ""
 }
 func (cm *nullCache) Put(cacheKey, sourcePath string) error { return nil }
+
+func (cm *nullCache) Drop(cacheKey string) error { return nil }
 
 func (cm *nullCache) Cleanup() error { return nil }
 
@@ -183,6 +187,33 @@ func (cm *CacheManager) Put(cacheKey, sourcePath string) error {
 	}
 
 	return cm.opportunisticCleanup()
+}
+
+// Drop drops an entry at given key.
+func (cm *CacheManager) Drop(cacheKey string) error {
+	if cacheKey == "" {
+		return nil
+	}
+
+	// always try to create the cache dir first or the following
+	// osutil.IsWritable will always fail if the dir is missing
+	_ = os.MkdirAll(cm.cacheDir, 0700)
+
+	// happens on e.g. `snap download` which runs as the user
+	if !osutil.IsWritable(cm.cacheDir) {
+		return nil
+	}
+
+	return func() error {
+		cm.cleanupLock.RLock()
+		defer cm.cleanupLock.RUnlock()
+
+		err := os.Remove(cm.path(cacheKey))
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		return nil
+	}()
 }
 
 // count returns the number of items in the cache

--- a/store/cache.go
+++ b/store/cache.go
@@ -230,8 +230,9 @@ func (cm *CacheManager) Drop(cacheKey string) error {
 // Open opens a cache entry for reading. The returned file handle remains
 // valid even if the entry is subsequently removed by another operation (e.g.
 // Drop or Cleanup), because on Linux an open file descriptor preserves access
-// to the inode data until it is closed.
-func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
+// to the inode data until it is closed. The returned int64 is the size of the
+// cached stream.
+func (cm *CacheManager) Open(cacheKey string) (f io.ReadSeekCloser, size int64, err error) {
 	if cacheKey == "" {
 		return nil, 0, fs.ErrNotExist
 	}
@@ -243,14 +244,20 @@ func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, int64, error) 
 	cm.cleanupLock.RLock()
 	defer cm.cleanupLock.RUnlock()
 
-	f, err := os.Open(cm.path(cacheKey))
+	fd, err := os.Open(cm.path(cacheKey))
 	if err != nil {
 		return nil, 0, err
 	}
-	fi, err := f.Stat()
+	defer func() {
+		if err != nil {
+			fd.Close()
+		}
+	}()
+	fi, err := fd.Stat()
 	if err != nil {
 		return nil, 0, err
 	}
+	f = fd
 
 	return f, fi.Size(), nil
 }

--- a/store/cache.go
+++ b/store/cache.go
@@ -73,8 +73,11 @@ type downloadCache interface {
 	GetPath(cacheKey string) string
 	// Drop an entry. Ignores errors when entry does not exist.
 	Drop(cacheKey string) error
-	// Open a stream to entry under a given key. Returns an
-	// io.ReadSeekCloser and the stream size.
+	// Open opens a cache entry for reading. The returned file handle
+	// remains valid even if the entry is subsequently removed by another
+	// operation (e.g. Drop or Cleanup), because on Linux an open file
+	// descriptor preserves access to the inode data until it is closed.
+	// Returns an io.ReadSeekCloser and the stream size.
 	Open(cacheKey string) (io.ReadSeekCloser, int64, error)
 	// Best effort cleanup of outstanding cache items. Returns ErrCleanupBusy
 	// when the cache is in use and cleanup should be retried at some later
@@ -224,7 +227,10 @@ func (cm *CacheManager) Drop(cacheKey string) error {
 	}()
 }
 
-// Open a stream for reading from an entry under a given key.
+// Open opens a cache entry for reading. The returned file handle remains
+// valid even if the entry is subsequently removed by another operation (e.g.
+// Drop or Cleanup), because on Linux an open file descriptor preserves access
+// to the inode data until it is closed.
 func (cm *CacheManager) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
 	if cacheKey == "" {
 		return nil, 0, fs.ErrNotExist

--- a/store/cache_test.go
+++ b/store/cache_test.go
@@ -117,6 +117,52 @@ func (s *cacheSuite) TestGet(c *C) {
 	c.Assert(targetPath, testutil.FileEquals, canary)
 }
 
+func (s *cacheSuite) TestDrop(c *C) {
+	canary := "some content"
+	p := s.makeTestFile(c, "foo", canary)
+	err := s.cm.Put("some-cache-key", p)
+	c.Assert(err, IsNil)
+	c.Check(s.cm.Count(), Equals, 1)
+
+	// remove the test file making the cache entry be unique instance of the
+	// content
+	c.Assert(os.Remove(p), IsNil)
+
+	targetPath := filepath.Join(s.tmp, "new-location")
+	cacheHit := s.cm.Get("some-cache-key", targetPath)
+	c.Check(cacheHit, Equals, true)
+	c.Check(osutil.FileExists(targetPath), Equals, true)
+
+	// grab the hardlink count, which should be 2 now
+	fi, err := os.Stat(targetPath)
+	c.Assert(err, IsNil)
+	cnt, err := store.HardLinkCount(fi)
+	c.Assert(err, IsNil)
+	c.Check(cnt, Equals, uint64(2))
+
+	err = s.cm.Drop("some-cache-key")
+	c.Assert(err, IsNil)
+
+	// hardlink count should be 1, as entry got dropped
+	fi, err = os.Stat(targetPath)
+	c.Assert(err, IsNil)
+	cnt, err = store.HardLinkCount(fi)
+	c.Assert(err, IsNil)
+	c.Check(cnt, Equals, uint64(1))
+
+	// cache count is 0
+	c.Check(s.cm.Count(), Equals, 0)
+
+	// no errors if key did not exist
+	err = s.cm.Drop("some-cache-key")
+	c.Assert(err, IsNil)
+
+	// empty cache key
+	err = s.cm.Drop("")
+	c.Assert(err, IsNil)
+	c.Check(osutil.IsDirectory(s.cm.CacheDir()), Equals, true)
+}
+
 func (s *cacheSuite) makeTestFiles(c *C, n int) (cacheKeys []string, testFiles []string) {
 	cacheKeys = make([]string, n)
 	testFiles = make([]string, n)

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -937,3 +937,9 @@ func (s *Store) SetCachePolicy(policy CachePolicy) {
 func (s *Store) CleanDownloadsCache() error {
 	return s.cacher.Cleanup()
 }
+
+// CleanDownloadsCacheEntry drops an entry associated with the provided download
+// info from the downloads cache.
+func (s *Store) CleanDownloadsCacheEntry(dl *snap.DownloadInfo) error {
+	return s.cacher.Drop(dl.Sha3_384)
+}

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -949,7 +949,7 @@ func (s *Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo)
 
 	if dl != nil {
 		maybeDropIfCorrupted := func() error {
-			f, oerr := s.cacher.Open(dl.Sha3_384)
+			f, sz, oerr := s.cacher.Open(dl.Sha3_384)
 			if oerr != nil {
 				if errors.Is(oerr, fs.ErrNotExist) {
 					return nil
@@ -958,18 +958,22 @@ func (s *Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo)
 			}
 			defer f.Close()
 
-			h := crypto.SHA3_384.New()
-			if _, cerr := io.Copy(h, f); cerr != nil {
-				return fmt.Errorf("cannot read: %w", cerr)
+			// If different size, we drop directly, otherwise we check also the hash
+			if sz == dl.Size {
+				h := crypto.SHA3_384.New()
+				if _, cerr := io.Copy(h, f); cerr != nil {
+					return fmt.Errorf("cannot read: %w", cerr)
+				}
+
+				actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
+				if dl.Sha3_384 == actualSha3 {
+					// the cached entry appears to be correct, let's keep it
+					return nil
+				}
 			}
 
-			actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
-			if dl.Sha3_384 == actualSha3 {
-				// the cached entry appears to be correct, let's keep it
-				return nil
-			}
-
-			// takes a lock inside, could block
+			// takes a lock inside, could block, ignore ENOENT as the entry may have
+			// been dropped while we were processing it
 			if derr := s.cacher.Drop(dl.Sha3_384); derr != nil && !errors.Is(derr, fs.ErrNotExist) {
 				return fmt.Errorf("cannot drop: %w", derr)
 			}

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -939,10 +939,14 @@ func (s *Store) CleanDownloadsCache() error {
 }
 
 // CleanupDownloadArtifacts attempts to clean up download artifacts associated
-// with a given snap.
+// with a given snap. The downloaded blob file is always removed because it can
+// be re-linked from cache on the next download attempt. The cache entry is only
+// dropped if it appears corrupted (size or hash mismatch), so that a valid
+// cached copy can be reused.
 func (s *Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error {
 	var err error
 	// TODO:GOVERSION: use errors.Join
+	// Always remove the blob; it can be re-linked from cache if needed.
 	if rerr := os.Remove(targetFn); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
 		err = strutil.JoinErrors(err, fmt.Errorf("cannot remove downloaded file: %w", rerr))
 	}

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -938,8 +938,48 @@ func (s *Store) CleanDownloadsCache() error {
 	return s.cacher.Cleanup()
 }
 
-// CleanDownloadsCacheEntry drops an entry associated with the provided download
-// info from the downloads cache.
-func (s *Store) CleanDownloadsCacheEntry(dl *snap.DownloadInfo) error {
-	return s.cacher.Drop(dl.Sha3_384)
+// CleanupDownloadArtifacts attempts to clean up download artifacts associated
+// with a given snap.
+func (s *Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error {
+	var err error
+	// TODO:GOVERSION: use errors.Join
+	if rerr := os.Remove(targetFn); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+		err = strutil.JoinErrors(err, fmt.Errorf("cannot remove downloaded file: %w", rerr))
+	}
+
+	if dl != nil {
+		maybeDropIfCorrupted := func() error {
+			f, oerr := s.cacher.Open(dl.Sha3_384)
+			if oerr != nil {
+				if errors.Is(oerr, fs.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("cannot open: %w", oerr)
+			}
+			defer f.Close()
+
+			h := crypto.SHA3_384.New()
+			if _, cerr := io.Copy(h, f); cerr != nil {
+				return fmt.Errorf("cannot read: %w", cerr)
+			}
+
+			actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
+			if dl.Sha3_384 == actualSha3 {
+				// the cached entry appears to be correct, let's keep it
+				return nil
+			}
+
+			// takes a lock inside, could block
+			if derr := s.cacher.Drop(dl.Sha3_384); derr != nil && !errors.Is(derr, fs.ErrNotExist) {
+				return fmt.Errorf("cannot drop: %w", derr)
+			}
+
+			return nil
+		}
+
+		if merr := maybeDropIfCorrupted(); merr != nil {
+			err = strutil.JoinErrors(err, fmt.Errorf("cannot drop cached download entry: %w", merr))
+		}
+	}
+	return err
 }

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -131,6 +131,11 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		return err
 	}
 
+	// TODO: the cache entry may have been corrupted (e.g. due to a power loss
+	// on a filesystem with metadata-only journaling), in which case Get() may
+	// link an invalid file as the download target. Ideally, Get() should verify
+	// the cached entry (e.g. check size against downloadInfo.Size) and treat a
+	// corrupted entry as a cache miss, triggering a re-download from the store.
 	if s.cacher.Get(downloadInfo.Sha3_384, targetPath) {
 		logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
 		return nil

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -818,7 +818,7 @@ func (co *cacheObserver) Drop(cacheKey string) error {
 	return nil
 }
 
-func (co *cacheObserver) Open(cacheKey string) (io.ReadSeekCloser, error) {
+func (co *cacheObserver) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
 	if co.inCache[cacheKey] {
 		s := "content"
 
@@ -830,9 +830,9 @@ func (co *cacheObserver) Open(cacheKey string) (io.ReadSeekCloser, error) {
 			*strings.Reader
 			io.Closer
 		}{sr, io.NopCloser(nil)}
-		return rsc, nil
+		return rsc, int64(len(s)), nil
 	}
-	return nil, errors.New("not found in cache")
+	return nil, 0, errors.New("not found in cache")
 }
 
 func (co *cacheObserver) Cleanup() error {
@@ -1166,36 +1166,63 @@ func (s *storeDownloadSuite) TestDownloadBadCache(c *C) {
 }
 
 func (s *storeDownloadSuite) TestDownloadCacheDropMocked(c *C) {
+	// sha3_384 of "content"
+	contentSha3 := "21e42a075b0d7bb6177c0eb3b3a1c8c6de6d4b4f902759eae5555e9cf3bebd21277a27102fd5426da989bde96c0cf848"
+	fakeSha3 := "fake-sha3"
 	obs := &cacheObserver{
 		inCache: map[string]bool{
-			"sha3_384-of-foo": true,
-		},
-		dropErr: map[string]error{
-			"sha3_384-of-unhappy": errors.New("mock error"),
+			contentSha3: true,
+			fakeSha3:    true,
 		},
 	}
 	defer s.store.MockCacher(obs)()
 
-	snapHappy := &snap.Info{}
-	snapHappy.RealName = "foo"
-	snapHappy.DownloadURL = "URL"
-	snapHappy.Size = 123
-	snapHappy.Sha3_384 = "sha3_384-of-foo"
-
-	err := s.store.CleanupDownloadArtifacts("foo.snap", &snapHappy.DownloadInfo)
+	snapInCache := &snap.Info{}
+	snapInCache.RealName = "foo"
+	snapInCache.DownloadURL = "URL"
+	snapInCache.Size = int64(len("content"))
+	snapInCache.Sha3_384 = contentSha3
+	// Size and hash ok, do not drop
+	err := s.store.CleanupDownloadArtifacts("foo.snap", &snapInCache.DownloadInfo)
 	c.Assert(err, IsNil)
+	c.Check(obs.drops, IsNil)
 
-	c.Check(obs.drops, DeepEquals, []string{"sha3_384-of-foo"})
+	// Size does not match, we drop
+	snapInCache.Size = int64(len("content")) + 1
+	obs.drops = nil
+	err = s.store.CleanupDownloadArtifacts("foo.snap", &snapInCache.DownloadInfo)
+	c.Assert(err, IsNil)
+	c.Check(obs.drops, DeepEquals, []string{contentSha3})
+
+	// Hash does not match, we drop
+	snapInCache.Size = int64(len("content"))
+	// This actually does not match "content", but it forces the hash check to fail
+	snapInCache.Sha3_384 = fakeSha3
+	obs.drops = nil
+	err = s.store.CleanupDownloadArtifacts("foo.snap", &snapInCache.DownloadInfo)
+	c.Assert(err, IsNil)
+	c.Check(obs.drops, DeepEquals, []string{fakeSha3})
+
+	// Error while dropping due to wrong size
+	snapInCache.Size = int64(len("content")) + 1
+	snapInCache.Sha3_384 = contentSha3
+	obs.dropErr = map[string]error{
+		contentSha3: errors.New("mock error"),
+	}
+	obs.drops = nil
+	err = s.store.CleanupDownloadArtifacts("foo.snap", &snapInCache.DownloadInfo)
+	c.Assert(err, ErrorMatches, "cannot drop cached download entry: cannot drop: mock error")
+	c.Check(obs.drops, DeepEquals, []string{contentSha3})
+
+	snapNotInCache := &snap.Info{}
+	snapNotInCache.RealName = "unhappy"
+	snapNotInCache.DownloadURL = "URL"
+	snapNotInCache.Size = 7
+	snapNotInCache.Sha3_384 = "sha3_384-of-unhappy"
 	obs.drops = nil
 
-	// errors are forwarded
-	snapUnhappy := &snap.Info{}
-	snapUnhappy.RealName = "unhappy"
-	snapUnhappy.DownloadURL = "URL"
-	snapUnhappy.Size = 123
-	snapUnhappy.Sha3_384 = "sha3_384-of-unhappy"
-
-	err = s.store.CleanupDownloadArtifacts("unhappy.snap", &snapUnhappy.DownloadInfo)
+	// Error, cannot open
+	err = s.store.CleanupDownloadArtifacts("unhappy.snap", &snapNotInCache.DownloadInfo)
 	c.Assert(err, ErrorMatches, "cannot drop cached download entry: cannot open: not found in cache")
 
 	c.Check(obs.drops, IsNil)
@@ -1222,7 +1249,7 @@ func (co *fakeCacher) Drop(cacheKey string) error {
 	panic("unexpected call")
 }
 
-func (co *fakeCacher) Open(cacheKey string) (io.ReadSeekCloser, error) {
+func (co *fakeCacher) Open(cacheKey string) (io.ReadSeekCloser, int64, error) {
 	panic("unexpected call")
 }
 

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -818,6 +818,23 @@ func (co *cacheObserver) Drop(cacheKey string) error {
 	return nil
 }
 
+func (co *cacheObserver) Open(cacheKey string) (io.ReadSeekCloser, error) {
+	if co.inCache[cacheKey] {
+		s := "content"
+
+		// strings.NewReader returns an *strings.Reader that implements io.{Reader,Seeker}
+		sr := strings.NewReader(s)
+
+		// io.NopCloser adds a no-op Close() method
+		var rsc io.ReadSeekCloser = struct {
+			*strings.Reader
+			io.Closer
+		}{sr, io.NopCloser(nil)}
+		return rsc, nil
+	}
+	return nil, errors.New("not found in cache")
+}
+
 func (co *cacheObserver) Cleanup() error {
 	co.cleanupCalls++
 	return nil
@@ -1165,7 +1182,7 @@ func (s *storeDownloadSuite) TestDownloadCacheDropMocked(c *C) {
 	snapHappy.Size = 123
 	snapHappy.Sha3_384 = "sha3_384-of-foo"
 
-	err := s.store.CleanDownloadsCacheEntry(&snapHappy.DownloadInfo)
+	err := s.store.CleanupDownloadArtifacts("foo.snap", &snapHappy.DownloadInfo)
 	c.Assert(err, IsNil)
 
 	c.Check(obs.drops, DeepEquals, []string{"sha3_384-of-foo"})
@@ -1178,10 +1195,10 @@ func (s *storeDownloadSuite) TestDownloadCacheDropMocked(c *C) {
 	snapUnhappy.Size = 123
 	snapUnhappy.Sha3_384 = "sha3_384-of-unhappy"
 
-	err = s.store.CleanDownloadsCacheEntry(&snapUnhappy.DownloadInfo)
-	c.Assert(err, ErrorMatches, "mock error")
+	err = s.store.CleanupDownloadArtifacts("unhappy.snap", &snapUnhappy.DownloadInfo)
+	c.Assert(err, ErrorMatches, "cannot drop cached download entry: cannot open: not found in cache")
 
-	c.Check(obs.drops, DeepEquals, []string{"sha3_384-of-unhappy"})
+	c.Check(obs.drops, IsNil)
 }
 
 type fakeCacher struct {
@@ -1202,6 +1219,10 @@ func (co *fakeCacher) Put(cacheKey, sourcePath string) error {
 }
 
 func (co *fakeCacher) Drop(cacheKey string) error {
+	panic("unexpected call")
+}
+
+func (co *fakeCacher) Open(cacheKey string) (io.ReadSeekCloser, error) {
 	panic("unexpected call")
 }
 

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -770,12 +770,15 @@ func (s *storeDownloadSuite) TestApplyDelta(c *C) {
 type cacheObserver struct {
 	inCache map[string]bool
 
-	gets []string
-	puts []string
+	gets  []string
+	puts  []string
+	drops []string
 
 	// list of errors to return on Put() to a specific key
 	putFailForKey map[string][]error
 	putErrHits    map[string]int
+
+	dropErr map[string]error
 
 	cleanupCalls int
 }
@@ -806,6 +809,15 @@ func (co *cacheObserver) Put(cacheKey, sourcePath string) error {
 	return nil
 }
 
+func (co *cacheObserver) Drop(cacheKey string) error {
+	co.drops = append(co.drops, cacheKey)
+
+	if co.dropErr != nil {
+		return co.dropErr[cacheKey]
+	}
+	return nil
+}
+
 func (co *cacheObserver) Cleanup() error {
 	co.cleanupCalls++
 	return nil
@@ -831,6 +843,7 @@ func (s *storeDownloadSuite) TestDownloadCacheHit(c *C) {
 
 	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", snap.Sha3_384, path)})
 	c.Check(obs.puts, IsNil)
+	c.Check(obs.drops, IsNil)
 	c.Check(obs.cleanupCalls, Equals, 0)
 }
 
@@ -856,6 +869,7 @@ func (s *storeDownloadSuite) TestDownloadCacheMiss(c *C) {
 
 	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
 	c.Check(obs.puts, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
+	c.Check(obs.drops, IsNil)
 }
 
 func (s *storeDownloadSuite) TestDownloadDeltaCacheMiss(c *C) {
@@ -940,6 +954,7 @@ func (s *storeDownloadSuite) TestDownloadDeltaCacheMiss(c *C) {
 	})
 	c.Check(obs.puts, DeepEquals, []string{fmt.Sprintf("%s:%s", snapInfo.Sha3_384, path)})
 	c.Check(obs.cleanupCalls, Equals, 0)
+	c.Check(obs.drops, IsNil)
 }
 
 func (s *storeDownloadSuite) TestDownloadDeltaRebuitlButCachePutFail(c *C) {
@@ -1133,6 +1148,42 @@ func (s *storeDownloadSuite) TestDownloadBadCache(c *C) {
 	c.Check(stream, IsNil)
 }
 
+func (s *storeDownloadSuite) TestDownloadCacheDropMocked(c *C) {
+	obs := &cacheObserver{
+		inCache: map[string]bool{
+			"sha3_384-of-foo": true,
+		},
+		dropErr: map[string]error{
+			"sha3_384-of-unhappy": errors.New("mock error"),
+		},
+	}
+	defer s.store.MockCacher(obs)()
+
+	snapHappy := &snap.Info{}
+	snapHappy.RealName = "foo"
+	snapHappy.DownloadURL = "URL"
+	snapHappy.Size = 123
+	snapHappy.Sha3_384 = "sha3_384-of-foo"
+
+	err := s.store.CleanDownloadsCacheEntry(&snapHappy.DownloadInfo)
+	c.Assert(err, IsNil)
+
+	c.Check(obs.drops, DeepEquals, []string{"sha3_384-of-foo"})
+	obs.drops = nil
+
+	// errors are forwarded
+	snapUnhappy := &snap.Info{}
+	snapUnhappy.RealName = "unhappy"
+	snapUnhappy.DownloadURL = "URL"
+	snapUnhappy.Size = 123
+	snapUnhappy.Sha3_384 = "sha3_384-of-unhappy"
+
+	err = s.store.CleanDownloadsCacheEntry(&snapUnhappy.DownloadInfo)
+	c.Assert(err, ErrorMatches, "mock error")
+
+	c.Check(obs.drops, DeepEquals, []string{"sha3_384-of-unhappy"})
+}
+
 type fakeCacher struct {
 	getPathCalls []string
 }
@@ -1147,6 +1198,10 @@ func (co *fakeCacher) GetPath(cacheKey string) string {
 }
 
 func (co *fakeCacher) Put(cacheKey, sourcePath string) error {
+	panic("unexpected call")
+}
+
+func (co *fakeCacher) Drop(cacheKey string) error {
 	panic("unexpected call")
 }
 

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -131,6 +131,10 @@ func (Store) CleanDownloadsCache() error {
 	panic("CleanDownloadsCache not expected")
 }
 
+func (Store) CleanDownloadsCacheEntry(dl *snap.DownloadInfo) error {
+	panic("CleanDownloadsCacheEntry not expected")
+}
+
 func (Store) ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error) {
 	panic("ExchangeMessages not expected")
 }

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -131,8 +131,8 @@ func (Store) CleanDownloadsCache() error {
 	panic("CleanDownloadsCache not expected")
 }
 
-func (Store) CleanDownloadsCacheEntry(dl *snap.DownloadInfo) error {
-	panic("CleanDownloadsCacheEntry not expected")
+func (Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error {
+	panic("CleaupnDownloadArtifacts not expected")
 }
 
 func (Store) ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error) {

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -132,7 +132,7 @@ func (Store) CleanDownloadsCache() error {
 }
 
 func (Store) CleanupDownloadArtifacts(targetFn string, dl *snap.DownloadInfo) error {
-	panic("CleaupnDownloadArtifacts not expected")
+	panic("CleanupDownloadArtifacts not expected")
 }
 
 func (Store) ExchangeMessages(ctx context.Context, req *store.MessageExchangeRequest) (*store.MessageExchangeResponse, error) {

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -69,7 +69,7 @@ execute: |
 
     echo "Verify installation change shows error"
     snap change --last refresh > change.out
-    MATCH "found corrupted snap file" < change.out
+    MATCH "ERROR cannot verify snap" < change.out
     MATCH "Undone.*Download snap.*test-snapd-sh-core24" < change.out
 
     echo "Verify undo cleaned up the corrupted file and the cache file"

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -1,7 +1,9 @@
 summary: Verify corrupted snap files are cleaned up when download task is undone
 
 details: |
-    Verify that undo of snap-download attempts to clean up corrupted snap files.
+    Verify that undo of snap-download cleans up corrupted snap blob files
+    while preserving valid cache entries that can be reused on the next
+    download attempt.
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
@@ -72,10 +74,10 @@ execute: |
     MATCH "ERROR cannot verify snap" < change.out
     MATCH "Undone.*Download snap.*test-snapd-sh-core24" < change.out
 
-    echo "Verify undo cleaned up the corrupted file and the cache file"
+    echo "Verify undo cleaned up the corrupted file"
     not test -f "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
-    echo "Cache entry for corrupted file was removed"
-    not test -f "$cache_file_rev_new"
+    echo "Cache entry for the valid download is preserved"
+    test -f "$cache_file_rev_new"
 
     echo "Subsequent refresh succeeds"
     snap refresh test-snapd-sh-core24

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -1,12 +1,17 @@
 summary: Verify corrupted snap files are cleaned up when download task is undone
 
 details: |
-    Verify that undo of snap-download cleans up corrupted snap blob files
-    while preserving valid cache entries that can be reused on the next
-    download attempt.
+    Verify that undo of snap-download cleans up corrupted snap blob files.
+    Two scenarios are tested:
+    - valid-cache: blob is zeroed but cache entry is valid; blob is removed
+      and cache is preserved for reuse on the next download attempt.
+    - corrupt-cache: both blob and cache entry are zeroed; both are removed
+      and the subsequent refresh re-downloads from the store.
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
+    CACHEMODE/corrupt_cache: corrupt
+    CACHEMODE/valid_cache: valid
 
 skip:
     - reason: This test needs test keys to be trusted
@@ -60,6 +65,11 @@ execute: |
     rm -fv "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
     touch "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
 
+    if [ "$CACHEMODE" = "corrupt" ]; then
+        echo "Also corrupt the cache entry"
+        truncate -s 0 "$cache_file_rev_new"
+    fi
+
     echo "Attempt refresh"
     if snap refresh test-snapd-sh-core24 2>install.err; then
         echo "Refresh should have failed but succeeded"
@@ -74,10 +84,16 @@ execute: |
     MATCH "ERROR cannot verify snap" < change.out
     MATCH "Undone.*Download snap.*test-snapd-sh-core24" < change.out
 
-    echo "Verify undo cleaned up the corrupted file"
+    echo "Verify undo cleaned up the corrupted blob"
     not test -f "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
-    echo "Cache entry for the valid download is preserved"
-    test -f "$cache_file_rev_new"
+
+    if [ "$CACHEMODE" = "corrupt" ]; then
+        echo "Corrupt cache entry was dropped"
+        not test -f "$cache_file_rev_new"
+    else
+        echo "Valid cache entry is preserved"
+        test -f "$cache_file_rev_new"
+    fi
 
     echo "Subsequent refresh succeeds"
     snap refresh test-snapd-sh-core24

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -1,0 +1,81 @@
+summary: Verify corrupted snap files are cleaned up when download task is undone
+
+details: |
+    Verify that undo of snap-download attempts to clean up corrupted snap files.
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+skip:
+    - reason: This test needs test keys to be trusted
+      if: test "$TRUST_TEST_KEYS" = "false"
+
+prepare: |
+    snap install test-snapd-sh-core24
+
+    echo "And the daemon is configured to point to the fake store"
+    "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+    tests.cleanup defer "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+
+    echo "Expose the needed assertions through the fakestore"
+    cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$BLOB_DIR/asserts"
+
+    # It is not enough to copy the assertions, we must also ack them otherwise we
+    # will get an error about not being able to resolve the account key
+    snap ack "$BLOB_DIR/asserts/testrootorg-store.account-key"
+    snap ack "$BLOB_DIR/asserts/developer1.account"
+    snap ack "$BLOB_DIR/asserts/developer1.account-key"
+
+    # Fake refresh of the test snap
+    "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" test-snapd-sh-core24
+
+execute: |
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    rev_old="$(readlink "$SNAP_MOUNT_DIR"/test-snapd-sh-core24/current)"
+
+    snap refresh test-snapd-sh-core24
+    snap list test-snapd-sh-core24 | MATCH '\+fake1'
+
+    snap refresh test-snapd-sh-core24
+    rev_new="$(readlink "$SNAP_MOUNT_DIR"/test-snapd-sh-core24/current)"
+
+    # Revert now, so that we can remove the new revision, and trigger it to be
+    # redownloaded.
+
+    snap revert test-snapd-sh-core24
+    test "$(readlink "$SNAP_MOUNT_DIR"/test-snapd-sh-core24/current)" = "$rev_old"
+
+    # Identify which cache file references the new revision blob
+    cache_file_rev_new="$(find /var/lib/snapd/cache -samefile \
+        "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap")"
+    [ -n "$cache_file_rev_new" ]
+
+    snap remove --revision "$rev_new" test-snapd-sh-core24
+
+    echo "Create corrupted (empty) snap file to short-circuit download task"
+    rm -fv "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
+    touch "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
+
+    echo "Attempt refresh"
+    if snap refresh test-snapd-sh-core24 2>install.err; then
+        echo "Refresh should have failed but succeeded"
+        exit 1
+    fi
+
+    echo "Verify installation failed"
+    MATCH "no matching signatures found" < install.err
+
+    echo "Verify installation change shows error"
+    snap change --last refresh > change.out
+    MATCH "found corrupted snap file" < change.out
+    MATCH "Undone.*Download snap.*test-snapd-sh-core24" < change.out
+
+    echo "Verify undo cleaned up the corrupted file and the cache file"
+    not test -f "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
+    echo "Cache entry for corrupted file was removed"
+    not test -f "$cache_file_rev_new"
+
+    echo "Subsequent refresh succeeds"
+    snap refresh test-snapd-sh-core24

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -3,9 +3,9 @@ summary: Verify corrupted snap files are cleaned up when download task is undone
 details: |
     Verify that undo of snap-download cleans up corrupted snap blob files.
     Two scenarios are tested:
-    - valid-cache: blob is zeroed but cache entry is valid; blob is removed
+    - valid_cache: blob is zeroed but cache entry is valid; blob is removed
       and cache is preserved for reuse on the next download attempt.
-    - corrupt-cache: both blob and cache entry are zeroed; both are removed
+    - corrupt_cache: both blob and cache entry are zeroed; both are removed
       and the subsequent refresh re-downloads from the store.
 
 environment:

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -77,7 +77,7 @@ execute: |
     fi
 
     echo "Verify installation failed"
-    MATCH "no matching signatures found" < install.err
+    MATCH "snap file is unexpected empty and possibly corrupted" < install.err
 
     echo "Verify installation change shows error"
     snap change --last refresh > change.out


### PR DESCRIPTION
Add proper undo to snap downloads step. Attempt to guess whether the
downloaded file could be corrupted and if it is, try to clean it up.

Related: SNAPDENG-36484 SF00423929

This is https://github.com/canonical/snapd/pull/16650 plus some test fixes. cc @bboozzoo .