### PR TITLE
interfaces, snap: attempt to fix content with parallel installs

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -202,46 +202,38 @@ func (iface *contentInterface) path(attrs interfaces.Attrer, name string) []stri
 	return out
 }
 
-type resolveSide int
-
-const (
-	sourceSide resolveSide = iota
-	targetSide
-)
-
 // resolveSpecialVariable resolves one of the three $SNAP* variables at the
 // beginning of a given path. The variables are $SNAP, $SNAP_DATA and
 // $SNAP_COMMON. If there are no variables then $SNAP is implicitly assumed
-// (this is the behavior that was used before the variables were supported).
-// Depending on the context in which the variable is resolved, $SNAP may mean
-// the actual snap instance.
-func resolveSpecialVariable(path string, snapInfo *snap.Info, forSide resolveSide) string {
-	// The source of the mount should always use a full snap instance name,
-	// thus ensuring we consume content from the exact connected instance,
-	// rather than from a snap without the instance key.
-	persp := snap.PerspectiveSelf
-	if forSide == sourceSide {
-		persp = snap.PerspectiveOther
-	}
+// (this is the behavior that was used before the variables were supported). The
+// perspective parameter controls how $SNAP is expanded accounting for features
+// like parallel installs: PerspectiveOther uses the most precise instance name
+// (e.g. snap_key), while PerspectiveSelf uses the snap name (e.g. snap).
+func resolveSpecialVariable(path string, snapInfo *snap.Info, perspective snap.ExpandSnapPerspective) string {
 	// Content cannot be mounted at arbitrary locations, validate the path
 	// for extra safety.
 	if err := snap.ValidatePathVariables(path); err == nil && strings.HasPrefix(path, "$") {
 		// The path starts with $ and ValidatePathVariables() ensures
 		// path contains only $SNAP, $SNAP_DATA, $SNAP_COMMON, and no
 		// other $VARs are present.
-		return snapInfo.ExpandSnapVariablesSetSnapMountDir(path, dirs.CoreSnapMountDir, persp)
+		return snapInfo.ExpandSnapVariablesSetSnapMountDir(path, dirs.CoreSnapMountDir, perspective)
 	}
 	// Always prefix with $SNAP if nothing else is provided or the path
 	// contains invalid variables.
-	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, persp)
+	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, perspective)
 }
 
 func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (string, string) {
 	var target string
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
-	source := resolveSpecialVariable(relSrc, slot.Snap(), sourceSide)
-	target = resolveSpecialVariable(target, plug.Snap(), targetSide)
+	// Source uses PerspectiveOther to resolve $SNAP to the provider's instance
+	// name, ensuring we mount content from the exact connected instance (which
+	// could be parallel installed) rather than a default instance without the
+	// instance key.
+	source := resolveSpecialVariable(relSrc, slot.Snap(), snap.PerspectiveOther)
+	// Target uses PerspectiveSelf as the consumer sees its own snap name.
+	target = resolveSpecialVariable(target, plug.Snap(), snap.PerspectiveSelf)
 
 	// Check if the "source" section is present.
 	var unused map[string]any
@@ -278,7 +270,9 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 `)
 		for i, w := range writePaths {
 			fmt.Fprintf(contentSnippet, "\"%s/**\" mrwklix,\n",
-				resolveSpecialVariable(w, slot.Snap(), sourceSide))
+				// Use PerspectiveOther: resolve to provider's precise instance
+				// name
+				resolveSpecialVariable(w, slot.Snap(), snap.PerspectiveOther))
 			source, target := sourceTarget(plug, slot, w)
 			emit("  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
 			emit("  mount options=(bind, rw) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
@@ -303,7 +297,8 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 `)
 		for i, r := range readPaths {
 			fmt.Fprintf(contentSnippet, "\"%s/**\" mrkix,\n",
-				resolveSpecialVariable(r, slot.Snap(), sourceSide))
+				// Use PerspectiveOther: resolve to provider's precise instance name
+				resolveSpecialVariable(r, slot.Snap(), snap.PerspectiveOther))
 
 			source, target := sourceTarget(plug, slot, r)
 			emit("  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
@@ -201,32 +202,46 @@ func (iface *contentInterface) path(attrs interfaces.Attrer, name string) []stri
 	return out
 }
 
+type resolveSide int
+
+const (
+	sourceSide resolveSide = iota
+	targetSide
+)
+
 // resolveSpecialVariable resolves one of the three $SNAP* variables at the
