### PR TITLE
o/snapstate: merge content-provider prerequisite updates into seed-refresh

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -298,6 +298,7 @@ func delayedCrossMgrInit() {
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.RemodelingChange = RemodelingChange
 	snapstate.SeedRefreshTasks = SeedRefreshTasks
+	snapstate.AppendSeedRefreshSetupTaskIDs = AppendSeedRefreshSetupTaskIDs
 }
 
 // proxyStore returns the store assertion for the proxy store if one is set.
@@ -1815,6 +1816,37 @@ func SeedRefreshTasks(st *state.State, snapSetupTasks, compSetupTasks []string) 
 		Finalize: finalize,
 		Remove:   removals,
 	}, nil
+}
+
+// AppendSeedRefreshSetupTaskIDs appends unique setup task IDs to the
+// create-recovery-system task recovery-system-setup payload.
+func AppendSeedRefreshSetupTaskIDs(create *state.Task, snapSetupTask string, compSetupTasks []string) error {
+	setup, err := taskRecoverySystemSetup(create)
+	if err != nil {
+		return err
+	}
+
+	setup.SnapSetupTasks = appendUnique(setup.SnapSetupTasks, snapSetupTask)
+	setup.ComponentSetupTasks = appendUnique(setup.ComponentSetupTasks, compSetupTasks...)
+
+	return setTaskRecoverySystemSetup(create, setup)
+}
+
+func appendUnique(slice []string, additions ...string) []string {
+	seen := make(map[string]bool, len(slice))
+	for _, id := range slice {
+		seen[id] = true
+	}
+
+	for _, id := range additions {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		slice = append(slice, id)
+		seen[id] = true
+	}
+
+	return slice
 }
 
 // seedRefreshLabelsToRemove returns the existing seed-refresh systems that

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2230,6 +2230,27 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
 	c.Check(labels, testutil.DeepUnsortedMatches, []string{"old-seed-refresh-1", "old-seed-refresh-2"})
 }
 
+func (s *deviceMgrSuite) TestAppendSeedRefreshSetupTaskIDs(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	create := s.state.NewTask("create-recovery-system", "...")
+	create.Set("recovery-system-setup", &devicestate.RecoverySystemSetup{
+		Label:               "20260227",
+		Directory:           filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", "20260227"),
+		SnapSetupTasks:      []string{"snap-1"},
+		ComponentSetupTasks: []string{"comp-1"},
+	})
+
+	c.Assert(devicestate.AppendSeedRefreshSetupTaskIDs(create, "snap-2", []string{"comp-2", "comp-1"}), IsNil)
+	c.Assert(devicestate.AppendSeedRefreshSetupTaskIDs(create, "snap-1", []string{"comp-3"}), IsNil)
+
+	var setup devicestate.RecoverySystemSetup
+	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
+	c.Check(setup.SnapSetupTasks, DeepEquals, []string{"snap-1", "snap-2"})
+	c.Check(setup.ComponentSetupTasks, DeepEquals, []string{"comp-1", "comp-2", "comp-3"})
+}
+
 func (s *deviceMgrSuite) TestRemoveRecoverySystemBlockedWhenAnotherRemovalRunning(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -558,19 +558,6 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		return nil, err
 	}
 
-	// TODO:SEEDREFRESH: lift this restriction. this can currently be avoided by
-	// ensuring that the content-provider prereq is a part of the original
-	// refresh. without this guard, the create-recovery-system task will not
-	// know about this incoming snap, and the seed won't end up using this new
-	// revision of the content-provider.
-	if changeCreatesRecoverySystem(t.Change()) {
-		for _, sn := range deviceCtx.Model().AllSnaps() {
-			if snapName == sn.Name {
-				return nil, errors.New("cannot update seed while also automatically updating content provider")
-			}
-		}
-	}
-
 	// TODO: as a temporary workaround for a bug that occurs when a snap updates
 	// a prereq, we disable rerefreshes.
 	//
@@ -616,6 +603,10 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		// content provider is (for now) a soft dependency
 		t.Logf("cannot update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), err)
 		return nil, nil
+	}
+
+	if err := maybeMergeLateSeedRefreshPrereq(t.Change(), deviceCtx, snapName, ts); err != nil {
+		return nil, err
 	}
 
 	return ts, nil

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -237,24 +237,37 @@ func defaultPrereqSnapsChannel() string {
 	return channel
 }
 
