### PR TITLE
i/builtin: only allow private shared-memory plugs to auto-connect to the system snap's slot

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -348,7 +348,16 @@ func (iface *sharedMemoryInterface) MountConnectedPlug(spec *mount.Specification
 }
 
 func (iface *sharedMemoryInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
-	// allow what declarations allowed
+	var private bool
+	if err := plug.Attr("private", &private); err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
+		return false
+	}
+
+	if private {
+		return implicitSystemPermanentSlot(slot)
+	}
+
+	// otherwise, allow what declarations allowed
 	return true
 }
 

--- a/interfaces/builtin/shared_memory_test.go
+++ b/interfaces/builtin/shared_memory_test.go
@@ -40,19 +40,21 @@ import (
 type SharedMemoryInterfaceSuite struct {
 	testutil.BaseTest
 
-	iface            interfaces.Interface
-	slotInfo         *snap.SlotInfo
-	slot             *interfaces.ConnectedSlot
-	plugInfo         *snap.PlugInfo
-	plug             *interfaces.ConnectedPlug
-	wildcardPlugInfo *snap.PlugInfo
-	wildcardPlug     *interfaces.ConnectedPlug
-	wildcardSlotInfo *snap.SlotInfo
-	wildcardSlot     *interfaces.ConnectedSlot
-	privatePlugInfo  *snap.PlugInfo
-	privatePlug      *interfaces.ConnectedPlug
-	privateSlotInfo  *snap.SlotInfo
-	privateSlot      *interfaces.ConnectedSlot
+	iface                interfaces.Interface
+	slotInfo             *snap.SlotInfo
+	slot                 *interfaces.ConnectedSlot
+	plugInfo             *snap.PlugInfo
+	plug                 *interfaces.ConnectedPlug
+	wildcardPlugInfo     *snap.PlugInfo
+	wildcardPlug         *interfaces.ConnectedPlug
+	wildcardSlotInfo     *snap.SlotInfo
+	wildcardSlot         *interfaces.ConnectedSlot
+	privatePlugInfo      *snap.PlugInfo
+	privatePlug          *interfaces.ConnectedPlug
+	privateSlotInfo      *snap.SlotInfo
+	privateSlot          *interfaces.ConnectedSlot
+	privateSnapdSlotInfo *snap.SlotInfo
+	privateSnapdSlot     *interfaces.ConnectedSlot
 }
 
 var _ = Suite(&SharedMemoryInterfaceSuite{
@@ -108,6 +110,16 @@ apps:
  app:
 `
 
+const sharedMemorySnapdYaml = `name: snapd
+version: 0
+type: snapd
+slots:
+ shared-memory:
+  interface: shared-memory
+apps:
+ app:
+`
+
 func (s *SharedMemoryInterfaceSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
@@ -119,6 +131,7 @@ func (s *SharedMemoryInterfaceSuite) SetUpTest(c *C) {
 
 	s.privatePlug, s.privatePlugInfo = MockConnectedPlug(c, sharedMemoryConsumerYaml, nil, "shmem-private")
 	s.privateSlot, s.privateSlotInfo = MockConnectedSlot(c, sharedMemoryCoreYaml, nil, "shared-memory")
+	s.privateSnapdSlot, s.privateSnapdSlotInfo = MockConnectedSlot(c, sharedMemorySnapdYaml, nil, "shared-memory")
 }
 
 func (s *SharedMemoryInterfaceSuite) TestName(c *C) {
@@ -485,6 +498,8 @@ func (s *SharedMemoryInterfaceSuite) TestMountSpec(c *C) {
 
 func (s *SharedMemoryInterfaceSuite) TestAutoConnect(c *C) {
 	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.privatePlugInfo, s.slotInfo), Equals, false)
+	c.Assert(s.iface.AutoConnect(s.privatePlugInfo, s.privateSnapdSlotInfo), Equals, true)
 }
 
 func (s *SharedMemoryInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -250,6 +250,7 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 		"lxd-support":     true,
 		// netlink-driver needs the family-name attributes to match
 		"netlink-driver": true,
+		"shared-memory":  true,
 	}
 
 	for _, iface := range all {


### PR DESCRIPTION
This means that we won't auto-connect private shared-memory plugs to other shared-memory slots, even if those shared-memory slots are auto-connect themselves, via a snap-declaration override.

This aligns with the docs:

"private (plug): when true, ... permits an auto-connection to the system:shared-memory slot"

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36753