-// beginning of a given path.  The variables are $SNAP, $SNAP_DATA and
+// beginning of a given path. The variables are $SNAP, $SNAP_DATA and
 // $SNAP_COMMON. If there are no variables then $SNAP is implicitly assumed
-// (this is the behavior that was used before the variables were supporter).
-func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
+// (this is the behavior that was used before the variables were supported).
+// Depending on the context in which the variable is resolved, $SNAP may mean
+// the actual snap instance.
+func resolveSpecialVariable(path string, snapInfo *snap.Info, forSide resolveSide) string {
+	// The source of the mount should always use a full snap instance name,
+	// thus ensuring we consume content from the exact connected instance,
+	// rather than from a snap without the instance key.
+	persp := snap.PerspectiveSelf
+	if forSide == sourceSide {
+		persp = snap.PerspectiveOther
+	}
 	// Content cannot be mounted at arbitrary locations, validate the path
 	// for extra safety.
 	if err := snap.ValidatePathVariables(path); err == nil && strings.HasPrefix(path, "$") {
 		// The path starts with $ and ValidatePathVariables() ensures
 		// path contains only $SNAP, $SNAP_DATA, $SNAP_COMMON, and no
-		// other $VARs are present. It is ok to use
-		// ExpandSnapVariables() since it only expands $SNAP, $SNAP_DATA
-		// and $SNAP_COMMON
-		return snapInfo.ExpandSnapVariables(path)
+		// other $VARs are present.
+		return snapInfo.ExpandSnapVariablesSetSnapMountDir(path, dirs.CoreSnapMountDir, persp)
 	}
 	// Always prefix with $SNAP if nothing else is provided or the path
 	// contains invalid variables.
-	return snapInfo.ExpandSnapVariables(filepath.Join("$SNAP", path))
+	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, persp)
 }
 
 func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (string, string) {
 	var target string
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
-	source := resolveSpecialVariable(relSrc, slot.Snap())
-	target = resolveSpecialVariable(target, plug.Snap())
+	source := resolveSpecialVariable(relSrc, slot.Snap(), sourceSide)
+	target = resolveSpecialVariable(target, plug.Snap(), targetSide)
 
 	// Check if the "source" section is present.
 	var unused map[string]any
@@ -263,7 +278,7 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 `)
 		for i, w := range writePaths {
 			fmt.Fprintf(contentSnippet, "\"%s/**\" mrwklix,\n",
-				resolveSpecialVariable(w, slot.Snap()))
+				resolveSpecialVariable(w, slot.Snap(), sourceSide))
 			source, target := sourceTarget(plug, slot, w)
 			emit("  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
 			emit("  mount options=(bind, rw) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
@@ -288,7 +303,7 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 `)
 		for i, r := range readPaths {
 			fmt.Fprintf(contentSnippet, "\"%s/**\" mrkix,\n",
-				resolveSpecialVariable(r, slot.Snap()))
+				resolveSpecialVariable(r, slot.Snap(), sourceSide))
 
 			source, target := sourceTarget(plug, slot, r)
 			emit("  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -397,20 +397,20 @@ func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
 	c.Check(info.SnapName(), Equals, "name")
 	c.Check(info.InstanceName(), Equals, "name")
 
-	for _, side := range []builtin.ResolveSide{builtin.TargetSide, builtin.SourceSide} {
-		c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name/42/foo")
-		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name/common/foo")
-		c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
-		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name/42")
-		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name/common")
-		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name/42/")
+	for _, persp := range []snap.ExpandSnapPerspective{snap.PerspectiveSelf, snap.PerspectiveOther} {
+		c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, persp), Equals, "/var/snap/name/42/foo")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, persp), Equals, "/var/snap/name/common/foo")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, persp), Equals, "/var/snap/name/42")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, persp), Equals, "/var/snap/name/common")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, persp), Equals, "/var/snap/name/42/")
 		// automatically prefixed with $SNAP
-		c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-		c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name/42/foo/snap/bar")
+		c.Check(builtin.ResolveSpecialVariable("foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+		c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, persp), Equals, "/snap/name/42/foo/snap/bar")
 		// contain invalid variables
-		c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name/42//bar")
-		c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name/42/bar//foo")
+		c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, persp), Equals, "/snap/name/42//bar")
+		c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, persp), Equals, "/snap/name/42/bar//foo")
 	}
 }
 
