### PR TITLE
many: test the root cause of issues when re-enabling the prompting notice backend

### DIFF
--- a/daemon/api_debug_features_test.go
+++ b/daemon/api_debug_features_test.go
@@ -38,7 +38,7 @@ type featuresDebugSuite struct {
 func (s *featuresDebugSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 	s.daemonWithOverlordMock()
-	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
+	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().NoticeManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
 	c.Assert(err, IsNil)
 	s.d.Overlord().AddManager(ifacemgr)
 }

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -380,7 +380,7 @@ func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	hookMgr, err := hookstate.Manager(st, runner)
 	c.Assert(err, IsNil)
 	overlord.AddManager(hookMgr)
-	ifaceMgr, err := ifacestate.Manager(st, hookMgr, runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(st, hookMgr, nil, runner, nil, nil)
 	c.Assert(err, IsNil)
 	overlord.AddManager(ifaceMgr)
 	overlord.AddManager(runner)

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -411,6 +411,7 @@ func (udb *userPromptDB) remove(id prompting.IDType) (*Prompt, error) {
 // called directly outside of a `time.AfterFunc` call which initializes the
 // timer for the user prompt DB when it is first created.
 func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
+	logger.Debugf("prompt timeout callback triggered")
 	pdb.mutex.Lock()
 	// We don't defer Unlock() since we may need to manually unlock later in
 	// the function in order to record a notice and send a reply without
@@ -420,6 +421,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	// expiration timer when the DB has been closed, since the timer will fire
 	// and do nothing.
 	if pdb.isClosed() {
+		logger.Debugf("prompt timeout callback returning early because prompt DB is closed")
 		pdb.mutex.Unlock()
 		return
 	}
@@ -433,6 +435,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 		// and the lock being released and subsequently acquired by this
 		// function. So reset the timer to activityTimeout, and do not
 		// purge prompts.
+		logger.Debugf("prompt timeout callback returning early because the timeout was reset before the callback acquired the DB lock")
 		udb.activityResetExpiration()
 		pdb.mutex.Unlock()
 		return
@@ -454,6 +457,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	pdb.mutex.Unlock()
 	data := map[string]string{"resolved": "expired"}
 	for _, p := range expiredPrompts {
+		logger.Debugf("calling notifyPrompt(%d, %s, %v)", user, p.ID, data)
 		pdb.notifyPrompt(user, p.ID, data)
 		p.sendReply(prompting.OutcomeDeny) // ignore any error, should not occur
 	}
@@ -715,7 +719,14 @@ func (pdb *PromptDB) HandleReadying(keyNamespace string) []string {
 		delete(pdb.requestMap, requestKey)
 		delete(pdb.pendingUnreceivedRequests, requestKey)
 		if !existingPrompts[entry.PromptID] {
+			// XXX: shouldn't we collect all the prompts which don't exist, then
+			// record a single notice each, rather than recording a notice for
+			// every request which mapped to a prompt which has had no matching
+			// requests re-received?
+			logger.Debugf("calling notifyPrompt(%d, %s, %v) because request %q was not re-received before readying", entry.UserID, entry.PromptID, data, requestKey)
 			pdb.notifyPrompt(entry.UserID, entry.PromptID, data)
+		} else {
+			logger.Debugf("not calling notifyPrompt(%d, %s, %v) for request %q because another request mapping to this prompt was re-received and the prompt was re-created", entry.UserID, entry.PromptID, data, requestKey)
 		}
 		// No need to send a reply to the request originator, since the request
 		// is gone. Also we can't, since there's no request to call Reply() on.
@@ -829,6 +840,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		existingPrompt.addRequest(request)
 		// Although the prompt itself has not changed from client POV,
 		// re-record a notice to re-notify clients to respond to this request.
+		logger.Debugf("calling notifyPrompt(%d, %s, %v) because new request %q matches existing prompt", metadata.User, existingPrompt.ID, nil, request.Key)
 		pdb.notifyPrompt(metadata.User, existingPrompt.ID, nil)
 		return existingPrompt, true, nil
 	}
@@ -871,6 +883,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		requests:    []*prompting.Request{request},
 	}
 	userEntry.add(prompt)
+	logger.Debugf("calling notifyPrompt(%d, %s, %v) because new prompt was created for request %q", metadata.User, promptID, nil, request.Key)
 	pdb.notifyPrompt(metadata.User, promptID, nil)
 	return prompt, false, nil
 }
@@ -1042,6 +1055,7 @@ func (pdb *PromptDB) Reply(user uint32, id prompting.IDType, outcome prompting.O
 	userEntry.remove(id)
 
 	data := map[string]string{"resolved": "replied"}
+	logger.Debugf("calling notifyPrompt(%d, %s, %v) because it received a direct reply", user, id, data)
 	pdb.notifyPrompt(user, id, data)
 	return prompt, nil
 }
@@ -1104,6 +1118,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		if !respond {
 			// No response necessary, though the prompt constraints were
 			// modified, so just record a notice for the prompt.
+			logger.Debugf("calling notifyPrompt(%d, %s, %v) because it was partially handled a new rule, but not resolved", metadata.User, prompt.ID, nil)
 			pdb.notifyPrompt(metadata.User, prompt.ID, nil)
 			continue
 		}
@@ -1143,6 +1158,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 
 		satisfiedPromptIDs = append(satisfiedPromptIDs, prompt.ID)
 		data := map[string]string{"resolved": "satisfied"}
+		logger.Debugf("calling notifyPrompt(%d, %s, %v) because prompt was satisfied by new rule", metadata.User, prompt.ID, data)
 		pdb.notifyPrompt(metadata.User, prompt.ID, data)
 	}
 	return satisfiedPromptIDs, nil

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -308,6 +308,7 @@ func (rdb *RuleDB) load() (retErr error) {
 		// The DB on disk was invalid, so drop every rule and start over
 		data := map[string]string{"removed": "dropped"}
 		for _, rule := range wrapped.Rules {
+			logger.Debugf("calling notifyRule(%d, %s, %v) because DB was invalid and all rules dropped", rule.User, rule.ID, data)
 			rdb.notifyRule(rule.User, rule.ID, data)
 		}
 		rdb.indexByID = make(map[prompting.IDType]int)
@@ -324,13 +325,16 @@ func (rdb *RuleDB) load() (retErr error) {
 		var data map[string]string
 		if expiredRules[rule.ID] {
 			data = expiredData
+			logger.Debugf("calling notifyRule(%d, %s, %v) because it was expired on load", rule.User, rule.ID, data)
 		} else if newID, exists := mergedRules[rule.ID]; exists {
 			data = map[string]string{
 				"removed":     "merged",
 				"merged-into": newID.String(),
 			}
+			logger.Debugf("calling notifyRule(%d, %s, %v) because it merged into rule %s on load", rule.User, rule.ID, data, newID)
 		} else if partiallyExpiredRules[rule.ID] {
 			// no-op, want to record notice with empty data
+			logger.Debugf("calling notifyRule(%d, %s, %v) on load because some (but not all) permissions were expired", rule.User, rule.ID, data)
 		} else {
 			// not expired or merged, so don't record notice
 			continue
@@ -759,11 +763,16 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 			// a new rule which overlaps with another rule which has partially
 			// expired.
 			continue
+
+			// XXX: shouldn't there be a notice recorded here?
 		}
 		_, err = rdb.removeRuleByID(ruleID)
 		// Error shouldn't occur. If it does, the rule was already removed.
 		if err == nil {
+			logger.Debugf("calling notifyRule(%d, %s, %v) because it was expired when another rule was added", maybeExpired.User, maybeExpired.ID, expiredData)
 			rdb.notifyRule(maybeExpired.User, maybeExpired.ID, expiredData)
+		} else {
+			logger.Debugf("not calling notifyRule(%d, %s, %v) because an error occurred when trying to remove the maybe expired rule", maybeExpired.User, maybeExpired.ID, expiredData)
 		}
 	}
 
@@ -1046,6 +1055,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 		return nil, fmt.Errorf("cannot add rule: %w", err)
 	}
 
