### PR TITLE
github: fix spread-tests.yaml to allow for a large number of artifacts

### DIFF
--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -55,7 +55,7 @@ jobs:
               });
               allArtifacts = allArtifacts.concat(response.data.artifacts);
               page++;
-            } while (response.data.artifacts.length === per_page);
+            } while (allArtifacts.length < response.data.total_count);
             let matchArtifact = allArtifacts.filter((artifact) => {
               return artifact.name == "pr_number"
             })[0];

--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -36,7 +36,7 @@ jobs:
               });
               allArtifacts = allArtifacts.concat(response.data.artifacts);
               page++;
-            } while (response.data.artifacts.length === per_page);
+            } while (allArtifacts.length < response.data.total_count);
             let matchArtifact = allArtifacts.filter((artifact) => {
               return artifact.name == "pr_number"
             })[0];
@@ -70,7 +70,7 @@ jobs:
               });
               allArtifacts = allArtifacts.concat(response.data.artifacts);
               page++;
-            } while (response.data.artifacts.length === per_page);
+            } while (allArtifacts.length < response.data.total_count);
 
             let matchingArtifacts = allArtifacts.filter((artifact) => {
               return artifact.name.startsWith(`spread-results-${context.payload.workflow_run.id}-${context.payload.workflow_run.run_attempt}`);

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -381,11 +381,21 @@ jobs:
           let child_process = require('child_process');
           let systems = process.env.SYSTEMS.split(' ');
 
-          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: context.runId,
-          });
+          let page = 1;
+          let per_page = 100;
+          let allArtifacts = [];
+          let response;
+          do {
+            response = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: per_page,
+              page: page
+            });
+            allArtifacts = allArtifacts.concat(response.data.artifacts);
+            page++;
+          } while (response.data.artifacts.length === per_page);
           
           for (let system of systems) {
             let artifactName = `package-${system}`;

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -395,7 +395,7 @@ jobs:
             });
             allArtifacts = allArtifacts.concat(response.data.artifacts);
             page++;
-          } while (response.data.artifacts.length === per_page);
+          } while (allArtifacts.length < response.data.total_count);
           
           for (let system of systems) {
             let artifactName = `package-${system}`;
@@ -405,7 +405,7 @@ jobs:
               const arch = match[2] || '';
               artifactName = `package-ubuntu-${version}.04${arch}-64`;
             }
-            let artifact = allArtifacts.data.artifacts.find(a => a.name === artifactName);
+            let artifact = allArtifacts.find(a => a.name === artifactName);
             if (!artifact) {
               console.log(`Artifact not found for system: ${system}`);
               continue;


### PR DESCRIPTION
Due to the large number of artifacts on PRs, the spread tests workflow was not finding the corresponding artifact. This change ensures all artifacts are searched when looking for the appropriate package.