### PR TITLE
tests/cloud-init: do not run for UC26

### DIFF
--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -5,6 +5,9 @@ details: |
     to the snaps. Run the test on a live backend which sets instance data
     properly.
 
+# Default track in core26 does not include cloud-init
+systems: [-ubuntu-core-26*]
+
 skip:
     - reason: This test is only valid for google and openstack backends that provide cloud info
       if: |


### PR DESCRIPTION
As we do not have cloud-init in the default track, so the image used in the main suite does not use it. The core26 cloud-init track is already tested in the nested tests.