+func maybeFindTaskInChangeForSnap(chg *state.Change, kind, snapName string) (*state.Task, error) {
+	for _, t := range chg.Tasks() {
+		if t.Status().Ready() || t.Kind() != kind {
+			continue
+		}
+
+		snapsup, err := TaskSnapSetup(t)
+		if err != nil {
+			return nil, err
+		}
+		if snapsup.InstanceName() == snapName {
+			return t, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func findLinkSnapTaskForSnap(st *state.State, snapName string) (*state.Task, error) {
 	for _, chg := range st.Changes() {
 		if chg.IsReady() {
 			continue
 		}
-		for _, tc := range chg.Tasks() {
-			if tc.Status().Ready() {
-				continue
-			}
-			if tc.Kind() == "link-snap" {
-				snapsup, err := TaskSnapSetup(tc)
-				if err != nil {
-					return nil, err
-				}
-				if snapsup.InstanceName() == snapName {
-					return tc, nil
-				}
-			}
+
+		t, err := maybeFindTaskInChangeForSnap(chg, "link-snap", snapName)
+		if err != nil {
+			return nil, err
+		}
+
+		if t != nil {
+			return t, nil
 		}
 	}
 

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -143,9 +143,85 @@ func setupTaskIDsForSeedCreation(seedSnapUpdates map[string]snapInstallTaskSet) 
 	return snapsupIDs, compsupIDs, nil
 }
 
+// maybeMergeLateSeedRefreshPrereq folds a prerequisite refresh into an
+// in-flight seed refresh when the prerequisite snap is part of the model.
+func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, snapName string, providerTS *state.TaskSet) error {
+	if !changeCreatesRecoverySystem(chg) {
+		return nil
+	}
+
+	// TODO:SEEDREFRESH: consider the intersections of snaps in the model and
+	// snaps currently present in the seed, not all snaps in the model
+	for _, sn := range dctx.Model().AllSnaps() {
+		if snapName != sn.SnapName() {
+			continue
+		}
+
+		return mergeLateSeedRefreshPrereq(chg, providerTS)
+	}
+
+	return nil
+}
+
+func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) error {
+	var create, finalize *state.Task
+	for _, t := range chg.Tasks() {
+		switch t.Kind() {
+		case "create-recovery-system":
+			create = t
+		case "finalize-recovery-system":
+			finalize = t
+		}
+	}
+
+	if create == nil || finalize == nil {
+		return errors.New("internal error: seed-refresh change is missing recovery-system tasks")
+	}
+
+	snapsup, err := providerTS.Edge(SnapSetupEdge)
+	if err != nil {
+		return errors.New("internal error: seed-refresh provider task set is missing required edge")
+	}
+
+	var compsups []string
+	if err := snapsup.Get("component-setup-tasks", &compsups); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	if err := AppendSeedRefreshSetupTaskIDs(create, snapsup.ID(), compsups); err != nil {
+		return err
+	}
+
+	for _, lane := range create.Lanes() {
+		providerTS.JoinLane(lane)
+	}
+
+	end, err := providerTS.Edge(EndEdge)
+	if err != nil {
+		return errors.New("internal error: seed-refresh provider task set is missing required edge")
+	}
+
+	lastBeforeLocal, err := providerTS.Edge(LastBeforeLocalModificationsEdge)
+	if err != nil {
+		return errors.New("internal error: seed-refresh provider task set is missing required edge")
+	}
+
+	// TODO:SEEDREFRESH: what about content-providers that are essential snaps?
+	// this ordering is probably too weak, since essential snap updates trigger
+	// reboots that would interfere with the original single-reboot
+	// orchestration. however, this is not a uniquely seed-refresh problem.
+
+	waitForIfNeeded(create, lastBeforeLocal)
+	waitForIfNeeded(finalize, end)
+
+	return nil
+}
+
 // taskSetsForSeedSnaps returns the selected refresh task sets keyed by
 // snap name for snaps present in the model.
 func taskSetsForSeedSnaps(stss []snapInstallTaskSet, dctx DeviceContext) map[string]snapInstallTaskSet {
+	// TODO:SEEDREFRESH: consider the intersections of snaps in the model and
+	// snaps currently present in the seed, not all snaps in the model
 	seedSnaps := make(map[string]bool)
 	for _, sn := range dctx.Model().AllSnaps() {
 		seedSnaps[sn.SnapName()] = true

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -230,6 +230,10 @@ func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, prov
 	return fmt.Errorf("cannot automatically update prerequisite %q during seed-refresh while base %q waits for create-recovery-system", snapsup.InstanceName(), base)
 }
 
+// mergeLateSeedRefreshPrereq folds a prerequisite refresh into the existing
+// seed-refresh task graph by adding its setup tasks to create-recovery-system,
+// joining its task set to the seed-refresh lanes, and ensuring seed creation
+// tasks depend on the prerequisite refresh tasks.
 func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) error {
 	create, finalize, err := findRecoverySystemTasks(chg)
 	if err != nil {

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -145,9 +145,10 @@ func setupTaskIDsForSeedCreation(seedSnapUpdates map[string]snapInstallTaskSet) 
 }
 
 // maybeMergeLateSeedRefreshPrereq folds a prerequisite refresh into an
-// in-flight seed refresh when the prerequisite snap is part of the model.
+// in-flight seed refresh when the current change still has pending
+// recovery-system tasks and the prerequisite snap is part of the model.
 func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, snapName string, providerTS *state.TaskSet) error {
-	if !changeCreatesRecoverySystem(chg) {
+	if !changeHasPendingSeedRefresh(chg) {
 		return nil
 	}
 

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -157,14 +158,18 @@ func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, snap
 			continue
 		}
 
+		// TODO:SEEDREFRESH: drop this check
+		if err := errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg, providerTS); err != nil {
+			return err
+		}
+
 		return mergeLateSeedRefreshPrereq(chg, providerTS)
 	}
 
 	return nil
 }
 
