### PR TITLE
cmd/snap: expose key commands in help listings

### DIFF
--- a/cmd/snap/cmd_create_key.go
+++ b/cmd/snap/cmd_create_key.go
@@ -40,7 +40,8 @@ func init() {
 		i18n.G("Create cryptographic key pair"),
 		i18n.G(`
 The create-key command creates a cryptographic key pair that can be
-used for signing assertions.
+used for signing assertions. You should use "snapcraft create-key"
+instead.
 `),
 		func() flags.Commander {
 			return &cmdCreateKey{}
@@ -50,7 +51,6 @@ used for signing assertions.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to create; defaults to 'default'"),
 		}})
-	cmd.hidden = true
 	cmd.completeHidden = true
 }
 

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -41,7 +41,7 @@ func init() {
 		i18n.G("Delete cryptographic key pair"),
 		i18n.G(`
 The delete-key command deletes the local cryptographic key pair with
-the given name.
+the given name. You should use snapcraft to manage your signing keys.
 `),
 		func() flags.Commander {
 			return &cmdDeleteKey{}
@@ -51,7 +51,6 @@ the given name.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to delete"),
 		}})
-	cmd.hidden = true
 	cmd.completeHidden = true
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -266,7 +266,7 @@ var helpCategories = []helpCategory{
 		Label:           i18n.G("Development"),
 		Description:     i18n.G("developer-oriented features"),
 		Commands:        []string{"download", "pack", "run", "try", "sign"},
-		AllOnlyCommands: []string{"prepare-image", "export-key"},
+		AllOnlyCommands: []string{"prepare-image", "create-key", "delete-key", "export-key", "keys"},
 	}, {
 		Label:       i18n.G("Quota Groups"),
 		Description: i18n.G("Manage quota groups for snaps"),

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -259,6 +259,19 @@ func (s *SnapSuite) TestManpageNoDoubleTP(c *check.C) {
 
 }
 
+func (s *SnapSuite) TestManpageListsKeyCommands(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "help", "--man"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.IsNil)
+
+	for _, cmd := range []string{"create-key", "delete-key", "export-key", "keys"} {
+		c.Check(s.Stdout(), check.Matches, fmt.Sprintf(`(?ms).*^\.SS %s$.*`, regexp.QuoteMeta(cmd)), check.Commentf("%q", cmd))
+	}
+}
+
 func (s *SnapSuite) TestBadSub(c *check.C) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -38,7 +38,7 @@ func init() {
 		i18n.G("List cryptographic keys"),
 		i18n.G(`
 The keys command lists cryptographic keys that can be used for signing
-assertions.
+assertions. You should use "snapcraft keys" instead.
 `),
 		func() flags.Commander {
 			return &cmdKeys{}
@@ -46,7 +46,6 @@ assertions.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"json": i18n.G("Output results in JSON format"),
 		}, nil)
-	cmd.hidden = true
 	cmd.completeHidden = true
 }
 
@@ -67,7 +66,7 @@ func outputJSON(keys []Key) error {
 
 func outputText(keys []Key) error {
 	if len(keys) == 0 {
-		fmt.Fprintf(Stderr, "No keys registered, see `snapcraft create-key`\n")
+		fmt.Fprintf(Stderr, "No keys registered, see 'snap create-key'\n")
 		return nil
 	}
 

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -121,7 +121,7 @@ func (s *SnapKeysSuite) TestKeysEmptyNoHeader(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
-	c.Check(s.Stderr(), Equals, "No keys registered, see `snapcraft create-key`\n")
+	c.Check(s.Stderr(), Equals, "No keys registered, see 'snap create-key'\n")
 }
 
 func (s *SnapKeysSuite) TestKeysJSON(c *C) {


### PR DESCRIPTION
Unhide create-key, delete-key and keys so these commands are discoverable. Include key management commands in the Development category for "snap help --all", update the empty-keys guidance to point to "snap create-key", and add a manpage regression test for key command sections.

Fixes: https://bugs.launchpad.net/snapd/+bug/1982499
