### PR TITLE
o/i/apparmorprompting: improve unit test reliability on slow systems

### DIFF
--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -1111,7 +1111,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			key := prompting.IDType(i).String()
 			notices, err := ruleBackend.BackendWaitNotices(ctx, &state.NoticeFilter{Keys: []string{key}})
@@ -1133,7 +1133,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		close(done)
 	}()
 	select {
-	case <-time.After(100 * time.Second):
+	case <-time.After(10 * time.Second):
 		c.Fatalf("timed out waiting for BackendWaitNotices goroutines to finish")
 	case <-done:
 	}

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -1111,7 +1111,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
 			defer cancel()
 			key := prompting.IDType(i).String()
 			notices, err := ruleBackend.BackendWaitNotices(ctx, &state.NoticeFilter{Keys: []string{key}})
@@ -1133,7 +1133,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		close(done)
 	}()
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Second):
 		c.Fatalf("timed out waiting for BackendWaitNotices goroutines to finish")
 	case <-done:
 	}

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -1111,7 +1111,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.HostScaledTimeout(10*time.Second))
 			defer cancel()
 			key := prompting.IDType(i).String()
 			notices, err := ruleBackend.BackendWaitNotices(ctx, &state.NoticeFilter{Keys: []string{key}})
@@ -1133,7 +1133,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		close(done)
 	}()
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(testutil.HostScaledTimeout(15*time.Second)):
 		c.Fatalf("timed out waiting for BackendWaitNotices goroutines to finish")
 	case <-done:
 	}

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -1133,7 +1133,7 @@ func (s *noticebackendSuite) TestBackendWaitNoticesConcurrent(c *C) {
 		close(done)
 	}()
 	select {
-	case <-time.After(testutil.HostScaledTimeout(15*time.Second)):
+	case <-time.After(testutil.HostScaledTimeout(15 * time.Second)):
 		c.Fatalf("timed out waiting for BackendWaitNotices goroutines to finish")
 	case <-done:
 	}

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -265,6 +265,10 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 			Path:        fmt.Sprintf("/home/test/%d", i),
 			Interface:   "home",
 			Permissions: []string{"write"},
+			Reply: func([]string) error {
+				c.Error("unexpectedly called request.Reply()")
+				return errors.New("unexpectedly called request.Reply()")
+			},
 		}
 		reqChan <- req
 	}
@@ -287,6 +291,10 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 		Path:        fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
 		Interface:   "home",
 		Permissions: []string{"write"},
+		Reply: func([]string) error {
+			c.Error("unexpectedly called request.Reply()")
+			return errors.New("unexpectedly called request.Reply()")
+		},
 	})
 	reqChan <- req
 	allowedPermissions, err := waitForReply(replyChan)
@@ -342,7 +350,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *prompting.R
 	defer restore()
 
 	// Simulate request from the kernel
-	s.fillInPartialRequest(req)
+	s.fillInPartialRequest(c, req)
 	whenSent := time.Now()
 	// push a request
 	reqChan <- req
@@ -397,7 +405,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *prompting.R
 
 // fillInPartialRequest fills in any blank fields from the given request
 // with default non-empty values.
-func (s *apparmorpromptingSuite) fillInPartialRequest(req *prompting.Request) {
+func (s *apparmorpromptingSuite) fillInPartialRequest(c *C, req *prompting.Request) {
 	if req.PID == 0 {
 		req.PID = 1234
 	}
@@ -418,6 +426,12 @@ func (s *apparmorpromptingSuite) fillInPartialRequest(req *prompting.Request) {
 	}
 	if req.Permissions == nil {
 		req.Permissions = []string{"read"}
+	}
+	if req.Reply == nil {
+		req.Reply = func(allowedPerms []string) error {
+			c.Errorf("unexpectedly called request.Reply(%#v)", allowedPerms)
+			return fmt.Errorf("unexpectedly called request.Reply(%#v)", allowedPerms)
+		}
 	}
 }
 
@@ -850,7 +864,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	req, replyChan := requestWithReplyChan(&prompting.Request{
 		Permissions: []string{"read", "write"},
 	})
-	s.fillInPartialRequest(req)
+	s.fillInPartialRequest(c, req)
 	whenSent := time.Now()
 	reqChan <- req
 	time.Sleep(10 * time.Millisecond)
@@ -943,7 +957,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	req, replyChan := requestWithReplyChan(&prompting.Request{
 		Permissions: []string{"read", "write"},
 	})
-	s.fillInPartialRequest(req)
+	s.fillInPartialRequest(c, req)
 	whenSent := time.Now()
 	reqChan <- req
 	time.Sleep(10 * time.Millisecond)
@@ -992,7 +1006,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	req, replyChan := requestWithReplyChan(&prompting.Request{
 		Permissions: []string{"read", "write"},
 	})
-	s.fillInPartialRequest(req)
+	s.fillInPartialRequest(c, req)
 	whenSent := time.Now()
 	reqChan <- req
 	time.Sleep(10 * time.Millisecond)
@@ -1313,14 +1327,14 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	writeReq, writeReplyChan := requestWithReplyChan(&prompting.Request{
 		Permissions: []string{"write"},
 	})
-	s.fillInPartialRequest(writeReq)
+	s.fillInPartialRequest(c, writeReq)
 	reqChan <- writeReq
 
 	// Add request for read and write
 	rwReq, rwReplyChan := requestWithReplyChan(&prompting.Request{
 		Permissions: []string{"read", "write"},
 	})
-	s.fillInPartialRequest(rwReq)
+	s.fillInPartialRequest(c, rwReq)
 	reqChan <- rwReq
 
 	// Check that kernel received replies
@@ -1851,7 +1865,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 		Key: "kernel:2",
 		UID: 1000,
 	}
-	s.fillInPartialRequest(req)
+	s.fillInPartialRequest(c, req)
 	reqChan <- req
 
 	// Check that the prompts are not ready yet

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -291,10 +291,6 @@ func (s *apparmorpromptingSuite) TestHandleRequestErrors(c *C) {
 		Path:        fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
 		Interface:   "home",
 		Permissions: []string{"write"},
-		Reply: func([]string) error {
-			c.Error("unexpectedly called request.Reply()")
-			return errors.New("unexpectedly called request.Reply()")
-		},
 	})
 	reqChan <- req
 	allowedPermissions, err := waitForReply(replyChan)


### PR DESCRIPTION
Zygmunt hit some test failures on a heavily loaded system running tests in parallel: https://chat.canonical.com/canonical/pl/xxsnpotxbprfjpjdhywuzm74ir

This increases the concurrent notice backend test timeout and ensures that a `Reply` method is defined for `Request`s in unit tests, even when we don't expect a reply to be sent.