-func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) error {
-	var create, finalize *state.Task
+func findRecoverySystemTasks(chg *state.Change) (create, finalize *state.Task, err error) {
 	for _, t := range chg.Tasks() {
 		switch t.Kind() {
 		case "create-recovery-system":
@@ -175,7 +180,56 @@ func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) er
 	}
 
 	if create == nil || finalize == nil {
-		return errors.New("internal error: seed-refresh change is missing recovery-system tasks")
+		return nil, nil, errors.New("internal error: seed-refresh change is missing recovery-system tasks")
+	}
+
+	return create, finalize, nil
+}
+
+// errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation rejects the currently
+// unsupported case where a prerequisite refresh depends on a base refresh whose
+// link-snap is ordered after create-recovery-system. Without extra
+// synchronization, the prerequisite refresh would wait forever on that base.
+func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, providerTS *state.TaskSet) error {
+	snapsupTask, err := providerTS.Edge(SnapSetupEdge)
+	if err != nil {
+		return errors.New("internal error: seed-refresh provider task set is missing required edge")
+	}
+
+	snapsup, err := TaskSnapSetup(snapsupTask)
+	if err != nil {
+		return err
+	}
+
+	if snapsup.Base == "" || snapsup.Base == "none" {
+		return nil
+	}
+
+	create, _, err := findRecoverySystemTasks(chg)
+	if err != nil {
+		return err
+	}
+
+	baseLink, err := maybeFindTaskInChangeForSnap(chg, "link-snap", snapsup.Base)
+	if err != nil {
+		return err
+	}
+	if baseLink == nil || !willWaitOn(baseLink, create) {
+		return nil
+	}
+
+	// TODO:SEEDREFRESH: introduce new form of prerequisite synchronization that
+	// lets a late prerequisite refresh account for a base refresh whose
+	// link-snap is ordered after create-recovery-system. without that extra
+	// ordering, the prerequisite task keeps retrying forever on the in-flight
+	// base link-snap.
+	return fmt.Errorf("cannot automatically update prerequisite %q during seed-refresh while base %q waits for create-recovery-system", snapsup.InstanceName(), snapsup.Base)
+}
+
+func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) error {
+	create, finalize, err := findRecoverySystemTasks(chg)
+	if err != nil {
+		return err
 	}
 
 	snapsup, err := providerTS.Edge(SnapSetupEdge)

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -40,6 +40,12 @@ var SeedRefreshTasks = func(st *state.State, snapSetupTasks, compSetupTasks []st
 	panic("internal error: snapstate.SeedRefreshTasks is unset")
 }
 
+// AppendSeedRefreshSetupTaskIDs is set by devicestate to avoid an import
+// cycle. See devicestate.AppendSeedRefreshSetupTaskIDs.
+var AppendSeedRefreshSetupTaskIDs = func(create *state.Task, snapSetupTask string, compSetupTasks []string) error {
+	panic("internal error: snapstate.AppendSeedRefreshSetupTaskIDs is unset")
+}
+
 // seedRefreshEnabled reports whether the experimental seed-refresh feature is
 // enabled.
 func seedRefreshEnabled(st *state.State) (bool, error) {

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -201,8 +201,12 @@ func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, prov
 		return err
 	}
 
-	if snapsup.Base == "" || snapsup.Base == "none" {
+	base := snapsup.Base
+	if base == "none" {
 		return nil
+	}
+	if base == "" {
+		base = defaultCoreSnapName
 	}
 
 	create, _, err := findRecoverySystemTasks(chg)
@@ -210,7 +214,7 @@ func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, prov
 		return err
 	}
 
-	baseLink, err := maybeFindTaskInChangeForSnap(chg, "link-snap", snapsup.Base)
+	baseLink, err := maybeFindTaskInChangeForSnap(chg, "link-snap", base)
 	if err != nil {
 		return err
 	}
@@ -223,7 +227,7 @@ func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, prov
 	// link-snap is ordered after create-recovery-system. without that extra
 	// ordering, the prerequisite task keeps retrying forever on the in-flight
 	// base link-snap.
-	return fmt.Errorf("cannot automatically update prerequisite %q during seed-refresh while base %q waits for create-recovery-system", snapsup.InstanceName(), snapsup.Base)
+	return fmt.Errorf("cannot automatically update prerequisite %q during seed-refresh while base %q waits for create-recovery-system", snapsup.InstanceName(), base)
 }
 
 func mergeLateSeedRefreshPrereq(chg *state.Change, providerTS *state.TaskSet) error {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -228,6 +228,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	oldEnsureSnapAbsentFromQuotaGroup := snapstate.EnsureSnapAbsentFromQuotaGroup
 	oldCreateRecoverySystemTasks := snapstate.SeedRefreshTasks
+	oldAppendSeedRefreshSetupTaskIDs := snapstate.AppendSeedRefreshSetupTaskIDs
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
 	snapstate.SetupInstallComponentHook = hookstate.SetupInstallComponentHook
 	snapstate.SetupPostRefreshComponentHook = hookstate.SetupPostRefreshComponentHook
@@ -254,6 +255,17 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 			Create:   create,
 			Finalize: finalize,
 		}, nil
