### PR TITLE
tests: ignore selinux denials from syslogd_t

### DIFF
--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -39,9 +39,15 @@ restore: |
 execute: |
     snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap"
 
+    # This is a first checkpoint after the session was started, so if denials
+    # were logged, they it will show up now, but not for subsequent checkpoints.
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
+
+    # Ignore expected SELinux denials from syslogd_t using netlink_tcpdiag_socket
+    # Fail on any other unexpected AVCs.
+    grep -v -E 'avc:  denied  \{ .* \} .* scontext=.*:syslogd_t:s0 .* tclass=netlink_tcpdiag_socket' < avc-after | \
     grep -v -E 'avc:  denied  { .* } .* comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0' avc-after | \
-        NOMATCH 'type=AVC'
+    NOMATCH 'type=AVC'
 
     MATCH 'install hook' < "/var/snap/$CLASSIC_SNAP/common/log"
     MATCH 'configure hook' < "/var/snap/$CLASSIC_SNAP/common/log"

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -46,7 +46,7 @@ execute: |
     # Ignore expected SELinux denials from syslogd_t using netlink_tcpdiag_socket
     # Fail on any other unexpected AVCs.
     grep -v -E 'avc:  denied  \{ .* \} .* scontext=.*:syslogd_t:s0 .* tclass=netlink_tcpdiag_socket' < avc-after | \
-    grep -v -E 'avc:  denied  { .* } .* comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0' avc-after | \
+    grep -v -E 'avc:  denied  { .* } .* comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0' | \
     NOMATCH 'type=AVC'
 
     MATCH 'install hook' < "/var/snap/$CLASSIC_SNAP/common/log"

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -45,7 +45,7 @@ execute: |
 
     # Ignore expected SELinux denials from syslogd_t using netlink_tcpdiag_socket
     # Fail on any other unexpected AVCs.
-    grep -v -E 'avc:  denied  \{ .* \} .* scontext=.*:syslogd_t:s0 .* tclass=netlink_tcpdiag_socket' < avc-after | \
+    grep -v -E 'avc:  denied  { .* } .* scontext=.*:syslogd_t:s0 .* tclass=netlink_tcpdiag_socket' < avc-after | \
     grep -v -E 'avc:  denied  { .* } .* comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0' | \
     NOMATCH 'type=AVC'
 
@@ -56,4 +56,8 @@ execute: |
 
     snap remove "$CLASSIC_SNAP"
 
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    # Ignore expected SELinux denials from systemd-journal and fail on others.
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | \
+    grep -v -E 'avc:  denied  { .* } .* scontext=.*:syslogd_t:s0 .* tclass=netlink_tcpdiag_socket' | \
+    grep -v -E 'avc:  denied  { .* } .* comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0' | \
+    NOMATCH 'type=AVC'

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -37,11 +37,11 @@ restore: |
     setenforce "$(cat enforcing.mode)"
 
 execute: |
-    snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap"
-
     # This is a first checkpoint after the session was started, so if denials
     # were logged, they it will show up now, but not for subsequent checkpoints.
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
+
+    snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap"
 
     # Ignore expected SELinux denials from syslogd_t using netlink_tcpdiag_socket
     # Fail on any other unexpected AVCs.


### PR DESCRIPTION
These denials are being generated in opensuse tumbleweed and need to be filtered.