@@ -420,35 +420,35 @@ func (s *ContentSuite) TestResolveSpecialVariableParallel(c *C) {
 	c.Check(info.SnapName(), Equals, "name")
 	c.Check(info.InstanceName(), Equals, "name_foo")
 
-	side := builtin.SourceSide
-	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name_foo/42/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name_foo/common/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name_foo/42")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name_foo/common")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name_foo/42/")
+	persp := snap.PerspectiveOther
+	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, persp), Equals, "/var/snap/name_foo/42/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, persp), Equals, "/var/snap/name_foo/common/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, persp), Equals, "/var/snap/name_foo/42")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, persp), Equals, "/var/snap/name_foo/common")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, persp), Equals, "/var/snap/name_foo/42/")
 	// automatically prefixed with $SNAP
-	c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name_foo/42/foo/snap/bar")
+	c.Check(builtin.ResolveSpecialVariable("foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, persp), Equals, "/snap/name_foo/42/foo/snap/bar")
 	// contain invalid variables
-	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name_foo/42//bar")
-	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name_foo/42/bar//foo")
+	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, persp), Equals, "/snap/name_foo/42//bar")
+	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, persp), Equals, "/snap/name_foo/42/bar//foo")
 
-	side = builtin.TargetSide
-	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name/42/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name/common/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name/42")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name/common")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name/42/")
+	persp = snap.PerspectiveSelf
+	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, persp), Equals, "/var/snap/name/42/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, persp), Equals, "/var/snap/name/common/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, persp), Equals, "/var/snap/name/42")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, persp), Equals, "/var/snap/name/common")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, persp), Equals, "/var/snap/name/42/")
 	// automatically prefixed with $SNAP
-	c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name/42/foo/snap/bar")
+	c.Check(builtin.ResolveSpecialVariable("foo", info, persp), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, persp), Equals, "/snap/name/42/foo/snap/bar")
 	// contain invalid variables
-	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name/42//bar")
-	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name/42/bar//foo")
+	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, persp), Equals, "/snap/name/42//bar")
+	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, persp), Equals, "/snap/name/42/bar//foo")
 }
 
 // Check that legacy syntax works and allows sharing read-only snap content

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -394,19 +394,61 @@ slots:
 
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
 	info := snaptest.MockInfo(c, "{name: name, version: 0}", &snap.SideInfo{Revision: snap.R(42)})
-	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info), Equals, "/var/snap/name/42/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info), Equals, "/var/snap/name/common/foo")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info), Equals, "/var/snap/name/42")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info), Equals, "/var/snap/name/common")
-	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info), Equals, "/var/snap/name/42/")
+	c.Check(info.SnapName(), Equals, "name")
+	c.Check(info.InstanceName(), Equals, "name")
+
+	for _, side := range []builtin.ResolveSide{builtin.TargetSide, builtin.SourceSide} {
+		c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name/42/foo")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name/common/foo")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name/42")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name/common")
+		c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name/42/")
+		// automatically prefixed with $SNAP
+		c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+		c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name/42/foo/snap/bar")
+		// contain invalid variables
+		c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name/42//bar")
+		c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name/42/bar//foo")
+	}
+}
+
+func (s *ContentSuite) TestResolveSpecialVariableParallel(c *C) {
+	info := snaptest.MockInfo(c, "{name: name, version: 0}", &snap.SideInfo{Revision: snap.R(42)})
+	info.InstanceKey = "foo"
+	c.Check(info.SnapName(), Equals, "name")
+	c.Check(info.InstanceName(), Equals, "name_foo")
+
+	side := builtin.SourceSide
+	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name_foo/42/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name_foo/common/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name_foo/42")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name_foo/common")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name_foo/42/")
 	// automatically prefixed with $SNAP
-	c.Check(builtin.ResolveSpecialVariable("foo", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
-	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info), Equals, "/snap/name/42/foo/snap/bar")
+	c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name_foo/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name_foo/42/foo/snap/bar")
 	// contain invalid variables