+	}
+	snapstate.AppendSeedRefreshSetupTaskIDs = func(create *state.Task, snapSetupTask string, compSetupTasks []string) error {
+		var setup map[string][]string
+		if err := create.Get("recovery-system-setup", &setup); err != nil {
+			return err
+		}
+
+		setup["snap-setup-tasks"] = append(setup["snap-setup-tasks"], snapSetupTask)
+		setup["component-setup-tasks"] = append(setup["component-setup-tasks"], compSetupTasks...)
+		create.Set("recovery-system-setup", setup)
+		return nil
 	}
 
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
@@ -302,6 +314,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 		snapstate.SnapServiceOptions = oldSnapServiceOptions
 		snapstate.EnsureSnapAbsentFromQuotaGroup = oldEnsureSnapAbsentFromQuotaGroup
 		snapstate.SeedRefreshTasks = oldCreateRecoverySystemTasks
+		snapstate.AppendSeedRefreshSetupTaskIDs = oldAppendSeedRefreshSetupTaskIDs
 
 		dirs.SetRootDir("/")
 	})

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20209,6 +20209,70 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 	c.Assert(chg.IsReady(), Equals, true)
 }
 
+// TODO:SEEDREFRESH: update this test once this scenario is supported
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesFailsForProviderSwitchingToInFlightNonEssentialBase(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider", "some-app"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		switch info.InstanceName() {
+		case "some-app":
+			info.Plugs = map[string]*snap.PlugInfo{
+				"shared-content": {
+					Snap:      info,
+					Name:      "shared-content",
+					Interface: "content",
+					Attrs: map[string]any{
+						"default-provider": "content-provider",
+						"content":          "shared-content",
+					},
+				},
+			}
+		case "content-provider":
+			info.Base = "some-base"
+		}
+
+		return nil
+	}
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "some-base", snapID: "some-base-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, _ := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}, {InstanceName: "some-base"}})
+	taskSetsBySnap, _ := parseSeedRefreshTaskSets(uts)
+	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
+
+	prereqs := findKindInTaskSet(appTS, "prerequisites")
+	c.Assert(prereqs, NotNil)
+
+	s.state.Unlock()
+	err := s.o.SettleWithBreakCondition(testutil.HostScaledTimeout(10*time.Second), func() bool {
+		s.state.Lock()
+		defer s.state.Unlock()
+		return prereqs.Status().Ready()
+	})
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(prereqs.Status(), Equals, state.ErrorStatus)
+
+	c.Assert(prereqs.Status(), Equals, state.ErrorStatus)
+	c.Assert(strings.Join(prereqs.Log(), "\n"), Matches, `(?s).*cannot install prerequisite "content-provider": cannot automatically update prerequisite "content-provider" during seed-refresh while base "some-base" waits for create-recovery-system.*`)
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelContentProviderRefresh(c *C) {
 	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20113,9 +20113,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBaseAndModelSnapRun(c *C
 	c.Assert(chg.IsReady(), Equals, true)
 }
 
-// TODO:SEEDREFRESH: drop this test once seed refresh can automatically update
-// model content providers.
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBlocksAutoUpdateOfModelContentProvider(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesModelSnap(c *C) {
 	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
 		"base":           "core18",
@@ -20146,9 +20144,6 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBlocksAutoUpdateOfModelC
 
 		return nil
 	}
-	defer func() {
-		s.fakeStore.mutateSnapInfo = nil
-	}()
 
 	mockSeedRefreshRebootHandlers(s, c, nil)
 
@@ -20166,14 +20161,52 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBlocksAutoUpdateOfModelC
 
 	appSnapSetupTask, err := appTS.Edge(snapstate.SnapSetupEdge)
 	c.Assert(err, IsNil)
+
 	appSnapSetup, err := snapstate.TaskSnapSetup(appSnapSetupTask)
 	c.Assert(err, IsNil)
 	c.Assert(appSnapSetup.PrereqContentAttrs, DeepEquals, map[string][]string{"content-provider": {"shared-content"}})
 
 	s.settle(c)
 
-	c.Assert(chg.Status(), Equals, state.ErrorStatus)
-	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install prerequisite "content-provider": cannot update seed while also automatically updating content provider.*`)
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+
+	var seedSetup recoverySystemSetupForTest
+	c.Assert(seedCreate.Get("recovery-system-setup", &seedSetup), IsNil)
+
+	providerSetupTaskID := seedSetup.SnapSetupTasks[len(seedSetup.SnapSetupTasks)-1]
+	providerSnapSetupTask := s.state.Task(providerSetupTaskID)
+	c.Assert(providerSnapSetupTask, NotNil)
+
+	providerSnapSetup, err := snapstate.TaskSnapSetup(providerSnapSetupTask)
+	c.Assert(err, IsNil)
+	c.Check(providerSnapSetup.InstanceName(), Equals, "content-provider")
+
+	c.Check(seedSetup.SnapSetupTasks, testutil.Contains, providerSnapSetupTask.ID())
+
+	waitTasksContainKindForSnap := func(c *C, waiter *state.Task, instanceName, kind string) bool {
+		for _, task := range waiter.WaitTasks() {
+			if task.Kind() != kind {
+				continue
+			}
+
+			snapsup, err := snapstate.TaskSnapSetup(task)
+			c.Assert(err, IsNil)
+			if snapsup.InstanceName() == instanceName {
+				return true
+			}
+		}
+		return false
+	}
+
+	// ensure create-recovery-system waits on the LastBeforeLocalModificationsEdge for content-provider
+	c.Check(waitTasksContainKindForSnap(c, seedCreate, "content-provider", "validate-snap"), Equals, true)
+	// ensure finalize-recovery-system waits on the EndEdge for content-provider
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, true)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelContentProviderRefresh(c *C) {
@@ -20207,9 +20240,6 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelCont
 
 		return nil
 	}
-	defer func() {
-		s.fakeStore.mutateSnapInfo = nil
-	}()
 
 	mockSeedRefreshRebootHandlers(s, c, nil)
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -309,6 +309,21 @@ func splitSeedRefreshTasks(c *C, seedTS *state.TaskSet) (create, finalize *state
 	return create, finalize, removals
 }
 
+func waitTasksContainKindForSnap(c *C, waiter *state.Task, instanceName, kind string) bool {
+	for _, task := range waiter.WaitTasks() {
+		if task.Kind() != kind {
+			continue
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		if snapsup.InstanceName() == instanceName {
+			return true
+		}
+	}
+	return false
+}
+
 func countTasksOfKind(tasks []*state.Task, kind string) int {
 	var count int
 	for _, task := range tasks {
@@ -20183,21 +20198,6 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 
 	c.Check(seedSetup.SnapSetupTasks, testutil.Contains, providerSnapSetupTask.ID())
 
-	waitTasksContainKindForSnap := func(c *C, waiter *state.Task, instanceName, kind string) bool {
-		for _, task := range waiter.WaitTasks() {
-			if task.Kind() != kind {
-				continue
-			}
-
-			snapsup, err := snapstate.TaskSnapSetup(task)
-			c.Assert(err, IsNil)
-			if snapsup.InstanceName() == instanceName {
-				return true
-			}
-		}
-		return false
-	}
-
 	// ensure create-recovery-system waits on the LastBeforeLocalModificationsEdge for content-provider
 	c.Check(waitTasksContainKindForSnap(c, seedCreate, "content-provider", "validate-snap"), Equals, true)
 	// ensure finalize-recovery-system waits on the EndEdge for content-provider
@@ -20207,6 +20207,88 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesDoNotMergeWhenSeedRefreshAlreadyReady(c *C) {
+	restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider", "some-app"},
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.InstanceName() != "some-app" {
+			return nil
+		}
+
+		info.Plugs = map[string]*snap.PlugInfo{
+			"shared-content": {
+				Snap:      info,
+				Name:      "shared-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "content-provider",
+					"content":          "shared-content",
+				},
+			},
+		}
+
+		return nil
+	}
+
+	mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+
+	// manually mark these as done to prove that prerequisites won't add a snap
+	// to an already completed seed-refresh
+	seedCreate.SetStatus(state.DoneStatus)
+	seedFinalize.SetStatus(state.DoneStatus)
+
+	s.settle(c)
+
+	var seedSetup recoverySystemSetupForTest
+	c.Assert(seedCreate.Get("recovery-system-setup", &seedSetup), IsNil)
+
+	// ensure that the first recovery-system-setup doesn't have the
+	// content-provider as a source
+	for _, taskID := range seedSetup.SnapSetupTasks {
+		task := s.state.Task(taskID)
+		c.Assert(task, NotNil)
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		c.Check(snapsup.InstanceName(), Not(Equals), "content-provider")
+	}
+
+	// ensure that the seed-refresh tasks didn't get dependencies on the
+	// content-provider
+	c.Check(waitTasksContainKindForSnap(c, seedCreate, "content-provider", "validate-snap"), Equals, false)
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, false)
+
+	c.Check(restart.Pending(s.state), Equals, restart.RestartSystem)
+
+	// since content-provider is part of the model, we should end up creating
+	// new recovery-system tasks, rather than updating the existing one
+	c.Check(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 2)
+	c.Check(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 2)
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, false)
 }
 
 // TODO:SEEDREFRESH: update this test once this scenario is supported


### PR DESCRIPTION
This enables a seed-refresh to pull in an updated content-provider prerequisite into a newly created seed.

Based on https://github.com/canonical/snapd/pull/16924, first commit is 03408861bd0b1735e0c983ee6393b7da332d336b.