### PR TITLE
tests: correct error in featcomposer and add script to easily analyze feature tagging locally

### DIFF
--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -4,10 +4,6 @@ on:
 
   workflow_dispatch:
     inputs:
-      features:
-        type: string
-        description: 'Comma-separated list of features to tag'
-        default: 'cmd,task,change,ensure,endpoint,interface'
       maximum-reruns:
         type: number
         description: 'Maximum number of times to rerun failed spread tasks'
@@ -26,7 +22,6 @@ jobs:
   set-inputs:
     runs-on: ubuntu-latest
     outputs:
-      features: ${{ steps.set-inputs.outputs.features }}
       maximum-reruns: ${{ steps.set-inputs.outputs.maximum-reruns }}
       run-one-system: ${{ steps.set-inputs.outputs.run-one-system }}
       skip-tests: ${{ steps.set-inputs.outputs.skip-tests }}
@@ -34,7 +29,6 @@ jobs:
       - name: Set inputs
         id: set-inputs
         run: |
-          echo "features=${{ inputs.features || 'cmd,task,change,ensure,endpoint,interface' }}" >> $GITHUB_OUTPUT
           echo "maximum-reruns=${{ inputs.maximum-reruns || 2 }}" >> $GITHUB_OUTPUT
           echo "run-one-system=${{ inputs.run-one-system || '' }}" >> $GITHUB_OUTPUT
           echo "skip-tests=${{ inputs.skip-tests || 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old core/persistent-journal' }}" >> $GITHUB_OUTPUT
@@ -208,65 +202,7 @@ jobs:
 
       - name: Create feature tags
         run: |
