### PR TITLE
overlord/snapstate: improve handling of failed downloads and cleanup of snap/component files

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -190,6 +190,9 @@ type fakeStore struct {
 
 	mu sync.Mutex
 
+	// download options are normalized to nil if they match the expected default value
+	expectedDefaultDownloadOpts *store.DownloadOptions
+
 	downloads           []fakeDownload
 	iconDownloads       []fakeIconDownload
 	refreshRevnos       map[string]snap.Revision
@@ -944,8 +947,12 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 	if user != nil {
 		macaroon = user.StoreMacaroon
 	}
-	// only add the options if they contain anything interesting
-	if dlOpts != nil && *dlOpts == (store.DownloadOptions{}) {
+	// only add the options if they differ from the defaults
+	dflt := f.expectedDefaultDownloadOpts
+	if dflt == nil {
+		dflt = &store.DownloadOptions{}
+	}
+	if dlOpts != nil && *dlOpts == *dflt {
 		dlOpts = nil
 	}
 	f.appendDownload(&fakeDownload{

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -361,12 +361,12 @@ func MockEnsuredDesktopFilesUpdated(m *SnapManager, ensured bool) (restore func(
 	}
 }
 
-func MockEnsuredDownloadsCleaned(m *SnapManager, ensured bool) (restore func()) {
-	old := m.ensuredDownloadsCleaned
-	m.ensuredDownloadsCleaned = ensured
-	return func() {
-		m.ensuredDownloadsCleaned = old
-	}
+func SetEnsuredDownloadsCleanedNext(m *SnapManager, next time.Time) {
+	m.ensuredDownloadsCleanedNext = next
+}
+
+func GetEnsuredDownloadsCleanedNext(m *SnapManager) time.Time {
+	return m.ensuredDownloadsCleanedNext
 }
 
 func MockPidsOfSnap(f func(instanceName string) (map[string][]int, error)) func() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -909,8 +909,9 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	iconURL := snapsup.Media.IconURL()
 
 	dlOpts := &store.DownloadOptions{
-		Scheduled: snapsup.IsAutoRefresh,
-		RateLimit: rate,
+		Scheduled:           snapsup.IsAutoRefresh,
+		RateLimit:           rate,
+		LeavePartialOnError: true,
 	}
 	if snapsup.DownloadInfo == nil {
 		vsets, err := EnforcedValidationSets(st)
@@ -1025,8 +1026,9 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	targetFn := snapsup.BlobPath()
 	dlOpts := &store.DownloadOptions{
 		// pre-downloads are only triggered in auto-refreshes
-		Scheduled: true,
-		RateLimit: autoRefreshRateLimited(st),
+		Scheduled:           true,
+		RateLimit:           autoRefreshRateLimited(st),
+		LeavePartialOnError: true,
 	}
 
 	perfTimings := state.TimingsForTask(t)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -201,8 +201,9 @@ func (m *SnapManager) doDownloadComponent(t *state.Task, tomb *tomb.Tomb) error 
 	timings.Run(perf, "download", fmt.Sprintf("download component %q", compsup.ComponentName()), func(timings.Measurer) {
 		compRef := compsup.CompSideInfo.Component.String()
 		opts := &store.DownloadOptions{
-			Scheduled: snapsup.IsAutoRefresh,
-			RateLimit: rate,
+			Scheduled:           snapsup.IsAutoRefresh,
+			RateLimit:           rate,
+			LeavePartialOnError: true,
 		}
 
 		err = sto.Download(tomb.Context(nil), compRef, target, compsup.DownloadInfo, meter, user, opts)

--- a/overlord/snapstate/handlers_components_download_test.go
+++ b/overlord/snapstate/handlers_components_download_test.go
@@ -35,6 +35,9 @@ func (s *downloadComponentSuite) SetUpTest(c *C) {
 	s.fakeStore = &fakeStore{
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
+		expectedDefaultDownloadOpts: &store.DownloadOptions{
+			LeavePartialOnError: true,
+		},
 	}
 
 	s.state.Lock()
@@ -139,8 +142,9 @@ func (s *downloadComponentSuite) testDoDownloadComponent(c *C, opts testDoDownlo
 	var downloadOpts *store.DownloadOptions
 	if opts.autoRefresh {
 		downloadOpts = &store.DownloadOptions{
-			RateLimit: 1234,
-			Scheduled: true,
+			RateLimit:           1234,
+			Scheduled:           true,
+			LeavePartialOnError: true,
 		}
 	}
 

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -53,6 +53,9 @@ func (s *downloadSnapSuite) SetUpTest(c *C) {
 	s.fakeStore = &fakeStore{
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
+		expectedDefaultDownloadOpts: &store.DownloadOptions{
+			LeavePartialOnError: true,
+		},
 	}
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -514,8 +517,9 @@ func (s *downloadSnapSuite) TestDoDownloadRateLimitedIntegration(c *C) {
 			name:   "foo",
 			target: filepath.Join(dirs.SnapBlobDir, "foo_11.snap"),
 			opts: &store.DownloadOptions{
-				RateLimit: 1234,
-				Scheduled: true,
+				RateLimit:           1234,
+				Scheduled:           true,
+				LeavePartialOnError: true,
 			},
 		},
 	})

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -87,10 +87,10 @@ type SnapManager struct {
 
 	preseed bool
 
-	ensuredMountsUpdated       bool
-	ensuredDesktopFilesUpdated bool
-	ensuredDownloadsCleaned    bool
-	ensureStoreCacheCleanNext  time.Time
+	ensuredMountsUpdated        bool
+	ensuredDesktopFilesUpdated  bool
+	ensuredDownloadsCleanedNext time.Time
+	ensureStoreCacheCleanNext   time.Time
 
 	changeCallbackID int
 }
@@ -822,7 +822,6 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 		preseed:                    preseed,
 		ensuredMountsUpdated:       false,
 		ensuredDesktopFilesUpdated: false,
-		ensuredDownloadsCleaned:    false,
 	}
 	if preseed {
 		m.backend = backend.NewForPreseedMode()
@@ -1601,10 +1600,6 @@ func (m *SnapManager) ensureDownloadsCleaned() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.ensuredDownloadsCleaned {
-		return nil
-	}
-
 	// only run after we are seeded
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
@@ -1615,13 +1610,19 @@ func (m *SnapManager) ensureDownloadsCleaned() error {
 		return nil
 	}
 
+	now := timeNow()
+
+	if !m.ensuredDownloadsCleanedNext.IsZero() && m.ensuredDownloadsCleanedNext.After(now) {
+		return nil
+	}
+
 	logger.Trace("ensure", "manager", "SnapManager", "func", "ensureDownloadsCleaned")
 
 	if err := cleanDownloads(m.state); err != nil {
 		return err
 	}
 
-	m.ensuredDownloadsCleaned = true
+	m.ensuredDownloadsCleanedNext = now.Add(maxUnusedDownloadRetention / 4)
 
 	return nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -4206,7 +4206,8 @@ var cleanDownloads = func(st *state.State) error {
 		}
 
 		if targetFile, _, partial := strings.Cut(file, ".partial"); partial {
-			if keep[filepath.Base(targetFile)] {
+			if keep[filepath.Base(targetFile)] && !osutil.FileExists(targetFile) {
+				// only keep the partial file if the target does not exist yet
 				continue
 			}
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -4230,19 +4229,26 @@ var cleanSnapDownloads = func(st *state.State, snapName string) error {
 		return err
 	}
 
-	regex := regexp.MustCompile(fmt.Sprintf("^%s_x?[0-9]+\\.snap$", snapName))
-
 	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_*.snap", snapName)))
 	if err != nil {
 		return err
 	}
-	for _, file := range matches {
-		if !regex.MatchString(filepath.Base(file)) {
-			continue
-		}
+	partial, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_*.snap.partial", snapName)))
+	if err != nil {
+		return err
+	}
+	for _, file := range append(matches, partial...) {
 		if keep[filepath.Base(file)] {
 			continue
 		}
+
+		if targetFile, _, partial := strings.Cut(file, ".partial"); partial {
+			if keep[filepath.Base(targetFile)] && !osutil.FileExists(targetFile) {
+				// only keep the partial file if the target does not exist yet
+				continue
+			}
+		}
+
 		if rmErr := maybeRemoveSnapDownload(file); rmErr != nil {
 			// continue deletion, report error in the end
 			err = rmErr

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -4097,23 +4097,33 @@ func downloadsToKeep(st *state.State) (map[string]bool, error) {
 	}
 
 	var downloadsToKeep map[string]bool
-	keep := func(name string, rev snap.Revision) {
+
+	keepBlob := func(blobPath string) {
+		if blobPath == "" {
+			return
+		}
+
 		if downloadsToKeep == nil {
 			downloadsToKeep = make(map[string]bool)
 		}
-		downloadsToKeep[fmt.Sprintf("%s_%s.snap", name, rev)] = true
+		downloadsToKeep[filepath.Base(blobPath)] = true
 	}
 
 	// keep revisions in snap's sequence
 	for snapName, snapst := range snapStates {
-		for _, si := range snapst.Sequence.SideInfos() {
-			keep(snapName, si.Revision)
+		for _, rss := range snapst.Sequence.Revisions {
+			keepBlob(snap.MountFile(snapName, rss.Snap.Revision))
+			for _, comp := range rss.Components {
+				cpi := snap.MinimalComponentContainerPlaceInfo(comp.SideInfo.Component.ComponentName,
+					comp.SideInfo.Revision, snapName)
+				keepBlob(cpi.MountFile())
+			}
 		}
 	}
 
 	// keep revisions in refresh hints
 	for snapName, hint := range refreshHints {
-		keep(snapName, hint.Revision())
+		keepBlob(snap.MountFile(snapName, hint.Revision()))
 	}
 
 	// keep revisions pointed to by a download task in an ongoing change
@@ -4122,14 +4132,30 @@ func downloadsToKeep(st *state.State) (map[string]bool, error) {
 			continue
 		}
 		for _, t := range chg.Tasks() {
-			if t.Kind() != "download-snap" {
-				continue
+			switch t.Kind() {
+			case "download-snap":
+				snapsup, err := TaskSnapSetup(t)
+				if err != nil {
+					return nil, err
+				}
+
+				keepBlob(snapsup.BlobPath())
+			case "download-component":
+				compsup, snapsup, err := TaskComponentSetup(t)
+				if err != nil {
+					return nil, err
+				}
+				keepBlob(snapsup.BlobPath())
+				// component download sets CompPath at some point when the
+				// download task runs, which may, or may not have run already.
+				if compsup.CompPath == "" {
+					cpi := snap.MinimalComponentContainerPlaceInfo(compsup.ComponentName(),
+						compsup.Revision(), snapsup.InstanceName())
+					keepBlob(cpi.MountFile())
+				} else {
+					keepBlob(compsup.CompPath)
+				}
 			}
-			snapsup, err := TaskSnapSetup(t)
-			if err != nil {
-				return nil, err
-			}
-			keep(snapsup.InstanceName(), snapsup.Revision())
 		}
 	}
 
@@ -4162,14 +4188,29 @@ var cleanDownloads = func(st *state.State) error {
 		return err
 	}
 
-	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*.snap"))
-	if err != nil {
-		return err
+	var blobs []string
+	for _, pattern := range []string{
+		"*.snap", "*.snap.partial", // snaps
+		"*.comp", "*.comp.partial", // and their components
+	} {
+		matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, pattern))
+		if err != nil {
+			return err
+		}
+		blobs = append(blobs, matches...)
 	}
-	for _, file := range matches {
+
+	for _, file := range blobs {
 		if keep[filepath.Base(file)] {
 			continue
 		}
+
+		if targetFile, _, partial := strings.Cut(file, ".partial"); partial {
+			if keep[filepath.Base(targetFile)] {
+				continue
+			}
+		}
+
 		if rmErr := maybeRemoveSnapDownload(file); rmErr != nil {
 			// continue deletion, report error in the end
 			err = rmErr

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12081,11 +12081,15 @@ func (s *snapmgrTestSuite) TestCleanDownloads(c *C) {
 
 	// check that we delete leftovers of non-existing snaps
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
+	// revision not in sequence should be removed
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), nil, 0644), IsNil)
+	// both files will be kept as revisions are present in the state
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), nil, 0644), IsNil)
+	// all of the rest goes away
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-yet-another-snap_1.snap.partial"), nil, 0644), IsNil)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -12101,14 +12105,13 @@ func (s *snapmgrTestSuite) TestCleanDownloads(c *C) {
 
 	err := snapstate.CleanDownloads(s.state)
 	c.Check(err, IsNil)
-	// leftovers from non-existing snaps should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), testutil.FileAbsent)
-	// revision not in sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
@@ -12122,6 +12125,7 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-yet-another-snap_1.snap.partial"), nil, 0644), IsNil)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -12141,11 +12145,16 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 	err := snapstate.CleanDownloads(s.state)
 	c.Check(err, IsNil)
 	// all snaps will be kept because retention period is still going
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-yet-another-snap_1.snap.partial"),
+	})
 
 	// simulate retention period passed
 	restore = snapstate.MockMaxUnusedDownloadRetention(0)
@@ -12153,14 +12162,85 @@ func (s *snapmgrTestSuite) TestCleanDownloadsKeepsNewDownloads(c *C) {
 
 	err = snapstate.CleanDownloads(s.state)
 	c.Check(err, IsNil)
-	// leftovers from non-existing snaps should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), testutil.FileAbsent)
-	// revision not in sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+
+	matches, err = filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		// revisions in sequence should be kept
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+	})
+}
+
+func (s *snapmgrTestSuite) TestCleanDownloadsKeepsPendingDownloads(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// check that we delete leftovers of non-existing snaps
+	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "other-snap_11.snap.partial"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap+standard-component_3.comp.partial"), nil, 0644), IsNil)
+
+	chgSnap := s.state.NewChange("install", "install a snap")
+	ts, err := snapstate.Install(context.Background(), s.state, "other-snap", nil, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chgSnap.AddAll(ts)
+
+	snapRev := snap.R(1)
+	compName := "standard-component"
+	info := createTestSnapInfoForComponent(c, "some-snap", snapRev, compName)
+
+	setStateWithOneSnap(s.state, "some-snap", snapRev)
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		return []store.SnapResourceResult{{
+			DownloadInfo: snap.DownloadInfo{
+				DownloadURL: "http://example.com/" + compName,
+			},
+			Name:      compName,
+			Revision:  3,
+			Type:      "component/standard",
+			Version:   "1.0",
+			CreatedAt: "2024-01-01T00:00:00Z",
+		}}
+	}
+
+	chgComp := s.state.NewChange("install", "install a component")
+	tss, err := snapstate.InstallComponents(context.Background(), s.state,
+		[]string{compName}, info, nil, snapstate.Options{UserID: s.user.ID})
+	c.Assert(err, IsNil)
+	for _, ts := range tss {
+		chgComp.AddAll(ts)
+	}
+
+	restore := snapstate.MockMaxUnusedDownloadRetention(0)
+	defer restore()
+
+	err = snapstate.CleanDownloads(s.state)
+	c.Check(err, IsNil)
+	// the partial file is kept as we have a pending operation, other files are gone
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		filepath.Join(dirs.SnapBlobDir, "other-snap_11.snap.partial"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap+standard-component_3.comp.partial"),
+	})
+
+	// abort both changes, making partial files no longer needed
+	chgSnap.Abort()
+	c.Check(chgSnap.IsReady(), Equals, true)
+
+	chgComp.Abort()
+	c.Check(chgComp.IsReady(), Equals, true)
+
+	// clean again, the partial file should be removed
+	err = snapstate.CleanDownloads(s.state)
+	c.Check(err, IsNil)
+	// all snaps will be kept because retention period is still going
+	matches, err = filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, HasLen, 0)
 }
 
 func (s *snapmgrTestSuite) TestRefreshInhibitProceedTime(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4003,7 +4003,7 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 	}
 
 	// prevent removing snap file
-	defer snapstate.MockEnsuredDownloadsCleaned(s.snapmgr, true)()
+	snapstate.SetEnsuredDownloadsCleanedNext(s.snapmgr, time.Now().Add(time.Hour))
 
 	defer snapstate.MockLocalInstallCleanupWait(200 * time.Millisecond)()
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0700), IsNil)
@@ -10712,11 +10712,8 @@ Exec=%s/test-snap
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateDownloadsCleanedBlockedOnSeeding(c *C) {
-	restore := snapstate.MockEnsuredDownloadsCleaned(s.snapmgr, false)
-	defer restore()
-
 	called := 0
-	restore = snapstate.MockCleanDownloads(func(st *state.State) error {
+	restore := snapstate.MockCleanDownloads(func(st *state.State) error {
 		called++
 		return nil
 	})
@@ -10735,7 +10732,17 @@ func (s *snapmgrTestSuite) TestEnsureSnapStateDownloadsCleanedBlockedOnSeeding(c
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateDownloadsCleaned(c *C) {
-	restore := snapstate.MockEnsuredDownloadsCleaned(s.snapmgr, false)
+	start := snapstate.GetEnsuredDownloadsCleanedNext(s.snapmgr)
+	c.Check(start.IsZero(), Equals, true)
+
+	now := time.Now()
+	restore := snapstate.MockTimeNow(func() time.Time {
+		return now
+	})
+	defer restore()
+
+	mockedRetention := 4 * time.Hour
+	restore = snapstate.MockMaxUnusedDownloadRetention(mockedRetention)
 	defer restore()
 
 	called := 0
@@ -10745,13 +10752,32 @@ func (s *snapmgrTestSuite) TestEnsureSnapStateDownloadsCleaned(c *C) {
 	})
 	defer restore()
 
+	c.Check(s.snapmgr.Ensure(), Equals, nil)
+
+	// called once
+	c.Check(called, Equals, 1)
+
 	// simulate ensure called many times
 	for i := 0; i < 5; i++ {
 		c.Check(s.snapmgr.Ensure(), Equals, nil)
 	}
 
-	// system-wide snap downloads cleaning should only run once
-	c.Check(called, Equals, 1)
+	// check that next is set reasonably
+	next := snapstate.GetEnsuredDownloadsCleanedNext(s.snapmgr)
+	c.Check(next, Equals, now.Add(mockedRetention/4))
+
+	restore = snapstate.MockTimeNow(func() time.Time {
+		return next.Add(time.Second)
+	})
+	defer restore()
+
+	c.Check(s.snapmgr.Ensure(), Equals, nil)
+
+	// called again
+	c.Check(called, Equals, 2)
+
+	next2 := snapstate.GetEnsuredDownloadsCleanedNext(s.snapmgr)
+	c.Check(next2.Equal(next.Add(time.Second).Add(mockedRetention/4)), Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -204,6 +204,9 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 		refreshRevnos:       make(map[string]snap.Revision),
 		idsToNames:          make(map[string]string),
 		namesToAssertedIDs:  make(map[string]string),
+		expectedDefaultDownloadOpts: &store.DownloadOptions{
+			LeavePartialOnError: true,
+		},
 	}
 
 	// make tests work consistently also in containers

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -11873,6 +11873,7 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsSequences(c *C) {
 	defer restore()
 
 	initSnapDownloads(c, []snap.Revision{snap.R(1), snap.R(1111), snap.R(2), snap.R(3)})
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_5.snap.partial"), nil, 0644), IsNil)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -11888,12 +11889,14 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsSequences(c *C) {
 
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// revision not in sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1111.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	// revisions not in sequence or partial downloads should be removed
+	c.Check(matches, DeepEquals, []string{
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanSnapDownloadsRefreshHint(c *C) {
@@ -11904,6 +11907,9 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsRefreshHint(c *C) {
 	defer restore()
 
 	initSnapDownloads(c, []snap.Revision{snap.R(1), snap.R(11111), snap.R(2), snap.R(3), snap.R(4)})
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "other-snap_4.snap"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "other-snap_5.snap.partial"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "other-snap_6.snap.partial"), nil, 0644), IsNil)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -11913,6 +11919,16 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsRefreshHint(c *C) {
 			},
 		},
 		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
+				{Snap: &snap.SideInfo{RealName: "other-snap", SnapID: "other-snap-id", Revision: snap.R(4)}},
+			},
+		},
+		Current:  snap.R(4),
 		SnapType: "app",
 	})
 	refreshHints := map[string]*snapstate.RefreshCandidate{
@@ -11925,19 +11941,52 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsRefreshHint(c *C) {
 				},
 			},
 		},
+		"other-snap": {
+			SnapSetup: snapstate.SnapSetup{
+				Type: "app",
+				SideInfo: &snap.SideInfo{
+					RealName: "other-snap",
+					Revision: snap.R(5),
+				},
+			},
+		},
 	}
 	s.state.Set("refresh-candidates", refreshHints)
 
+	// check the first snap
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// revisions not in refresh hint or sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_11111.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
-	// revisions in refresh hint should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_4.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	// revisions of some-snap not in refresh hint or sequence should be removed
+	c.Check(matches, DeepEquals, []string{
+		// other snaps are untouched
+		filepath.Join(dirs.SnapBlobDir, "other-snap_4.snap"),
+		filepath.Join(dirs.SnapBlobDir, "other-snap_5.snap.partial"),
+		filepath.Join(dirs.SnapBlobDir, "other-snap_6.snap.partial"),
+
+		// exists in sequence
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+		// fully downloaded revision in refresh hint
+		filepath.Join(dirs.SnapBlobDir, "some-snap_4.snap"),
+	})
+
+	// and now the other snap
+	err = snapstate.CleanSnapDownloads(s.state, "other-snap")
+	c.Check(err, IsNil)
+	matches, err = filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	// revisions of other-snap not in refresh hint or sequence should be removed
+	c.Check(matches, DeepEquals, []string{
+		// revisions in sequence should be kept
+		filepath.Join(dirs.SnapBlobDir, "other-snap_4.snap"),
+		// as well as partial downloads of snaps in refresh hints
+		filepath.Join(dirs.SnapBlobDir, "other-snap_5.snap.partial"),
+
+		// other snaps are untouched
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_4.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanSnapDownloadsOngoingChange(c *C) {
@@ -11983,14 +12032,15 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsOngoingChange(c *C) {
 
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// revisions in a finished change should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FileAbsent)
-	// revisions pointed to by a pre-download task don't count and should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FilePresent)
-	// revisions pointed to by a download task in an ongoing change should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_4.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	// revisions in a finished change, or pointed to by a pre-download task should be removed
+	c.Check(matches, DeepEquals, []string{
+		// revisions in sequence should be kept
+		filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"),
+		// revisions pointed to by a download task in an ongoing change should be kept
+		filepath.Join(dirs.SnapBlobDir, "some-snap_4.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanSnapDownloadsLocalRevisions(c *C) {
@@ -12016,11 +12066,13 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsLocalRevisions(c *C) {
 
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// revision not in sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_x1.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_x2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_x3.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		// revisions in sequence should be kept
+		filepath.Join(dirs.SnapBlobDir, "some-snap_x2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_x3.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanSnapDownloadsParallelInstalls(c *C) {
@@ -12033,7 +12085,6 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsParallelInstalls(c *C) {
 	// parallel install downloads
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_1_1.snap"), nil, 0644), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_2_2.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_3_x3.snap"), nil, 0644), IsNil)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -12046,13 +12097,38 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsParallelInstalls(c *C) {
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
+	snapstate.Set(s.state, "some-snap_1", &snapstate.SnapState{
+		Active: true,
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
+				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}},
+			},
+		},
+		Current:     snap.R(1),
+		SnapType:    "app",
+		InstanceKey: "1",
+	})
+	snapstate.Set(s.state, "some-snap_3", &snapstate.SnapState{
+		Active: true,
+		Sequence: sequence.SnapSequence{
+			Revisions: []*sequence.RevisionSideState{
+				{Snap: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(-3)}},
+			},
+		},
+		Current:     snap.R(-3),
+		SnapType:    "app",
+		InstanceKey: "3",
+	})
 
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// parallel installs should not be affected
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1_1.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3_x3.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		// parallel installs should not be affected
+		filepath.Join(dirs.SnapBlobDir, "some-snap_1_1.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3_x3.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanSnapDownloadsKeepsNewDownloads(c *C) {
@@ -12079,10 +12155,14 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsKeepsNewDownloads(c *C) {
 	err := snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
 	// all snaps will be kept because retention period is still going
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1111.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+	matches, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_1111.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+	})
 
 	// simulate retention period passed
 	restore = snapstate.MockMaxUnusedDownloadRetention(0)
@@ -12090,12 +12170,13 @@ func (s *snapmgrTestSuite) TestCleanSnapDownloadsKeepsNewDownloads(c *C) {
 
 	err = snapstate.CleanSnapDownloads(s.state, "some-snap")
 	c.Check(err, IsNil)
-	// revision not in sequence should be removed
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1.snap"), testutil.FileAbsent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_1111.snap"), testutil.FileAbsent)
-	// revisions in sequence should be kept
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), testutil.FilePresent)
-	c.Check(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), testutil.FilePresent)
+	matches, err = filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*"))
+	c.Assert(err, IsNil)
+	c.Check(matches, DeepEquals, []string{
+		// parallel installs should not be affected
+		filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"),
+		filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"),
+	})
 }
 
 func (s *snapmgrTestSuite) TestCleanDownloads(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12112,6 +12112,8 @@ func (s *snapmgrTestSuite) TestCleanDownloads(c *C) {
 	// both files will be kept as revisions are present in the state
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_2.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap"), nil, 0644), IsNil)
+	// unlikely but a duplicate of a fully downloaded snap
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-snap_3.snap.partial"), nil, 0644), IsNil)
 	// all of the rest goes away
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-snap_1.snap"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(dirs.SnapBlobDir, "some-other-other-snap_1.snap"), nil, 0644), IsNil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -12509,7 +12509,25 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(
 
 	// check that the auto-refresh was completed without asking the store for refresh info
 	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action"), Equals, 0)
-	c.Assert(s.fakeStore.downloads, HasLen, 2)
+	c.Assert(s.fakeBackend.ops.Count("storesvc-download"), Equals, 2)
+	c.Assert(s.fakeStore.downloads, DeepEquals, []fakeDownload{
+		{
+			name:   "foo",
+			target: filepath.Join(dirs.SnapBlobDir, "foo_2.snap"),
+			opts: &store.DownloadOptions{
+				Scheduled:           true,
+				LeavePartialOnError: true,
+			},
+		},
+		{
+			name:   "foo",
+			target: filepath.Join(dirs.SnapBlobDir, "foo_2.snap"),
+			opts: &store.DownloadOptions{
+				Scheduled:           true,
+				LeavePartialOnError: true,
+			},
+		},
+	})
 }
 
 func findChange(st *state.State, kind string) *state.Change {

--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -8,7 +8,12 @@ details: |
   an installed core (to install core).
 
 # only needs a test on classic
-systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-24.04-64]
+
+skip:
+    - reason: requires python3
+      if: |
+            not command -v python3
 
 prepare: |
 
@@ -63,11 +68,6 @@ restore: |
     systemctl stop tinyproxy || true
 
 execute: |
-    if ! command -v python3; then
-       echo "SKIP: need python3"
-       exit 0
-    fi
-
     # We need the tiny proxy just when snapd does not connect to the store through a real proxy
     PROXY="$HTTPS_PROXY"
     if [ "${SNAPD_USE_PROXY:-}" != true ]; then

--- a/tests/main/resume-partial-snap-downloads/task.yaml
+++ b/tests/main/resume-partial-snap-downloads/task.yaml
@@ -61,7 +61,7 @@ execute: |
     # This ensures some successful write chunks are delivered before the
     # connection is severed, leaving a meaningful partial file.
     kill_after=20971520
-    curl -s -X POST http://localhost:11028/debug \
+    curl --fail -s -X POST http://localhost:11028/debug \
         -d "{\"action\":\"kill-request\",\"kill-path\":\"/download/$snap_file\",\"kill-after\":$kill_after}"
 
     echo "First install attempt: expect failure due to interrupted download"
@@ -79,15 +79,16 @@ execute: |
     test "$partial_size" -gt 0
     test "$partial_size" -lt "$snap_size"
     echo "Partial download preserved: $partial_size bytes of $snap_size total"
+    birth_time="$(stat -c '%w' "$partial_path")"
+    mod_time="$(stat -c '%y' "$partial_path")"
+
+    # Reset error injection
+    curl --fail -s -X POST http://localhost:11028/debug \
+        -d "{\"action\":\"reset\"}"
 
     # Make sure the logs for the fakestore are not polluted by previous snapd download
     # retries starting from last cursor.
     cursor=$("$TESTSTOOLS"/journal-state get-last-cursor)
-    not "$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor" -u fakestore | MATCH "requested range for /download/$snap_file"
-
-    # Clear the kill rule so the next download completes fully
-    curl -s -X POST http://localhost:11028/debug \
-        -d "{\"action\":\"kill-request\",\"kill-path\":\"/download/$snap_file\",\"kill-after\":0}"
 
     echo "Second install attempt: expect success with resumed download"
     snap install test-snap-resume
@@ -98,3 +99,10 @@ execute: |
 
     # Verify snap is installed
     snap list test-snap-resume
+
+    complete_path="/var/lib/snapd/snaps/test-snap-resume_1.snap"
+    test -f "$complete_path"
+    complete_birth_time="$(stat -c '%w' "$complete_path")"
+    complete_mod_time="$(stat -c '%y' "$complete_path")"
+    test "$birth_time" = "$complete_birth_time"
+    test "$mod_time" != "$complete_mod_time"

--- a/tests/main/resume-partial-snap-downloads/task.yaml
+++ b/tests/main/resume-partial-snap-downloads/task.yaml
@@ -1,0 +1,100 @@
+summary: Check that snap download resumes after interruption
+
+details: |
+    Verify that when a snap download is interrupted mid-way, the partial
+    download file is preserved and the subsequent download attempt resumes
+    from where it left off using an HTTP Range header.
+
+    The test uses the fakestore debug endpoint to force-kill the TCP
+    connection after a configured number of bytes have been served,
+    simulating a network interruption during download.
+
+# ubuntu-14.04: systemd-run not supported
+systems: [-ubuntu-14.04*]
+
+kill-timeout: 5m
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+skip:
+    - reason: This test needs test keys to be trusted
+      if: |
+        [ "$TRUST_TEST_KEYS" = "false" ]
+
+restore: |
+    snap remove --purge test-snap-resume || true
+    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+    rm -rf test-snap test-snap-resume_1.0_all.snap
+    rm -f /var/lib/snapd/snaps/test-snap-resume_*.snap.partial
+
+debug: |
+    ls -la /var/lib/snapd/snaps/test-snap-resume_* 2>/dev/null || true
+    "$TESTSTOOLS"/journal-state get-log -u fakestore | tail -50 || true
+
+execute: |
+    "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+
+    # Create a snap large enough for partial download testing.
+    # The snap needs to span multiple HTTP write chunks (~32KB each)
+    # so the fakestore kill-after mechanism can interrupt mid-transfer.
+    mkdir -p test-snap/meta
+    cat > test-snap/meta/snap.yaml << 'EOF'
+    name: test-snap-resume
+    version: 1.0
+    summary: Test snap for download resume
+    description: A test snap with padding data for resume testing
+    EOF
+    # Using urandom data ensures squashfs cannot compress it away
+    dd if=/dev/urandom of=test-snap/data.bin bs=1M count=100 2>/dev/null
+    snap pack test-snap
+
+    snap_file="test-snap-resume_1.0_all.snap"
+    snap_size=$(stat -c %s "$snap_file")
+    echo "Snap file size: $snap_size"
+
+    "$TESTSTOOLS"/store-state make-snap-installable "$BLOB_DIR" "$snap_file"
+
+    # Tell the fakestore to kill the download connection after 20MB.
+    # This ensures some successful write chunks are delivered before the
+    # connection is severed, leaving a meaningful partial file.
+    kill_after=20971520
+    curl -s -X POST http://localhost:11028/debug \
+        -d "{\"action\":\"kill-request\",\"kill-path\":\"/download/$snap_file\",\"kill-after\":$kill_after}"
+
+    echo "First install attempt: expect failure due to interrupted download"
+    not snap install test-snap-resume
+
+    # Confirm the fakestore actually killed the connection
+    "$TESTSTOOLS"/journal-state get-log -u fakestore | MATCH "/download/$snap_file was force killed, quota exceeded"
+
+    # Verify a partial download file was preserved.
+    # The fakestore assigns revision 1 by default.
+    partial_path="/var/lib/snapd/snaps/test-snap-resume_1.snap.partial"
+    test -f "$partial_path"
+
+    partial_size=$(stat -c %s "$partial_path")
+    test "$partial_size" -gt 0
+    test "$partial_size" -lt "$snap_size"
+    echo "Partial download preserved: $partial_size bytes of $snap_size total"
+
+    # Make sure the logs for the fakestore are not polluted by previous snapd download
+    # retries starting from last cursor.
+    cursor=$("$TESTSTOOLS"/journal-state get-last-cursor)
+    not "$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor" -u fakestore | MATCH "requested range for /download/$snap_file"
+
+    # Clear the kill rule so the next download completes fully
+    curl -s -X POST http://localhost:11028/debug \
+        -d "{\"action\":\"kill-request\",\"kill-path\":\"/download/$snap_file\",\"kill-after\":0}"
+
+    echo "Second install attempt: expect success with resumed download"
+    snap install test-snap-resume
+
+    # Verify the fakestore received a Range header on the resumed download,
+    # confirming that snapd resumed from the partial file offset
+    "$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor" -u fakestore | MATCH "requested range for /download/$snap_file"
+
+    # Verify snap is installed
+    snap list test-snap-resume

--- a/tests/main/resume-partial-snap-downloads/task.yaml
+++ b/tests/main/resume-partial-snap-downloads/task.yaml
@@ -10,7 +10,9 @@ details: |
     simulating a network interruption during download.
 
 # ubuntu-14.04: systemd-run not supported
-systems: [-ubuntu-14.04*]
+# ubuntu-core: needs curl
+# TODO implement fakestore CLI for debug API calls
+systems: [-ubuntu-14.04*, -ubuntu-core-*]
 
 kill-timeout: 5m
 

--- a/tests/main/resume-partial-snap-downloads/task.yaml
+++ b/tests/main/resume-partial-snap-downloads/task.yaml
@@ -79,7 +79,7 @@ execute: |
     test "$partial_size" -gt 0
     test "$partial_size" -lt "$snap_size"
     echo "Partial download preserved: $partial_size bytes of $snap_size total"
-    birth_time="$(stat -c '%w' "$partial_path")"
+    partial_inode="$(stat -c '%i' "$partial_path")"
     mod_time="$(stat -c '%y' "$partial_path")"
 
     # Reset error injection
@@ -102,7 +102,8 @@ execute: |
 
     complete_path="/var/lib/snapd/snaps/test-snap-resume_1.snap"
     test -f "$complete_path"
-    complete_birth_time="$(stat -c '%w' "$complete_path")"
+    complete_inode="$(stat -c '%i' "$complete_path")"
     complete_mod_time="$(stat -c '%y' "$complete_path")"
-    test "$birth_time" = "$complete_birth_time"
+    # same inode proves, file was renamed, not removed an recreated
+    test "$partial_inode" = "$complete_inode"
     test "$mod_time" != "$complete_mod_time"


### PR DESCRIPTION
Keep the partial files if the download failed, so that we can resume from them if the action is retried.

Improve downloads cleanup to keep component files for ones that are
present in the state, or referenced by any pending changes.

Extend the code to keep track of partially downloaded
files (named *.snap.partial or *.comp.partial) and keep the ones that
are part of pending changes.

Related: SNAPDENG-36634

Solves LP: [2146337](https://bugs.launchpad.net/snapd/+bug/2146337)