### PR TITLE
release: 2.74.1+ubuntu xx.xx.5 (deb only, resolute only release)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a
+	github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a h1:eKljZN+SzPKM1ua7KG5E2vQdbw9JQn17tbbukHj6hvw=
-github.com/snapcore/secboot v0.0.0-20260320145120-26dce572077a/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
+github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70 h1:EewX3F1DSpJz8wPZxFxC3MdOnFiFVAazbOIv1OQNDME=
+github.com/snapcore/secboot v0.0.0-20260410084611-3f8b98c2db70/go.mod h1:+qs2Juv0XZeTmQHJgFTtAd9520h7QUWRDyvSwbJ3xEU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -49,13 +49,6 @@ Homepage: https://github.com/snapcore/snapd
 Vcs-Browser: https://github.com/snapcore/snapd
 Vcs-Git: https://github.com/snapcore/snapd.git
 
-Package: golang-github-ubuntu-core-snappy-dev
-Architecture: all
-Depends: golang-github-snapcore-snapd-dev, ${misc:Depends}
-Section: oldlibs
-Description: transitional dummy package
- This is a transitional dummy package. It can safely be removed.
-
 Package: golang-github-snapcore-snapd-dev
 Architecture: all
 Breaks: golang-github-ubuntu-core-snappy-dev (<< 2.0.6),
@@ -102,47 +95,3 @@ Description: Daemon and tooling that enable snap packages
  cloud, servers, desktops and the internet of things.
  .
  Start with 'snap list' to see installed snaps.
-
-Package: ubuntu-snappy
-Architecture: all
-Depends: snapd, ${misc:Depends}
-Section: oldlibs
-Description: transitional dummy package
- This is a transitional dummy package. It can safely be removed.
-
-Package: ubuntu-snappy-cli
-Architecture: all
-Depends: snapd, ${misc:Depends}
-Section: oldlibs
-Description: transitional dummy package
- This is a transitional dummy package. It can safely be removed.
-
-Package: ubuntu-core-snapd-units
-Architecture: all
-Depends: snapd, ${misc:Depends}
-Section: oldlibs
-Description: transitional dummy package
- This is a transitional dummy package. It can safely be removed.
-
-Package: snap-confine
-Architecture: any
-Section: oldlibs
-Depends: snapd (= ${binary:Version}), ${misc:Depends}
-Description: Transitional package for snapd
- This is a transitional dummy package. It can safely be removed.
-
-Package: ubuntu-core-launcher
-Architecture: any
-Depends: snapd (= ${binary:Version}), ${misc:Depends}
-Section: oldlibs
-Pre-Depends: dpkg (>= 1.15.7.2)
-Description: Transitional package for snapd
- This is a transitional dummy package. It can safely be removed.
-
-Package: snapd-xdg-open
-Architecture: any
-Depends: snapd (= ${binary:Version}), ${misc:Depends}
-Section: oldlibs
-Pre-Depends: dpkg (>= 1.15.7.2)
-Description: Transitional package for snapd-xdg-open
- This is a transitional dummy package. It can safely be removed.

--- a/packaging/ubuntu-16.04/snap-confine.maintscript
+++ b/packaging/ubuntu-16.04/snap-confine.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~

--- a/packaging/ubuntu-16.04/snapd.maintscript
+++ b/packaging/ubuntu-16.04/snapd.maintscript
@@ -1,3 +1,4 @@
+# inherited from the snap-confine maintenance script
 rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~
 # keep mount point busy
 # we used to ship a custom grub config that is no longer needed

--- a/packaging/ubuntu-16.04/ubuntu-snappy-cli.dirs
+++ b/packaging/ubuntu-16.04/ubuntu-snappy-cli.dirs
@@ -1,2 +1,0 @@
-usr/lib/snapd
-var/lib/snapd/snaps

--- a/tests/nested/manual/hybrid-tpm-fde-preinstall-check/task.yaml
+++ b/tests/nested/manual/hybrid-tpm-fde-preinstall-check/task.yaml
@@ -132,22 +132,18 @@ execute: |
   api_get_v2_systems_classic | gojq '.result["storage-encryption"].support' | MATCH "unavailable"
   api_get_v2_systems_classic | gojq '.result["storage-encryption"]."availability-check-errors"' > availability-check-errors
 
-  cat <<EOF > availability-check-errors.reference
-  [
-    {
-      "actions": [
-        "contact-oem"
-      ],
-      "args": {
-        "pcr": 7
-      },
-      "kind": "tpm-pcr-unusable",
-      "message": "error with secure boot policy (PCR7) measurements: OS initial boot loader was not verified by any X.509 certificate measured by any EV_EFI_VARIABLE_AUTHORITY event"
-    }
-  ]
+  cat <<'EOF' > availability-check-errors.reference.jq
+  length == 1 and
+  .[0].actions == ["contact-oem"] and
+  .[0].args == {"pcr": 7} and
+  .[0].kind == "tpm-pcr-unusable" and
+  (
+    .[0].message
+    | test("^error with secure boot policy \\(PCR7\\) measurements: OS-present EV_EFI_BOOT_SERVICES_APPLICATION event for .*shimx64\\.efi is not associated with the initial boot loader image$")
+  )
   EOF
 
-  diff availability-check-errors availability-check-errors.reference
+  jq -e -f availability-check-errors.reference.jq availability-check-errors >/dev/null
 
   # Check that the basic availability check that do not consider shim, grub and kernel still works
   remote.exec "sudo cp /etc/os-release /etc/os-release.orig"
@@ -219,10 +215,10 @@ execute: |
   api_get_v2_systems_classic | gojq '.result["storage-encryption"].support' | MATCH "unavailable"
   api_get_v2_systems_classic | gojq '.result["storage-encryption"]."availability-check-errors"' > availability-check-errors
 
-  diff availability-check-errors availability-check-errors.reference
+  jq -e -f availability-check-errors.reference.jq availability-check-errors >/dev/null
 
   # - Then request an action
   echo '{"action": "fix-encryption-support", "fix-action": ""}' | api_post_v2_systems_classic |
   gojq '.result["storage-encryption"]."availability-check-errors"' > availability-check-errors
 
-  diff availability-check-errors availability-check-errors.reference
+  jq -e -f availability-check-errors.reference.jq availability-check-errors >/dev/null


### PR DESCRIPTION
Follow up on https://github.com/canonical/snapd/pull/16857:
- Reinstatement (via revert) of drop transitional packages specifically required for resolute.
- Update secboot for latest TPM/FDE bug fixes (Same as https://github.com/canonical/snapd/pull/16886)

**Requires rebase merge**