-          shopt -s nullglob 
-          
-          featdir="extracted-tags"
-          mkdir -p "$featdir"
-          composedir="composed-tags"
-          mkdir -p "$composedir"
-          IFS=',' read -ra features <<< "${{ needs.set-inputs.outputs.features }}"
-          for file in "feature-tags-artifacts"/*; do
-            mkdir working
-            tar -xzf "$file" -C working
-            if ! [ -d "working/spread-artifacts/feature-tags" ]; then
-              echo "Artifact $file has no artifact data"
-              rm -r working
-              continue
-            fi
-            for dir in "working/spread-artifacts/feature-tags"/*/; do
-              if [ -f "${dir}/journal.txt" ] && [ -f "${dir}/state.json" ]; then
-                ./tests/utils/features/featextractor.py \
-                  -f "${features[@]}" \
-                  --journal "${dir}/journal.txt" \
-                  --state "${dir}/state.json" \
-                  --output "$featdir/$(basename ${dir})"
-              elif [ -f "${dir}/journal.txt" ] && [ ! -f "${dir}/state.json" ]; then
-                ./tests/utils/features/featextractor.py \
-                  -f "${features[@]}" \
-                  --journal "${dir}/journal.txt" \
-                  --output "$featdir/$(basename ${dir})"
-              elif [ ! -f "${dir}/journal.txt" ]; then
-                echo "No journal.txt present in $dir"
-                exit 1
-              fi
-            done
-            ./tests/utils/features/featcomposer.py \
-                --dir "$featdir" \
-                --output "$composedir" \
-                --failed-tests "working/spread-artifacts/failed-tests.txt" \
-                --run-attempt "$(cat "working/spread-artifacts/run-attempt.txt")" \
-                --env-variables "$(cat "working/spread-artifacts/env-variables.txt")"
-            rm -r working
-          done
-          ./tests/utils/features/featcomposer.py \
-            --dir "$composedir" \
-            --output "final-feature-tags" \
-            --replace-old-runs
-
-          for json in final-feature-tags/*; do
-              if grep -qE "-nested.*04-64" <<<"$json"; then
-                  version=${json#*ubuntu-}
-                  version=${version%%.*}
-                  core_file=$(find final-feature-tags -name "*ubuntu-core-$version-64*" || true)
-                  if [ -n "$core_file" ]; then
-                      echo "merging $json into $core_file"
-                      jq -s '.[0].tests += .[1].tests | .[0]' "$core_file" "$json" > temp.json && mv temp.json "$core_file"
-                      rm "$json"
-                  fi
-              fi
-          done
-          
-          ./tests/utils/features/feattranslator.py -f all-features.json -o final-feature-tags/all-features.json
+          WORK_DIR=. ./tests/utils/features/process-features.sh
 
           tar -czf "final-feature-tags.tar.gz" "final-feature-tags"
 

--- a/tests/utils/features/featcomposer.py
+++ b/tests/utils/features/featcomposer.py
@@ -125,7 +125,8 @@ def get_system_list(dir: str) -> set[str]:
 
 def _replace_tests(old_json_file: str, new_json_file: str) -> features.SystemFeatures:
     '''
-    The new_json_file contains a subset of the tests found in the old_json_file.
+    The new_json_file contains a set of the tests, some of which may be found
+    in the old_json_file, some of which may not.
     This function leaves not-rerun tests untouched, while replacing old test
     runs with their rerun counterparts found in new_json_file. The resulting
     json in output therefore contains a mix of tests that were not rerun and
@@ -141,12 +142,16 @@ def _replace_tests(old_json_file: str, new_json_file: str) -> features.SystemFea
     with open(new_json_file, 'r', encoding='utf-8') as f:
         new_json = json.load(f)
     for test in new_json['tests']:
+        found = False
         for old_test in old_json['tests']:
             if old_test['task_name'] == test['task_name'] and old_test['suite'] == test['suite'] and old_test['variant'] == test['variant']:
+                found = True
                 old_test.clear()
                 for key, value in test.items():
                     old_test[key] = value
                 break
+        if not found:
+            old_json['tests'].append(test)
     return old_json
 
 
@@ -227,9 +232,12 @@ def replace_old_runs(dir: str, output_dir: str) -> None:
         if len(original) != 1:
             raise RuntimeError(
                 f'The rerun {rerun} does not have a corresponding original run')
-        tests = _replace_tests(os.path.join(
-            dir, original[0]), os.path.join(dir, rerun))
-        with open(os.path.join(output_dir, result_name + '.json'), 'w', encoding='utf-8') as f:
+        original_file=os.path.join(dir, original[0])
+        result_file=os.path.join(output_dir, result_name + '.json')
+        if os.path.isfile(result_file):
+            original_file = result_file
+        tests = _replace_tests(original_file, os.path.join(dir, rerun))
+        with open(result_file, 'w', encoding='utf-8') as f:
             f.write(json.dumps(tests))
 
     # Search for system test results that had no reruns and

--- a/tests/utils/features/process-features.sh
+++ b/tests/utils/features/process-features.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+shopt -s nullglob 
+
+work_dir="${WORK_DIR:-$(mktemp -d)}"
+run_id="${RUN_ID:-}"
+features="${FEATURES:-cmd,task,change,ensure,endpoint,interface}"
+
+if ! [ -d "$work_dir/feature-tags-artifacts" ]; then
+    if [ -z "$run_id" ]; then
+        echo "RUN_ID is not set. Please set it to the ID of the GitHub Actions run to download artifacts from."
+        exit 1
+    fi
+    gh run download "$run_id" --pattern "spread-artifacts-*" --dir "$work_dir/feature-tags-artifacts"
+    mkdir "$work_dir/tmp"
+    find "$work_dir"/feature-tags-artifacts/ -type f -exec mv {} "$work_dir"/tmp/ \;
+    rm -r "$work_dir/feature-tags-artifacts/"
+    mv "$work_dir/tmp" "$work_dir/feature-tags-artifacts"
+fi
+if ! [ -f "$work_dir/all-features.json" ]; then
+    if [ -z "$run_id" ]; then
+        echo "RUN_ID is not set. Please set it to the ID of the GitHub Actions run to download artifacts from."
+        exit 1
+    fi
+    gh run download "$run_id" --name "all-features" --dir "$work_dir/all-features"
+    mv "$work_dir/all-features/all-features.json" "$work_dir/all-features.json"
+    rm -r "$work_dir/all-features"
+fi
+          
+composedir="$work_dir/composed-tags"
+mkdir -p "$composedir"
+IFS=',' read -ra features <<< "$features"
+for file in "$work_dir/feature-tags-artifacts"/*; do
+    echo "Processing artifact $file"
+    mkdir "$work_dir/working"
+    tar -xzf "$file" -C "$work_dir/working"
+    featdir="$work_dir/working/extracted-tags"
+    mkdir -p "$featdir"
+    if ! [ -d "$work_dir/working/spread-artifacts/feature-tags" ]; then
+        echo "Artifact $file has no artifact data"
+        rm -r "$work_dir/working"
+        continue
+    fi
+    for dir in "$work_dir/working/spread-artifacts/feature-tags"/*/; do
+        if [ -f "${dir}/journal.txt" ] && [ -f "${dir}/state.json" ]; then
+            ./tests/utils/features/featextractor.py \
+                -f "${features[@]}" \
+                --journal "${dir}/journal.txt" \
+                --state "${dir}/state.json" \
+                --output "$featdir/$(basename "${dir}")"
+        elif [ -f "${dir}/journal.txt" ] && [ ! -f "${dir}/state.json" ]; then
+            ./tests/utils/features/featextractor.py \
+                -f "${features[@]}" \
+                --journal "${dir}/journal.txt" \
+                --output "$featdir/$(basename "${dir}")"
+        elif [ ! -f "${dir}/journal.txt" ]; then
+            echo "No journal.txt present in $dir"
+            exit 1
+        fi
+    done
+    ./tests/utils/features/featcomposer.py \
+        --dir "$featdir" \
+        --output "$composedir" \
+        --failed-tests "$work_dir/working/spread-artifacts/failed-tests.txt" \
+        --run-attempt "$(cat "$work_dir/working/spread-artifacts/run-attempt.txt")" \
+        --env-variables "$(cat "$work_dir/working/spread-artifacts/env-variables.txt")"
+    rm -r "$work_dir/working"
+done
+./tests/utils/features/featcomposer.py \
+    --dir "$composedir" \
+    --output "$work_dir/final-feature-tags" \
+    --replace-old-runs
+
+./tests/utils/features/feattranslator.py -f "$work_dir/all-features.json" -o "$work_dir/final-feature-tags/all-features.json"