-	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info), Equals, "/snap/name/42//bar")
-	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info), Equals, "/snap/name/42/bar//foo")
+	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name_foo/42//bar")
+	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name_foo/42/bar//foo")
+
+	side = builtin.TargetSide
+	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info, side), Equals, "/var/snap/name/42/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON/foo", info, side), Equals, "/var/snap/name/common/foo")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42"))
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA", info, side), Equals, "/var/snap/name/42")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_COMMON", info, side), Equals, "/var/snap/name/common")
+	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/", info, side), Equals, "/var/snap/name/42/")
+	// automatically prefixed with $SNAP
+	c.Check(builtin.ResolveSpecialVariable("foo", info, side), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
+	c.Check(builtin.ResolveSpecialVariable("foo/snap/bar", info, side), Equals, "/snap/name/42/foo/snap/bar")
+	// contain invalid variables
+	c.Check(builtin.ResolveSpecialVariable("$PRUNE/bar", info, side), Equals, "/snap/name/42//bar")
+	c.Check(builtin.ResolveSpecialVariable("bar/$PRUNE/foo", info, side), Equals, "/snap/name/42/bar//foo")
 }
 
 // Check that legacy syntax works and allows sharing read-only snap content

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -39,6 +39,13 @@ var (
 	StringListAttribute         = stringListAttribute
 )
 
