### PR TITLE
many: switch to apparmor 5.x with 4 ABI

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -160,8 +160,8 @@ parts:
       - g++
       - pkg-config
       - wget
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0-alpha6/apparmor-v5.0.0-alpha6.tar.gz
-    source-checksum: sha256/9557bd5ee317a2ae8a5daea4ca4f92ccb792ae8889b2dec433a2a139fbcdb84f
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0-beta1/apparmor-v5.0.0-beta1.tar.gz
+    source-checksum: sha256/f338a6bf3b273c54621973d7481580beeabb45639bf5629a2f32dff25b91d0b8
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -160,8 +160,8 @@ parts:
       - g++
       - pkg-config
       - wget
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v4.1.7/apparmor-v4.1.7.tar.gz
-    source-checksum: sha256/ded4cd419b8a05002a108a0912208e2098695752664c6a59464d2dda418e0452
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0-alpha2/apparmor-v5.0.0-alpha2.tar.gz
+    source-checksum: sha256/f6c927a5978ed2475b025ccd56425ced9eb748cbdd4b2cbbb4be374c422c7eaa
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -173,7 +173,7 @@ parts:
 
       cd "${CRAFT_PART_BUILD}"/libraries/libapparmor
       ./autogen.sh
-      ./configure --prefix=/usr --libdir="/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}" --disable-man-pages --disable-perl --disable-python --disable-ruby
+      ./configure --prefix=/usr --libdir="/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}" --disable-man-pages --disable-perl --disable-python --disable-ruby --disable-shared
       make -j"${CRAFT_PARALLEL_BUILD_COUNT}"
       make -C src install DESTDIR="${CRAFT_PART_INSTALL}"
       make -C include install DESTDIR="${CRAFT_PART_INSTALL}"
@@ -182,7 +182,7 @@ parts:
       # parser gets built to support as many as possible even if glibc in
       # the current build environment does not support them
       cp -a "${LOCAL_APPARMOR_DIR}"/af_names.h .
-      make -j"${CRAFT_PARALLEL_BUILD_COUNT}"
+      make -j"${CRAFT_PARALLEL_BUILD_COUNT}" WITH_STATIC_LINKING=1
       install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" apparmor_parser
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd/apparmor" parser.conf
       cd "${CRAFT_PART_BUILD}/profiles"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -160,8 +160,8 @@ parts:
       - g++
       - pkg-config
       - wget
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0-alpha2/apparmor-v5.0.0-alpha2.tar.gz
-    source-checksum: sha256/f6c927a5978ed2475b025ccd56425ced9eb748cbdd4b2cbbb4be374c422c7eaa
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0-alpha6/apparmor-v5.0.0-alpha6.tar.gz
+    source-checksum: sha256/9557bd5ee317a2ae8a5daea4ca4f92ccb792ae8889b2dec433a2a139fbcdb84f
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 AS_IF([test "x$enable_apparmor" = "xyes"], [
     # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 5.0.0~alpha2], [
+        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 5.0.0~alpha6], [
             AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
             AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 AS_IF([test "x$enable_apparmor" = "xyes"], [
     # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 5.0.0~alpha6], [
+        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 5.0.0~beta1], [
             AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
             AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -82,11 +82,11 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 
 # Check if apparmor userspace library is available.
 AS_IF([test "x$enable_apparmor" = "xyes"], [
-    # Expect AppArmor4 when building as a snap under snapcraft
+    # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 4.1.7], [
-            AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor4 support])], [
-            AC_MSG_ERROR([unable to find apparmor4 for snap build of snapd])])], [
+        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 5.0.0~alpha2], [
+            AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
+            AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [
       AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor support])])])
 ], [


### PR DESCRIPTION
This is apparmor 5.x release with ABI 4.0, which should theoretically be a drop-in replacement over current apparmor 4.1.7.

Note that the beta release we are using is not up-to-date with some fixes from 4.1.7 (new 5.x release is pending) so some failures are expected.

For apparmor master with 5 abi please see: https://github.com/canonical/snapd/pull/16780
For apparmor 5.x with 5 ABI please see: https://github.com/canonical/snapd/pull/15967
For apparmor 5.x with 4 ABI please see: https://github.com/canonical/snapd/pull/16781