+	logger.Debugf("calling notifyRule(%d, %s, %v) when the rule was first added", user, newRule.ID, nil)
 	rdb.notifyRule(user, newRule.ID, nil)
 	return newRule, nil
 }
@@ -1291,6 +1301,7 @@ func (rdb *RuleDB) RemoveRule(user uint32, id prompting.IDType) (*Rule, error) {
 	// rule was affected. We want the rule fully removed, so this is fine.
 
 	data := map[string]string{"removed": "removed"}
+	logger.Debugf("calling notifyRule(%d, %s, %v) when the rule was removed", user, id, data)
 	rdb.notifyRule(user, id, data)
 	return rule, nil
 }
@@ -1346,6 +1357,7 @@ func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) error {
 		rdb.removeRuleFromTree(rule)
 		// If error occurs, rule was still fully removed from tree, and no other
 		// rule was affected. We want the rule fully removed, so this is fine.
+		logger.Debugf("calling notifyRule(%d, %s, %v) when the rule was removed", user, rule.ID, data)
 		rdb.notifyRule(user, rule.ID, data)
 	}
 	return nil
@@ -1474,6 +1486,7 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 		return nil, err
 	}
 
+	logger.Debugf("calling notifyRule(%d, %s, %v) when the rule was patched", newRule.User, newRule.ID, nil)
 	rdb.notifyRule(newRule.User, newRule.ID, nil)
 	return newRule, nil
 }

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -20,6 +20,7 @@
 package requestrules_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -244,12 +245,22 @@ func (s *requestrulesSuite) testLoadError(c *C, expectedErr string, rules []*req
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
-	logErr := fmt.Errorf("%s", strings.TrimSpace(logbuf.String()))
-	c.Check(logErr, ErrorMatches, fmt.Sprintf(".*cannot load rule database: %s; using new empty rule database", expectedErr))
+	filtered := filterOutDebugLogs(logbuf)
+	c.Check(filtered, Matches, fmt.Sprintf(".*cannot load rule database: %s; using new empty rule database.*", expectedErr))
 	if checkWritten {
 		s.checkWrittenRuleDB(c, nil)
 	}
 	s.checkNewNoticesSimple(c, map[string]string{"removed": "dropped"}, rules...)
+}
+
+func filterOutDebugLogs(logbuf *bytes.Buffer) string {
+	var filteredLines []string
+	for _, logline := range strings.Split(logbuf.String(), "\n") {
+		if !strings.Contains(logline, "DEBUG") {
+			filteredLines = append(filteredLines, logline)
+		}
+	}
+	return strings.TrimSpace(strings.Join(filteredLines, "\n"))
 }
 
 func (s *requestrulesSuite) checkWrittenRuleDB(c *C, expectedRules []*requestrules.Rule) {
@@ -327,7 +338,7 @@ func (s *requestrulesSuite) TestLoadErrorUnmarshal(c *C) {
 	// unmarshal should catch invalid rule and exit before attempting to add.
 	rules := []*requestrules.Rule{good1, bad, good2}
 	s.writeRules(c, dbPath, rules)
-	s.testLoadError(c, `invalid interface: "foo".*`, nil, checkWritten)
+	s.testLoadError(c, `invalid interface: "foo"`, nil, checkWritten)
 }
 
 const ruleTemplatePathPattern = "/home/test/foo"
@@ -403,7 +414,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingID(c *C) {
 	s.writeRules(c, dbPath, rules)
 
 	checkWritten := true
-	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", prompting_errors.ErrRuleIDConflict), rules, checkWritten)
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v", prompting_errors.ErrRuleIDConflict), rules, checkWritten)
 }
 
 func setPermissionsOutcomeLifespanExpirationSession(c *C, rule *requestrules.Rule, permissions []string, outcome prompting.OutcomeType, lifespan prompting.LifespanType, expiration time.Time, userSessionID prompting.IDType) {
@@ -434,7 +445,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingPattern(c *C) {
 	s.writeRules(c, dbPath, rules)
 
 	checkWritten := true
-	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", prompting_errors.ErrRuleConflict), rules, checkWritten)
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v", prompting_errors.ErrRuleConflict), rules, checkWritten)
 }
 
 func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
@@ -469,7 +480,7 @@ func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	expectedWrittenRules := []*requestrules.Rule{good1, good2, good3}
 	s.checkWrittenRuleDB(c, expectedWrittenRules)
@@ -678,7 +689,7 @@ func (s *requestrulesSuite) TestLoadMergedRules(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	expectedWrittenRules := []*requestrules.Rule{expected1, expected2, expected3, expected4}
 	s.checkWrittenRuleDB(c, expectedWrittenRules)
@@ -759,7 +770,7 @@ func (s *requestrulesSuite) TestLoadHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
-	c.Check(logbuf.String(), HasLen, 0)
+	c.Check(filterOutDebugLogs(logbuf), HasLen, 0)
 
 	s.checkWrittenRuleDB(c, rules)
 	s.checkNewNotices(c, nil)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -716,7 +716,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(err, IsNil)
 	o.AddManager(snapmgr)
 
-	ifacemgr, err := ifacestate.Manager(st, nil, o.TaskRunner(), nil, nil)
+	ifacemgr, err := ifacestate.Manager(st, nil, nil, o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	o.AddManager(ifacemgr)
 	c.Assert(o.StartUp(), IsNil)

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -238,6 +238,7 @@ func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data
 		delete(ntb.idToNotice, expiredNotice.ID())
 	}
 
+	logger.Debugf("calling ntb.cond.Broadcast()")
 	ntb.cond.Broadcast()
 
 	logger.Debugf("successfully added notice with ID %s", noticeID)
@@ -332,6 +333,7 @@ func (ntb *noticeTypeBackend) simplifyFilter(filter *state.NoticeFilter) (simpli
 	}
 	if !filter.BeforeOrAt.IsZero() && !filter.After.IsZero() && !filter.After.Before(filter.BeforeOrAt) {
 		// No possible timestamp can satisfy both After and BeforeOrAt filters
+		logger.Debugf("no possible timestamp can satisfy both After and BeforeOrAt filters: %+v", filter)
 		return simplified, false
 	}
 	var keys []string
@@ -348,6 +350,7 @@ func (ntb *noticeTypeBackend) simplifyFilter(filter *state.NoticeFilter) (simpli
 		if len(keys) == 0 {
 			// There were keys specified in the original filter but none were
 			// viable, so it's impossible for notices to match this filter.
+			logger.Debugf("no possible keys from this backend can satisfy the Keys filter: %+v", filter)
 			return simplified, false
 		}
 	}
@@ -367,7 +370,7 @@ func (ntb *noticeTypeBackend) simplifyFilter(filter *state.NoticeFilter) (simpli
 // filter.
 func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*state.Notice {
 	var filteredNotices []*state.Notice
-	// Discard expired notices or those with last repeated timestamp before f.After (if given)
+	// Discard expired notices or those with last repeated timestamp <= f.After (if given)
 	for i, notice := range notices {
 		if notice.Expired(now) {
 			continue
@@ -380,6 +383,7 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 	}
 	if len(filteredNotices) == 0 {
 		// Never found a non-expired notice matching After filter
+		logger.Debugf("found no non-expired notices matching the After filter (skipped %d notices)", len(notices))
 		return nil
 	}
 	// Discard notices with last repeated timestamp after f.BeforeOrAt (if given).
@@ -395,11 +399,13 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 			}
 			allAfter = false
 			// Discard all notices with timestamps after this one
+			logger.Debugf("skipping notices with timestamp after that of %s: %v", filteredNotices[i].Key(), filteredNotices[i].LastRepeated())
 			filteredNotices = filteredNotices[:i+1]
 			break
 		}
 		if allAfter {
 			// All notices had timestamps after f.BeforeOrAt
+			logger.Debugf("all %d notices had timestamps after f.BeforeOrAt: %v", len(filteredNotices), f.BeforeOrAt)
 			return nil
 		}
 	}
@@ -407,6 +413,7 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 	// Now have non-expired notices matching After/BeforeOrAt filters.
 	// If filter has no keys, we're done.
 	if len(f.Keys) == 0 {
+		logger.Debugf("returning %d filtered notices as there is no Keys filter", len(filteredNotices))
 		return filteredNotices
 	}
 
@@ -421,6 +428,7 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 			break
 		}
 	}
+	logger.Debugf("returning %d filtered notices matching Keys filter", len(keyNotices))
 	return keyNotices
 }
 