--- a/tests/utils/features/test_featcomposer.py
+++ b/tests/utils/features/test_featcomposer.py
@@ -141,7 +141,8 @@ class TestReplace(unittest.TestCase):
             original_json = {'system.version': 'my:system.version', 'tests': [{'task_name': 'task1', 'suite': 'my/suite', 'variant': '', 'success': False, 'cmds': [{'cmd': 'original run'}]},
                                                               {'task_name': 'task2', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'original run'}]}]}
             rerun_json = {'system.version': 'my:system.version', 'tests': [
-                {'task_name': 'task1', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'rerun 1'}, {'cmd': 'another'}]}]}
+                {'task_name': 'task1', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'rerun 1'}, {'cmd': 'another'}]},
+                {'task_name': 'task3', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'rerun 2'}]}]}
             run_once_json = {'system.version': 'my:other-system.version', 'tests': [
                 {'task_name': 'task', 'suite': 'my/suite', 'variant': 'v1', 'success': True}]}
             with open(original, 'w') as f:
@@ -160,9 +161,10 @@ class TestReplace(unittest.TestCase):
                 actual = json.load(f)
                 assert len(actual) == 2
                 assert 'system.version' in actual and actual['system.version'] == 'my:system.version'
-                assert 'tests' in actual and len(actual['tests']) == 2
+                assert 'tests' in actual and len(actual['tests']) == 3
                 assert {'task_name': 'task1', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'rerun 1'}, {'cmd': 'another'}]} in actual['tests']
                 assert {'task_name': 'task2', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'original run'}]} in actual['tests']
+                assert {'task_name': 'task3', 'suite': 'my/suite', 'variant': '', 'success': True, 'cmds': [{'cmd': 'rerun 2'}]} in actual['tests']
             with open(os.path.join(tmpdir, output_dir, 'my:other-system.version.json'), 'r') as f:
                 actual = json.load(f)
                 assert len(actual) == 2


### PR DESCRIPTION
The `featcomposer.py` script incorrectly assumed that each rerun would contain a subset of the tests from the previous run. This is unfortunately not the case if some tests in a previous run were aborted. The script now allows for tests contained in a rerun that were not in an original. 

Additionally, to make local testing easier, the commands for processing feature tagging data is now a separate bash script that can work locally by specifying a run ID. So for instance, one can generate the compiled feature tagging data of the last feature tagging run (https://github.com/canonical/snapd/actions/runs/23151191185) by running 
```
RUN_ID=23151191185 ./tests/utils/features/process-features.sh
```