### PR TITLE
overlord/fdestate: use any primary key matching digest when adding a keyslot

### DIFF
--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -187,3 +187,7 @@ func MockOsutilBootID(f func() (string, error)) (restore func()) {
 func MockSecbootShouldAttemptRepair(f func(as *secboot.ActivateState) bool) (restore func()) {
 	return testutil.Mock(&secbootShouldAttemptRepair, f)
 }
+
+func MockSecbootGetPrimaryKey(f func(devices []string, fallbackKeyFiles []string) ([]byte, error)) (restore func()) {
+	return testutil.Mock(&secbootGetPrimaryKey, f)
+}

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -855,17 +855,6 @@ func ReplacePlatformKey(st *state.State, volumesAuth *device.VolumesAuthOptions,
 		}
 	}
 
-	activateState, err := SystemState(st)
-	if err != nil {
-		return nil, err
-	}
-	if !RunningWithPlatformKeys(activateState.Status) {
-		// Primary key might be missing from kernel keyring if disk was
-		// unlocked with recovery key during boot.
-		// We need to allow degraded state, as this function might be part of fixing.
-		return nil, fmt.Errorf("cannot replace platform keys if FDE is not active (current state: %v)", activateState.Status)
-	}
-
 	// Note: Checking that there are no ongoing conflicting changes and that the
 	// targeted key slots exist while state is locked ensures that we don't suffer
 	// from TOCTOU.

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -23,7 +23,6 @@ package fdestate_test
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -901,18 +900,6 @@ func (s *fdeMgrSuite) TestReplacePlatformKeyErrors(c *C) {
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default"}
 	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "system-data", name: "default"\): unsupported type "recovery", expected "platform"`)
-
-	// recovery mode
-	s.createUnlockedState(c, sb.ActivationSucceededWithRecoveryKey)
-	s.st.Cache(fdestate.CachedActivateStateKey{}, nil)
-
-	_, err = fdestate.ReplacePlatformKey(s.st, nil, nil)
-	c.Assert(err, ErrorMatches, `cannot replace platform keys if FDE is not active \(current state: recovery\)`)
-	// cleanup
-	c.Assert(os.RemoveAll(filepath.Join(dirs.SnapBootstrapRunDir, "unlocked.json")), IsNil)
-
-	s.createUnlockedState(c, sb.ActivationSucceededWithPlatformKey)
-	s.st.Cache(fdestate.CachedActivateStateKey{}, nil)
 
 	// change conflict with fde changes
 	chg := s.st.NewChange("fde-change-passphrase", "")

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -36,6 +36,7 @@ var (
 	secbootAddContainerTPMProtectedKey = secboot.AddContainerTPMProtectedKey
 	secbootDeleteContainerKey          = secboot.DeleteContainerKey
 	secbootRenameContainerKey          = secboot.RenameContainerKey
+	secbootGetPrimaryKey               = secboot.GetPrimaryKey
 )
 
 func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) (err error) {
@@ -224,6 +225,49 @@ func (m *FDEManager) doRenameKeys(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+type primaryKeyCache struct {
+	mainKey []byte
+	keys    map[int][]byte
+}
+
+func (cache *primaryKeyCache) findPrimaryKey(fdemgr *FDEManager, keyslotRole string) ([]byte, error) {
+	roleInfo, err := fdemgr.GetRoleInfo(keyslotRole)
+	if err != nil {
+		return nil, err
+	}
+	primaryKeyCached, hasPrimaryKeyCached := cache.keys[roleInfo.PrimaryKeyID]
+	if hasPrimaryKeyCached {
+		return primaryKeyCached, nil
+	}
+
+	containers, err := fdemgr.GetEncryptedContainers()
+	if err != nil {
+		return nil, err
+	}
+
+	if cache.mainKey == nil {
+		var devices []string
+
+		for _, container := range containers {
+			devices = append(devices, container.DevPath())
+		}
+
+		primaryKey, err := secbootGetPrimaryKey(devices, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		cache.mainKey = primaryKey
+	}
+
+	if !fdemgr.VerifyPrimaryKeyAgainstState(roleInfo.PrimaryKeyID, cache.mainKey) {
+		return nil, fmt.Errorf("no primary key found for role %q", keyslotRole)
+	}
+
+	cache.keys[roleInfo.PrimaryKeyID] = cache.mainKey
+	return cache.mainKey, nil
+}
+
 func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) {
 	m.state.Lock()
 	defer m.state.Unlock()
@@ -272,17 +316,6 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 
 	// XXX: unlock state and let conflict detection handle the rest?
 
-	activateState, err := SystemState(m.state)
-	if err != nil {
-		return err
-	}
-	if !RunningWithPlatformKeys(activateState.Status) {
-		// primary key might be missing from kernel keyring if disk was
-		// unlocked with recovery key during boot.
-		// We need to allow degraded state, as this function might be part of fixing
-		return fmt.Errorf("cannot add platform keys if FDE is not active (current state: %v)", activateState.Status)
-	}
-
 	containers, err := m.GetEncryptedContainers()
 	if err != nil {
 		return err
@@ -325,6 +358,8 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 		return err
 	}
 
+	primaryKeys := &primaryKeyCache{keys: make(map[int][]byte)}
+
 	// we only care about missing key slots because this might be
 	// a re-run due a force reboot or abrupt shutdown, so we want
 	// to continue adding the remaining key slots.
@@ -337,6 +372,11 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 			return fmt.Errorf("internal error: expected one key role, found %v", roles)
 		}
 		role := roles[0]
+
+		primaryKey, err := primaryKeys.findPrimaryKey(m, role)
+		if err != nil {
+			return err
+		}
 
 		// NOTE: this is safe to call here even though internally the state is unlocked
 		// because there is conflict detection enforced to prevent other tasks that might
@@ -358,6 +398,7 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 			PCRPolicyCounterHandle: fdeKeyslotRoles[role].TPM2PCRPolicyRevocationCounter,
 			KeyRole:                role,
 			VolumesAuth:            volumesAuth,
+			PrimaryKey:             primaryKey,
 		}
 		// TODO:FDEM: support FDE hook setup
 		if err := secbootAddContainerTPMProtectedKey(devicePath, ref.Name, &params); err != nil {

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -21,6 +21,8 @@
 package fdestate_test
 
 import (
+	"crypto"
+	"crypto/hmac"
 	"errors"
 	"fmt"
 	"os"
@@ -941,12 +943,12 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 			expectedErr: "cannot find authentication options in memory: unexpected snapd restart",
 		},
 		{
-			authMode: device.AuthModePassphrase, noVolumesAuth: true,
-			expectedErr: "cannot find authentication options in memory: unexpected snapd restart",
+			authMode: device.AuthModePassphrase, recoveryMode: true,
+			expectedAdds: []string{"/dev/disk/by-uuid/data:tmp-default"},
 		},
 		{
-			authMode: device.AuthModePassphrase, recoveryMode: true,
-			expectedErr: `cannot add platform keys if FDE is not active \(current state: recovery\)`,
+			authMode: device.AuthModePassphrase, noVolumesAuth: true,
+			expectedErr: "cannot find authentication options in memory: unexpected snapd restart",
 		},
 		{
 			authMode:    device.AuthModePassphrase,
@@ -1074,6 +1076,32 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 
 		c.Assert(device.StampSealedKeys(dirs.GlobalRootDir, device.SealingMethodTPM), IsNil)
 
+		salt := []byte{1, 2, 3, 4}
+		primaryKey := []byte{5, 6, 7, 8}
+
+		defer fdestate.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFiles []string) ([]byte, error) {
+			c.Check(devices, DeepEquals, []string{
+				"/dev/disk/by-uuid/data",
+				"/dev/disk/by-uuid/save",
+			})
+			c.Check(fallbackKeyFiles, HasLen, 0)
+			return primaryKey, nil
+		})()
+
+		h := hmac.New(crypto.Hash(crypto.SHA256).New, salt[:])
+		h.Write(primaryKey)
+		digest := h.Sum(nil)
+
+		var fdeSt fdestate.FdeState
+		err := s.st.Get("fde", &fdeSt)
+		c.Assert(err, IsNil)
+		fdeSt.PrimaryKeys[0] = fdestate.PrimaryKeyInfo{fdestate.KeyDigest{
+			Algorithm: secboot.HashAlg(crypto.SHA256),
+			Salt:      salt,
+			Digest:    digest,
+		}}
+		s.st.Set("fde", &fdeSt)
+
 		task := s.st.NewTask("fde-add-platform-keys", "test")
 		task.Set("keyslots", tc.keyslots)
 		task.Set("auth-mode", tc.authMode)
@@ -1170,6 +1198,32 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeysIdempotence(c *C) {
 
 	s.st.Lock()
 	defer s.st.Unlock()
+
+	salt := []byte{1, 2, 3, 4}
+	primaryKey := []byte{5, 6, 7, 8}
+
+	defer fdestate.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFiles []string) ([]byte, error) {
+		c.Check(devices, DeepEquals, []string{
+			"/dev/disk/by-uuid/data",
+			"/dev/disk/by-uuid/save",
+		})
+		c.Check(fallbackKeyFiles, HasLen, 0)
+		return primaryKey, nil
+	})()
+
+	h := hmac.New(crypto.Hash(crypto.SHA256).New, salt[:])
+	h.Write(primaryKey)
+	digest := h.Sum(nil)
+
+	var fdeSt fdestate.FdeState
+	err := s.st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	fdeSt.PrimaryKeys[0] = fdestate.PrimaryKeyInfo{fdestate.KeyDigest{
+		Algorithm: secboot.HashAlg(crypto.SHA256),
+		Salt:      salt,
+		Digest:    digest,
+	}}
+	s.st.Set("fde", &fdeSt)
 
 	keyslotRefs := []fdestate.KeyslotRef{
 		{ContainerRole: "system-data", Name: "default-0"},

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -285,6 +285,8 @@ type ProtectKeyParams struct {
 	KeyRole string
 	// Optional volume authentication options
 	VolumesAuth *device.VolumesAuthOptions
+	// Primary key
+	PrimaryKey []byte
 }
 
 // EncryptedPartitionName returns the name/label used by an encrypted partition

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -5123,7 +5123,6 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 		tpmErr              error
 		sealErr             error
 		addErr              error
-		primaryKeyErr       error
 		unlockKeyErr        error
 		keydataWriteErr     error
 		sealCalls           int
@@ -5133,7 +5132,6 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 	}{
 		{tpmEnabled: false, expectedErr: "TPM device is not enabled"},
 		{tpmEnabled: true, sealCalls: 1},
-		{tpmEnabled: true, primaryKeyErr: mockErr, expectedErr: "cannot get primary key from kernel keyring for unlocked disk /dev/foo: some error"},
 		{tpmEnabled: true, unlockKeyErr: mockErr, expectedErr: "cannot get unlock key from kernel keyring for unlocked disk /dev/foo: some error"},
 		{tpmEnabled: true, tpmErr: mockErr, expectedErr: "cannot connect to TPM: some error"},
 		{tpmEnabled: true, sealErr: mockErr, sealCalls: 1, expectedErr: "cannot seal key: some error"},
@@ -5148,13 +5146,6 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 
 		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, nil, false)
 		c.Assert(err, IsNil)
-
-		defer secboot.MockSbGetPrimaryKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.PrimaryKey, error) {
-			c.Check(prefix, Equals, "ubuntu-fde")
-			c.Check(devicePath, Equals, "/dev/foo")
-			c.Check(remove, Equals, false)
-			return sb.PrimaryKey{'p', 'r', 'i', 'm', 'a', 'r', 'y'}, tc.primaryKeyErr
-		})()
 
 		defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {
 			c.Check(prefix, Equals, "ubuntu-fde")
@@ -5230,6 +5221,7 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 			PCRPolicyCounterHandle: 12,
 			KeyRole:                "somerole",
 			VolumesAuth:            tc.volumesAuth,
+			PrimaryKey:             sb.PrimaryKey{'p', 'r', 'i', 'm', 'a', 'r', 'y'},
 		}
 		err = secboot.AddContainerTPMProtectedKey("/dev/foo", "bar", &params)
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -1399,20 +1399,10 @@ func FindFreeHandle() (uint32, error) {
 }
 
 // AddContainerRecoveryKey adds a new TPM protected key to specified device.
-//
-// Note: The unlock and primary keys are implicitly obtained from the kernel
-// keyring so this will not work if the disk was unlocked with a recovery key
-// during boot.
 func AddContainerTPMProtectedKey(devicePath, slotName string, params *ProtectKeyParams) (err error) {
 	var pcrProfile sb_tpm2.PCRProtectionProfile
 	if _, err := mu.UnmarshalFromBytes(params.PCRProfile, &pcrProfile); err != nil {
 		return fmt.Errorf("cannot unmarshal PCR profile: %v", err)
-	}
-
-	// this will fail if the disk was unlocked with a recovery key during boot.
-	primaryKey, err := sbGetPrimaryKeyFromKernel(defaultKeyringPrefix, devicePath, false)
-	if err != nil {
-		return fmt.Errorf("cannot get primary key from kernel keyring for unlocked disk %s: %v", devicePath, err)
 	}
 
 	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, devicePath, false)
@@ -1433,7 +1423,7 @@ func AddContainerTPMProtectedKey(devicePath, slotName string, params *ProtectKey
 		PCRProfile:             &pcrProfile,
 		Role:                   params.KeyRole,
 		PCRPolicyCounterHandle: tpm2.Handle(params.PCRPolicyCounterHandle),
-		PrimaryKey:             primaryKey,
+		PrimaryKey:             params.PrimaryKey,
 	}
 
 	protectedKey, _, newKey, err := newTPMProtectedKey(tpm, creationParams, params.VolumesAuth)

--- a/tests/nested/manual/fde-auth-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/fde-auth-support-on-hybrid/task.yaml
@@ -62,8 +62,9 @@ prepare: |
     --store-dir "${STORE_DIR}" \
     --gadget pc.snap \
     --gadget-assertion pc.assert \
-     --kernel pc-kernel-repacked.snap \
-     --kernel-assertion pc-kernel-from-store.assert
+    --kernel pc-kernel-repacked.snap \
+    --kernel-assertion pc-kernel-from-store.assert \
+    --recovery-key-out "$(pwd)"/recovery-key
 
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
@@ -101,16 +102,18 @@ execute: |
   # system-data is encrypted but not protected by a passphrase or PIN yet
   gojq '.result."by-container-role"."system-data"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^none$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^none$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # system-save is also encrypted not protected by a passphrase or PIN yet
   gojq '.result."by-container-role"."system-save"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^none$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^none$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # shellcheck source=tests/lib/prepare.sh
   . "$TESTSLIB/prepare.sh"
@@ -145,16 +148,18 @@ execute: |
   # system-data is encrypted and protected by a passphrase
   gojq '.result."by-container-role"."system-data"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^passphrase$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^passphrase$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # system-save is also encrypted and protected by a passphrase
   gojq '.result."by-container-role"."system-save"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^none$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^passphrase$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # Test changing passphrases
   remote_action_request '{"action": "change-passphrase", "old-passphrase": "ubuntu-1", "new-passphrase": "ubuntu-2"}'
@@ -261,16 +266,18 @@ execute: |
   # system-data is encrypted and protected by a PIN
   gojq '.result."by-container-role"."system-data"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^pin$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^pin$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # system-save is also encrypted and protected by a PIN
   gojq '.result."by-container-role"."system-save"' < containers.out > container.out
   gojq '.encrypted' < container.out | MATCH "^true$"
-  gojq '.keyslots | length' < container.out | MATCH "^2$"
+  gojq '.keyslots | length' < container.out | MATCH "^3$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^none$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^pin$"
+  gojq --raw-output '.keyslots."default-recovery".type' < container.out | MATCH "^recovery$"
 
   # Let's switch to a passphrase one more time for good measure
   remote_action_request '{"action": "replace-platform-key", "auth-mode": "passphrase", "passphrase": "ubuntu-4"}'
@@ -278,3 +285,12 @@ execute: |
   remote.exec sudo snap watch "$change_id"
 
   reboot_with_passphrase "ubuntu-4"
+
+  # Now let's see if we can remove the passphrase when booted with a recovery key
+  reboot_with_passphrase "$(cat recovery-key)"
+
+  remote_action_request '{"action": "replace-platform-key", "auth-mode": "none"}'
+  change_id="$(gojq --raw-output .change < resp)"
+  remote.exec sudo snap watch "$change_id"
+
+  reboot_with_passphrase ""


### PR DESCRIPTION
The use case is such: the user unlocked the disk with recovery key because they forgot their passphrase or pin. They want to reset it.

In most cases we do not need a full reprovision, because we should have the primary key. The save partition was unlocked using the protector key and the primary key of the save key should be the same as the data partition.

In this change we look for primary keys for all disks and we match them with the role of the keyslot we are modifying instead of looking at the primary key for the encrypted container the keyslot belongs to.