### PR TITLE
packaging/ubuntu16.04: modify snapd ubuntu packaging to be dep17 compliant

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -68,8 +68,7 @@ ifneq (${VERSION_ID},"16.04")
 	DH_SYSTEMD_START_OPTS += --restart-after-upgrade
 endif
 
-# this is overridden in the ubuntu/14.04 release branch
-SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
+SYSTEMD_UNITS_DESTDIR="$(shell pkg-config --variable=systemdsystemunitdir systemd)"
 
 # The go tool does not fully support vendoring with gccgo, but we can
 # work around that by constructing the appropriate -I flag by hand.
@@ -217,7 +216,6 @@ endif
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 	cp -a bootloader/assets/data _build/src/$(DH_GOPKG)/bootloader/assets
-
 	# this is the main go build
 
 	# note that dh-golang invokes go generate as the first step, which may invoke

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -216,6 +216,7 @@ endif
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 	cp -a bootloader/assets/data _build/src/$(DH_GOPKG)/bootloader/assets
+
 	# this is the main go build
 
 	# note that dh-golang invokes go generate as the first step, which may invoke

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -373,4 +373,4 @@ override_dh_systemd_start:
 	# Then service
 	dh_systemd_start $(DH_SYSTEMD_START_OPTS) snapd.service
 	# Then the rest
-	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(shell ls debian/snapd/lib/systemd/system/))
+	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR)/*)))

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -69,6 +69,7 @@ ifneq (${VERSION_ID},"16.04")
 endif
 
 SYSTEMD_UNITS_DESTDIR="$(shell pkg-config --variable=systemdsystemunitdir systemd)"
+SYSTEMD_UNITS_DESTDIR_UNQUOTED=$(subst ",,$(SYSTEMD_UNITS_DESTDIR))
 
 # The go tool does not fully support vendoring with gccgo, but we can
 # work around that by constructing the appropriate -I flag by hand.
@@ -373,4 +374,4 @@ override_dh_systemd_start:
 	# Then service
 	dh_systemd_start $(DH_SYSTEMD_START_OPTS) snapd.service
 	# Then the rest
-	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR)/*)))
+	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR_UNQUOTED)/*)))

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -68,8 +68,7 @@ ifneq (${VERSION_ID},"16.04")
 	DH_SYSTEMD_START_OPTS += --restart-after-upgrade
 endif
 
-SYSTEMD_UNITS_DESTDIR="$(shell pkg-config --variable=systemdsystemunitdir systemd)"
-SYSTEMD_UNITS_DESTDIR_UNQUOTED=$(subst ",,$(SYSTEMD_UNITS_DESTDIR))
+SYSTEMD_UNITS_DESTDIR:=$(or $(shell pkg-config --variable=systemdsystemunitdir systemd),$(error pkg-config did not return systemdsystemunitdir))
 
 # The go tool does not fully support vendoring with gccgo, but we can
 # work around that by constructing the appropriate -I flag by hand.
@@ -374,4 +373,4 @@ override_dh_systemd_start:
 	# Then service
 	dh_systemd_start $(DH_SYSTEMD_START_OPTS) snapd.service
 	# Then the rest
-	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR_UNQUOTED)/*)))
+	dh_systemd_start $(DH_SYSTEMD_START_OPTS) $(filter-out snapd.socket snapd.service snapd.mounts-pre.target, $(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR)/*)))

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -47,5 +47,5 @@ NEWS.md /usr/share/doc/snapd/
 
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
-# but system generators end up in lib
+# system generators use <systemdutildir>/system-generators (resolved via pkg-config)
 @systemd-lib@/system-generators

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,4 +1,4 @@
-/usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
+/usr/lib/snapd/snap-device-helper  /usr/lib/udev/snappy-app-dev
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket


### PR DESCRIPTION
Modify snapd Ubuntu packaging to be DEP17 complaint on Noble, Questing and Resolute.

JIRA: https://warthogs.atlassian.net/browse/SNAPDENG-36430
DEP17: https://dep-team.pages.debian.net/deps/dep17/

VERIFICATION:

**Builds and Package file list checks**
- [Resolute](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165141/+listing-archive-extra): https://paste.ubuntu.com/p/3kkSHMFHSz/
- [Questing](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165147/+listing-archive-extra): https://paste.ubuntu.com/p/3JFb5XkDn5/
- [Noble](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165142/+listing-archive-extra): https://paste.ubuntu.com/p/DqPvMgFRsn/
- [Jammy](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165144/+listing-archive-extra): https://paste.ubuntu.com/p/rD9BySwRwn/
- [Focal](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165145/+listing-archive-extra)
- [Bionic](https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+sourcepub/18165146/+listing-archive-extra)

**Installation check after dh_systemd_start fix**
 - Resolute: https://paste.ubuntu.com/p/sKH8V5qzyy/

**Backwards compatibility**
- Confirmed successful builds on Resolute, Questing, Noble, Jammy, Focal and Bionic.
- This also confirms the `pkg-config --variable=systemdsystemunitdir systemd` mechanism works fine on all of them (otherwise it would stop immediately with explicit error).
- Installation on Resolute, Questing, Noble, Jammy, Focal and Bionic was tested.

Notes The build failures on armhf and s390x does not related to these changes, and is fixed here: https://github.com/canonical/snapd/pull/16758


Solves LP: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2139213