### PR TITLE
overlord: support racing Loop and Stop correctly

### DIFF
--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -95,7 +95,8 @@ type Overlord struct {
 
 	stateEng *StateEngine
 	// ensure loop
-	loopTomb    *tomb.Tomb
+	loopTomb    tomb.Tomb
+	loopProceed chan struct{}
 	ensureLock  sync.Mutex
 	ensureTimer *time.Timer
 	ensureNext  time.Time
@@ -134,8 +135,11 @@ var storeNew = store.New
 // It can be provided with an optional restart.Handler.
 func New(restartHandler restart.Handler) (*Overlord, error) {
 	o := &Overlord{
-		inited: true,
+		inited:      true,
+		loopProceed: make(chan struct{}),
 	}
+	// create the loop goroutine
+	o.loopTomb.Go(o.loop)
 
 	backend := &overlordStateBackend{
 		path:         dirs.SnapStateFile,
@@ -496,43 +500,51 @@ func (o *Overlord) Loop() {
 	if preseed {
 		o.runner.OnTaskError(preseedExitWithError)
 	}
-	if o.loopTomb == nil {
-		o.loopTomb = new(tomb.Tomb)
+	// proceed with the loop
+	close(o.loopProceed)
+}
+
+func (o *Overlord) loop() error {
+	select {
+	case <-o.loopProceed:
+		// proceed with the loop
+	case <-o.loopTomb.Dying():
+		return nil
 	}
-	o.loopTomb.Go(func() error {
-		for {
-			// TODO: pass a proper context into Ensure
-			o.ensureTimerReset()
-			// in case of errors engine logs them,
-			// continue to the next Ensure() try for now
-			err := o.stateEng.Ensure()
-			if err != nil && preseed {
-				st := o.State()
-				// acquire state lock to ensure nothing attempts to write state
-				// as we are exiting; there is no deferred unlock to avoid
-				// potential race on exit.
-				st.Lock()
-				preseedExitWithError(err)
-			}
-			o.ensureDidRun()
-			pruneC := pruneTickerC(o.pruneTicker)
-			select {
-			case <-o.loopTomb.Dying():
-				return nil
-			case <-o.ensureTimer.C:
-			case <-pruneC:
-				if preseed {
-					// in preseed mode avoid setting StartOfOperationTime (it's
-					// an error), and don't Prune.
-					continue
-				}
-				st := o.State()
-				st.Lock()
-				st.Prune(o.startOfOperationTime, pruneWait, abortWait, pruneMaxChanges)
-				st.Unlock()
-			}
+	preseed := snapdenv.Preseeding()
+
+	for {
+		// TODO: pass a proper context into Ensure
+		o.ensureTimerReset()
+		// in case of errors engine logs them,
+		// continue to the next Ensure() try for now
+		err := o.stateEng.Ensure()
+		if err != nil && preseed {
+			st := o.State()
+			// acquire state lock to ensure nothing attempts to write state
+			// as we are exiting; there is no deferred unlock to avoid
+			// potential race on exit.
+			st.Lock()
+			preseedExitWithError(err)
 		}
-	})
+		o.ensureDidRun()
+		pruneC := pruneTickerC(o.pruneTicker)
+		select {
+		case <-o.loopTomb.Dying():
+			return nil
+		case <-o.ensureTimer.C:
+		case <-pruneC:
+			if preseed {
+				// in preseed mode avoid setting StartOfOperationTime (it's
+				// an error), and don't Prune.
+				continue
+			}
+			st := o.State()
+			st.Lock()
+			st.Prune(o.startOfOperationTime, pruneWait, abortWait, pruneMaxChanges)
+			st.Unlock()
+		}
+	}
 }
 
 func (o *Overlord) ensureDidRun() {
@@ -546,11 +558,8 @@ func (o *Overlord) CanStandby() bool {
 
 // Stop stops the ensure loop and the managers under the StateEngine.
 func (o *Overlord) Stop() error {
-	var err error
-	if o.loopTomb != nil {
-		o.loopTomb.Kill(nil)
-		err = o.loopTomb.Wait()
-	}
+	o.loopTomb.Kill(nil)
+	err := o.loopTomb.Wait()
 	o.stateEng.Stop()
 	if o.stateFLock != nil {
 		// This will also unlock the file
@@ -773,8 +782,12 @@ func Mock() *Overlord {
 // disk. Managers can be added with AddManager. For testing.
 func MockWithState(s *state.State) *Overlord {
 	o := &Overlord{
-		inited: false,
+		inited:      false,
+		loopProceed: make(chan struct{}),
 	}
+	// create the loop goroutine
+	o.loopTomb.Go(o.loop)
+
 	if s == nil {
 		s = state.New(mockBackend{o: o})
 	}

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -382,6 +382,34 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (ovs *overlordSuite) TestNewAndStop(c *C) {
+	o, err := overlord.New(nil)
+	c.Assert(err, IsNil)
+	errCh := make(chan error)
+	go func() {
+		errCh <- o.Stop()
+	}()
+	c.Assert(<-errCh, IsNil)
+}
+
+func (ovs *overlordSuite) TestRacingLoopAndStop(c *C) {
+	o, err := overlord.New(nil)
+	c.Assert(err, IsNil)
+
+	markSeeded(o)
+	// make sure we don't try to talk to the store
+	snapstate.CanAutoRefresh = nil
+
+	go func() {
+		o.Loop()
+	}()
+	errCh := make(chan error)
+	go func() {
+		errCh <- o.Stop()
+	}()
+	c.Assert(<-errCh, IsNil)
+}
+
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
 	o, err := overlord.New(nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
TestRacingLoopAndStop would fail the race detector with the old code.