@@ -453,6 +461,7 @@ func (ntb *noticeTypeBackend) doNotices(filter ntbFilter, now time.Time) []*stat
 	if filter.UserID != nil {
 		userNotices, ok := ntb.userNotices[*filter.UserID]
 		if !ok {
+			logger.Debugf("no notices exist in notice backend for UID: %d", *filter.UserID)
 			return nil
 		}
 		notices = append(notices, filter.filterNotices(userNotices, now)...)
@@ -469,8 +478,10 @@ func (ntb *noticeTypeBackend) doNotices(filter ntbFilter, now time.Time) []*stat
 	}
 	if nonEmptyUserNotices > 1 {
 		// Since we concatenated notices from multiple users, need to re-sort
+		logger.Debugf("found %d notices matching filter for %d users, re-sorting", len(notices), nonEmptyUserNotices)
 		state.SortNotices(notices)
 	}
+	logger.Debugf("found %d notices matching filter, all for the same user", len(notices))
 	return notices
 }
 
@@ -522,17 +533,20 @@ func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *st
 		ntb.rwmu.Lock()
 		defer ntb.rwmu.Unlock()
 
+		logger.Debugf("calling ntb.cond.Broadcast() because the context expired")
 		ntb.cond.Broadcast()
 	})
 	defer stop()
 
 	for {
 		// Wait until a new notice occurs or ctx is cancelled.
+		logger.Debugf("calling ntb.cond.Wait()")
 		ntb.cond.Wait()
 
 		// If ctx was cancelled, return the error.
 		ctxErr := ctx.Err()
 		if ctxErr != nil {
+			logger.Debugf("ctx was cancelled with error: %v", ctxErr)
 			return nil, ctxErr
 		}
 
@@ -540,16 +554,20 @@ func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *st
 		// Otherwise, check if there are now matching notices.
 		notices = ntb.doNotices(simplifiedFilter, now)
 		if len(notices) > 0 {
+			logger.Debugf("returning %d notices from BackendWaitNotices", len(notices))
 			return notices, nil
 		}
 
+		logger.Debugf("after ntb.cond.Wait() returned, no notices matched the filter")
 		if !simplifiedFilter.BeforeOrAt.IsZero() && now.After(simplifiedFilter.BeforeOrAt) {
 			// Since we just checked with the now timestamp and there were no
 			// matching notices, and any new notices must have a later timestamp
 			// after simplifiedFilter.BeforeOrAt, it's impossible for a new
 			// notice to match the filter.
+			logger.Noticef("it is impossible for new notices to match the BeforeOrAt filter")
 			return nil, nil
 		}
+		logger.Debugf("trying again")
 	}
 }
 

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -60,13 +60,24 @@ func newNoticeBackends(noticeMgr *notices.NoticeManager) (*noticeBackends, error
 		return nil, fmt.Errorf("cannot create interfaces requests run directory: %w", err)
 	}
 
+	if err := os.MkdirAll(dirs.SnapInterfacesRequestsStateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("cannot create interfaces requests state directory: %w", err)
+	}
+
+	// The prompting notice backend is more tightly coupled to the prompt/rule
+	// state, since they rely on the prompt/rule state providing unique IDs.
+	// Thus, store prompt/rule notice state in the same directory as the
+	// prompts/rules themselves.
+
+	// Store prompt notices alongside the prompt ID mapping, in the run dir.
 	path := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "prompt-notices.json")
 	promptNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsPromptNotice, promptNoticeNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	path = filepath.Join(dirs.SnapInterfacesRequestsRunDir, "rule-notices.json")
+	// Store rule notices alongside the rule state, in the state dir.
+	path = filepath.Join(dirs.SnapInterfacesRequestsStateDir, "rule-notices.json")
 	ruleNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsRuleUpdateNotice, ruleNoticeNamespace)
 	if err != nil {
 		return nil, err

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -244,6 +244,7 @@ func (m *InterfacesRequestsManager) listenerReadyForTheFirstTime() <-chan struct
 func (m *InterfacesRequestsManager) handleRequest(req *prompting.Request) error {
 	if req.UID == 0 {
 		// Deny any request for the root user
+		logger.Debugf("denied request from root user: %s", req.Key)
 		return req.Reply(nil)
 	}
 

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -86,33 +86,16 @@ type InterfacesRequestsManager struct {
 	listenerAlreadySignalled chan struct{}
 
 	askRequests chan *prompting.Request
-
-	notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error
-	notifyRule   func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 }
 
-func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
-	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyPrompt calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
-			Data: data,
-		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsPromptNotice, promptID.String(), &options)
-		return err
-	}
-	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyRule calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
-			Data: data,
-		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
-		return err
+func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr error) {
+	// First initialize notice backends to load notices from disk and allow
+	// prompting managers to record notices. Don't register the notice backends
+	// with the state until we're sure initialization was successful and
+	// prompting will be enabled.
+	noticeBackends, err := newNoticeBackends(noticeMgr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize prompting notice backend: %w", err)
 	}
 
 	listenerBackend, err := listenerRegister()
@@ -125,7 +108,7 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
-	promptsBackend, err := requestprompts.New(notifyPrompt)
+	promptsBackend, err := requestprompts.New(noticeBackends.promptBackend.addNotice)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request prompts backend: %w", err)
 	}
@@ -135,7 +118,7 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
-	rulesBackend, err := requestrules.New(notifyRule)
+	rulesBackend, err := requestrules.New(noticeBackends.ruleBackend.addNotice)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request rules backend: %w", err)
 	}
@@ -145,14 +128,19 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		}
 	}()
 
+	// Now that all prompting managers were successfully initialized, register
+	// the notice backends with the state as notice providers.
+	if err = noticeBackends.registerWithManager(noticeMgr); err != nil {
+		// This should never occur
+		return nil, fmt.Errorf("cannot register notice backends for prompting manager: %w", err)
+	}
+
 	m = &InterfacesRequestsManager{
 		listener:                 listenerBackend,
 		prompts:                  promptsBackend,
 		rules:                    rulesBackend,
 		listenerAlreadySignalled: make(chan struct{}),
 		askRequests:              make(chan *prompting.Request),
-		notifyPrompt:             notifyPrompt,
-		notifyRule:               notifyRule,
 	}
 
 	m.tomb.Go(m.run)

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/notices"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -86,16 +86,33 @@ type InterfacesRequestsManager struct {
 	listenerAlreadySignalled chan struct{}
 
 	askRequests chan *prompting.Request
+
+	notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error
+	notifyRule   func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 }
 
