### PR TITLE
spread.yaml,tests: ensure test python scripts can run on UC26

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -11,7 +11,7 @@ environment:
     GOPROXY: https://proxy.golang.org,direct
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
-    PATH: $PROJECT_PATH/tests/bin:$GOHOME/bin:/snap/bin:$PATH:/var/lib/snapd/snap/bin
+    PATH: $PROJECT_PATH/tests/bin:$GOHOME/bin:/snap/bin:$PATH:/var/lib/snapd/snap/bin:/usr/lib/python
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     TESTSTMP: /var/tmp/snapd-tools

--- a/tests/core/gadget-update-pc/generate.py
+++ b/tests/core/gadget-update-pc/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/tests/lib/external/snapd-testing-tools/utils/check-test-format
+++ b/tests/lib/external/snapd-testing-tools/utils/check-test-format
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 This tool is used to verify a correct format of spread tests

--- a/tests/lib/fakegpio/fake-gpio.py
+++ b/tests/lib/fakegpio/fake-gpio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Mock the /sys/class/gpio subsystem"""
 
 import atexit

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/lib/snaps/store/test-snapd-dbus-service/bin/test-snapd-dbus-service
+++ b/tests/lib/snaps/store/test-snapd-dbus-service/bin/test-snapd-dbus-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/lib/snaps/store/test-snapd-portal-client/client.py
+++ b/tests/lib/snaps/store/test-snapd-portal-client/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from urllib.parse import urlparse, unquote

--- a/tests/lib/snaps/store/test-snapd-python-webserver/server.py
+++ b/tests/lib/snaps/store/test-snapd-python-webserver/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/lib/snaps/test-snapd-service-sigterm/bin/start-stop-mode-sigterm
+++ b/tests/lib/snaps/test-snapd-service-sigterm/bin/start-stop-mode-sigterm
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import subprocess
 import os
 import os.path

--- a/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
+++ b/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import signal
 import socket

--- a/tests/lib/snaps/test-snapd-user-service-sockets/bin/start
+++ b/tests/lib/snaps/test-snapd-user-service-sockets/bin/start
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import asyncio
 import os

--- a/tests/lib/tinyproxy/tinyproxy.py
+++ b/tests/lib/tinyproxy/tinyproxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Tiny HTTP Proxy. Based on the work of SUZUKI Hisao.
 #

--- a/tests/lib/tools/sha3-384
+++ b/tests/lib/tools/sha3-384
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import hashlib

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/main/fake-netplan-apply/fake-netplan-service.py
+++ b/tests/main/fake-netplan-apply/fake-netplan-service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from gi.repository import GLib
 import dbus.mainloop.glib

--- a/tests/main/interfaces-desktop-launch/api-client/bin/api-client.py
+++ b/tests/main/interfaces-desktop-launch/api-client/bin/api-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/main/interfaces-network-control-tuntap/test-snapd-tuntap/bin/tuntap.py
+++ b/tests/main/interfaces-network-control-tuntap/test-snapd-tuntap/bin/tuntap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import contextlib
 import os

--- a/tests/main/interfaces-network-status-classic/fake-portal-network-monitor.py
+++ b/tests/main/interfaces-network-status-classic/fake-portal-network-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/main/interfaces-ros-snapd-support/api-apps-client/bin/api-apps-client.py
+++ b/tests/main/interfaces-ros-snapd-support/api-apps-client/bin/api-apps-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/main/interfaces-snap-interfaces-requests-control/api-client/bin/api-client.py
+++ b/tests/main/interfaces-snap-interfaces-requests-control/api-client/bin/api-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/main/interfaces-snap-refresh-observe/api-client/bin/api-client.py
+++ b/tests/main/interfaces-snap-refresh-observe/api-client/bin/api-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/main/security-devpts/test-snapd-devpts/bin/openpty
+++ b/tests/main/security-devpts/test-snapd-devpts/bin/openpty
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import pty
 import sys

--- a/tests/main/security-devpts/test-snapd-devpts/bin/useptmx
+++ b/tests/main/security-devpts/test-snapd-devpts/bin/useptmx
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 from ctypes import *

--- a/tests/main/snap-run-inhibition-flow/api-client/bin/api-client.py
+++ b/tests/main/snap-run-inhibition-flow/api-client/bin/api-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/main/theme-install/api-client/bin/api-client.py
+++ b/tests/main/theme-install/api-client/bin/api-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import http.client

--- a/tests/nested/core/core20-gadget-reseal/manip_gadget.py
+++ b/tests/nested/core/core20-gadget-reseal/manip_gadget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
@@ -23,7 +23,7 @@ prepare: |
   unsquashfs -d corebase corebase.snap
   mv corebase/sbin/cryptsetup corebase/sbin/cryptsetup.real
   cat >corebase/sbin/cryptsetup <<'EOF'
-  #!/usr/bin/python3
+  #!/usr/bin/env python3
   import os,sys
   with open("/run/mnt/ubuntu-seed/cryptsetup.calls", "a") as fp:
     fp.write(f"{sys.argv}\n")

--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -76,7 +76,7 @@ execute: |
     ############## SECCOMP
     echo "Ensure seccomp sandbox works"
     cat >sec.py <<'EOF'
-    #!/usr/bin/python3
+    #!/usr/bin/env python3
     from ctypes import c_long, CDLL, get_errno
     from ctypes.util import find_library
     import errno, sys


### PR DESCRIPTION
- Change PATH in tests so python can be found easily
- Replace hard coded python paths by using env