### PR TITLE
interfaces/builtin: allow missing resolve1 link setters

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -103,7 +103,7 @@ dbus (send)
      bus=system
      path="/org/freedesktop/resolve1/link/*"
      interface="org.freedesktop.resolve1.Link"
-     member="Set{DNS,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
+     member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"
      peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -89,7 +89,7 @@ dbus (send)
      bus=system
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
-     member="SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
+     member="SetLink*"
      peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)
@@ -103,7 +103,7 @@ dbus (send)
      bus=system
      path="/org/freedesktop/resolve1/link/*"
      interface="org.freedesktop.resolve1.Link"
-     member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"
+     member="Set*"
      peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -92,6 +92,9 @@ func (s *NetworkControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Check(spec.UsesSysModuleCapability(), Equals, false)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/netns/* rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `path="/org/freedesktop/resolve1/link/*"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface="org.freedesktop.resolve1.Link"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"`)
 	// No "xdp" feature is available, so this rule should not be added
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "network xdp,")
 	c.Assert(spec.UpdateNS(), DeepEquals, []string{`

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -94,7 +94,7 @@ func (s *NetworkControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/netns/* rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `path="/org/freedesktop/resolve1/link/*"`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface="org.freedesktop.resolve1.Link"`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `member="Set*"`)
 	// No "xdp" feature is available, so this rule should not be added
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "network xdp,")
 	c.Assert(spec.UpdateNS(), DeepEquals, []string{`

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -168,7 +168,7 @@ dbus (send)
      bus=system
      path="/org/freedesktop/resolve1/link/*"
      interface="org.freedesktop.resolve1.Link"
-     member="Set{DNS,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
+     member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"
      peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -199,6 +199,7 @@ func (s *NetworkManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	err = apparmorSpec.AddPermanentSlot(s.iface, s.slotInfo)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager.nm"), testutil.Contains, `member="Set{DefaultRoute,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,DNSOverTLS,Domains,LLMNR,MulticastDNS}"`)
 
 	dbusSpec := dbus.NewSpecification(s.slot.AppSet())
 	err = dbusSpec.AddPermanentSlot(s.iface, s.slotInfo)


### PR DESCRIPTION
The network-control and network-manager AppArmor snippets allowed
SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,...} on
org.freedesktop.resolve1.Manager but omitted the equivalent methods
on org.freedesktop.resolve1.Link.

Add DefaultRoute, DNSOverTLS, and DNSEx to the Link member list
for both interfaces, and add regression checks in the corresponding
tests to ensure the member set stays in sync.

Fixes: https://bugs.launchpad.net/bugs/2143934
