### PR TITLE
o/snapstate: use change id to prevent nested seed-refresh spawned by prerequisites

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -533,10 +533,10 @@ func (r *remodeler) maybeInstallOrUpdate(ctx context.Context, st *state.State, r
 		}
 
 		_, ts, err := snapstateInstallOne(ctx, st, goal, snapstate.Options{
-			DeviceCtx:     r.deviceCtx,
-			FromChange:    r.fromChange,
-			PrereqTracker: r.tracker,
-			Flags:         snapstate.Flags{NoReRefresh: true, Required: true, NoDelayedSideEffects: true},
+			DeviceCtx:       r.deviceCtx,
+			ConflictOptions: snapstate.ConflictOptions{FromChange: r.fromChange},
+			PrereqTracker:   r.tracker,
+			Flags:           snapstate.Flags{NoReRefresh: true, Required: true, NoDelayedSideEffects: true},
 		})
 		if err != nil {
 			return 0, nil, err
@@ -619,10 +619,10 @@ func (r *remodeler) maybeInstallOrUpdate(ctx context.Context, st *state.State, r
 		}
 
 		ts, err := snapstateUpdateOne(ctx, st, goal, nil, snapstate.Options{
-			DeviceCtx:     r.deviceCtx,
-			FromChange:    r.fromChange,
-			PrereqTracker: r.tracker,
-			Flags:         snapstate.Flags{NoReRefresh: true, NoDelayedSideEffects: true},
+			DeviceCtx:       r.deviceCtx,
+			ConflictOptions: snapstate.ConflictOptions{FromChange: r.fromChange},
+			PrereqTracker:   r.tracker,
+			Flags:           snapstate.Flags{NoReRefresh: true, NoDelayedSideEffects: true},
 		})
 		if err != nil {
 			return 0, nil, err
@@ -915,9 +915,9 @@ func (r *remodeler) installComponents(ctx context.Context, st *state.State, info
 			}
 
 			ts, err := snapstateInstallComponentPath(st, lc.SideInfo, info, lc.Path, snapstate.Options{
-				DeviceCtx:     r.deviceCtx,
-				FromChange:    r.fromChange,
-				PrereqTracker: r.tracker,
+				DeviceCtx:       r.deviceCtx,
+				ConflictOptions: snapstate.ConflictOptions{FromChange: r.fromChange},
+				PrereqTracker:   r.tracker,
 			})
 			if err != nil {
 				return nil, err
@@ -931,9 +931,9 @@ func (r *remodeler) installComponents(ctx context.Context, st *state.State, info
 	}
 
 	return snapstateInstallComponents(ctx, st, components, info, r.vsets, snapstate.Options{
-		DeviceCtx:     r.deviceCtx,
-		FromChange:    r.fromChange,
-		PrereqTracker: r.tracker,
+		DeviceCtx:       r.deviceCtx,
+		ConflictOptions: snapstate.ConflictOptions{FromChange: r.fromChange},
+		PrereqTracker:   r.tracker,
 	})
 }
 

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -407,7 +407,7 @@ func createSnapctlInstallTasks(hctx *hookstate.Context, cmd managementCommand) (
 		return nil, err
 	}
 	return snapstateInstallComponents(context.TODO(), st, cmd.components, info, vsets,
-		snapstate.Options{ExpectOneSnap: true, FromChange: changeIDIfNotEphemeral(hctx)})
+		snapstate.Options{ExpectOneSnap: true, ConflictOptions: snapstate.ConflictOptions{FromChange: changeIDIfNotEphemeral(hctx)}})
 }
 
 func createSnapctlRemoveTasks(hctx *hookstate.Context, cmd managementCommand) (tss []*state.TaskSet, err error) {
@@ -417,7 +417,7 @@ func createSnapctlRemoveTasks(hctx *hookstate.Context, cmd managementCommand) (t
 
 	return snapstateRemoveComponents(st, hctx.InstanceName(), cmd.components,
 		snapstate.RemoveComponentsOpts{RefreshProfile: true,
-			FromChange: changeIDIfNotEphemeral(hctx)})
+			ConflictOptions: snapstate.ConflictOptions{FromChange: changeIDIfNotEphemeral(hctx)}})
 }
 
 func runSnapManagementCommand(hctx *hookstate.Context, cmd managementCommand) error {

--- a/overlord/hookstate/ctlcmd/snap_management_test.go
+++ b/overlord/hookstate/ctlcmd/snap_management_test.go
@@ -117,7 +117,7 @@ func (s *installSuite) testMngmtCommand(c *C, cmd string) {
 		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error) {
 			c.Check(names, DeepEquals, []string{"comp1", "comp2"})
 			c.Check(opts, DeepEquals, snapstate.Options{ExpectOneSnap: true,
-				FromChange: s.mockContext.ChangeID()})
+				ConflictOptions: snapstate.ConflictOptions{FromChange: s.mockContext.ChangeID()}})
 			var ts state.TaskSet
 			ts.AddTask(task)
 			return []*state.TaskSet{&ts}, nil
