### PR TITLE
o/c/configcore: adjust prompting no handler service error message

### DIFF
--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -134,7 +134,7 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 		}
 
 		if len(handlers) == 0 {
-			return fmt.Errorf("cannot enable prompting feature no interfaces requests handler services are installed")
+			return fmt.Errorf("cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
 		}
 
 		// try to start all the handlers for all active users

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -134,7 +134,7 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 		}
 
 		if len(handlers) == 0 {
-			return fmt.Errorf("cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
+			return fmt.Errorf("cannot enable prompting feature: no interfaces requests handler services are installed, consider installing the 'prompting-client' snap")
 		}
 
 		// try to start all the handlers for all active users

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -377,7 +377,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersNone(c
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
+		"cannot enable prompting feature: no interfaces requests handler services are installed, consider installing the 'prompting-client' snap")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyButNoHandlerApp(c *C) {
@@ -394,7 +394,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyBu
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
+		"cannot enable prompting feature: no interfaces requests handler services are installed, consider installing the 'prompting-client' snap")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDisconnected(c *C) {
@@ -423,7 +423,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDiscon
 	s.state.Unlock()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
+		"cannot enable prompting feature: no interfaces requests handler services are installed, consider installing the 'prompting-client' snap")
 }
 
 type promptEnableWithServicesTestCase struct {

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -377,7 +377,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersNone(c
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handler services are installed")
+		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyButNoHandlerApp(c *C) {
@@ -394,7 +394,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyBu
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handler services are installed")
+		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDisconnected(c *C) {
@@ -423,7 +423,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDiscon
 	s.state.Unlock()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handler services are installed")
+		"cannot enable prompting feature: no interfaces requests handler services are installed; consider installing the 'prompting-client' snap")
 }
 
 type promptEnableWithServicesTestCase struct {


### PR DESCRIPTION
Present a clearer error message when trying to enable prompting when no handler service is present.

This relates to https://github.com/canonical/desktop-security-center/pull/204

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36607