### PR TITLE
cmd/snap-confine: support transparent_hugepage in AA profile

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -93,6 +93,10 @@
     /sys/fs/cgroup/ r,
     /sys/fs/cgroup/** r,
 
+    # required by glibc and usually provided by <abstractions/base>
+    /sys/kernel/mm/transparent_hugepage/enabled r,
+    /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+
     # cgroup: reading own cgroup
     @{PROC}/@{pid}/cgroup r,
 


### PR DESCRIPTION
These are required by glibc https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/sysdeps/unix/sysv/linux/malloc-hugepages.c#L56 and usually provided by <abstractions/base> which snap-confine's profile does not include.

https://warthogs.atlassian.net/browse/SNAPDENG-36779