### PR TITLE
snap/pack: validate content interface plug target exists for core26+

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -6332,8 +6332,12 @@ plugs:
     default-provider: foo-content
 `
 	missing := ""
+	var files [][]string
 	if strutil.ListContains(missingWhat, "base") {
 		missing += "base: foo-base\n"
+		files = [][]string{
+			{"data-dir/", ""},
+		}
 	} else {
 		missing += "base: core20\n"
 	}
@@ -6343,7 +6347,7 @@ plugs:
 	}
 	fooYaml = strings.Replace(fooYaml, "@MISSING@", missing, 1)
 	// the gadget needs to be mocked
-	info := snaptest.MakeSnapFileAndDir(c, fooYaml, nil, &snap.SideInfo{
+	info := snaptest.MakeSnapFileAndDir(c, fooYaml, files, &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("foo-missing-deps"),
 		Revision: snap.R(1),
 		RealName: "foo-missing-deps",
@@ -6588,7 +6592,9 @@ plugs:
     target: $SNAP/data-dir
     default-provider: foo-content
 `
-	fooInfo := snaptest.MakeSnapFileAndDir(c, fooYaml, nil, &snap.SideInfo{
+	fooInfo := snaptest.MakeSnapFileAndDir(c, fooYaml, [][]string{
+		{"data-dir/"},
+	}, &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("foo-missing-deps"),
 		Revision: snap.R(1),
 		RealName: "foo-missing-deps",
@@ -6644,7 +6650,9 @@ plugs:
     default-provider: foo-content
 `
 	// the gadget needs to be mocked
-	barInfo := snaptest.MakeSnapFileAndDir(c, barYaml, nil, &snap.SideInfo{
+	barInfo := snaptest.MakeSnapFileAndDir(c, barYaml, [][]string{
+		{"data-dir/"},
+	}, &snap.SideInfo{
 		SnapID:   snaptest.AssertedSnapID("bar-missing-deps"),
 		Revision: snap.R(1),
 		RealName: "bar-missing-deps",

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -9067,7 +9067,10 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 		"snap-name": "prereq",
 	})
 
-	snapPath, _ := s.makeStoreTestSnap(c, prereqSnapYaml, "1")
+	snapPath, _ := s.makeStoreTestSnapWithFiles(c, prereqSnapYaml, "1", [][]string{
+		// using non-standard base, the cotnent target needs to be pre-created
+		{"data-dir/"},
+	})
 	s.serveSnap(snapPath, "1")
 
 	snapstate.Set(st, "core", nil)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -9068,7 +9068,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 	})
 
 	snapPath, _ := s.makeStoreTestSnapWithFiles(c, prereqSnapYaml, "1", [][]string{
-		// using non-standard base, the cotnent target needs to be pre-created
+		// using non-standard base, the content target needs to be pre-created
 		{"data-dir/"},
 	})
 	s.serveSnap(snapPath, "1")

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -126,6 +126,11 @@ func validateContentPlugTargets(container snap.Container, info *snap.Info) error
 		if strings.HasPrefix(target, "$SNAP_DATA") || strings.HasPrefix(target, "$SNAP_COMMON") {
 			continue
 		}
+		// split cleanup in 2 steps so that we handle all possible weird cases:
+		// - $SNAP   # weird but accepted
+		// - $SNAP/  # same as above
+		// - path    # implicit $SNAP/
+		// - /path   # implicit $SNAP/
 		relPath := strings.TrimPrefix(target, "$SNAP")
 		relPath = strings.TrimPrefix(relPath, "/")
 		if relPath == "" {

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -106,7 +106,7 @@ func validateContentPlugTargets(container snap.Container, info *snap.Info) error
 	// Content plug target validation does not apply to bases
 	// before core26.
 	excluded := []string{
-		"bare", "core", "core18", "core20", "core22", "core24",
+		"core", "core18", "core20", "core22", "core24",
 	}
 	if strutil.ListContains(excluded, base) {
 		return nil

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/kernel"
@@ -31,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/snap/squashfs"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // this could be shipped as a file like "info", and save on the memory and the
@@ -92,6 +94,50 @@ func debArchitecture(info *snap.Info) string {
 	}
 }
 
+// validateContentPlugTargets checks that content interface plug target
+// directories exist in the snap source tree. This check only applies to
+// snaps with base core26 or later.
+func validateContentPlugTargets(container snap.Container, info *snap.Info) error {
+	// An empty base is equivalent to "core".
+	base := info.Base
+	if base == "" {
+		base = "core"
+	}
+	// Content plug target validation does not apply to bases
+	// before core26.
+	excluded := []string{
+		"bare", "core", "core18", "core20", "core22", "core24",
+	}
+	if strutil.ListContains(excluded, base) {
+		return nil
+	}
+
+	for plugName, plug := range info.Plugs {
+		if plug.Interface != "content" {
+			continue
+		}
+		var target string
+		if err := plug.Attr("target", &target); err != nil || target == "" {
+			continue
+		}
+		// Only $SNAP paths (or paths with no variable prefix) can be checked at
+		// pack time; $SNAP_DATA and $SNAP_COMMON are read-write runtime
+		// directories and mount points can be created as needed.
+		if strings.HasPrefix(target, "$SNAP_DATA") || strings.HasPrefix(target, "$SNAP_COMMON") {
+			continue
+		}
+		relPath := strings.TrimPrefix(target, "$SNAP")
+		relPath = strings.TrimPrefix(relPath, "/")
+		if relPath == "" {
+			continue
+		}
+		if _, err := container.Lstat(relPath); err != nil {
+			return fmt.Errorf("content interface plug %q has target %q which does not exist", plugName, target)
+		}
+	}
+	return nil
+}
+
 // CheckSkeleton attempts to validate snap data in source directory
 func CheckSkeleton(w io.Writer, sourceDir string) error {
 	yaml, err := os.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
@@ -122,6 +168,9 @@ func loadAndValidate(sourceDir string, yaml []byte) (*snap.Info, error) {
 	}
 
 	if err := snap.ValidateSnapContainer(container, info, logger.Noticef); err != nil {
+		return nil, err
+	}
+	if err := validateContentPlugTargets(container, info); err != nil {
 		return nil, err
 	}
 	if _, err := snap.ReadSnapshotYamlFromSnapFile(container); err != nil {

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -131,8 +131,12 @@ func validateContentPlugTargets(container snap.Container, info *snap.Info) error
 		if relPath == "" {
 			continue
 		}
-		if _, err := container.Lstat(relPath); err != nil {
-			return fmt.Errorf("content interface plug %q has target %q which does not exist", plugName, target)
+		fi, err := container.Lstat(relPath)
+		if err != nil {
+			return fmt.Errorf("content interface plug %q target %q does not exist", plugName, target)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("content interface plug %q target %q must be a directory", plugName, target)
 		}
 	}
 	return nil

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -131,9 +131,11 @@ func validateContentPlugTargets(container snap.Container, info *snap.Info) error
 		// - $SNAP/  # same as above
 		// - path    # implicit $SNAP/
 		// - /path   # implicit $SNAP/
+		// - /       # implicit $SNAP/
 		relPath := strings.TrimPrefix(target, "$SNAP")
 		relPath = strings.TrimPrefix(relPath, "/")
 		if relPath == "" {
+			// only the $SNAP and/or / combination prefix was present
 			continue
 		}
 		fi, err := container.Lstat(relPath)

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -132,11 +132,8 @@ func validateContentPlugTargets(container snap.Container, info *snap.Info) error
 			continue
 		}
 		fi, err := container.Lstat(relPath)
-		if err != nil {
-			return fmt.Errorf("content interface plug %q target %q does not exist", plugName, target)
-		}
-		if !fi.IsDir() {
-			return fmt.Errorf("content interface plug %q target %q must be a directory", plugName, target)
+		if err != nil || !fi.IsDir() {
+			return fmt.Errorf("content interface plug %q target %v must exist and must be a directory, ensure it is present in the snap or created before packing", plugName, target)
 		}
 	}
 	return nil

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -177,6 +177,9 @@ func loadAndValidate(sourceDir string, yaml []byte) (*snap.Info, error) {
 	if err := validateContentPlugTargets(container, info); err != nil {
 		return nil, err
 	}
+	// TODO: validate content interface slot source (read/write) paths
+	// exist in the snap source tree, see validateContentPlugTargets.
+
 	if _, err := snap.ReadSnapshotYamlFromSnapFile(container); err != nil {
 		return nil, err
 	}

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -676,12 +676,26 @@ plugs:
   interface: content
   target: $SNAP/import
 `
-	for _, base := range []string{"bare", "core", "core18", "core20", "core22", "core24"} {
+	for _, base := range []string{"core", "core18", "core20", "core22", "core24"} {
 		sourceDir := makeExampleSnapSourceDir(c, fmt.Sprintf(snapYamlTemplate, base))
 		var buf bytes.Buffer
 		err := pack.CheckSkeleton(&buf, sourceDir)
 		c.Assert(err, IsNil, Commentf("base: %s", base))
 	}
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetBareBase(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: bare
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" does not exist`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetEmptyBase(c *C) {

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -649,7 +649,7 @@ plugs:
 `)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target \$SNAP/import must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetNotDirectory(c *C) {
@@ -664,7 +664,7 @@ plugs:
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "import"), []byte(""), 0644), IsNil)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" must be a directory`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target \$SNAP/import must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetOldBaseSkipped(c *C) {
@@ -695,7 +695,7 @@ plugs:
 `)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target \$SNAP/import must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetEmptyBase(c *C) {
@@ -739,7 +739,7 @@ plugs:
 `)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "import" does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target import must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetMultiplePlugs(c *C) {
@@ -757,5 +757,5 @@ plugs:
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, "existing"), 0755), IsNil)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "plug-missing" target "\$SNAP/missing" does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "plug-missing" target \$SNAP/missing must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -742,6 +742,37 @@ plugs:
 	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target import must exist and must be a directory, ensure it is present in the snap or created before packing`)
 }
 
+func (s *packSuite) TestCheckSkeletonContentPlugTargetEdgeCases(c *C) {
+	const snapYamlTemplate = `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: %s
+`
+	for _, tc := range []struct {
+		target string
+		ok     bool
+	}{
+		// all of these resolve to $SNAP and validation is always successful
+		{"$SNAP", true},
+		{"$SNAP/", true},
+		{"/", true},
+		// /path has implicit $SNAP prefix, leading / is stripped
+		{"/import", false},
+	} {
+		sourceDir := makeExampleSnapSourceDir(c, fmt.Sprintf(snapYamlTemplate, tc.target))
+		var buf bytes.Buffer
+		err := pack.CheckSkeleton(&buf, sourceDir)
+		if tc.ok {
+			c.Assert(err, IsNil, Commentf("target: %s", tc.target))
+		} else {
+			c.Assert(err, ErrorMatches, `content interface plug "shared-data" target.*must exist and must be a directory.*`, Commentf("target: %s", tc.target))
+		}
+	}
+}
+
 func (s *packSuite) TestCheckSkeletonContentPlugTargetMultiplePlugs(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 0

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -649,7 +649,22 @@ plugs:
 `)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" has target "\$SNAP/import" which does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" does not exist`)
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetNotDirectory(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`)
+	c.Assert(os.WriteFile(filepath.Join(sourceDir, "import"), []byte(""), 0644), IsNil)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "\$SNAP/import" must be a directory`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetOldBaseSkipped(c *C) {
@@ -710,7 +725,7 @@ plugs:
 `)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "shared-data" has target "import" which does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" target "import" does not exist`)
 }
 
 func (s *packSuite) TestCheckSkeletonContentPlugTargetMultiplePlugs(c *C) {
@@ -728,5 +743,5 @@ plugs:
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, "existing"), 0755), IsNil)
 	var buf bytes.Buffer
 	err := pack.CheckSkeleton(&buf, sourceDir)
