### PR TITLE
wrappers: keep idle services with activation units stopped on reload

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1245,17 +1245,17 @@ func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices
 
 		var unitsToRestart []string
 
-		// If the service is activated, then we must also consider it's activators
-		// as long as we are not requesting a reload. For activated units reload
-		// is not a supported action. In that case treat it like a non-activated
-		// service.
-		if len(st.ActivatorUnitStatuses()) != 0 && !opts.Reload {
-			// Restart any activators first and operate normally on these
-			for _, act := range st.ActivatorUnitStatuses() {
-				// Use the primary name here for shouldRestart, as the caller
-				// will never refer directly to the sub-services.
-				if shouldRestart(act.Active, act.Enabled, unitName) {
-					unitsToRestart = append(unitsToRestart, act.Name)
+		// If the service is activated, then we must also consider its activators.
+		// On reload we skip activators and only operate on the active primary
+		// unit.
+		if len(st.ActivatorUnitStatuses()) != 0 {
+			if !opts.Reload {
+				for _, act := range st.ActivatorUnitStatuses() {
+					// Use the primary name here for shouldRestart, as the caller
+					// will never refer directly to the sub-services.
+					if shouldRestart(act.Active, act.Enabled, unitName) {
+						unitsToRestart = append(unitsToRestart, act.Name)
+					}
 				}
 			}
 
@@ -1287,15 +1287,16 @@ func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices
 	return nil
 }
 
-// Restart or reload active services in `svcs`.
-// If reload flag is set then "systemctl reload-or-restart" is attempted.
-// The services mentioned in `explicitServices` should be a subset of the
-// services in svcs. The services included in explicitServices are always
-// restarted, regardless of their state. The services in the `svcs` argument
-// are only restarted if they are active, so if a service is meant to be
-// restarted no matter it's state, it should be included in the
-// explicitServices list.
-// The list of explicitServices needs to use systemd unit names.
+// RestartServices restarts or reloads services in `svcs`. If reload flag is set
+// then "systemctl reload-or-restart" is attempted. For activated services,
+// reload skips activators and only applies to the active primary unit. The
+// services mentioned in `explicitServices` should be a subset of the services
+// in svcs. For ordinary services, entries in `explicitServices` are always
+// restarted regardless of their state. For activated services,
+// `explicitServices` and AlsoEnabledNonActive only affect activators; the
+// primary unit is still only restarted or reloaded when it is already active.
+// The list of `explicitServices` needs to use systemd unit names.
+//
 // TODO: change explicitServices format to be less unusual, more consistent
 // (introduce AppRef?)
 func RestartServices(apps []*snap.AppInfo, explicitServices []string,

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -5406,8 +5406,8 @@ apps:
 		{"start", srvFile1},
 	})
 
-	// Restart but with restarting non-active, this means that the activated services
-	// should be restarted now
+	// Restart but with restarting non-active. This restarts the activators for the
+	// activated service, but the inactive primary unit still stays stopped.
 	s.sysdLog = nil
 	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -5422,11 +5422,9 @@ apps:
 		{"start", srvFile2Sock1, srvFile2Sock2},
 	})
 
-	// Restart but also reload. When reloading we expect to see different behaviour.
-	// Reloading activated units is not supported by systemd, and for that reason they must
-	// not appear in the list of systemctl calls.
-	// The only call we expect to appear here is the primary service of svc1 as
-	// that one is the only one reported as active here.
+	// Restart but also reload. Reload skips activators, and idle activated
+	// services still keep their primary unit stopped. The only reload here is for
+	// svc1, which is the only primary unit reported active.
 	s.sysdLog = nil
 	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -5493,10 +5491,9 @@ apps:
 		{"start", srvFile2Sock1, srvFile2Sock2},
 	})
 
-	// Restart but with restarting non-active, which means that all services
-	// **except** for any activated service will restart  (svc2 primary unit).
-	// The activator service units should restart, but not the main one since
-	// it was reported as inactive
+	// Restart but with restarting non-active. The non-activated service restarts,
+	// and the activated service only restarts its activators because the primary
+	// unit was reported inactive.
 	s.sysdLog = nil
 	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -5511,10 +5508,8 @@ apps:
 		{"start", srvFile2Sock1, srvFile2Sock2},
 	})
 
-	// Restart but also reload. We do not expect any services to be restarted here as
-	// both the primary units are reported inactive. (Only the activation units are
-	// reported active). The reason we don't expect to see the activation units restarted
-	// when reloading, is that these units do not support reloading by systemd.
+	// Restart but also reload. The primary units are reported inactive, so they
+	// must stay stopped.
 	s.sysdLog = nil
 	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -5577,6 +5572,63 @@ apps:
 		{"show", "--property=ActiveState", srvFile2Sock2},
 		{"show", "--property=ActiveState", srvFile2},
 		{"start", srvFile2Sock1, srvFile2Sock2, srvFile2},
+	})
+
+	// Restart but also reload. Only the active primary unit should be
+	// reload-or-restarted.
+	s.sysdLog = nil
+	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
+		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
+		{"reload-or-restart", srvFile2},
+	})
+}
+
+func (s *servicesTestSuite) TestRestartWithActivatedServicesInactiveExplicitReload(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  svc1:
+    daemon: simple
+    plugs: [network-bind]
+    sockets:
+      sock1:
+        listen-stream: $SNAP_DATA/sock1.socket
+        socket-mode: 0666
+      sock2:
+        listen-stream: $SNAP_COMMON/sock2.socket
+`
+	srvFile1 := "snap.test-snap.svc1.service"
+	srvFile1Sock1 := "snap.test-snap.svc1.sock1.socket"
+	srvFile1Sock2 := "snap.test-snap.svc1.sock2.socket"
+
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		states := map[string]systemdtest.ServiceState{
+			srvFile1:      {ActiveState: "inactive", UnitFileState: "enabled"},
+			srvFile1Sock1: {ActiveState: "inactive", UnitFileState: "enabled"},
+			srvFile1Sock2: {ActiveState: "inactive", UnitFileState: "enabled"},
+		}
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, states); out != nil {
+			return out, nil
+		}
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	s.sysdLog = nil
+	services := info.Services()
+	sort.Sort(snap.AppInfoBySnapApp(services))
+	c.Assert(wrappers.RestartServices(services, []string{srvFile1}, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1},
+		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile1Sock1, srvFile1Sock2},
 	})
 }
 


### PR DESCRIPTION
When `RestartServicesOptions.Reload` is set, restart activation units, but only `reload-or-restart` the main service if it is currently active. This makes reload follow the existing non-reload behavior for services with activation units, avoiding startup of an idle main service.

This extends the behavior introduced in https://github.com/canonical/snapd/pull/14242 to also take effect when `--reload` is used.

Also related: https://github.com/canonical/snapd/pull/14724