### PR TITLE
o/state,o/snapstate: move IsErrAndNotWait from o/snapstate to o/state

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2520,7 +2520,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (retErr error) {
 	defer func() {
 		// if link snap fails and this is a first install, then we need to clean up
 		// the sequence file
-		if IsErrAndNotWait(retErr) && firstInstall {
+		if state.IsErrAndNotWait(retErr) && firstInstall {
 			snapst.MigratedHidden = false
 			snapst.MigratedToExposedHome = false
 			if err := writeSeqFile(snapsup.InstanceName(), snapst); err != nil {
@@ -2543,7 +2543,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (retErr error) {
 	// defer a cleanup helper which will unlink the snap if anything fails after
 	// this point
 	defer func() {
-		if !IsErrAndNotWait(retErr) {
+		if !state.IsErrAndNotWait(retErr) {
 			return
 		}
 		// retErr is not nil, we need to try and unlink the snap to cleanup after
@@ -2665,7 +2665,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (retErr error) {
 		return err
 	}
 	defer func() {
-		if IsErrAndNotWait(retErr) {
+		if state.IsErrAndNotWait(retErr) {
 			undo()
 		}
 	}()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -505,16 +505,6 @@ func CheckExpectedRestart(st *state.State) error {
 	return ErrUnexpectedRuntimeRestart
 }
 
-// IsErrAndNotWait returns true if err is not nil and neither state.Wait, it is
-// useful for code using FinishTaskWithRestart to not undo work in the presence
-// of a state.Wait return.
-func IsErrAndNotWait(err error) bool {
-	if _, ok := err.(*state.Wait); err == nil || ok {
-		return false
-	}
-	return true
-}
-
 // defaultProviderContentAttrs takes a snap.Info and returns a map of
 // default providers to the value of content attributes they should
 // provide. Content attributes already provided by a snap in the system are omitted. What is returned depends on the behavior of the passed PrereqTracker.

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -63,6 +63,15 @@ func (r *Wait) Error() string {
 	return "task set to wait, manual action required"
 }
 
+// IsErrAndNotWait returns true if err is neither nil nor a *Wait. It is
+// useful to not undo work in the presence of a *Wait return.
+func IsErrAndNotWait(err error) bool {
+	if _, ok := err.(*Wait); err == nil || ok {
+		return false
+	}
+	return true
+}
+
 type blockedFunc func(t *Task, running []*Task) bool
 
 // TaskRunner controls the running of goroutines to execute known task kinds.


### PR DESCRIPTION
`IsErrAndNotWait` depends only on `state.Wait` and is useful to decide not to undo changes in case a task returns `*state.Wait`. This is useful for many `state` users, one of the first ones outside of `snapstate` being `UndoTracker` from #16861. This would in turn help in moving `UndoTracker` out of `snapstate`. See https://github.com/canonical/snapd/pull/16861#discussion_r3078499999