-func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr error) {
-	// First initialize notice backends to load notices from disk and allow
-	// prompting managers to record notices. Don't register the notice backends
-	// with the state until we're sure initialization was successful and
-	// prompting will be enabled.
-	noticeBackends, err := newNoticeBackends(noticeMgr)
-	if err != nil {
-		return nil, fmt.Errorf("cannot initialize prompting notice backend: %w", err)
+func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
+	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
+		// TODO: add some sort of queue so that notifyPrompt calls can return
+		// quickly without waiting for state lock and AddNotice() to return.
+		s.Lock()
+		defer s.Unlock()
+		options := state.AddNoticeOptions{
+			Data: data,
+		}
+		_, err := s.AddNotice(&userID, state.InterfacesRequestsPromptNotice, promptID.String(), &options)
+		return err
+	}
+	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
+		// TODO: add some sort of queue so that notifyRule calls can return
+		// quickly without waiting for state lock and AddNotice() to return.
+		s.Lock()
+		defer s.Unlock()
+		options := state.AddNoticeOptions{
+			Data: data,
+		}
+		_, err := s.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
+		return err
 	}
 
 	listenerBackend, err := listenerRegister()
@@ -108,7 +125,7 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		}
 	}()
 
-	promptsBackend, err := requestprompts.New(noticeBackends.promptBackend.addNotice)
+	promptsBackend, err := requestprompts.New(notifyPrompt)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request prompts backend: %w", err)
 	}
@@ -118,7 +135,7 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		}
 	}()
 
-	rulesBackend, err := requestrules.New(noticeBackends.ruleBackend.addNotice)
+	rulesBackend, err := requestrules.New(notifyRule)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request rules backend: %w", err)
 	}
@@ -128,19 +145,14 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		}
 	}()
 
