### PR TITLE
strutil: remove obsolete FIXME in VersionCompare

### DIFF
--- a/strutil/version.go
+++ b/strutil/version.go
@@ -150,7 +150,6 @@ func compareSubversion(va, vb string) int {
 //	 0 if a equals b
 //	+1 if a is bigger than b
 func VersionCompare(va, vb string) (res int, err error) {
-	// FIXME: return err here instead
 	if !versionIsValid(va) {
 		return 0, fmt.Errorf("invalid version %q", va)
 	}


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

I have signed the Canonical CLA

This removes an obsolete FIXME comment in VersionCompare.

The function already correctly returns errors for invalid versions, so the comment is no longer accurate.

This reduces technical debt and avoids confusion.