### PR TITLE
release-tools/is-lp-fips-build: attempt to workaround LP FIPS build detection problem

### DIFF
--- a/release-tools/is-lp-fips-build.sh
+++ b/release-tools/is-lp-fips-build.sh
@@ -7,9 +7,7 @@ set -e
 # recipe https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
 #
 # - git origin https://git.launchpad.net/~snappy-dev/snapd/+git/snapd
-# - one of the following is true:
-#   - build path: /build/snapd-fips (but not always)
-#   - openssl-fips-module-3 package is available (meaning FIPS PPA is present)
+# - openssl-fips-module-3 package is available (meaning FIPS PPA is present)
 #
 # TODO: we really need knobs on LP/snapcraft side to make this explicit
 
@@ -18,18 +16,7 @@ if ! git remote get-url origin | grep "git.launchpad.net" >&2 ; then
     exit 0
 fi
 
-# LP has no means of injecting additional configuration to the snap build, so
-# try a couple of simple checks that let us identify whether we are building a
-# FIPS target
-if echo "$PWD" | grep '^/build/snapd-fips/' >&2 ; then
-    # when building from
-    # https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips recipe, the
-    # code is cloned at /build/snapd-fips/. However if the build is published to the
-    # store using 'snapd' as the store package name, LP clones the source tree into
-    # directory named 'snapd', so the check is not always successful.
-    echo "true"
-    exit 0
-elif apt show openssl-fips-module-3 > /dev/null; then
+if apt show openssl-fips-module-3 > /dev/null; then
     echo ":: openssl-fips-module-3 package is available" >&2
     # when building with Pro FIPS Updates PPA
     # https://launchpad.net/~ubuntu-advantage/+archive/ubuntu/pro-fips-updates, the

--- a/release-tools/is-lp-fips-build.sh
+++ b/release-tools/is-lp-fips-build.sh
@@ -7,20 +7,37 @@ set -e
 # recipe https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
 #
 # - git origin https://git.launchpad.net/~snappy-dev/snapd/+git/snapd
-# - build path: /build/snapd-fips
+# - one of the following is true:
+#   - build path: /build/snapd-fips (but not always)
+#   - openssl-fips-module-3 package is available (meaning FIPS PPA is present)
+#
+# TODO: we really need knobs on LP/snapcraft side to make this explicit
 
 if ! git remote get-url origin | grep "git.launchpad.net" >&2 ; then
     echo "false"
     exit 0
 fi
 
-# when building from https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
-# recipe, the code is cloned at /build/snapd-fips/
-if ! echo "$PWD" | grep '^/build/snapd-fips/' >&2 ; then
-    echo "false"
+# LP has no means of injecting additional configuration to the snap build, so
+# try a couple of simple checks that let us identify whether we are building a
+# FIPS target
+if echo "$PWD" | grep '^/build/snapd-fips/' >&2 ; then
+    # when building from
+    # https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips recipe, the
+    # code is cloned at /build/snapd-fips/. However if the build is published to the
+    # store using 'snapd' as the store package name, LP clones the source tree into
+    # directory named 'snapd', so the check is not always successful.
+    echo "true"
+    exit 0
+elif apt show openssl-fips-module-3 > /dev/null; then
+    echo ":: openssl-fips-module-3 package is available" >&2
+    # when building with Pro FIPS Updates PPA
+    # https://launchpad.net/~ubuntu-advantage/+archive/ubuntu/pro-fips-updates, the
+    # openssl-fips-module-3 package will be available
+    echo "true"
     exit 0
 fi
 
 # TODO check if a FIPS PPA is enabled?
 
-echo "true"
+echo "false"


### PR DESCRIPTION
Turns out that when the LP snap job publishes the snap to a store using the name provided in the snap configuration, the git repository is cloned to a directory using that same name. This with the snapd-fips job using 'snapd' store name, our detection of a FIPS build job on snapd no longer works.

Attempt a workaround, where we check whether the OpenSSL FIPS provider module package - openssl-fips-module-3 is available. It will only be present when the FIPS PPA is added.

Verified on LP in: https://launchpad.net/~ubuntu-advantage/fips-cc-stig/+snap/snapd-fips-test using my LP fork: https://code.launchpad.net/~maciek-borzecki/+git/snapd/+ref/fips-test-lp

Related: SNAPDENG-21236

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