@@ -127,7 +127,7 @@ func (s *installSuite) testMngmtCommand(c *C, cmd string) {
 			c.Check(compNames, DeepEquals, []string{"comp1", "comp2"})
 			c.Check(opts, DeepEquals,
 				snapstate.RemoveComponentsOpts{RefreshProfile: true,
-					FromChange: s.mockContext.ChangeID()})
+					ConflictOptions: snapstate.ConflictOptions{FromChange: s.mockContext.ChangeID()}})
 			var ts state.TaskSet
 			ts.AddTask(task)
 			return []*state.TaskSet{&ts}, nil
@@ -190,8 +190,8 @@ func (s *installSuite) TestInstallCommandUsesPendingValidationSets(c *C) {
 		c.Assert(vsets.Keys(), DeepEquals, []snapasserts.ValidationSetKey{snapasserts.NewValidationSetKey(vs)})
 		c.Check(names, DeepEquals, []string{"comp1", "comp2"})
 		c.Check(opts, DeepEquals, snapstate.Options{
-			ExpectOneSnap: true,
-			FromChange:    s.mockContext.ChangeID(),
+			ExpectOneSnap:   true,
+			ConflictOptions: snapstate.ConflictOptions{FromChange: s.mockContext.ChangeID()},
 		})
 
 		return []*state.TaskSet{state.NewTaskSet(task)}, nil

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -146,7 +146,7 @@ func InstallComponents(
 		// the component task chains. this results in multiple parallel tasks
 		// (one per component) that have synchronization points at the
 		// setupSecurity and kmodSetup tasks.
-		cts, err := doInstallComponent(st, &snapst, compsup, &snapsup, setupSecurity, setupSecurity, kmodSetup, opts.FromChange)
+		cts, err := doInstallComponent(st, &snapst, compsup, &snapsup, setupSecurity, setupSecurity, kmodSetup, opts.ConflictOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +303,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 		},
 	}
 
-	cts, err := doInstallComponent(st, &snapst, compSetup, &snapsup, nil, nil, nil, "")
+	cts, err := doInstallComponent(st, &snapst, compSetup, &snapsup, nil, nil, nil, ConflictOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +371,7 @@ func newComponentInstallChoreographer(
 	snapsup *SnapSetup,
 	snapst *SnapState,
 	compsup *ComponentSetup,
-	fromChange string,
+	copts ConflictOptions,
 	snapsupTask, setupSecurityTask, kmodSetupTask *state.Task,
 ) (*componentInstallChoreographer, error) {
 	if compsup.SkipAssertionsDownload {
@@ -400,7 +400,7 @@ func newComponentInstallChoreographer(
 	}
 
 	// we consider the same conflicts as if the component was actually the snap.
-	if err := checkChangeConflictIgnoringOneChange(st, snapsup.InstanceName(), snapst, fromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, snapsup.InstanceName(), snapst, copts); err != nil {
 		return nil, err
 	}
 
@@ -655,10 +655,10 @@ func doInstallComponent(
 	snapsup *SnapSetup,
 	snapsupTask *state.Task,
 	setupSecurity, kmodSetup *state.Task,
-	fromChange string,
+	copts ConflictOptions,
 ) (componentInstallTaskSet, error) {
 	cc, err := newComponentInstallChoreographer(
-		st, snapsup, snapst, &compsup, fromChange,
+		st, snapsup, snapst, &compsup, copts,
 		snapsupTask, setupSecurity, kmodSetup,
 	)
 	if err != nil {
@@ -675,7 +675,7 @@ func doInstallComponent(
 
 type RemoveComponentsOpts struct {
 	RefreshProfile bool
-	FromChange     string
+	ConflictOptions
 }
 
 // RemoveComponents returns a taskset that removes the components in compName
@@ -716,7 +716,7 @@ func RemoveComponents(st *state.State, snapName string, compName []string, opts 
 				CompRev:   snap.R(0),
 			}
 		}
-		ts, err := removeComponentTasks(st, &snapst, compst, info, setupSecurity, opts.FromChange)
+		ts, err := removeComponentTasks(st, &snapst, compst, info, setupSecurity, opts.ConflictOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -730,12 +730,12 @@ func RemoveComponents(st *state.State, snapName string, compName []string, opts 
 	return tss, nil
 }
 
-func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.ComponentState, info *snap.Info, setupSecurity *state.Task, fromChange string) (*state.TaskSet, error) {
+func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.ComponentState, info *snap.Info, setupSecurity *state.Task, copts ConflictOptions) (*state.TaskSet, error) {
 	instName := info.InstanceName()
 
 	// For the moment we consider the same conflicts as if the component
 	// was actually the snap.
-	if err := checkChangeConflictIgnoringOneChange(st, instName, nil, fromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, instName, nil, copts); err != nil {
 		return nil, err
 	}
 

--- a/overlord/snapstate/component_remove_test.go
+++ b/overlord/snapstate/component_remove_test.go
@@ -426,7 +426,7 @@ func (s *snapmgrTestSuite) TestRemoveComponentUpdateNoConflict(c *C) {
 
 	// No conflict as this remove would be part of the change
 	tss, err := snapstate.RemoveComponents(s.state, snapName, []string{compName},
-		snapstate.RemoveComponentsOpts{FromChange: chg.ID()})
+		snapstate.RemoveComponentsOpts{ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID()}})
 
 	c.Assert(err, IsNil)
 	c.Assert(len(tss), Equals, 1)

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -361,7 +361,7 @@ func (s *snapmgrTestSuite) testComponentRemoveValidationSet(c *C, targetSnapName
 		return vss, nil
 	})
 
-	_, err = snapstate.RemoveComponentTasks(s.state, snapSt, compSt, info, nil, "")
+	_, err = snapstate.RemoveComponentTasks(s.state, snapSt, compSt, info, nil, snapstate.ConflictOptions{})
 
 	if expectedErrorMsg != "" {
 		c.Assert(err, NotNil)

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -256,13 +256,14 @@ func CheckChangeConflictRunExclusively(st *state.State, newChangeKind string) er
 	return checkChangeConflictExclusiveKinds(st, newChangeKind, "")
 }
 
-// isIrrelevantChange checks if a change is ready or it can be ignored
-// if matching the passed ID, for conflict checking purposes.
-func isIrrelevantChange(chg *state.Change, ignoreChangeID string) bool {
+// isIrrelevantChange checks if a change is ready or it can be ignored if it
+// matches the ID in the given options. We will still consider this change if
+// the given options indicates that we must still consider the given change ID.
+func isIrrelevantChange(chg *state.Change, opts ConflictOptions) bool {
 	if chg == nil || chg.IsReady() {
 		return true
 	}
-	if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
+	if opts.FromChange != "" && chg.ID() == opts.FromChange && !opts.IncludeFromChangeInTaskConflictCheck {
 		return true
 	}
 	switch chg.Kind() {
@@ -298,19 +299,23 @@ func isIrrelevantChange(chg *state.Change, ignoreChangeID string) bool {
 // It's like CheckChangeConflict, but for multiple snaps, and does not
 // check snapst.
 func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChangeID string) error {
+	return checkChangeConflictManyWithOptions(st, instanceNames, ConflictOptions{FromChange: ignoreChangeID})
+}
+
+func checkChangeConflictManyWithOptions(st *state.State, instanceNames []string, opts ConflictOptions) error {
 	snapMap := make(map[string]bool, len(instanceNames))
 	for _, k := range instanceNames {
 		snapMap[k] = true
 	}
 
 	// check whether there are other changes that need to run exclusively
-	if err := CheckChangeConflictExclusiveKinds(st, ignoreChangeID); err != nil {
+	if err := CheckChangeConflictExclusiveKinds(st, opts.FromChange); err != nil {
 		return err
 	}
 
 	for _, task := range st.Tasks() {
 		chg := task.Change()
-		if isIrrelevantChange(chg, ignoreChangeID) {
+		if isIrrelevantChange(chg, opts) {
 			continue
 		}
 
@@ -338,11 +343,11 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 // progress. It also ensures that snapst (if not nil) did not get
 // modified. If a conflict is detected an error is returned.
 func CheckChangeConflict(st *state.State, instanceName string, snapst *SnapState) error {
-	return checkChangeConflictIgnoringOneChange(st, instanceName, snapst, "")
+	return checkChangeConflictIgnoringOneChange(st, instanceName, snapst, ConflictOptions{})
 }
 
-func checkChangeConflictIgnoringOneChange(st *state.State, instanceName string, snapst *SnapState, ignoreChangeID string) error {
-	if err := CheckChangeConflictMany(st, []string{instanceName}, ignoreChangeID); err != nil {
+func checkChangeConflictIgnoringOneChange(st *state.State, instanceName string, snapst *SnapState, opts ConflictOptions) error {
+	if err := checkChangeConflictManyWithOptions(st, []string{instanceName}, opts); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -263,7 +263,7 @@ func isIrrelevantChange(chg *state.Change, opts ConflictOptions) bool {
 	if chg == nil || chg.IsReady() {
 		return true
 	}
-	if opts.FromChange != "" && chg.ID() == opts.FromChange && !opts.IncludeFromChangeInTaskConflictCheck {
+	if opts.FromChange != "" && chg.ID() == opts.FromChange && !opts.DoNotIgnoreFromChangeInTaskConflictCheck {
 		return true
 	}
 	switch chg.Kind() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -591,7 +591,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 			FromChange: t.Change().ID(),
 			// setting this lets us use snap update conflict detection, even
 			// though we're passing in the change ID
-			IncludeFromChangeInTaskConflictCheck: true,
+			DoNotIgnoreFromChangeInTaskConflictCheck: true,
 		},
 	})
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -581,7 +581,19 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 	flags.NoReRefresh = true
 
 	// default provider is missing some content tags (likely outdated) so update it
-	ts, err := UpdateWithDeviceContext(st, snapName, nil, userID, flags, nil, deviceCtx, "")
+	ts, err := UpdateOne(context.Background(), st, StoreUpdateGoal(StoreUpdate{
+		InstanceName: snapName,
+	}), nil, Options{
+		Flags:     flags,
+		UserID:    userID,
+		DeviceCtx: deviceCtx,
+		ConflictOptions: ConflictOptions{
+			FromChange: t.Change().ID(),
+			// setting this lets us use snap update conflict detection, even
+			// though we're passing in the change ID
+			IncludeFromChangeInTaskConflictCheck: true,
+		},
+	})
 	if err != nil {
 		if conflErr, ok := err.(*ChangeConflictError); ok {
 			// If we aren't seeded, then it's too early to do any updates and we cannot

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -235,7 +235,7 @@ func arrangeRebootAndUpdateSeed(
 	st *state.State,
 	stss []snapInstallTaskSet,
 	earlyDownloads map[string]bool,
-	dctx DeviceContext,
+	opts Options,
 ) (seedRefreshTS *state.TaskSet, err error) {
 	for _, sts := range stss {
 		if len(sts.beforeLocalSystemModificationsTasks) == 0 ||
@@ -251,7 +251,7 @@ func arrangeRebootAndUpdateSeed(
 	// note that seedSnapTaskSets will contain all snaps being refreshed that
 	// will go into the seed, and it might contain a combination of essential
 	// and non-essential snaps.
-	seedTS, seedSnapTaskSets, err := seedRefreshAndSeedSnapTaskSets(st, stss, dctx)
+	seedTS, seedSnapTaskSets, err := seedRefreshAndSeedSnapTaskSets(st, stss, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func arrangeRebootAndUpdateSeed(
 		return tasks[len(tasks)-1]
 	}
 
-	bootBase, err := deviceModelBootBase(st, nil)
+	bootBase, err := deviceModelBootBase(st, opts.DeviceCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -445,7 +445,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsUC16NoSplits(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// core, kernel should have individual restart boundaries
@@ -471,7 +471,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssential(c *C) {
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Snapd should have no restart boundaries
@@ -512,7 +512,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -583,7 +583,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadget(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -650,7 +650,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsGadgetKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -718,7 +718,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadgetKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	linkSnapBase := stss[0].TaskSet().MaybeEdge(snapstate.MaybeRebootEdge)
@@ -814,7 +814,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloads(c *C) {
 		"core20":    true,
 		"my-kernel": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	baseLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -843,7 +843,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdEarlyDownload(c *C) {
 	earlyDownloads := map[string]bool{
 		"snapd": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	snapdLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -880,7 +880,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssentialEarlyDownlo
 		"snapd":  true,
 		"core20": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	snapdEnd, err := stss[0].TaskSet().Edge(snapstate.EndEdge)
@@ -922,7 +922,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloadedAppWaitsAfter
 		"my-kernel": true,
 		"some-app":  true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	finalEssential, err := stss[1].TaskSet().Edge(snapstate.EndEdge)
@@ -951,7 +951,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsNoEarlyDownloads(c *C) {
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	baseLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -997,7 +997,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshComponentExclusiv
 		s.componentExclusiveInstallTaskSetForSnapSetup("some-app", snap.TypeApp),
 	}
 
-	seedUpdateTS, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	seedUpdateTS, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 	c.Assert(seedUpdateTS, NotNil)
 
@@ -1024,7 +1024,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapd(c *C) {
 		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Do not expect any restart boundaries to be set on snapd
@@ -1049,7 +1049,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBootBaseAndOtherBases(c *C) 
 		s.snapInstallTaskSetForSnapSetup("core18", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Only the boot-base should have restart boundary.
@@ -1073,7 +1073,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBaseAndWithout(c 
 		s.snapInstallTaskSetForSnapSetup("snap-base-app", "snap-base", snap.TypeApp),
 		s.snapInstallTaskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// No restart boundaries
@@ -1103,7 +1103,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBootBaseAndWithou
 		s.snapInstallTaskSetForSnapSetup("snap-core20-app", "snap-core20", snap.TypeApp),
 		s.snapInstallTaskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// Restart boundaries is set for core20 as the boot-base
@@ -1137,7 +1137,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsAll(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core", "", snap.TypeOS),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, IsNil)
 
 	// snapd has no restart boundaries set
@@ -1168,6 +1168,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsFailsSplit(c *C) {
 	stss := []snapstate.SnapInstallTaskSet{
 		snapstate.NewSnapInstallTaskSetForTest(nil, nil, nil, nil, nil, nil),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, s.deviceCtx(c))
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
 	c.Assert(err, ErrorMatches, `internal error: snap install task set has empty slices`)
 }

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -53,7 +53,7 @@ func seedRefreshEnabled(st *state.State) (bool, error) {
 
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
-func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, deviceCtx DeviceContext) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
+func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
 	enabled, err := seedRefreshEnabled(st)
 	if err != nil {
 		return nil, nil, err
@@ -63,7 +63,13 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 		return nil, nil, nil
 	}
 
-	deviceCtx, err = DeviceCtx(st, nil, deviceCtx)
+	// if the tasks here are being created from within a change that is already
+	// creating a recovery system, then we don't want to create another one.
+	if chg := st.Change(opts.FromChange); chg != nil && changeCreatesRecoverySystem(chg) {
+		return nil, nil, nil
+	}
+
+	deviceCtx, err := DeviceCtx(st, nil, opts.DeviceCtx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -51,6 +51,19 @@ func seedRefreshEnabled(st *state.State) (bool, error) {
 	return seedRefresh, nil
 }
 
+func changeHasPendingSeedRefresh(chg *state.Change) bool {
+	for _, t := range chg.Tasks() {
+		switch t.Kind() {
+		case "create-recovery-system", "finalize-recovery-system":
+			if !t.Status().Ready() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
 func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
@@ -63,9 +76,9 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 		return nil, nil, nil
 	}
 
-	// if the tasks here are being created from within a change that is already
-	// creating a recovery system, then we don't want to create another one.
-	if chg := st.Change(opts.FromChange); chg != nil && changeCreatesRecoverySystem(chg) {
+	// if the tasks here are being created from within a change that is still
+	// performing a seed refresh, then we don't want to create another one.
+	if chg := st.Change(opts.FromChange); chg != nil && changeHasPendingSeedRefresh(chg) {
 		return nil, nil, nil
 	}
 

--- a/overlord/snapstate/snap.go
+++ b/overlord/snapstate/snap.go
@@ -46,8 +46,8 @@ import (
 type installContext struct {
 	SkipConfigure       bool
 	NoRestartBoundaries bool
-	FromChange          string
-	DeviceCtx           DeviceContext
+	ConflictOptions
+	DeviceCtx DeviceContext
 }
 
 // snapInstallTaskSet captures the task ranges involved in a snap installation.
@@ -150,7 +150,7 @@ func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *tas
 	})
 
 	componentTSS, err := splitComponentTasksForInstall(
-		sc.compsups, st, sc.snapst, sc.snapsup, prepare, ic.FromChange)
+		sc.compsups, st, sc.snapst, sc.snapsup, prepare, ic.ConflictOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -841,7 +841,7 @@ func checkInstallPreconditions(st *state.State, snapst *SnapState, snapsup *Snap
 		return err
 	}
 
-	if err := checkChangeConflictIgnoringOneChange(st, snapsup.InstanceName(), snapst, ic.FromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, snapsup.InstanceName(), snapst, ic.ConflictOptions); err != nil {
 		return err
 	}
 
@@ -918,11 +918,11 @@ func splitComponentTasksForInstall(
 	snapst *SnapState,
 	snapsup *SnapSetup,
 	snapsupTask *state.Task,
-	fromChange string,
+	copts ConflictOptions,
 ) (multiComponentInstallTaskSet, error) {
 	componentTSS := make([]componentInstallTaskSet, 0, len(compsups))
 	for _, compsup := range compsups {
-		cts, err := doInstallComponent(st, snapst, compsup, snapsup, snapsupTask, nil, nil, fromChange)
+		cts, err := doInstallComponent(st, snapst, compsup, snapsup, snapsupTask, nil, nil, copts)
 		if err != nil {
 			return multiComponentInstallTaskSet{}, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -723,11 +723,11 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 	})
 
 	_, ts, err := InstallOne(ctx, st, target, Options{
-		Flags:         flags,
-		UserID:        userID,
-		FromChange:    fromChange,
-		PrereqTracker: prqt,
-		DeviceCtx:     deviceCtx,
+		Flags:           flags,
+		UserID:          userID,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		PrereqTracker:   prqt,
+		DeviceCtx:       deviceCtx,
 	})
 	if err != nil {
 		return nil, err
@@ -759,11 +759,11 @@ func InstallPathWithDeviceContext(st *state.State, si *snap.SideInfo, path, name
 	})
 
 	_, ts, err := InstallOne(context.Background(), st, target, Options{
-		Flags:         flags,
-		UserID:        userID,
-		FromChange:    fromChange,
-		PrereqTracker: prqt,
-		DeviceCtx:     deviceCtx,
+		Flags:           flags,
+		UserID:          userID,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		PrereqTracker:   prqt,
+		DeviceCtx:       deviceCtx,
 	})
 	if err != nil {
 		return nil, err
@@ -1295,10 +1295,10 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 
 	goal := StoreUpdateGoal(updates...)
 	return UpdateWithGoal(ctx, st, goal, filter, Options{
-		Flags:      *flags,
-		UserID:     userID,
-		FromChange: fromChange,
-		DeviceCtx:  nil,
+		Flags:           *flags,
+		UserID:          userID,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		DeviceCtx:       nil,
 	})
 }
 
@@ -1561,7 +1561,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 
 	if len(mustPruneAutoAliases) != 0 {
 		var err error
-		pruningAutoAliasesTs, err = applyAutoAliasesDelta(st, mustPruneAutoAliases, "prune", refreshAll, opts.FromChange, func(snapName string, _ *state.TaskSet) {
+		pruningAutoAliasesTs, err = applyAutoAliasesDelta(st, mustPruneAutoAliases, "prune", refreshAll, opts.ConflictOptions, func(snapName string, _ *state.TaskSet) {
 			if nameSet[snapName] {
 				reportUpdated[snapName] = true
 			}
@@ -1627,7 +1627,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 		// Do not set any default restart boundaries, we do it when we have access to all
 		// the task-sets in preparation for single-reboot.
 		sts, err := doInstallOrPreDownload(st, &up.SnapState, &up.Setup, up.Components, installContext{
-			FromChange:          opts.FromChange,
+			ConflictOptions:     opts.ConflictOptions,
 			DeviceCtx:           opts.DeviceCtx,
 			NoRestartBoundaries: true,
 		})
@@ -1670,7 +1670,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 	}
 
 	if len(newAutoAliases) != 0 {
-		addAutoAliasesTs, err := applyAutoAliasesDelta(st, newAutoAliases, "refresh", refreshAll, opts.FromChange, scheduleUpdate)
+		addAutoAliasesTs, err := applyAutoAliasesDelta(st, newAutoAliases, "refresh", refreshAll, opts.ConflictOptions, scheduleUpdate)
 		if err != nil {
 			return nil, false, nil, err
 		}
@@ -1724,7 +1724,7 @@ func maybeSwitchSnapMetadataTaskSet(st *state.State, snapsup SnapSetup, snapst S
 		return nil, nil
 	}
 
-	if err := checkChangeConflictIgnoringOneChange(st, snapst.InstanceName(), nil, opts.FromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, snapst.InstanceName(), nil, opts.ConflictOptions); err != nil {
 		return nil, err
 	}
 
@@ -1833,7 +1833,7 @@ func reRefreshSummary(updated []string, flags *Flags) string {
 	return msg
 }
 
-func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string, refreshAll bool, fromChange string, linkTs func(instanceName string, ts *state.TaskSet)) (*state.TaskSet, error) {
+func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string, refreshAll bool, copts ConflictOptions, linkTs func(instanceName string, ts *state.TaskSet)) (*state.TaskSet, error) {
 	applyTs := state.NewTaskSet()
 	kind := "refresh-aliases"
 	msg := i18n.G("Refresh aliases for snap %q")
@@ -1842,7 +1842,7 @@ func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string
 		msg = i18n.G("Prune automatic aliases for snap %q")
 	}
 	for instanceName, aliases := range delta {
-		if err := checkChangeConflictIgnoringOneChange(st, instanceName, nil, fromChange); err != nil {
+		if err := checkChangeConflictIgnoringOneChange(st, instanceName, nil, copts); err != nil {
 			if refreshAll {
 				// doing "refresh all", just skip this snap
 				logger.Noticef("cannot %s automatic aliases for snap %q: %v", op, instanceName, err)
@@ -2227,11 +2227,11 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	})
 
 	return UpdateOne(context.Background(), st, goal, nil, Options{
-		Flags:         flags,
-		UserID:        userID,
-		DeviceCtx:     deviceCtx,
-		FromChange:    fromChange,
-		PrereqTracker: prqt,
+		Flags:           flags,
+		UserID:          userID,
+		DeviceCtx:       deviceCtx,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		PrereqTracker:   prqt,
 	})
 }
 
@@ -2259,11 +2259,11 @@ func UpdatePathWithDeviceContext(st *state.State, si *snap.SideInfo, path, name 
 		RevOpts:      *opts,
 	})
 	return UpdateOne(context.Background(), st, goal, nil, Options{
-		Flags:         flags,
-		UserID:        userID,
-		DeviceCtx:     deviceCtx,
-		PrereqTracker: prqt,
-		FromChange:    fromChange,
+		Flags:           flags,
+		UserID:          userID,
+		DeviceCtx:       deviceCtx,
+		PrereqTracker:   prqt,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
 	})
 }
 
@@ -2366,7 +2366,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 			continue
 		}
 
-		if err := checkChangeConflictIgnoringOneChange(st, name, &t.snapst, fromChange); err != nil {
+		if err := checkChangeConflictIgnoringOneChange(st, name, &t.snapst, ConflictOptions{FromChange: fromChange}); err != nil {
 			logger.Noticef("cannot refresh snap %q: %v", name, err)
 		} else {
 			updates = append(updates, name)
@@ -2511,10 +2511,10 @@ func autoRefreshPhase2(st *state.State, candidates []*refreshCandidate, flags *F
 
 	const userID = 0
 	_, updateTss, err := doPotentiallySplitUpdate(st, nil, updates, Options{
-		Flags:      *flags,
-		UserID:     userID,
-		FromChange: fromChange,
-		DeviceCtx:  deviceCtx,
+		Flags:           *flags,
+		UserID:          userID,
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		DeviceCtx:       deviceCtx,
 	})
 	if err != nil {
 		return nil, err
@@ -2689,7 +2689,7 @@ func LinkNewBaseOrKernel(st *state.State, name string, fromChange string, device
 		return nil, err
 	}
 
-	if err := checkChangeConflictIgnoringOneChange(st, name, nil, fromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, name, nil, ConflictOptions{FromChange: fromChange}); err != nil {
 		return nil, err
 	}
 
@@ -2874,7 +2874,7 @@ func SwitchToNewGadget(st *state.State, name string, fromChange string) (*state.
 		return nil, err
 	}
 
-	if err := checkChangeConflictIgnoringOneChange(st, name, nil, fromChange); err != nil {
+	if err := checkChangeConflictIgnoringOneChange(st, name, nil, ConflictOptions{FromChange: fromChange}); err != nil {
 		return nil, err
 	}
 
@@ -3607,7 +3607,9 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		})
 	}
 
-	installTS, err := doInstallOrPreDownload(st, &snapst, &snapsup, compsups, installContext{FromChange: fromChange})
+	installTS, err := doInstallOrPreDownload(st, &snapst, &snapsup, compsups, installContext{
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1655,7 +1655,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 		scheduleUpdate(up.Setup.InstanceName(), sts.ts)
 	}
 
-	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, nil, opts.DeviceCtx)
+	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, nil, opts)
 	if err != nil {
 		return nil, false, nil, err
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20851,6 +20851,50 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAddition
 	c.Check(seedSetup.ComponentSetupTasks, DeepEquals, appCompSetupTaskIDs)
 }
 
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedBasedOnFromChange(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app", "content-provider"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+	)
+
+	countTasksOfKind := func(tasks []*state.Task, kind string) int {
+		var count int
+		for _, task := range tasks {
+			if task.Kind() == kind {
+				count++
+			}
+		}
+		return count
+	}
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	c.Assert(findSeedRefreshTaskSet(uts.Refresh), NotNil)
+	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
+	c.Assert(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 1)
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "content-provider"})
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
+		UserID:          s.user.ID,
+		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID()},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
+	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+}
+
 func (s *snapmgrTestSuite) TestUpdateOneIncludeFromChangeInTaskConflictCheckIgnoresSameChangeSeedRefreshExclusivity(c *C) {
 	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -309,6 +309,16 @@ func splitSeedRefreshTasks(c *C, seedTS *state.TaskSet) (create, finalize *state
 	return create, finalize, removals
 }
 
+func countTasksOfKind(tasks []*state.Task, kind string) int {
+	var count int
+	for _, task := range tasks {
+		if task.Kind() == kind {
+			count++
+		}
+	}
+	return count
+}
+
 func assertTaskSetStatus(c *C, ts *state.TaskSet, expected state.Status) {
 	for _, t := range ts.Tasks() {
 		c.Check(t.Status(), Equals, expected)
@@ -20851,7 +20861,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAddition
 	c.Check(seedSetup.ComponentSetupTasks, DeepEquals, appCompSetupTaskIDs)
 }
 
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedBasedOnFromChange(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedWhileParentSeedRefreshNotReady(c *C) {
 	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
 		"base":           "core18",
@@ -20869,16 +20879,6 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedBasedOnFromChange
 		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
 	)
 
-	countTasksOfKind := func(tasks []*state.Task, kind string) int {
-		var count int
-		for _, task := range tasks {
-			if task.Kind() == kind {
-				count++
-			}
-		}
-		return count
-	}
-
 	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
 	c.Assert(findSeedRefreshTaskSet(uts.Refresh), NotNil)
 	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
@@ -20893,6 +20893,107 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedBasedOnFromChange
 
 	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
 	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowedOnceParentSeedRefreshReady(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app", "content-provider"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	seedTS := findSeedRefreshTaskSet(uts.Refresh)
+	c.Assert(seedTS, NotNil)
+
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+	seedCreate.SetStatus(state.DoneStatus)
+	seedFinalize.SetStatus(state.DoneStatus)
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "content-provider"})
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
+		UserID:          s.user.ID,
+		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID()},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 1)
+	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 1)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshReRefreshCreatesSecondSeed(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restartRequested := mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	s.fakeStore.refreshRevnos = map[string]snap.Revision{"some-app-id": snap.R(11)}
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	c.Assert(findSeedRefreshTaskSet(uts.Refresh), NotNil)
+
+	var rerefreshCalls int
+	defer snapstate.MockReRefreshUpdateMany(func(ctx context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, fromChange string) ([]string, *snapstate.UpdateTaskSets, error) {
+		rerefreshCalls++
+		c.Check(snaps, DeepEquals, []string{"some-app"})
+		c.Check(fromChange, Equals, chg.ID())
+
+		s.fakeStore.refreshRevnos["some-app-id"] = snap.R(12)
+		goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "some-app"})
+		return snapstate.UpdateWithGoal(ctx, st, goal, nil, snapstate.Options{
+			UserID:          userID,
+			Flags:           *flags,
+			ConflictOptions: snapstate.ConflictOptions{FromChange: fromChange},
+		})
+	})()
+
+	// initial refresh reaches the first seed reboot boundary.
+	s.settle(c)
+	c.Check(restart.Pending(s.state), Equals, restart.RestartSystem)
+	c.Check(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
+	c.Check(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 1)
+
+	// after the first reboot, check-rerefresh adds the second refresh and reaches
+	// the next seed reboot boundary.
+	s.mockRestartAndSettle(c, chg)
+	c.Check(restart.Pending(s.state), Equals, restart.RestartSystem)
+	c.Check(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 2)
+	c.Check(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 2)
+
+	// the second reboot completes the re-refresh seed update.
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	c.Assert(chg.IsReady(), Equals, true, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	c.Check(*restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem, restart.RestartSystem})
+
+	var someAppState snapstate.SnapState
+	err := snapstate.Get(s.state, "some-app", &someAppState)
+	c.Assert(err, IsNil)
+	c.Check(someAppState.Current, Equals, snap.R(12))
 }
 
 func (s *snapmgrTestSuite) TestUpdateOneIncludeFromChangeInTaskConflictCheckIgnoresSameChangeSeedRefreshExclusivity(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20851,6 +20851,48 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAddition
 	c.Check(seedSetup.ComponentSetupTasks, DeepEquals, appCompSetupTaskIDs)
 }
 
+func (s *snapmgrTestSuite) TestUpdateOneIncludeFromChangeInTaskConflictCheckIgnoresSameChangeSeedRefreshExclusivity(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+	)
+
+	chg := s.state.NewChange("refresh-snap", "...")
+	chg.AddTask(s.state.NewTask("create-recovery-system", "Create recovery system"))
+
+	other := s.state.NewTask("same-change-update", "same-change update for content-provider")
+	other.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "content-provider",
+			Revision: snap.R(11),
+		},
+	})
+	chg.AddTask(other)
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "content-provider"})
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
+		UserID:          s.user.ID,
+		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID(), IncludeFromChangeInTaskConflictCheck: true},
+	})
+	c.Assert(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Assert(err, ErrorMatches, `snap "content-provider" has "refresh-snap" change in progress`)
+
+	var conflErr *snapstate.ChangeConflictError
+	c.Assert(errors.As(err, &conflErr), Equals, true)
+	c.Check(conflErr.ChangeID, Equals, chg.ID())
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBlockedByOtherChanges(c *C) {
 	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel": "kernel",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -21028,7 +21028,7 @@ func (s *snapmgrTestSuite) TestUpdateOneIncludeFromChangeInTaskConflictCheckIgno
 	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "content-provider"})
 	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
 		UserID:          s.user.ID,
-		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID(), IncludeFromChangeInTaskConflictCheck: true},
+		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID(), DoNotIgnoreFromChangeInTaskConflictCheck: true},
 	})
 	c.Assert(err, FitsTypeOf, &snapstate.ChangeConflictError{})
 	c.Assert(err, ErrorMatches, `snap "content-provider" has "refresh-snap" change in progress`)

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -37,6 +37,18 @@ import (
 	"github.com/snapcore/snapd/store"
 )
 
+// ConflictOptions contains optional settings for conflict checks triggered by
+// nested operations that were spawned from an existing change.
+type ConflictOptions struct {
+	// FromChange is the change that triggered the operation.
+	FromChange string
+	// IncludeFromChangeInTaskConflictCheck makes task-level conflict checks
+	// continue to inspect tasks in FromChange while still ignoring FromChange
+	// for exclusive change conflicts. This is for internal use by nested
+	// operations spawned from an existing change.
+	IncludeFromChangeInTaskConflictCheck bool
+}
+
 // Options contains optional parameters for the snapstate operations. All of
 // these fields are optional and can be left unset. The options in this struct
 // apply to all snaps that are part of an operation. Options that apply to
@@ -53,8 +65,7 @@ type Options struct {
 	// track of all snaps (explicitly requested and implicitly required snaps)
 	// that might need to be installed during the operation.
 	PrereqTracker PrereqTracker
-	// FromChange is the change that triggered the operation.
-	FromChange string
+	ConflictOptions
 	// Seed should be true while seeding the device. This indicates that we
 	// shouldn't require that the device is seeded before installing/updating
 	// snaps.
@@ -893,9 +904,9 @@ func InstallWithGoal(ctx context.Context, st *state.State, goal InstallGoal, opt
 		}
 
 		installTS, err := doInstallOrPreDownload(st, &t.snapst, &snapsup, compsups, installContext{
-			FromChange:    opts.FromChange,
-			DeviceCtx:     opts.DeviceCtx,
-			SkipConfigure: opts.Flags.SkipConfigure,
+			ConflictOptions: opts.ConflictOptions,
+			DeviceCtx:       opts.DeviceCtx,
+			SkipConfigure:   opts.Flags.SkipConfigure,
 		})
 		if err != nil {
 			return nil, nil, err

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -42,11 +42,11 @@ import (
 type ConflictOptions struct {
 	// FromChange is the change that triggered the operation.
 	FromChange string
-	// IncludeFromChangeInTaskConflictCheck makes task-level conflict checks
+	// DoNotIgnoreFromChangeInTaskConflictCheck makes task-level conflict checks
 	// continue to inspect tasks in FromChange while still ignoring FromChange
 	// for exclusive change conflicts. This is for internal use by nested
 	// operations spawned from an existing change.
-	IncludeFromChangeInTaskConflictCheck bool
+	DoNotIgnoreFromChangeInTaskConflictCheck bool
 }
 
 // Options contains optional parameters for the snapstate operations. All of


### PR DESCRIPTION
Since this change now actually sets `opts.FromChange` when updating a snap from the `prerequisites` task, we can no longer rely on the internal conflict detection code to check for same-change conflicts.

Thus, we do this check a bit earlier now, and only use the internal conflict detection code to handle cross-change conflicts.