### PR TITLE
i/builtin: drop explicit deny send_destination in bluez dbus configuration

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -240,9 +240,6 @@ const bluezPermanentSlotDBus = `
     <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
     <allow send_interface="org.freedesktop.DBus.Properties"/>
 </policy>
-<policy context="default">
-    <deny send_destination="org.bluez"/>
-</policy>
 `
 
 type bluezInterface struct{}


### PR DESCRIPTION
This denial overlaps with usage of the `dbus` slot itself, which explicitly allows sending to dbus as a non-root user. This `deny send_destination` is the default behavior anyways, so removal enables us to continue using `dbus` and `bluez` together, without the two snippets clashing with each other.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36731