-	// Now that all prompting managers were successfully initialized, register
-	// the notice backends with the state as notice providers.
-	if err = noticeBackends.registerWithManager(noticeMgr); err != nil {
-		// This should never occur
-		return nil, fmt.Errorf("cannot register notice backends for prompting manager: %w", err)
-	}
-
 	m = &InterfacesRequestsManager{
 		listener:                 listenerBackend,
 		prompts:                  promptsBackend,
 		rules:                    rulesBackend,
 		listenerAlreadySignalled: make(chan struct{}),
 		askRequests:              make(chan *prompting.Request),
+		notifyPrompt:             notifyPrompt,
+		notifyRule:               notifyRule,
 	}
 
 	m.tomb.Go(m.run)

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -49,7 +49,6 @@ func Test(t *testing.T) { TestingT(t) }
 type apparmorpromptingSuite struct {
 	testutil.BaseTest
 
-	st        *state.State
 	noticeMgr *notices.NoticeManager
 
 	defaultUser uint32
@@ -63,8 +62,8 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	s.st = state.New(nil)
-	s.noticeMgr = notices.NewNoticeManager(s.st)
+	st := state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(st)
 
 	s.defaultUser = 1000
 
@@ -93,7 +92,7 @@ func (s *apparmorpromptingSuite) TestNew(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -114,7 +113,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
@@ -131,7 +130,7 @@ func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -160,7 +159,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -176,7 +175,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	promptDB := mgr.PromptDB()
@@ -225,7 +224,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestDenyRoot(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Send request for root
@@ -249,7 +248,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	clientActivity := true
@@ -315,7 +314,7 @@ func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	req, replyChan := requestWithReplyChan(&prompting.Request{})
@@ -447,7 +446,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	_, prompt := s.simulateRequest(c, reqChan, mgr, &prompting.Request{}, false)
@@ -527,7 +526,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 	defer func() {
 		c.Check(mgr.Stop(), IsNil)
@@ -637,7 +636,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeSending(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	const (
@@ -689,7 +688,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	neverClose := make(chan struct{})
@@ -794,7 +793,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownViaChannelBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	snapdShuttingDown := make(chan struct{})
@@ -838,7 +837,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match read permission
@@ -904,7 +903,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add rule to match read permission
@@ -933,7 +932,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -976,7 +975,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -1031,7 +1030,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1103,7 +1102,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1169,7 +1168,7 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1264,7 +1263,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1358,7 +1357,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Requests with identical *original* abstract permissions are merged into
@@ -1431,7 +1430,7 @@ func (s *apparmorpromptingSuite) TestRules(c *C) {
 
 func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompting.InterfacesRequestsManager, rules []*requestrules.Rule) {
 	var err error
-	mgr, err = apparmorprompting.New(s.st)
+	mgr, err = apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	whenAdded := time.Now()
@@ -1551,7 +1550,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1636,7 +1635,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsReady(c *C) {
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1679,7 +1678,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsNotReady(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1726,7 +1725,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfN
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1771,7 +1770,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1842,7 +1841,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -2003,7 +2002,11 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	// Need a new noticeMgr each time so we can re-register backends with the same types
+	st := state.New(nil)
+	noticeMgr := notices.NewNoticeManager(st)
+
+	mgr, err := apparmorprompting.New(noticeMgr)
 	c.Assert(err, IsNil)
 
 	startChan := make(chan time.Time)

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -48,7 +49,7 @@ func Test(t *testing.T) { TestingT(t) }
 type apparmorpromptingSuite struct {
 	testutil.BaseTest
 
-	st *state.State
+	noticeMgr *notices.NoticeManager
 
 	defaultUser uint32
 }
@@ -61,7 +62,9 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	s.st = state.New(nil)
+	st := state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(st)
+
 	s.defaultUser = 1000
 
 	currSession := prompting.IDType(0x12345)
@@ -89,7 +92,7 @@ func (s *apparmorpromptingSuite) TestNew(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -110,7 +113,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
@@ -127,7 +130,7 @@ func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -156,7 +159,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -172,7 +175,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	promptDB := mgr.PromptDB()
@@ -221,7 +224,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestDenyRoot(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Send request for root
@@ -245,7 +248,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	clientActivity := true
@@ -267,8 +270,15 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 			Permissions: []string{"write"},
 		}
 		reqChan <- req
+		// Poke the prompts backend to ensure there's no timeout
+		_, err = mgr.Prompts(s.defaultUser, clientActivity)
+		c.Assert(err, IsNil)
 	}
-	time.Sleep(10 * time.Millisecond)
+	lastPromptID := prompting.IDType(1000).String()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	_, err = s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{lastPromptID}})
+	c.Assert(err, IsNil)
 
 	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
 	c.Assert(err, IsNil)
@@ -304,7 +314,7 @@ func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	req, replyChan := requestWithReplyChan(&prompting.Request{})
@@ -350,7 +360,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *prompting.R
 	// which should generate a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -436,7 +446,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	_, prompt := s.simulateRequest(c, reqChan, mgr, &prompting.Request{}, false)
@@ -516,7 +526,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 	defer func() {
 		c.Check(mgr.Stop(), IsNil)
@@ -560,7 +570,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	// Wait for a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -626,7 +636,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeSending(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	const (
@@ -678,7 +688,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	neverClose := make(chan struct{})
@@ -783,7 +793,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownViaChannelBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	snapdShuttingDown := make(chan struct{})
@@ -827,7 +837,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match read permission
@@ -874,22 +884,18 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 }
 
 func (s *apparmorpromptingSuite) checkRecordedPromptNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
 func (s *apparmorpromptingSuite) checkRecordedRuleUpdateNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsRuleUpdateNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
@@ -897,7 +903,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add rule to match read permission
@@ -926,7 +932,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -969,7 +975,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -1024,7 +1030,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1096,7 +1102,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1162,7 +1168,7 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1257,7 +1263,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1351,7 +1357,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Requests with identical *original* abstract permissions are merged into
@@ -1424,7 +1430,7 @@ func (s *apparmorpromptingSuite) TestRules(c *C) {
 
 func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompting.InterfacesRequestsManager, rules []*requestrules.Rule) {
 	var err error
-	mgr, err = apparmorprompting.New(s.st)
+	mgr, err = apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	whenAdded := time.Now()
@@ -1544,7 +1550,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1629,7 +1635,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsReady(c *C) {
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1672,7 +1678,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsNotReady(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1719,7 +1725,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfN
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1764,7 +1770,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1784,7 +1790,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	// Wait for a notice
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
@@ -1835,7 +1841,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1996,7 +2002,11 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.st)
+	// Need a new noticeMgr each time so we can re-register backends with the same types
+	st := state.New(nil)
+	noticeMgr := notices.NewNoticeManager(st)
+
+	mgr, err := apparmorprompting.New(noticeMgr)
 	c.Assert(err, IsNil)
 
 	startChan := make(chan time.Time)

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -49,6 +49,7 @@ func Test(t *testing.T) { TestingT(t) }
 type apparmorpromptingSuite struct {
 	testutil.BaseTest
 
+	st        *state.State
 	noticeMgr *notices.NoticeManager
 
 	defaultUser uint32
@@ -62,8 +63,8 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	st := state.New(nil)
-	s.noticeMgr = notices.NewNoticeManager(st)
+	s.st = state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(s.st)
 
 	s.defaultUser = 1000
 
@@ -92,7 +93,7 @@ func (s *apparmorpromptingSuite) TestNew(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	select {
@@ -113,7 +114,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
@@ -130,7 +131,7 @@ func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -159,7 +160,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -175,7 +176,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	promptDB := mgr.PromptDB()
@@ -224,7 +225,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestDenyRoot(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Send request for root
@@ -248,7 +249,7 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	clientActivity := true
@@ -314,7 +315,7 @@ func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	req, replyChan := requestWithReplyChan(&prompting.Request{})
@@ -446,7 +447,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	_, prompt := s.simulateRequest(c, reqChan, mgr, &prompting.Request{}, false)
@@ -526,7 +527,7 @@ func (s *apparmorpromptingSuite) testAskWithOutcome(c *C, outcome prompting.Outc
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 	defer func() {
 		c.Check(mgr.Stop(), IsNil)
@@ -636,7 +637,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeSending(c *C) {
 	_, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	const (
@@ -688,7 +689,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	neverClose := make(chan struct{})
@@ -793,7 +794,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownViaChannelBeforeReply(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	snapdShuttingDown := make(chan struct{})
@@ -837,7 +838,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match read permission
@@ -903,7 +904,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add rule to match read permission
@@ -932,7 +933,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -975,7 +976,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add deny rule to match read permission
@@ -1030,7 +1031,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1102,7 +1103,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1168,7 +1169,7 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1263,7 +1264,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1357,7 +1358,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Requests with identical *original* abstract permissions are merged into
@@ -1430,7 +1431,7 @@ func (s *apparmorpromptingSuite) TestRules(c *C) {
 
 func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompting.InterfacesRequestsManager, rules []*requestrules.Rule) {
 	var err error
-	mgr, err = apparmorprompting.New(s.noticeMgr)
+	mgr, err = apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	whenAdded := time.Now()
@@ -1550,7 +1551,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Add read request
@@ -1635,7 +1636,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsReady(c *C) {
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1678,7 +1679,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsNotReady(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	select {
@@ -1725,7 +1726,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfN
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1770,7 +1771,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -1841,7 +1842,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	mgr, err := apparmorprompting.New(s.noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	// Check that the prompts are not ready yet
@@ -2002,11 +2003,7 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
 	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
 
-	// Need a new noticeMgr each time so we can re-register backends with the same types
-	st := state.New(nil)
-	noticeMgr := notices.NewNoticeManager(st)
-
-	mgr, err := apparmorprompting.New(noticeMgr)
+	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
 
 	startChan := make(chan time.Time)

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
-	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -136,7 +135,7 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	}
 }
 
-func MockCreateInterfacesRequestsManager(new func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+func MockCreateInterfacesRequestsManager(new func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
 	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -135,7 +136,7 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	}
 }
 
-func MockCreateInterfacesRequestsManager(new func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+func MockCreateInterfacesRequestsManager(new func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
 	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -135,7 +136,7 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	}
 }
 
-func MockCreateInterfacesRequestsManager(new func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+func MockCreateInterfacesRequestsManager(new func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
 	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -431,7 +431,7 @@ apps:
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -504,7 +504,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -557,7 +557,7 @@ func (s *helpersSuite) TestProfileRegenerationDoesNotDelay(c *C) {
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -610,7 +610,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -840,7 +840,7 @@ func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
 	ovld := overlord.Mock()
 	st := ovld.State()
 	// manager
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	// installs the ifacemgr helper
 	err = mgr.StartUp()

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -185,7 +185,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.o.AddManager(hookMgr)
 
-	s.mgr, err = ifacestate.Manager(s.state, hookMgr, s.o.TaskRunner(), nil, nil)
+	s.mgr, err = ifacestate.Manager(s.state, hookMgr, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	s.o.AddManager(s.mgr)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/swfeats"
@@ -50,6 +51,9 @@ type deviceData struct {
 type InterfaceManager struct {
 	state *state.State
 	repo  *interfaces.Repository
+
+	// Notice Manager (because interfacesRequestsManager may be a notice backend)
+	noticeManager *notices.NoticeManager
 
 	udevMonMu           sync.Mutex
 	udevMon             udevmonitor.Interface
@@ -75,7 +79,7 @@ type InterfaceManager struct {
 
 // Manager returns a new InterfaceManager.
 // Extra interfaces can be provided for testing.
-func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
+func Manager(s *state.State, hookManager *hookstate.HookManager, noticeManager *notices.NoticeManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
 	delayedCrossMgrInit()
 
 	// NOTE: hookManager is nil only when testing.
@@ -87,6 +91,8 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	m := &InterfaceManager{
 		state: s,
 		repo:  interfaces.NewRepository(),
+		// noticeManager is stored to register future notice backends
+		noticeManager: noticeManager,
 		// note: enumeratedDeviceKeys is reset to nil when enumeration is done
 		enumeratedDeviceKeys: make(map[string]map[snap.HotplugKey]bool),
 		hotplugDevicePaths:   make(map[string][]deviceData),
@@ -600,16 +606,16 @@ var interfacesRequestsControlHandlerServicePresent = func(m *InterfaceManager) (
 // initInterfacesRequestsManager initializes the prompting backends which make
 // up the interfaces requests manager.
 //
+// Pass the notice manager to the backends so that they can be registered as
+// providers of prompting-related notices.
+//
 // This function should only be called if prompting is supported and enabled,
 // and at least one installed snap has a "snap-interfaces-requests-control"
 // connection with the "handler-service" attribute declared.
-//
-// The state lock must not be held when this function is called, so that
-// notices can be recorded if necessary.
 func (m *InterfaceManager) initInterfacesRequestsManager() error {
 	m.interfacesRequestsManagerMu.Lock()
 	defer m.interfacesRequestsManagerMu.Unlock()
-	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.noticeManager)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -615,7 +615,7 @@ var interfacesRequestsControlHandlerServicePresent = func(m *InterfaceManager) (
 func (m *InterfaceManager) initInterfacesRequestsManager() error {
 	m.interfacesRequestsManagerMu.Lock()
 	defer m.interfacesRequestsManagerMu.Unlock()
-	interfacesRequestsManager, err := createInterfacesRequestsManager(m.noticeManager)
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -615,7 +615,7 @@ var interfacesRequestsControlHandlerServicePresent = func(m *InterfaceManager) (
 func (m *InterfaceManager) initInterfacesRequestsManager() error {
 	m.interfacesRequestsManagerMu.Lock()
 	defer m.interfacesRequestsManagerMu.Unlock()
-	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.noticeManager)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -316,7 +316,7 @@ slots:
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
 }
 
-var fakeCreateInterfacesRequestsManager = func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+var fakeCreateInterfacesRequestsManager = func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 	return nil, nil
 }
 
@@ -397,7 +397,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -443,7 +443,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		c.Errorf("unexpectedly called m.initInterfacesRequestsManager")
 		createCount++
 		return fakeManager, nil
@@ -7438,7 +7438,7 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -7485,7 +7485,7 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -7526,7 +7526,7 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer restore()
 
 	createError := fmt.Errorf("custom error")
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return nil, createError
 	})
 	defer restore()
@@ -7563,7 +7563,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 	})
 	defer restore()
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return fakeManager, nil
 	})
 	defer restore()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
@@ -179,6 +180,7 @@ type interfaceManagerSuite struct {
 	o              *overlord.Overlord
 	state          *state.State
 	se             *overlord.StateEngine
+	noticeMgr      *notices.NoticeManager
 	privateMgr     *ifacestate.InterfaceManager
 	privateHookMgr *hookstate.HookManager
 	extraIfaces    []interfaces.Interface
@@ -244,6 +246,8 @@ func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
+
+	s.noticeMgr = notices.NewNoticeManager(s.state)
 
 	s.SetupAsserts(c, s.state, &s.BaseTest)
 
@@ -312,7 +316,7 @@ slots:
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
 }
 
-var fakeCreateInterfacesRequestsManager = func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+var fakeCreateInterfacesRequestsManager = func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 	return nil, nil
 }
 
@@ -341,7 +345,7 @@ func addForeignTaskHandlers(runner *state.TaskRunner) {
 
 func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 	if s.privateMgr == nil {
-		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
+		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.noticeMgr, s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
 		c.Assert(err, IsNil)
 		addForeignTaskHandlers(s.o.TaskRunner())
 		mgr.DisableUDevMonitor()
@@ -393,12 +397,8 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
-		// InterfacesRequestsManager may record notices during creation, so
-		// simulate it acquiring the state lock to do so.
-		s.Lock()
-		defer s.Unlock()
 		return fakeManager, nil
 	})
 	defer restore()
@@ -443,7 +443,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		c.Errorf("unexpectedly called m.initInterfacesRequestsManager")
 		createCount++
 		return fakeManager, nil
@@ -7438,13 +7438,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7485,13 +7485,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7526,12 +7526,12 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer restore()
 
 	createError := fmt.Errorf("custom error")
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return nil, createError
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7563,7 +7563,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 	})
 	defer restore()
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return fakeManager, nil
 	})
 	defer restore()
@@ -8806,7 +8806,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -8847,7 +8847,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -8883,7 +8883,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -316,7 +316,7 @@ slots:
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
 }
 
-var fakeCreateInterfacesRequestsManager = func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+var fakeCreateInterfacesRequestsManager = func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 	return nil, nil
 }
 
@@ -397,7 +397,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -443,7 +443,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		c.Errorf("unexpectedly called m.initInterfacesRequestsManager")
 		createCount++
 		return fakeManager, nil
@@ -7438,7 +7438,7 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -7485,7 +7485,7 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
@@ -7526,7 +7526,7 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer restore()
 
 	createError := fmt.Errorf("custom error")
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return nil, createError
 	})
 	defer restore()
@@ -7563,7 +7563,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 	})
 	defer restore()
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(st *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return fakeManager, nil
 	})
 	defer restore()

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -236,15 +237,19 @@ func (nm *NoticeManager) Notices(filter *state.NoticeFilter) []*state.Notice {
 	defer nm.rwMu.RUnlock()
 
 	backendsToCheck := nm.relevantBackendsForFilter(filter)
+	logger.Debugf("backendsToCheck for filter %+v: %#v", filter, backendsToCheck)
 	switch len(backendsToCheck) {
 	case 0:
 		// This should be impossible, since state is always an implicit backend
 		// if no other backend is registered for a given type.
+		logger.Debugf("WARNING: zero notice backends capable of matching filter: %+v", filter)
 		return nil
 	case 1:
+		logger.Debugf("one notice backend capable of matching filter %+v: %#v", filter, backendsToCheck[0])
 		return backendsToCheck[0].BackendNotices(filter)
 	}
 
+	logger.Debugf("multiple notice backends capable of matching filter %+v: %#v", filter, backendsToCheck)
 	now := time.Now()
 	return doNotices(backendsToCheck, filter, now)
 }
@@ -364,14 +369,19 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 	defer nm.rwMu.RUnlock()
 
 	backendsToCheck := nm.relevantBackendsForFilter(filter)
+	logger.Debugf("backendsToCheck for filter %+v: %#v", filter, backendsToCheck)
 	switch len(backendsToCheck) {
 	case 0:
 		// This should be impossible, since state is always an implicit backend
 		// if no other backend is registered for a given type.
+		logger.Debugf("WARNING: zero notice backends capable of matching filter: %+v", filter)
 		return nil, nil
 	case 1:
+		logger.Debugf("one notice backend capable of matching filter %+v: %#v", filter, backendsToCheck[0])
 		return backendsToCheck[0].BackendWaitNotices(ctx, filter)
 	}
+
+	logger.Debugf("multiple notice backends capable of matching filter %+v: %#v", filter, backendsToCheck)
 
 	now := time.Now()
 
@@ -381,6 +391,7 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 	// and then another backend recording a new notice.
 	notices := doNotices(backendsToCheck, filter, now)
 	if len(notices) > 0 {
+		logger.Debugf("found %d notices immediately when calling WaitNotices", len(notices))
 		return notices, nil
 	}
 
@@ -388,6 +399,7 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 		// Since each backend returned, none can create a notice with a
 		// timestamp before now, and since the original filter's Before field
 		// is <= now, no notices can be created matching the filter.
+		logger.Debugf("filter has Before filter set before now, so it's impossible to get matching notice")
 		return nil, nil
 	}
 
@@ -407,16 +419,19 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 		// error, which we'll handle below.
 		backendNotices, _ := bknd.BackendWaitNotices(backendCtx, filter)
 		if len(backendNotices) == 0 {
+			logger.Debugf("backend returned no notices from BackendWaitNotices with filter %+v: %#v", filter, bknd)
 			return
 		}
 		select {
 		case noticesChan <- backendNotices:
 			// Successfully sent notices back to caller. Cancel any of the other
 			// goroutinues that are inside of BackendWaitNotices
+			logger.Debugf("backend returned notices, so calling cancel(): %#v", bknd)
 			cancel()
 		default:
 			// This channel was already full, so we know that another backend
 			// already wrote some notices to the channel.
+			logger.Debugf("backend failed to write backendNotices to noticeChan, likely because the channel is already full: %#v", bknd)
 		}
 	}
 
@@ -445,6 +460,7 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 
 	// Get the last repeated timestamp of the newest received notice
 	lastRepeated := notices[len(notices)-1].LastRepeated()
+	logger.Debugf("lastRepeated timestamp from %d notices: %v", len(notices), lastRepeated)
 
 	// Re-query all backends for any notices which occurred before or at the
 	// last repeated timestamp.

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -369,7 +369,7 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 	defer nm.rwMu.RUnlock()
 
 	backendsToCheck := nm.relevantBackendsForFilter(filter)
-	logger.Debugf("backendsToCheck for filter %+v: %#v", filter, backendsToCheck)
+	logger.Debugf("%d backendsToCheck for filter %+v: %#v", len(backendsToCheck), filter, backendsToCheck)
 	switch len(backendsToCheck) {
 	case 0:
 		// This should be impossible, since state is always an implicit backend
@@ -377,11 +377,9 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 		logger.Debugf("WARNING: zero notice backends capable of matching filter: %+v", filter)
 		return nil, nil
 	case 1:
-		logger.Debugf("one notice backend capable of matching filter %+v: %#v", filter, backendsToCheck[0])
+		logger.Debugf("one notice backend capable of matching filter %+v: %T", filter, backendsToCheck[0])
 		return backendsToCheck[0].BackendWaitNotices(ctx, filter)
 	}
-
-	logger.Debugf("multiple notice backends capable of matching filter %+v: %#v", filter, backendsToCheck)
 
 	now := time.Now()
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -184,7 +184,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 	o.addManager(assertMgr)
 
-	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.noticeMgr, o.runner, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/snapcore/snapd/logger"
 )
 
 const (
@@ -391,6 +393,8 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	s.noticesMu.Lock()
 	defer s.noticesMu.Unlock()
 
+	logger.Debugf("called AddNotice(%v, %s, %s, %v)", userID, noticeType, key, options.Data)
+
 	now := options.Time
 	if now.IsZero() {
 		now = s.NextNoticeTimestamp()
@@ -403,17 +407,21 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	if !ok {
 		// First occurrence of this notice userID+type+key
 		s.lastNoticeId++
+		logger.Debugf("calling NewNotice(%s, %d, %s, %s, ...)", strconv.Itoa(s.lastNoticeId), userID, noticeType, key)
 		notice = NewNotice(strconv.Itoa(s.lastNoticeId), userID, noticeType, key, now, options.Data, options.RepeatAfter, defaultNoticeExpireAfter)
 		s.notices[uniqueKey] = notice
 		newOrRepeated = true
 	} else {
 		// Additional occurrence, update existing notice
+		logger.Debugf("calling notice.Reoccur() for notice with ID %s", notice.ID())
 		newOrRepeated = notice.Reoccur(now, options.Data, options.RepeatAfter)
 	}
 
 	if newOrRepeated {
+		logger.Debugf("calling s.noticeCond.Broadcast()")
 		s.noticeCond.Broadcast()
 	}
+	logger.Debugf("successfully added notice with ID %s", notice.ID())
 
 	return notice.id, nil
 }
@@ -569,6 +577,7 @@ func (s *State) Notices(filter *NoticeFilter) []*Notice {
 func (s *State) doNotices(filter *NoticeFilter) []*Notice {
 	notices := s.filterNotices(filter)
 	SortNotices(notices)
+	logger.Debugf("returning %d notices from doNotices", len(notices))
 	return notices
 }
 
@@ -680,6 +689,7 @@ func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notic
 		s.noticesMu.Lock()
 		defer s.noticesMu.Unlock()
 
+		logger.Debugf("calling s.noticeCond.Broadcast() because the context expired")
 		s.noticeCond.Broadcast()
 	})
 	defer stop()
@@ -693,6 +703,7 @@ func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notic
 		// notices which match the filter.
 		now := time.Now()
 		if !filter.futureNoticesPossible(now) {
+			logger.Debugf("it is impossible for new notices to match the BeforeOrAt filter")
 			return nil, nil
 		}
 
@@ -700,19 +711,23 @@ func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notic
 		// This unlocks noticeCond.L, so for this reason, it is essential that
 		// noticeCond.L is noticesMu.RLocker, since that is what we hold during
 		// this function call.
+		logger.Debugf("calling s.noticeCond.Wait()")
 		s.noticeCond.Wait()
 
 		// If this context is cancelled, return the error.
 		ctxErr := ctx.Err()
 		if ctxErr != nil {
+			logger.Debugf("ctx was cancelled with error: %v", ctxErr)
 			return nil, ctxErr
 		}
 
 		// Otherwise check if there are now matching notices.
 		notices = s.doNotices(filter)
 		if len(notices) > 0 {
+			logger.Debugf("returning %d notices from WaitNotices", len(notices))
 			return notices, nil
 		}
+		logger.Debugf("after s.noticeCond.Wait() returned, no notices matched the filter; trying again")
 	}
 }
 

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -523,5 +523,6 @@ func (l *Listener[R]) encodeAndSendResponse(resp *notify.MsgNotificationResponse
 	}
 	ioctlBuf := notify.IoctlRequestBuffer(buf)
 	_, err = l.doIoctl(notify.APPARMOR_NOTIF_SEND, ioctlBuf)
+	logger.Debugf("sent response to the kernel with allowed permissions (%s): %+v", notify.FilePermission(resp.Allow), resp)
 	return err
 }

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -45,103 +45,10 @@ debug: |
 execute: |
     RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
 
-    echo "Since there is no user 1000 active on the system, write a user session ID"
-    echo "xattr to /run/user/1000/"
+    echo "Since there is no user 1000 active on the system, write a known user session ID xattr to /run/user/1000/"
     USER_SESSION_PATH="/run/user/1000"
     mkdir -p "$USER_SESSION_PATH"
     setfattr -n trusted.snapd_user_session_id -v "0123456789ABCDEF" "$USER_SESSION_PATH"
-
-    echo "Write three rules to disk, one of which is partially expired,"
-    echo "another is fully expired, and the last is not expired whatsoever"
-    mkdir -p "$(dirname $RULES_PATH)"
-    echo '{
-      "rules": [
-        {
-          "id": "0000000000000002",
-          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
-          "user": 1000,
-          "snap": "shellcheck",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Projects/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000003",
-          "timestamp": "2004-10-20T16:47:32.138415627-05:00",
-          "user": 1000,
-          "snap": "firefox",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/**",
-            "permissions": {
-              "read": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "2005-04-08T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "session-id": "F00BA4F00BA40000"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000005",
-          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
-          "user": 1000,
-          "snap": "thunderbird",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "session-id": "0123456789ABCDEF"
-              }
-            }
-          }
-        }
-      ]
-    }' | tee "$RULES_PATH"
-
-    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
-
-    # Wait a second to make sure any notices are recorded after CURRTIME
-    sleep 1
 
     echo "Enable AppArmor prompting experimental feature"
     snap set system experimental.apparmor-prompting=true
@@ -150,154 +57,212 @@ execute: |
     sleep 5
 
     echo "Check that snapd is able to start up"
-    retry --wait 1 -n 60 systemctl is-active snapd
-
-    echo "Check that apparmor prompting is supported and enabled"
-    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
-
-    # Write expected rules after the expired rule has been removed
-    echo '{
-      "rules": [
-        {
-          "id": "0000000000000002",
-          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
-          "user": 1000,
-          "snap": "shellcheck",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Projects/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              }
-            }
-          }
-        },
-        {
-          "id": "0000000000000005",
-          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
-          "user": 1000,
-          "snap": "thunderbird",
-          "interface": "home",
-          "constraints": {
-            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
-            "permissions": {
-              "read": {
-                "outcome": "allow",
-                "lifespan": "forever",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "write": {
-                "outcome": "allow",
-                "lifespan": "timespan",
-                "expiration": "9999-01-01T00:00:00Z",
-                "session-id": "0000000000000000"
-              },
-              "execute": {
-                "outcome": "deny",
-                "lifespan": "session",
-                "expiration": "0001-01-01T00:00:00Z",
-                "session-id": "0123456789ABCDEF"
-              }
-            }
-          }
-        }
-      ]
-    }' | gojq | tee expected.json
-    # Parse existing rules through (go)jq so they can be compared
-
-    if ! tests.info is-reexec-in-use && os.query is-ubuntu-ge 25.04; then
-        echo "Expect snapd to be built with go 1.24+, which supports omitzero,"
-        echo "so remove the zero-valued fields from the rules."
-        gojq 'del(.rules.[].constraints.permissions.[]."expiration" | select(. == "0001-01-01T00:00:00Z"))' < expected.json | \
-        gojq 'del(.rules.[].constraints.permissions.[]."session-id" | select(. == "0000000000000000"))' | tee expected-modified.json
-        mv expected-modified.json expected.json
-    fi
-
-    echo "Check that rules on disk match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
-
-    echo "Check that we received two notices, one of which marked a rule as expired"
-    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result' | grep -c '"removed": "expired"' | MATCH '^1$'
-    echo "One notice for rule with ID 0000000000000002, which was modified but not expired"
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000002" | \
-        gojq '.result | length' | MATCH '^1$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000002" | \
-        gojq '.result' | NOMATCH '"last-data"'
-    echo "One notice for rule with ID 0000000000000003, which expired"
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000003" | \
-        gojq '.result | length' | MATCH '^1$'
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000&keys=0000000000000003" | \
-        gojq '.result[0]."last-data".removed' | MATCH '"expired"'
-
-    echo "Check that only the first and last rules are still valid (must be done with UID 1000)"
-    snap debug api --fail "/v2/interfaces/requests/rules?user-id=1000" | gojq
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
-
-    echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
-
-    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
-
-    echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
-    echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
-    echo "Check that we received no new notices notices, as the non-expired rules did not change on restart"
+    echo "Add first rule (which we'll later modify manually to expire some permissions)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "shellcheck",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Projects/**",
+          "permissions": {
+            "read": {
+              "outcome": "allow",
+              "lifespan": "forever"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "timespan",
+              "duration": "100h"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE1_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE1_ID"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Add second rule (which we'll later modify manually to expire all permissions)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "firefox",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Downloads/**",
+          "permissions": {
+            "read": {
+              "outcome": "deny",
+              "lifespan": "timespan",
+              "duration": "15m"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "session"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api --fail -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE2_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE2_ID"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Add third rule (which we'll leave unchanged on disk)"
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "thunderbird",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
+          "permissions": {
+            "read": {
+              "outcome": "allow",
+              "lifespan": "forever"
+            },
+            "write": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            },
+            "execute": {
+              "outcome": "deny",
+              "lifespan": "session"
+            }
+          }
+        }
+      }
+    }' | gojq | snap debug api --fail -X POST '/v2/interfaces/requests/rules?user-id=1000' > result.json
+    MATCH '"status-code": 200' < result.json
+    RULE3_ID="$(gojq '.result.id' < result.json)"
+
+    echo "Check that we received a notice when the rule was added"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "$RULE3_ID"
+
+    echo "Stop snapd so we can edit rules on disk, and ensure it is not in failure mode"
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
+
+    echo "Edit the rules on disk to expire some permissions"
+    gojq '(.rules.[] | select(.id == '"$RULE1_ID"')).constraints.permissions.write.expiration = "2005-04-08T00:00:00Z"' < "$RULES_PATH" | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.read.expiration = "2005-04-08T00:00:00Z"' | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.write.expiration = "2005-04-08T00:00:00Z"' | \
+    gojq '(.rules.[] | select(.id == '"$RULE2_ID"')).constraints.permissions.execute."session-id" = "F00BA4F00BA40000"' | tee modified.json
+    mv modified.json "$RULES_PATH"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Enable snapd so it will remove the expired permissions and record notices"
+    systemctl enable --now snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that only the first and last rules are still valid (must be done with UID 1000)"
+    snap debug api --fail "/v2/interfaces/requests/rules?user-id=1000" | gojq
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
+
+    echo "Check that the expired permissions of the non-expired rules were removed"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE1_ID"') | .constraints.permissions | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE1_ID"') | .constraints.permissions.write' | MATCH 'null'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[] | select(.id == '"$RULE3_ID"') | .constraints.permissions | length' | MATCH '^3$'
+
+    echo "Check that we received two notices, one of which marked a rule as expired"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[].key' | MATCH "$RULE1_ID"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[].key' | MATCH "$RULE2_ID"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result' | grep -c '"removed": "expired"' | MATCH '^1$'
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result.[] | select(.key == '"$RULE2_ID"')' | MATCH '"removed": "expired"'
+
+    cp "$RULES_PATH" expected.json
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl enable --now snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk were not changed after snapd restart"
+    diff expected.json "$RULES_PATH"
+
+    echo "Check that only the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
+
+    echo "Check that we received no new notices since the rules were not changed on load"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result | length' | MATCH '^0$'
 
-    echo "Check that only the non-expired rules are still valid (must be done with UID 1000)"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
-
     echo '### Simulate failure to open interfaces requests manager ###'
 
     echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
 
     echo "Corrupt the max prompt ID file (by making it a dir) so it will fail to start up next time"
     # This simulates what would happen on system restart, if e.g. /run/snapd did not yet exist during StartUp
     MAX_ID_FILEPATH="/run/snapd/interfaces-requests/request-prompt-max-id"
-    rm -f "$MAX_ID_FILEPATH"
+    mv "$MAX_ID_FILEPATH" "$MAX_ID_FILEPATH".bak
     mkdir -p "$MAX_ID_FILEPATH"
 
     echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
+    systemctl enable --now snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
@@ -307,8 +272,7 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    diff expected.json "$RULES_PATH"
 
     echo "Check that accessing a prompting endpoint results in an expected error"
     snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '."status-code"' | MATCH '^500$'
@@ -317,18 +281,17 @@ execute: |
     echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
 
     echo "Stop snapd and ensure it is not in failure mode"
-    systemctl stop snapd.service snapd.socket
-    # Try for a while to make sure it's not in failure mode
-    echo "Check that systemctl is-failed is never true after a while"
-    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+    systemctl disable --now snapd.service snapd.socket
+    not retry --wait 1 -n 10 systemctl is-failed snapd.service snapd.socket
 
     echo "Remove corrupted max prompt ID file"
     rm -rf "$MAX_ID_FILEPATH"
+    mv "$MAX_ID_FILEPATH".bak "$MAX_ID_FILEPATH"
 
     CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
     echo "Restart snapd and ensure it starts properly"
-    systemctl start snapd.service snapd.socket
+    systemctl enable --now snapd.service snapd.socket
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
@@ -336,15 +299,14 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
-    gojq < "$RULES_PATH" > current.json
-    diff expected.json current.json
+    diff expected.json "$RULES_PATH"
+
+    echo "Check that the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE1_ID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.[].id' | MATCH "$RULE3_ID"
 
     echo "Check that we received no new notices, as the non-expired rules did not changed on restart"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result | length' | MATCH '^0$'
-
-    echo "Check that the non-expired rules are still valid (must be done with UID 1000)"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH '^2$'
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
-    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"

--- a/tests/nightly/prompting-client-integration-tests/task.yaml
+++ b/tests/nightly/prompting-client-integration-tests/task.yaml
@@ -32,6 +32,9 @@ prepare: |
 
     echo "Clone the prompting-client repo"
     git clone https://github.com/canonical/prompting-client
+    pushd prompting-client
+    git checkout 5039741f4cd5153af771eb3b07e1d29763019b2b
+    popd
 
     echo "Build the test snap"
     pushd prompting-client/testing-snap


### PR DESCRIPTION
This is a testing branch based on #16303 with extra logging and commits to easily enable/disable the prompting notice backend, and ensure that the tests are run with a `prompting-client` version which doesn't fix the original issue.

This PR should NOT be merged.