-	c.Assert(err, ErrorMatches, `content interface plug "plug-missing" has target "\$SNAP/missing" which does not exist`)
+	c.Assert(err, ErrorMatches, `content interface plug "plug-missing" target "\$SNAP/missing" does not exist`)
 }

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -622,3 +622,111 @@ func (s *packSuite) TestPackWithCompressionUnhappy(c *C) {
 		c.Assert(snapfile, Equals, "")
 	}
 }
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetExists(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`)
+	c.Assert(os.Mkdir(filepath.Join(sourceDir, "import"), 0755), IsNil)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, IsNil)
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetMissing(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" has target "\$SNAP/import" which does not exist`)
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetOldBaseSkipped(c *C) {
+	const snapYamlTemplate = `name: hello
+version: 0
+base: %s
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`
+	for _, base := range []string{"bare", "core", "core18", "core20", "core22", "core24"} {
+		sourceDir := makeExampleSnapSourceDir(c, fmt.Sprintf(snapYamlTemplate, base))
+		var buf bytes.Buffer
+		err := pack.CheckSkeleton(&buf, sourceDir)
+		c.Assert(err, IsNil, Commentf("base: %s", base))
+	}
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetEmptyBase(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+plugs:
+ shared-data:
+  interface: content
+  target: $SNAP/import
+`)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, IsNil)
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetRuntimePathSkipped(c *C) {
+	const snapYamlTemplate = `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: %s/import
+`
+	for _, prefix := range []string{"$SNAP_DATA", "$SNAP_COMMON"} {
+		sourceDir := makeExampleSnapSourceDir(c, fmt.Sprintf(snapYamlTemplate, prefix))
+		var buf bytes.Buffer
+		err := pack.CheckSkeleton(&buf, sourceDir)
+		c.Assert(err, IsNil, Commentf("target prefix: %s", prefix))
+	}
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetNoPrefix(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: core26
+plugs:
+ shared-data:
+  interface: content
+  target: import
+`)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, ErrorMatches, `content interface plug "shared-data" has target "import" which does not exist`)
+}
+
+func (s *packSuite) TestCheckSkeletonContentPlugTargetMultiplePlugs(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+base: core26
+plugs:
+ plug-existing:
+  interface: content
+  target: $SNAP/existing
+ plug-missing:
+  interface: content
+  target: $SNAP/missing
+`)
+	c.Assert(os.Mkdir(filepath.Join(sourceDir, "existing"), 0755), IsNil)
+	var buf bytes.Buffer
+	err := pack.CheckSkeleton(&buf, sourceDir)
+	c.Assert(err, ErrorMatches, `content interface plug "plug-missing" has target "\$SNAP/missing" which does not exist`)
+}

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -241,19 +241,34 @@ func MockSnapWithFiles(c *check.C, yamlText string, si *snap.SideInfo, files [][
 	return info
 }
 
-// PopulateDir populates the directory with files specified as pairs of relative file path and its content. Useful to add extra files to a snap.
+// PopulateDir populates the directory with files specified as pairs of relative
+// file path and its content. Useful to add extra files to a snap. A path entry
+// ending with "/" indicates a directory, in which case there should be no
+// associated content element or it should be empty.
 func PopulateDir(dir string, files [][]string) {
 	for _, filenameAndContent := range files {
 		filename := filenameAndContent[0]
-		content := filenameAndContent[1]
 		fpath := filepath.Join(dir, filename)
-		err := os.MkdirAll(filepath.Dir(fpath), 0755)
-		if err != nil {
-			panic(err)
-		}
-		err = os.WriteFile(fpath, []byte(content), 0755)
-		if err != nil {
-			panic(err)
+		if strings.HasSuffix(filename, "/") {
+			if len(filenameAndContent) > 1 && filenameAndContent[1] != "" {
+				panic(fmt.Sprintf("unexpected cotnent for directory entry %q", filename))
+			}
+			// actually it's a directory
+			err := os.MkdirAll(fpath, 0755)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			content := filenameAndContent[1]
+			fpath := filepath.Join(dir, filename)
+			err := os.MkdirAll(filepath.Dir(fpath), 0755)
+			if err != nil {
+				panic(err)
+			}
+			err = os.WriteFile(fpath, []byte(content), 0755)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 }

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -253,7 +253,7 @@ func PopulateDir(dir string, files [][]string) {
 		fpath := filepath.Join(dir, filename)
 		if strings.HasSuffix(filename, "/") {
 			if len(filenameAndContent) > 1 && filenameAndContent[1] != "" {
-				panic(fmt.Sprintf("unexpected cotnent for directory entry %q", filename))
+				panic(fmt.Sprintf("unexpected content for directory entry %q", filename))
 			}
 			// actually it's a directory
 			err := os.MkdirAll(fpath, 0755)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -246,6 +246,8 @@ func MockSnapWithFiles(c *check.C, yamlText string, si *snap.SideInfo, files [][
 // ending with "/" indicates a directory, in which case there should be no
 // associated content element or it should be empty.
 func PopulateDir(dir string, files [][]string) {
+	// TODO: tweak the API to take a list of interfaces, each one with its
+	// own creation method
 	for _, filenameAndContent := range files {
 		filename := filenameAndContent[0]
 		fpath := filepath.Join(dir, filename)

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -250,6 +250,8 @@ func (s *snapTestSuite) TestMakeSnapFileAndDir(c *C) {
 	files := [][]string{
 		{"canary", "canary"},
 		{"foo", "foo"},
+		{"bar/", ""},
+		{"no-content-bar/"},
 	}
 	info := snaptest.MakeSnapFileAndDir(c, sampleYaml, files, &snap.SideInfo{
 		Revision: snap.R(3),
@@ -262,4 +264,10 @@ func (s *snapTestSuite) TestMakeSnapFileAndDir(c *C) {
 	can, err := f.ReadFile("canary")
 	c.Assert(err, IsNil)
 	c.Check(can, DeepEquals, []byte("canary"))
+	fi, err := f.Lstat("bar")
+	c.Check(err, IsNil)
+	c.Check(fi.IsDir(), Equals, true)
+	fi, err = f.Lstat("no-content-bar")
+	c.Check(err, IsNil)
+	c.Check(fi.IsDir(), Equals, true)
 }


### PR DESCRIPTION
Validate that content interface plug target directories exist in the snap source tree when packing snaps with core26 and later bases as well as the "bare" base. Snaps using bases before core26 (core, core18, core20, core22, core24).

Related: SNAPDENG-36626

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