+type ResolveSide = resolveSide
+
+const (
+	SourceSide = sourceSide
+	TargetSide = targetSide
+)
+
 type GbmDriverLibsInterface gbmDriverLibsInterface
 
 func SymlinksUserIfaceFromGbmIface(iface interfaces.Interface) interfaces.SymlinksUser {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -39,13 +39,6 @@ var (
 	StringListAttribute         = stringListAttribute
 )
 
-type ResolveSide = resolveSide
-
-const (
-	SourceSide = sourceSide
-	TargetSide = targetSide
-)
-
 type GbmDriverLibsInterface gbmDriverLibsInterface
 
 func SymlinksUserIfaceFromGbmIface(iface interfaces.Interface) interfaces.SymlinksUser {

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -188,8 +188,15 @@ func (s *specSuite) TestMountEntryFromLayout(c *C) {
 }
 
 func (s *specSuite) TestMountEntryFromExtraLayouts(c *C) {
+	const minimalSnap = `
+name: vanguard
+version: 0
+`
+	snapInfo := snaptest.MockInfo(c, minimalSnap, &snap.SideInfo{Revision: snap.R(42)})
+	s.spec.AddLayout(snapInfo)
 	extraLayouts := []snap.Layout{
 		{
+			Snap: snapInfo,
 			Path: "/test",
 			Bind: "/usr/home/test",
 			Mode: 0755,

--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -105,7 +105,9 @@ func (a *SnapAppSet) ExpandSliceSnapVariablesWithOrder(paths []string) []Expande
 			expandedDirs = append(expandedDirs, ExpandedDirWithIdx{Path: filepath.Clean(
 				a.info.ExpandSnapVariablesSetSnapMountDir(
 					filepath.Join(dirs.GlobalRootDir, dir),
-					dirs.StripRootDir(dirs.SnapMountDir))),
+					dirs.StripRootDir(dirs.SnapMountDir),
+					snap.PerspectiveSelf,
+				)),
 				Idx: idx,
 			})
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -56,7 +56,7 @@ var snapstateFinishRestart = snapstate.FinishRestart
 
 // journalQuotaLayout returns the necessary journal quota mount layouts
 // to mimick what systemd does for services with log namespaces.
-func journalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
+func journalQuotaLayout(info *snap.Info, quotaGroup *quota.Group) []snap.Layout {
 	if quotaGroup.JournalLimit == nil {
 		return nil
 	}
@@ -64,6 +64,7 @@ func journalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
 	// bind mount the journal namespace folder on top of the journal folder
 	// /run/systemd/journal.<ns> -> /run/systemd/journal
 	layouts := []snap.Layout{{
+		Snap: info,
 		Bind: path.Join(dirs.SnapSystemdRunDir, fmt.Sprintf("journal.%s", quotaGroup.JournalNamespaceName())),
 		Path: path.Join(dirs.SnapSystemdRunDir, "journal"),
 		Mode: 0755,
@@ -82,7 +83,7 @@ func getExtraLayouts(st *state.State, snapInfo *snap.Info) ([]snap.Layout, error
 
 	var extraLayouts []snap.Layout
 	if snapOpts.QuotaGroup != nil {
-		extraLayouts = append(extraLayouts, journalQuotaLayout(snapOpts.QuotaGroup)...)
+		extraLayouts = append(extraLayouts, journalQuotaLayout(snapInfo, snapOpts.QuotaGroup)...)
 	}
 
 	return extraLayouts, nil

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -21,11 +21,15 @@ package ifacestate_test
 
 import (
 	"errors"
+	"fmt"
 	"path"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -37,10 +41,12 @@ import (
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
 )
 
 const snapAyaml = `name: snap-a
 type: app
+version: 1
 base: base-snap-a
 `
 
@@ -222,4 +228,39 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	c.Check(opts.Classic, Equals, flags.Classic)
 	c.Check(opts.DevMode, Equals, flags.DevMode)
 	c.Check(opts.JailMode, Equals, flags.JailMode)
+}
+
+func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespaceMountProfileCheck(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	m := ifacestate.NewInterfaceManagerWithAppArmorPrompting(false)
+
+	tr := config.NewTransaction(s.st)
+	tr.Set("core", "experimental.quota-groups", true)
+	tr.Commit()
+
+	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
+	err := servicestatetest.MockQuotaInState(s.st, "foo", "", []string{snapInfo.InstanceName()}, nil, quota.NewResourcesBuilder().WithJournalNamespace().Build())
+	c.Assert(err, IsNil)
+
+	opts, err := m.BuildConfinementOptions(s.st, nil, snapInfo, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(opts.ExtraLayouts, HasLen, 1)
+
+	repo := interfaces.NewRepository()
+	backend := &mount.Backend{}
+	c.Assert(repo.AddBackend(backend), IsNil)
+
+	appSet, err := interfaces.NewSnapAppSet(snapInfo, nil)
+	c.Assert(err, IsNil)
+	c.Assert(repo.AddAppSet(appSet), IsNil)
+
+	err = backend.Setup(appSet, opts, interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther},
+		repo, timings.New(nil).StartSpan("", ""))
+	c.Assert(err, IsNil)
+
+	c.Check(filepath.Join(dirs.SnapMountPolicyDir, "snap.snap-a.fstab"), testutil.FileEquals,
+		fmt.Sprintf("%[1]s/run/systemd/journal.snap-foo %[1]s/run/systemd/journal none rbind,rw,x-snapd.origin=layout 0 0\n",
+			dirs.GlobalRootDir))
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -806,20 +806,40 @@ func (s *Info) ExpandSnapVariables(path string) string {
 	// always inside the mount namespace snap-confine creates and there
 	// we will always have a /snap directory available regardless if the
 	// system we're running on supports this or not.
-	return s.ExpandSnapVariablesSetSnapMountDir(path, dirs.CoreSnapMountDir)
+	return s.ExpandSnapVariablesSetSnapMountDir(path, dirs.CoreSnapMountDir, PerspectiveSelf)
 }
+
+type ExpandSnapPerspective int
+
+const (
+	// Expand variables from own perspective, assuming the parallel instance
+	// magic mapping of $SNAP_INSTANCE_NAME to $SNAP is in effect.
+	PerspectiveSelf ExpandSnapPerspective = iota
+	// Expand special variables from other snap's perspective, where $SNAP means
+	// the actual instance name
+	PerspectiveOther
+)
 
 // ExpandSnapVariablesSetSnapMountDir resolves $SNAP, $SNAP_DATA and
 // $SNAP_COMMON in path for this snap using snapMountDir as root directory.
-func (s *Info) ExpandSnapVariablesSetSnapMountDir(path, snapMountDir string) string {
+// Depending on the context, e.g. $SNAP used on the slot side of the connection,
+// while being expanded for use in the context of the plug, special variables
+// may mean instance-specific value.
+func (s *Info) ExpandSnapVariablesSetSnapMountDir(path, snapMountDir string, expandFor ExpandSnapPerspective) string {
+	name := s.SnapName()
+
+	if expandFor == PerspectiveOther {
+		name = s.InstanceName()
+	}
+
 	return os.Expand(path, func(v string) string {
 		switch v {
 		case "SNAP":
-			return filepath.Join(snapMountDir, s.SnapName(), s.Revision.String())
+			return filepath.Join(snapMountDir, name, s.Revision.String())
 		case "SNAP_DATA":
-			return DataDir(s.SnapName(), s.Revision)
+			return DataDir(name, s.Revision)
 		case "SNAP_COMMON":
-			return CommonDataDir(s.SnapName())
+			return CommonDataDir(name)
 		}
 		return ""
 	})

--- a/tests/main/parallel-install-content/task.yaml
+++ b/tests/main/parallel-install-content/task.yaml
@@ -168,17 +168,12 @@ execute: |
     wait || true
     
     # join it to observe updated content
-    # TODO: the output should be:
-    # however due to a buggy handling of mount ns update new content is not
-    # visible in c1
     test-snapd-content-consumer.app |& tee out-after.4
     test-snapd-content-consumer_c2.app |& tee out_c2-after.4
 
     MATCH '^connected-content: special content mod v1$'    < out-after.4
     MATCH '^connected-content-2: special content mod v1$'  < out-after.4
-    # TODO: this is buggy, we should observe
-    # '^connected-content-v2: special content mod v3$'
-    MATCH '^connected-content-v2: special content mod v2$' < out-after.4
+    MATCH '^connected-content-v2: special content mod v3$' < out-after.4
     
     MATCH '^connected-content: special content mod v1$'    < out_c2-after.4
     MATCH '^connected-content-2: <not found>$'             < out_c2-after.4

--- a/tests/main/parallel-install-content/task.yaml
+++ b/tests/main/parallel-install-content/task.yaml
@@ -80,11 +80,17 @@ execute: |
     # but consumer_c2 mount ns remains untouched
     test -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
 
-    # we observe the modified content (which recreates the mount ns0)
+    # we observe the modified content (which recreates the mount ns)
     test-snapd-content-consumer.app |& tee out-after.1
-    MATCH '^connected-content: special content mod v1$' < out-after.1
-    MATCH '^connected-content-2: special content v1$'   < out-after.1
-    MATCH '^connected-content-v2: special content v2$'  < out-after.1
+    # the ordering of connected-content and connected-content-2 is
+    # non-deterministic (map iteration in the interface repository)
+    if MATCH '^connected-content: special content mod v1$' < out-after.1; then
+        MATCH '^connected-content-2: special content v1$' < out-after.1
+    else
+        MATCH '^connected-content: special content v1$' < out-after.1
+        MATCH '^connected-content-2: special content mod v1$' < out-after.1
+    fi
+    MATCH '^connected-content-v2: special content v2$' < out-after.1
 
     # the output hasn't changed
     test-snapd-content-consumer_c2.app |& tee out_c2-after.1
@@ -102,9 +108,14 @@ execute: |
     test ! -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
 
     test-snapd-content-consumer.app |& tee out-after.2
-    # p1 changed
-    MATCH '^connected-content: special content mod v1$'    < out-after.2
-    MATCH '^connected-content-2: special content v1$'      < out-after.2
+    # p1 changed, ordering of connected-content and connected-content-2 is
+    # non-deterministic
+    if MATCH '^connected-content: special content mod v1$' < out-after.2; then
+        MATCH '^connected-content-2: special content v1$' < out-after.2
+    else
+        MATCH '^connected-content: special content v1$' < out-after.2
+        MATCH '^connected-content-2: special content mod v1$' < out-after.2
+    fi
     # p-v2 changed
     MATCH '^connected-content-v2: special content mod v2$' < out-after.2
 

--- a/tests/main/parallel-install-content/task.yaml
+++ b/tests/main/parallel-install-content/task.yaml
@@ -1,0 +1,185 @@
+summary: Exercise update with multiple content connections and parallel installs
+
+details: |
+    Exercise an update where content providers have multiple consumers
+    connected, both sides using parallel installs.
+
+prepare: |
+    snap set system experimental.parallel-instances=true
+    tests.cleanup defer snap set system experimental.parallel-instances=null
+
+    snap install core24
+
+execute: |
+    # implicitly referred to as c1
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-consumer
+
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-content-consumer test-snapd-content-consumer_c2
+
+    # implicitly referred to as p1
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-provider
+    "$TESTSTOOLS"/snaps-state install-local-as test-snapd-content-provider test-snapd-content-provider_p2
+
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-provider-v2
+
+    # prepare modified versions
+    (
+    cd test-snapd-content-provider
+    echo 'special content mod v1' > special-content-file
+    snap pack
+    )
+
+    (
+    cd test-snapd-content-provider-v2
+    echo 'special content mod v2' > special-content-file
+    snap pack
+    )
+
+    # establish some connections
+    # c1 -> p1, p2, p-v2
+    # c2 -> p1, p2
+
+    # c1 -> p1
+    snap connect test-snapd-content-consumer:special-content \
+        test-snapd-content-provider:special-content
+    # c1 -> p2
+    snap connect test-snapd-content-consumer:special-content \
+        test-snapd-content-provider_p2:special-content
+
+    # c1 -> p-v2
+    snap connect test-snapd-content-consumer:special-content-v2 \
+        test-snapd-content-provider-v2:special-content-v2
+
+    # c2 -> p2
+    snap connect test-snapd-content-consumer_c2:special-content \
+        test-snapd-content-provider_p2:special-content
+    # c2 -> p-v2
+    snap connect test-snapd-content-consumer_c2:special-content-v2 \
+        test-snapd-content-provider-v2:special-content-v2
+
+    # establish a baseline
+    test-snapd-content-consumer.app |& tee out
+    MATCH "hello from app test-snapd-content-consumer" < out
+    MATCH '^connected-content: special content v1$'    < out
+    MATCH '^connected-content-2: special content v1$'  < out
+    MATCH '^connected-content-v2: special content v2$' < out
+
+    test-snapd-content-consumer_c2.app |& tee out_c2
+    MATCH "hello from app test-snapd-content-consumer_c2" < out_c2
+    MATCH '^connected-content: special content v1$'       < out_c2
+    # only one connection to a p provider
+    MATCH '^connected-content-2: <not found>$'            < out_c2
+    MATCH '^connected-content-v2: special content v2$'    < out_c2
+
+    # update p1, affects test-snapd-content-consumer
+    echo "Update a snap affecting test-snapd-content-consumer only"
+    snap install --dangerous test-snapd-content-provider/test-snapd-content-provider_*.snap
+    # no apps were running, so consumer mount ns got discarded
+    test ! -e /run/snapd/ns/test-snapd-content-consumer.mnt
+    # but consumer_c2 mount ns remains untouched
+    test -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
+
+    # we observe the modified content (which recreates the mount ns0)
+    test-snapd-content-consumer.app |& tee out-after.1
+    MATCH '^connected-content: special content mod v1$' < out-after.1
+    MATCH '^connected-content-2: special content v1$'   < out-after.1
+    MATCH '^connected-content-v2: special content v2$'  < out-after.1
+
+    # the output hasn't changed
+    test-snapd-content-consumer_c2.app |& tee out_c2-after.1
+    diff -up out_c2 out_c2-after.1
+
+    # update of 2 provider snaps, affects both consumer snaps
+    # p1 affects c1
+    # p-v2 affects both c1 and c2
+    echo "Update a snap affecting test-snapd-content-consumer and _c2"
+    snap install --dangerous \
+        test-snapd-content-provider/test-snapd-content-provider_*.snap \
+        test-snapd-content-provider-v2/test-snapd-content-provider-v2_*.snap
+    # both mount namespaces got discarded
+    test ! -e /run/snapd/ns/test-snapd-content-consumer.mnt
+    test ! -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
+
+    test-snapd-content-consumer.app |& tee out-after.2
+    # p1 changed
+    MATCH '^connected-content: special content mod v1$'    < out-after.2
+    MATCH '^connected-content-2: special content v1$'      < out-after.2
+    # p-v2 changed
+    MATCH '^connected-content-v2: special content mod v2$' < out-after.2
+
+    test-snapd-content-consumer_c2.app |& tee out_c2-after.2
+    # p2 was unchanged
+    MATCH '^connected-content: special content v1$'        < out_c2-after.2
+    MATCH '^connected-content-2: <not found>$'             < out_c2-after.2
+    # p-2 changed
+    MATCH '^connected-content-v2: special content mod v2$' < out_c2-after.2
+
+    # update p2, affects both snaps
+    snap install --dangerous \
+        test-snapd-content-provider/test-snapd-content-provider_*.snap \
+        --name test-snapd-content-provider_p2
+
+    test-snapd-content-consumer.app |& tee out-after.3
+    test-snapd-content-consumer_c2.app |& tee out_c2-after.3
+
+    MATCH '^connected-content: special content mod v1$'    < out-after.3
+    MATCH '^connected-content-2: special content mod v1$'  < out-after.3
+    MATCH '^connected-content-v2: special content mod v2$' < out-after.3
+
+    # _c2 observes new content
+    MATCH '^connected-content: special content mod v1$'    < out_c2-after.3
+    MATCH '^connected-content-2: <not found>$'             < out_c2-after.3
+    MATCH '^connected-content-v2: special content mod v2$' < out_c2-after.3
+
+    echo "Observe mount namespace update when an application is running"
+    # another modification
+    (
+    cd test-snapd-content-provider-v2
+    echo 'special content mod v3' > special-content-file
+    snap pack
+    )
+
+    # make sure namespaces are present
+    test -e /run/snapd/ns/test-snapd-content-consumer.mnt
+    test -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
+
+    # start application that prevents the mount ns from being discarded
+    snap run --shell test-snapd-content-consumer.app -c \
+         'sleep 3600' &
+    sleeppid_c1=$!
+
+    snap run --shell test-snapd-content-consumer_c2.app -c \
+         'sleep 3600' &
+    sleeppid_c2=$!
+    
+    snap install --dangerous \
+        test-snapd-content-provider-v2/test-snapd-content-provider-v2_*.snap
+    snap change --last install | tee change.out
+    test "$(grep -c 'Apply delayed' < change.out)" = "2"
+
+    # namespaces are still present
+    test -e /run/snapd/ns/test-snapd-content-consumer.mnt
+    test -e /run/snapd/ns/test-snapd-content-consumer_c2.mnt
+
+    kill "$sleeppid_c1"
+    kill "$sleeppid_c2"
+    wait || true
+    wait || true
+    
+    # join it to observe updated content
+    # TODO: the output should be:
+    # however due to a buggy handling of mount ns update new content is not
+    # visible in c1
+    test-snapd-content-consumer.app |& tee out-after.4
+    test-snapd-content-consumer_c2.app |& tee out_c2-after.4
+
+    MATCH '^connected-content: special content mod v1$'    < out-after.4
+    MATCH '^connected-content-2: special content mod v1$'  < out-after.4
+    # TODO: this is buggy, we should observe
+    # '^connected-content-v2: special content mod v3$'
+    MATCH '^connected-content-v2: special content mod v2$' < out-after.4
+    
+    MATCH '^connected-content: special content mod v1$'    < out_c2-after.4
+    MATCH '^connected-content-2: <not found>$'             < out_c2-after.4
+    MATCH '^connected-content-v2: special content mod v3$' < out_c2-after.4

--- a/tests/main/parallel-install-content/test-snapd-content-consumer/bin/app
+++ b/tests/main/parallel-install-content/test-snapd-content-consumer/bin/app
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "hello from app $SNAP_INSTANCE_NAME"
+
+cd "$SNAP" || exit 1
+
+for f in connected-content{,-2,-v2}/special-content-file; do
+    if [ -f "$f" ]; then
+        echo "$(dirname "$f"): $(cat "$f")" || true
+    else
+        echo "$(dirname "$f"): <not found>"
+    fi
+done

--- a/tests/main/parallel-install-content/test-snapd-content-consumer/meta/snap.yaml
+++ b/tests/main/parallel-install-content/test-snapd-content-consumer/meta/snap.yaml
@@ -1,0 +1,18 @@
+name: test-snapd-content-consumer
+version: 1.0.0
+base: core24
+
+apps:
+    app:
+        command: bin/app
+        plugs:
+            - special-content
+
+plugs:
+    special-content:
+        interface: content
+        target: $SNAP/connected-content
+
+    special-content-v2:
+        interface: content
+        target: $SNAP/connected-content-v2

--- a/tests/main/parallel-install-content/test-snapd-content-provider-v2/meta/snap.yaml
+++ b/tests/main/parallel-install-content/test-snapd-content-provider-v2/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-content-provider-v2
+version: 2.0.0
+base: core24
+
+slots:
+    special-content-v2:
+        interface: content
+        read:
+            - /

--- a/tests/main/parallel-install-content/test-snapd-content-provider-v2/special-content-file
+++ b/tests/main/parallel-install-content/test-snapd-content-provider-v2/special-content-file
@@ -1,0 +1,1 @@
+special content v2

--- a/tests/main/parallel-install-content/test-snapd-content-provider/meta/snap.yaml
+++ b/tests/main/parallel-install-content/test-snapd-content-provider/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-content-provider
+version: 1.0.0
+base: core24
+
+slots:
+    special-content:
+        interface: content
+        read:
+            - /

--- a/tests/main/parallel-install-content/test-snapd-content-provider/special-content-file
+++ b/tests/main/parallel-install-content/test-snapd-content-provider/special-content-file
@@ -1,0 +1,1 @@
+special content v1


### PR DESCRIPTION
Attempt to fix content interface connections when the slot side is
provided by a snap with an instance key. Specifically, avoid the
situation in which the content could erroneously mount data from a
default instance of a snap slot side snap (one without the instance
key).

Related: SNAPDENG-36567