### PR TITLE
cmd/snap-update-ns: switch to a multi-pass process

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -74,9 +74,6 @@ func (c Change) String() string {
 	return fmt.Sprintf("%s (%s)", c.Action, c.Entry)
 }
 
-// changePerform is Change.Perform that can be mocked for testing.
-var changePerform func(*Change, *Assumptions) ([]*Change, error)
-
 // mimicRequired provides information if an error warrants a writable mimic.
 //
 // The returned path is the location where a mimic should be constructed.
@@ -254,14 +251,33 @@ func (c *Change) ensureSource(as *Assumptions) ([]*Change, error) {
 	return changes, err
 }
 
-// changePerformImpl is the real implementation of Change.Perform
-func changePerformImpl(c *Change, as *Assumptions) (changes []*Change, err error) {
+// Perform performs the change having prepared the source and target directories.
+func (c *Change) Perform(as *Assumptions) ([]*Change, error) {
+	changes, err := c.PrepareToPerform(as)
+	if err != nil {
+		return changes, err
+	}
+
+	return changes, c.DoPerform(as)
+}
+
+var prepareToPerformChangeOverride func(c *Change, as *Assumptions) (changes []*Change, err error)
+
+// PrepareToPerform prepares source and target inodes.
+//
+// This function may synthesize *additional* changes that were necessary to
+// perform this change (such as mounted tmpfs or overlayfs).
+func (c *Change) PrepareToPerform(as *Assumptions) (changes []*Change, err error) {
+	if prepareToPerformChangeOverride != nil {
+		return prepareToPerformChangeOverride(c, as)
+	}
+
 	if c.Action == Mount {
 		var changesSource, changesTarget []*Change
 		// We may be asked to bind mount a file, bind mount a directory, mount
 		// a filesystem over a directory, or create a symlink (which is abusing
 		// the "mount" concept slightly). That actual operation is performed in
-		// c.lowLevelPerform. Here we just set the stage to make that possible.
+		// DoPerform. Here we just set the stage to make that possible.
 		//
 		// As a result of this ensure call we may need to make the medium writable
 		// and that's why we may return more changes as a result of performing this
@@ -289,27 +305,19 @@ func changePerformImpl(c *Change, as *Assumptions) (changes []*Change, err error
 		}
 	}
 
-	// Perform the underlying mount / unmount / unlink call.
-	err = c.lowLevelPerform(as)
-	return changes, err
+	return changes, nil
 }
 
-func init() {
-	changePerform = changePerformImpl
-}
+var doPerformChangeOverride func(c *Change, as *Assumptions) error
 
-// Perform executes the desired mount or unmount change using system calls.
+// DoPerform executes the desired mount or unmount change using system calls.
 // Filesystems that depend on helper programs or multiple independent calls to
 // the kernel (--make-shared, for example) are unsupported.
-//
-// Perform may synthesize *additional* changes that were necessary to perform
-// this change (such as mounted tmpfs or overlayfs).
-func (c *Change) Perform(as *Assumptions) ([]*Change, error) {
-	return changePerform(c, as)
-}
+func (c *Change) DoPerform(as *Assumptions) error {
+	if doPerformChangeOverride != nil {
+		return doPerformChangeOverride(c, as)
+	}
 
-// lowLevelPerform is simple bridge from Change to mount / unmount syscall.
-func (c *Change) lowLevelPerform(as *Assumptions) error {
 	var err error
 
 	kind := c.Entry.XSnapdKind()
@@ -326,7 +334,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 		kind := c.Entry.XSnapdKind()
 		switch kind {
 		case "symlink":
-			// symlinks are handled in createInode directly, nothing to do here.
+			// symlinks are handled in ensureTarget directly, nothing to do here.
 		case "", "file":
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
 			// Split the mount flags from the event propagation changes.
@@ -540,7 +548,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 // dir+fstype, being fstype either none or tmpfs.
 //
 // TODO Ideally we should have only one mount per mountpoint, but we
-// perform mounts as we create the changes in Change.Perform which
+// perform mounts as we create the changes in Change.DoPerform which
 // makes it difficult to create the full list of changes and then
 // clean-up repeated mountpoints. In any case using this is still
 // needed to handle mount namespaces created by older snapd versions.

--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -92,14 +92,14 @@ func (s *changeSuite) TestContentLayout2InitiallyConnectedThenDisconnected(c *C)
 	// https://warthogs.atlassian.net/browse/SNAPDENG-31644
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "keep", Entry: current.Entries[4]},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 	})
 
 	// The actual entry for clarity.
-	c.Assert(changes[3].Entry, DeepEquals, osutil.MountEntry{
+	c.Assert(changes[1].Entry, DeepEquals, osutil.MountEntry{
 		Name:    "/snap/test-snapd-content/x1",
 		Dir:     "/snap/test-snapd-layout/x2/attached-content",
 		Type:    "none",
@@ -191,9 +191,9 @@ func (s *changeSuite) TestContentLayout5InitiallyConnectedThenContentRefreshed(c
 	// This test shows similar behavior to -2- test - the layout stays propagated.
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "keep", Entry: current.Entries[4]},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 		{Action: "mount", Entry: desired.Entries[1]},
 	})
@@ -211,9 +211,9 @@ func (s *changeSuite) TestContentLayout6InitiallyConnectedThenAppRefreshed(c *C)
 	// and both the layout and content are re-made.
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "unmount", Entry: withDetachOption(current.Entries[4])},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 		// It is interesting to note that we first mount the content to $SNAP/attached-content
 		// and only then construct the layout from $SNAP/attached-content to /usr/share/secureboot/potato.

--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -232,15 +232,15 @@ func withDetachOption(e osutil.MountEntry) osutil.MountEntry {
 
 func showCurrentDesiredAndChanges(c *C, current, desired *osutil.MountProfile, changes []*update.Change) {
 	c.Logf("Number of current entires: %d", len(current.Entries))
-	for _, entry := range current.Entries {
-		c.Logf("- current : %v", entry)
+	for i, entry := range current.Entries {
+		c.Logf("- current[%d] : %v", i, entry)
 	}
 	c.Logf("Number of desired entires: %d", len(desired.Entries))
-	for _, entry := range desired.Entries {
-		c.Logf("- desired: %v", entry)
+	for i, entry := range desired.Entries {
+		c.Logf("- desired[%d]: %v", i, entry)
 	}
 	c.Logf("Number of changes: %d", len(changes))
-	for _, change := range changes {
-		c.Logf("- change: %v", change)
+	for i, change := range changes {
+		c.Logf("- change[%d]: %v", i, change)
 	}
 }

--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -231,11 +231,11 @@ func withDetachOption(e osutil.MountEntry) osutil.MountEntry {
 }
 
 func showCurrentDesiredAndChanges(c *C, current, desired *osutil.MountProfile, changes []*update.Change) {
-	c.Logf("Number of current entires: %d", len(current.Entries))
+	c.Logf("Number of current entries: %d", len(current.Entries))
 	for i, entry := range current.Entries {
 		c.Logf("- current[%d] : %v", i, entry)
 	}
-	c.Logf("Number of desired entires: %d", len(desired.Entries))
+	c.Logf("Number of desired entries: %d", len(desired.Entries))
 	for i, entry := range desired.Entries {
 		c.Logf("- desired[%d]: %v", i, entry)
 	}

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -163,11 +163,14 @@ func MockGetgid(fn func() sys.GroupID) (restore func()) {
 	}
 }
 
-func MockChangePerform(f func(chg *Change, as *Assumptions) ([]*Change, error)) func() {
-	origChangePerform := changePerform
-	changePerform = f
+func MockChangePerform(prepare func(chg *Change, as *Assumptions) ([]*Change, error), do func(chg *Change, as *Assumptions) error) func() {
+	origPrepareToPerformChange := prepareToPerformChangeOverride
+	origDoPerformChange := doPerformChangeOverride
+	prepareToPerformChangeOverride = prepare
+	doPerformChangeOverride = do
 	return func() {
-		changePerform = origChangePerform
+		prepareToPerformChangeOverride = origPrepareToPerformChange
+		doPerformChangeOverride = origDoPerformChange
 	}
 }
 

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -67,6 +67,8 @@ func (s *mainSuite) TestExecuteMountProfileUpdate(c *C) {
 
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -160,6 +162,9 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 				Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
 		}
 		return synthetic, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -247,6 +252,9 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -298,6 +306,9 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -341,6 +352,9 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -369,6 +383,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
 		n++
 		switch n {
 		case 0:
@@ -381,7 +397,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 					Options: []string{"bind", "x-snapd.ignore-missing"},
 				},
 			})
-			return nil, update.ErrIgnoredMissingMount
+			return update.ErrIgnoredMissingMount
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
@@ -412,6 +428,9 @@ func (s *mainSuite) TestApplyUserFstabHomeRequiredAndValid(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		changes = append(changes, *chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -450,6 +469,9 @@ func (s *mainSuite) TestApplyUserFstabErrorHomeRequiredAndMissing(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		changes = append(changes, *chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -337,7 +337,11 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
 		n++
+		c.Logf("call: %s, n %v", chg, n)
 		switch n {
 		case 0:
 			c.Assert(chg, DeepEquals, &update.Change{
@@ -348,13 +352,10 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 					Options: []string{"rbind", "x-snapd.origin=overname"},
 				},
 			})
-			return nil, fmt.Errorf("testing")
+			return fmt.Errorf("testing")
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
-	}, func(chg *update.Change, as *update.Assumptions) error {
-		// This is the doPerform side of the mock that is doing nothing in this test.
-		return nil
 	})
 	defer restore()
 

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/1-initially-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/1-initially-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/1-initially-connected.current.fstab
@@ -2,10 +2,6 @@
 # created at / during construction of the mount namespace, before
 # snap-update-ns is even invoked.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-# This is the result of a content interface connection, all of
-# test-snapd-content at revision x1 is shared to test-snapd-layout at
-# revision x2, to directory $SNAP/attached-content.
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 # This is a writable mimic created on /usr/share/secureboot, so that the
 # subdirectory "potato" can be created inside. There's nothing special about
 # the path. It was used as there are relatvely few elements that need to be
@@ -17,6 +13,10 @@ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share
 # unmounted. The real source is somewhat more complicated and cannot be
 # expressed with the limited syntax of fstab mount entries.
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+# This is the result of a content interface connection, all of
+# test-snapd-content at revision x1 is shared to test-snapd-layout at
+# revision x2, to directory $SNAP/attached-content.
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 # This is the layout entry replicating the attached content. This is the root
 # of all evil, as the very popular behavior used by nearly all the snaps relies
 # on an implementation detail that was never envisioned to work this way.

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,5 +1,5 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 /snap/test-snapd-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,5 +1,5 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 /snap/test-snapd-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/annotations-1.patch
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/annotations-1.patch
@@ -7,10 +7,6 @@ index 54fbe65b9b..412f98e827 100644
 +# created at / during construction of the mount namespace, before
 +# snap-update-ns is even invoked.
  tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-+# This is the result of a content interface connection, all of
-+# test-snapd-content at revision x1 is shared to test-snapd-layout at
-+# revision x2, to directory $SNAP/attached-content.
- /snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 +# This is a writable mimic created on /usr/share/secureboot, so that the
 +# subdirectory "potato" can be created inside. There's nothing special about
 +# the path. It was used as there are relatvely few elements that need to be
@@ -22,6 +18,10 @@ index 54fbe65b9b..412f98e827 100644
 +# unmounted. The real source is somewhat more complicated and cannot be
 +# expressed with the limited syntax of fstab mount entries.
  /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
++# This is the result of a content interface connection, all of
++# test-snapd-content at revision x1 is shared to test-snapd-layout at
++# revision x2, to directory $SNAP/attached-content.
+ /snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 +# This is the layout entry replicating the attached content. This is the root
 +# of all evil, as the very popular behavior used by nearly all the snaps relies
 +# on an implementation detail that was never envisioned to work this way.

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -71,7 +71,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 
 	var changesMade []*Change
 	changeErr := make([]error, len(changesNeeded))
-	// In the first pass we fully apply keep and umount changes
+	// In the first pass we fully apply keep and unmount changes
 	for i, change := range changesNeeded {
 		if change.Action == Mount {
 			// This is done in 2nd and 3rd passes.

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -71,13 +71,16 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 
 	var changesMade []*Change
 	changeErr := make([]error, len(changesNeeded))
+	logger.Debugf("1. pass keep/unmount")
 	// In the first pass we fully apply keep and unmount changes
 	for i, change := range changesNeeded {
 		if change.Action == Mount {
 			// This is done in 2nd and 3rd passes.
+			logger.Debugf("skipping %v", change)
 			continue
 		}
 
+		logger.Debugf("apply: %v", change)
 		// Non-mount changes (so unmount or keep) do nothing in
 		// PrepareToPerform so we can safely call DoPerform which does not
 		// return any synthetic changes.
@@ -89,11 +92,36 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	}
 
 	// In the second pass we prepare to perform all mount changes
+	logger.Debugf("2. pass prep")
+	logger.Debugf("2.1. pass prep (overname)")
+	// Keep the invariant that overname (parallel installs mocking) needs to be applied first.
 	for i, change := range changesNeeded {
-		if change.Action != Mount {
-			// This was already done in the first pass.
+		if change.Action != Mount || change.Entry.XSnapdOrigin() != "overname" {
 			continue
 		}
+
+		logger.Debugf("prep overname apply: %v", change)
+		var synthesized []*Change
+		synthesized, changeErr[i] = change.PrepareToPerform(as)
+		changesMade = append(changesMade, synthesized...)
+		if changeErr[i] == nil {
+			changeErr[i] = change.DoPerform(as)
+		}
+		if err := changeErr[i]; err != nil {
+			return err
+		}
+		changesMade = append(changesMade, change)
+	}
+
+	logger.Debugf("2.2. pass prep")
+	for i, change := range changesNeeded {
+		if change.Action != Mount || change.Entry.XSnapdOrigin() == "overname" {
+			// This was already done in pass 2.1.
+			logger.Debugf("skipping %v", change)
+			continue
+		}
+
+		logger.Debugf("prep apply: %v", change)
 		var synthesized []*Change
 		synthesized, changeErr[i] = change.PrepareToPerform(as)
 		// We may have done something even if Perform itself has failed.
@@ -102,18 +130,21 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	}
 
 	// In the third and final pass, we perform all the mount changes
+	logger.Debugf("3. pass mount")
 	for i, change := range changesNeeded {
-		if change.Action != Mount {
-			// This was already done in the first pass.
+		if change.Action != Mount || change.Entry.XSnapdOrigin() == "overname" {
+			// Non mount changes were done earlier.
+			// Overname mount changes are applied in 2.1 pass.
 			continue
 		}
+		logger.Debugf("mount apply: %v", change)
 		if changeErr[i] == nil {
 			// Only perform the change if preparation has not failed.
 			changeErr[i] = change.DoPerform(as)
 		}
 		if err := changeErr[i]; err != nil {
 			origin := change.Entry.XSnapdOrigin()
-			if origin == "layout" || origin == "overname" {
+			if origin == "layout" {
 				// TODO: convert the test to a method over origin.
 				return err
 			} else if err != ErrIgnoredMissingMount {

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 )
@@ -71,88 +73,164 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 
 	var changesMade []*Change
 	changeErr := make([]error, len(changesNeeded))
+
+	var errContinue = errors.New("continue")
+
+	applyIf := func(
+		pred func(c *Change) bool,
+		f func(idx int, c *Change) (extraChangesMade []*Change, err error),
+	) error {
+		for i, change := range changesNeeded {
+			if !pred(change) {
+				logger.Debugf("skipping %v", change)
+				continue
+			}
+
+			logger.Debugf("apply: %v", change)
+			actualChangesMade, err := f(i, change)
+			if err != nil {
+				if err == errContinue {
+					continue
+				}
+				return err
+			}
+			changesMade = append(changesMade, actualChangesMade...)
+		}
+		return nil
+	}
+
+	// Apply all the changes in separate passes in the following order:
+	// 1. Unmounts/keeps
+	//    Things are either going away or we keep them, establish a new world order before doing
+	//    anything else
+	// 2. Dependencies:
+	// 2.1. overname (parallel installs)
+	//    Mock $SNAP_INSTANCE_NAME -> $SNAP mount, must come before everything else
+	// 2.2. content
+	//    Content from other snaps, make sure to bring it in as soon as possible, as layouts may
+	//    distribute it inside the world view
+	// 3. layouts
+	//    Everything else the snap ever wanted
+	//
+	// Passes 2.2 and 3. are split into separate sub-passes that do prepare &
+	// apply independently.
+
 	logger.Debugf("1. pass keep/unmount")
 	// In the first pass we fully apply keep and unmount changes
-	for i, change := range changesNeeded {
-		if change.Action == Mount {
-			// This is done in 2nd and 3rd passes.
-			logger.Debugf("skipping %v", change)
-			continue
-		}
-
-		logger.Debugf("apply: %v", change)
-		// Non-mount changes (so unmount or keep) do nothing in
-		// PrepareToPerform so we can safely call DoPerform which does not
-		// return any synthetic changes.
-		if err := change.DoPerform(as); err != nil {
-			changeErr[i] = err
-			continue
-		}
-		changesMade = append(changesMade, change)
+	err = applyIf(
+		func(c *Change) bool { return c.Action != Mount },
+		func(i int, change *Change) ([]*Change, error) {
+			// Non-mount changes (so unmount or keep) do nothing in
+			// PrepareToPerform so we can safely call DoPerform which does not
+			// return any synthetic changes.
+			if err := change.DoPerform(as); err != nil {
+				changeErr[i] = err
+				logger.Noticef("cannot change mount namespace according to change %s: %s", change, err)
+				return nil, errContinue
+			}
+			return []*Change{change}, nil
+		})
+	if err != nil {
+		return err
 	}
 
 	// In the second pass we prepare to perform all mount changes
 	logger.Debugf("2. pass prep")
-	logger.Debugf("2.1. pass prep (overname)")
+	logger.Debugf("2.1. pass prep+apply (overname)")
 	// Keep the invariant that overname (parallel installs mocking) needs to be applied first.
-	for i, change := range changesNeeded {
-		if change.Action != Mount || change.Entry.XSnapdOrigin() != "overname" {
-			continue
-		}
-
-		logger.Debugf("prep overname apply: %v", change)
-		var synthesized []*Change
-		synthesized, changeErr[i] = change.PrepareToPerform(as)
-		changesMade = append(changesMade, synthesized...)
-		if changeErr[i] == nil {
-			changeErr[i] = change.DoPerform(as)
-		}
-		if err := changeErr[i]; err != nil {
-			return err
-		}
-		changesMade = append(changesMade, change)
-	}
-
-	logger.Debugf("2.2. pass prep")
-	for i, change := range changesNeeded {
-		if change.Action != Mount || change.Entry.XSnapdOrigin() == "overname" {
-			// This was already done in pass 2.1.
-			logger.Debugf("skipping %v", change)
-			continue
-		}
-
-		logger.Debugf("prep apply: %v", change)
-		var synthesized []*Change
-		synthesized, changeErr[i] = change.PrepareToPerform(as)
-		// We may have done something even if Perform itself has failed.
-		// We need to collect synthesized changes and store them.
-		changesMade = append(changesMade, synthesized...)
-	}
-
-	// In the third and final pass, we perform all the mount changes
-	logger.Debugf("3. pass mount")
-	for i, change := range changesNeeded {
-		if change.Action != Mount || change.Entry.XSnapdOrigin() == "overname" {
-			// Non mount changes were done earlier.
-			// Overname mount changes are applied in 2.1 pass.
-			continue
-		}
-		logger.Debugf("mount apply: %v", change)
-		if changeErr[i] == nil {
-			// Only perform the change if preparation has not failed.
-			changeErr[i] = change.DoPerform(as)
-		}
-		if err := changeErr[i]; err != nil {
-			origin := change.Entry.XSnapdOrigin()
-			if origin == "layout" {
-				// TODO: convert the test to a method over origin.
-				return err
-			} else if err != ErrIgnoredMissingMount {
-				logger.Noticef("cannot change mount namespace according to change %s: %s", change, err)
+	err = applyIf(
+		func(c *Change) bool {
+			return c.Action == Mount && c.Entry.XSnapdOrigin() == "overname"
+		},
+		func(i int, change *Change) ([]*Change, error) {
+			var synthesized []*Change
+			synthesized, changeErr[i] = change.PrepareToPerform(as)
+			if changeErr[i] == nil {
+				changeErr[i] = change.DoPerform(as)
 			}
-			continue
-		}
-		changesMade = append(changesMade, change)
+			if err := changeErr[i]; err != nil {
+				return synthesized, err
+			}
+			return append(synthesized, change), nil
+		})
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("2.2.1 pass prep (content)")
+	err = applyIf(
+		func(c *Change) bool {
+			// TODO is this seriously the only way to identify a content mount?
+			return c.Action == Mount && c.Entry.XSnapdOrigin() == ""
+		},
+		func(i int, change *Change) ([]*Change, error) {
+			var synthesized []*Change
+			synthesized, changeErr[i] = change.PrepareToPerform(as)
+			// We may have done something even if Perform itself has failed.
+			// We need to collect synthesized changes and store them.
+			return synthesized, nil
+		})
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("2.2.2 pass apply (content)")
+	err = applyIf(
+		func(c *Change) bool {
+			return c.Action == Mount && c.Entry.XSnapdOrigin() == ""
+		},
+		func(i int, change *Change) ([]*Change, error) {
+			if changeErr[i] == nil {
+				// Only perform the change if preparation has not failed.
+				changeErr[i] = change.DoPerform(as)
+			}
+			if err := changeErr[i]; err != nil {
+				if err != ErrIgnoredMissingMount {
+					logger.Noticef("cannot change mount namespace according to change %s: %s", change, err)
+				}
+				return nil, errContinue
+			}
+			return []*Change{change}, nil
+		})
+	if err != nil {
+		return err
+	}
+
+	// In the third and final pass, we perform all the mount changes related to layouts
+	logger.Debugf("3. pass mount")
+	logger.Debugf("3.1 pass prep (layout)")
+	err = applyIf(
+		func(c *Change) bool {
+			return c.Action == Mount && c.Entry.XSnapdOrigin() == "layout"
+		},
+		func(i int, change *Change) ([]*Change, error) {
+			var synthesized []*Change
+			synthesized, changeErr[i] = change.PrepareToPerform(as)
+			// We may have done something even if Perform itself has failed.
+			// We need to collect synthesized changes and store them.
+			return synthesized, nil
+		})
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("3.2 pass apply (layout)")
+	err = applyIf(
+		func(c *Change) bool {
+			return c.Action == Mount && c.Entry.XSnapdOrigin() == "layout"
+		},
+		func(i int, change *Change) ([]*Change, error) {
+			if changeErr[i] == nil {
+				// Only perform the change if preparation has not failed.
+				changeErr[i] = change.DoPerform(as)
+			}
+			if changeErr[i] == nil {
+				return []*Change{change}, nil
+			}
+			return nil, changeErr[i]
+		})
+	if err != nil {
+		return err
 	}
 
 	// Compute the new current profile so that it contains only changes that were made

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -70,19 +70,21 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	// needed, collecting those that we managed to perform or that
 	// were performed already.
 	changesNeeded := NeededChanges(currentBefore, desired)
+	// TODO: NeededChanges could return changes grouped by origin (overname,
+	// non-layout, layout) instead of a flat list, removing the need to
+	// filter by origin in each pass.
 
 	var changesMade []*Change
 	changeErr := make([]error, len(changesNeeded))
 
 	var errContinue = errors.New("continue")
 
-	applyIf := func(
+	applyOnly := func(
 		pred func(c *Change) bool,
-		f func(idx int, c *Change) (extraChangesMade []*Change, err error),
+		f func(idx int, c *Change) (changesMade []*Change, err error),
 	) error {
 		for i, change := range changesNeeded {
 			if !pred(change) {
-				logger.Debugf("skipping %v", change)
 				continue
 			}
 
@@ -106,9 +108,10 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	// 2. Dependencies:
 	// 2.1. overname (parallel installs)
 	//    Mock $SNAP_INSTANCE_NAME -> $SNAP mount, must come before everything else
-	// 2.2. content
-	//    Content from other snaps, make sure to bring it in as soon as possible, as layouts may
-	//    distribute it inside the world view
+	// 2.2. non-layout dependencies
+	//    Everything that is not a layout mount, including content interface mounts
+	//    and host filesystem mounts. Content needs to be brought in early as
+	//    layouts may distribute it inside the world view.
 	// 3. layouts
 	//    Everything else the snap ever wanted
 	//
@@ -117,7 +120,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 
 	logger.Debugf("1. pass keep/unmount")
 	// In the first pass we fully apply keep and unmount changes
-	err = applyIf(
+	err = applyOnly(
 		func(c *Change) bool { return c.Action != Mount },
 		func(i int, change *Change) ([]*Change, error) {
 			// Non-mount changes (so unmount or keep) do nothing in
@@ -138,7 +141,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	logger.Debugf("2. pass prep")
 	logger.Debugf("2.1. pass prep+apply (overname)")
 	// Keep the invariant that overname (parallel installs mocking) needs to be applied first.
-	err = applyIf(
+	err = applyOnly(
 		func(c *Change) bool {
 			return c.Action == Mount && c.Entry.XSnapdOrigin() == "overname"
 		},
@@ -157,10 +160,11 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 		return err
 	}
 
-	logger.Debugf("2.2.1 pass prep (content)")
-	err = applyIf(
+	logger.Debugf("2.2.1 pass prep (non-layout)")
+	err = applyOnly(
 		func(c *Change) bool {
-			// TODO is this seriously the only way to identify a content mount?
+			// Non-layout entries have no explicit origin set, this includes
+			// content interface mounts and host filesystem mounts.
 			return c.Action == Mount && c.Entry.XSnapdOrigin() == ""
 		},
 		func(i int, change *Change) ([]*Change, error) {
@@ -174,8 +178,8 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 		return err
 	}
 
-	logger.Debugf("2.2.2 pass apply (content)")
-	err = applyIf(
+	logger.Debugf("2.2.2 pass apply (non-layout)")
+	err = applyOnly(
 		func(c *Change) bool {
 			return c.Action == Mount && c.Entry.XSnapdOrigin() == ""
 		},
@@ -199,7 +203,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	// In the third and final pass, we perform all the mount changes related to layouts
 	logger.Debugf("3. pass mount")
 	logger.Debugf("3.1 pass prep (layout)")
-	err = applyIf(
+	err = applyOnly(
 		func(c *Change) bool {
 			return c.Action == Mount && c.Entry.XSnapdOrigin() == "layout"
 		},
@@ -215,7 +219,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	}
 
 	logger.Debugf("3.2 pass apply (layout)")
-	err = applyIf(
+	err = applyOnly(
 		func(c *Change) bool {
 			return c.Action == Mount && c.Entry.XSnapdOrigin() == "layout"
 		},

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -768,6 +768,8 @@ func (s *utilsSuite) TestExecWirableMimicSuccess(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		c.Assert(plan, testutil.DeepContains, chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -811,6 +813,8 @@ func (s *utilsSuite) TestExecWirableMimicErrorWithRecovery(c *C) {
 			recoveryPlan = append(recoveryPlan, chg)
 		}
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -840,7 +844,9 @@ func (s *utilsSuite) TestExecWirableMimicErrorNothingDone(c *C) {
 
 	// Mock the act of performing changes and just fail on any request.
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		return nil, errTesting
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return errTesting
 	})
 	defer restore()
 
@@ -867,11 +873,13 @@ func (s *utilsSuite) TestExecWirableMimicErrorCannotUndo(c *C) {
 	// recovery path and will have to return a fatal error.
 	i := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
 		i++
 		if i > 0 {
-			return nil, fmt.Errorf("failure-%d", i)
+			return fmt.Errorf("failure-%d", i)
 		}
-		return nil, nil
+		return nil
 	})
 	defer restore()
 


### PR DESCRIPTION
Historically Change.Perform was a two-step process, first it would ensure that
both the source and destination of the operation are ready and only then it
would call the lowLevelPerform function to actually mount or unmount.

This works for simple cases but has the problem that the desired changes are
interleaved with construction of writable mimics, especially in
ensure{Source,Target}. This is a problem because it may end up performing a
sequence of operations where a mount we perform is duplicated by the mimic,
like in the example given below:

High-level view:
- unmount /target
- mount --bind /source1 /target/dir
- mount --bind /source2 /target/dir/subdir

Low-level view:
- umount --lazy /target
- make writable mimic /target/dir
- mount --bind /source1/ /target/dir
- make writable mimic /target/dir/subdir
- mount --bind /source2 /target/dir/subdir

The bind mount /target/dir now has two instances, one performed directly and
then another that was created during the construction of a mimic at
/target/dir/ in order to create the sub-directory subdir.

The new order of operations, for the example given above, is now:

New low-level view:
- umount --lazy /target
- make writable mimic /target/dir
- make writable mimic /target/dir/subdir
- mount --bind /source1/ /target/dir
- mount --bind /source2 /target/dir/subdir

The new multi-pass approach breaks that to (slightly modified from original approach proposed in #14658):
 - apply all keep and unmount actions
 - apply mounts in the order of how their 'effects' are used
   - overname (aka. parallel installs)
   - content, split into:
     - prepare which constructs sources & targets
     - apply - actually mount the content
   - layout
     - prepare & apply pass

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-23293

Based on #14658
