### PR TITLE
github: fail go channels job if no go channels were found

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -26,6 +26,14 @@ jobs:
           include-snapd-build-fips-go-channel: true
           include-latest-go-channel: false
 
+      - name: Check go channels
+        run: |
+          echo "Resolved Go channels: ${{ steps.resolve-go-channels.outputs.go-channels }}"
+          if [ -z "${{ steps.resolve-go-channels.outputs.go-channels }}" ]; then
+            echo "Error: No Go channels resolved"
+            exit 1
+          fi
+
   snap-builds:
     uses: ./.github/workflows/snap-builds.yaml
     with:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "Resolved Go channels: ${{ steps.resolve-go-channels.outputs.go-channels }}"
           if [ -z "${{ steps.resolve-go-channels.outputs.go-channels }}" ]; then
-            echo "Error: No Go channels resolved"
+            echo "Error: No Go channels resolved" >&2
             exit 1
           fi
 


### PR DESCRIPTION
When no go channels are found, as in this case https://github.com/canonical/snapd/actions/runs/24192824467/job/70789242301#step:3:143, the job should fail so developers know what tests need to be rerun.