### PR TITLE
build-aux: update snapd to build-base core24

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 adopt-info: snapd
 # build-base is needed here for snapcraft to build this snap as with "modern"
 # snapcraft
-build-base: core22
+build-base: core24
 package-repositories:
   - type: apt
     ppa: snappy-dev/image
@@ -52,7 +52,7 @@ parts:
       - python3-pyelftools
       - xz-utils
     source: https://git.launchpad.net/ubuntu/+source/glibc
-    source-branch: ubuntu/jammy-updates
+    source-branch: ubuntu/noble-updates
     source-type: git
     <<:
       - &dynamic-linker


### PR DESCRIPTION
Update the dynamic linker to the one from noble as well, as the one from jammy doesn't like the newer libc and issues warnings.