### PR TITLE
netutil/activation: fix use of umask in GetListener

### DIFF
--- a/netutil/activation.go
+++ b/netutil/activation.go
@@ -29,8 +29,11 @@ import (
 	"github.com/snapcore/snapd/logger"
 )
 
-// GetListener tries to get a listener for the given socket path from
-// the listener map, and if it fails it tries to set it up directly.
+// GetListener tries to get a listener for the given socket path from the
+// listener map, and if it fails it tries to set it up directly. The socket, if
+// needed to be created, is owned by the current user and its mode is set to
+// 0666. Upon returning, the caller can change to mode using os.Chmod() if
+// required.
 func GetListener(socketPath string, listenerMap map[string]net.Listener) (net.Listener, error) {
 	if listener, ok := listenerMap[socketPath]; ok {
 		return listener, nil
@@ -55,9 +58,9 @@ func GetListener(socketPath string, listenerMap map[string]net.Listener) (net.Li
 		return nil, err
 	}
 	// if we reached here, the socket was clearly not in the set passed as
-	// activation sockets, so make sure it has the same mode as systemd's
-	// default (0666). The caller knows the path and can adjust the mode to
-	// their liking.
+	// activation sockets. It is owned by current user, but its mode is 0777 &
+	// ~umask. Update the mode to same value as systemd's default (0666). The
+	// caller knows the path and can adjust the mode to their liking.
 	if err := os.Chmod(socketPath, 0666); err != nil {
 		listener.Close()
 		return nil, err

--- a/netutil/activation.go
+++ b/netutil/activation.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
-	unix "syscall"
 
 	"github.com/coreos/go-systemd/activation"
 
@@ -52,12 +50,16 @@ func GetListener(socketPath string, listenerMap map[string]net.Listener) (net.Li
 		return nil, err
 	}
 
-	runtime.LockOSThread()
-	oldmask := unix.Umask(0111)
 	listener, err := net.ListenUnix("unix", address)
-	unix.Umask(oldmask)
-	runtime.UnlockOSThread()
 	if err != nil {
+		return nil, err
+	}
+	// if we reached here, the socket was clearly not in the set passed as
+	// activation sockets, so make sure it has the same mode as systemd's
+	// default (0666). The caller knows the path and can adjust the mode to
+	// their liking.
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		listener.Close()
 		return nil, err
 	}
 

--- a/netutil/activation_test.go
+++ b/netutil/activation_test.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package netutil_test
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/netutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type activationSuite struct{}
+
+var _ = Suite(&activationSuite{})
+
+func (s *activationSuite) TestGetListenerSocketMode(c *C) {
+	socketPath := filepath.Join(c.MkDir(), "test.sock")
+
+	// create a socket at the path and set its mode to 0644. The
+	// listener is closed via SetUnlinkOnClose(false) to keep the
+	// stale socket file on disk so we can later verify that
+	// GetListener recreates it with mode 0666.
+	addr, err := net.ResolveUnixAddr("unix", socketPath)
+	c.Assert(err, IsNil)
+	stale, err := net.ListenUnix("unix", addr)
+	c.Assert(err, IsNil)
+	stale.SetUnlinkOnClose(false)
+	c.Assert(stale.Close(), IsNil)
+
+	err = os.Chmod(socketPath, 0644)
+	c.Assert(err, IsNil)
+
+	// GetListener should remove the stale socket, create a new one
+	// and chmod it to 0666.
+	listener, err := netutil.GetListener(socketPath, nil)
+	c.Assert(err, IsNil)
+	defer listener.Close()
+
+	c.Check(listener.Addr().String(), Equals, socketPath)
+
+	fi, err := os.Stat(socketPath)
+	c.Assert(err, IsNil)
+	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0666))
+}
+
+func (s *activationSuite) TestGetListenerSocketAlreadyInUse(c *C) {
+	socketPath := filepath.Join(c.MkDir(), "test.sock")
+
+	// Create a listener and keep it open so the socket is actively
+	// in use.
+	addr, err := net.ResolveUnixAddr("unix", socketPath)
+	c.Assert(err, IsNil)
+	active, err := net.ListenUnix("unix", addr)
+	c.Assert(err, IsNil)
+	defer active.Close()
+
+	// GetListener should detect the active socket via Dial and
+	// return an error.
+	listener, err := netutil.GetListener(socketPath, nil)
+	c.Assert(err, ErrorMatches, `socket ".*" already in use`)
+	c.Assert(listener, IsNil)
+}
+
+func (s *activationSuite) TestGetListenerFromListenerMap(c *C) {
+	socketPath := filepath.Join(c.MkDir(), "test.sock")
+
+	// Create a listener and register it in the listener map, as
+	// systemd activation would.
+	addr, err := net.ResolveUnixAddr("unix", socketPath)
+	c.Assert(err, IsNil)
+	existing, err := net.ListenUnix("unix", addr)
+	c.Assert(err, IsNil)
+	defer existing.Close()
+
+	listenerMap := map[string]net.Listener{
+		socketPath: existing,
+	}
+
+	// GetListener should return the listener from the map directly.
+	listener, err := netutil.GetListener(socketPath, listenerMap)
+	c.Assert(err, IsNil)
+	c.Assert(listener, Equals, existing)
+}


### PR DESCRIPTION
Umask is a shared global resource. Even if the runtime thread is locked
during execution of GetListener(), the code still modifies a global
resource. Thus another thread running in parallel, may accidentally
create a file with incorrect mode if it executes a file/directory operation
which references umask during the brief time it is modified in GetListener().

Since the intention is to set the mode to the same value as the default
for systemd socket units, refactor the code to chmod() explicitly.