### PR TITLE
overlord/ifacestate: disallow auto-connect to parallel installed slot snaps

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1677,7 +1677,14 @@ func getAllowOptionAsString(inter string, tr *config.Transaction) (string, error
 	return "", nil
 }
 
-func isSnapSlotAllowed(st *state.State, snapID string, slot *snap.SlotInfo, tr *config.Transaction) (bool, error) {
+func isSnapSlotAutoConnectAllowed(st *state.State, snapID string, slot *snap.SlotInfo, tr *config.Transaction) (bool, error) {
+	if slot.Snap.InstanceKey != "" {
+		// Disallow auto connecting to parallel installed slot snaps
+		// TODO:parallel-installs: figure out the policy for auto
+		// connections and parallel installed slot side snaps
+		return false, nil
+	}
+
 	// Until we decide that we want to support other interfaces, do a
 	// quick allow check for x11 only.
 	if slot.Interface != "x11" {
@@ -1705,7 +1712,7 @@ func filterAllowedAutoConnectionSlots(st *state.State, snapID string, ssi []*sna
 	var filtered []*snap.SlotInfo
 	tr := config.NewTransaction(st)
 	for _, slot := range ssi {
-		if allowed, err := isSnapSlotAllowed(st, snapID, slot, tr); err != nil {
+		if allowed, err := isSnapSlotAutoConnectAllowed(st, snapID, slot, tr); err != nil {
 			// In case there is any error of filtering auto-connections, assume something is horribly
 			// wrong and return to the default behaviour. However make sure we log this error from the
 			// caller.
@@ -1713,8 +1720,7 @@ func filterAllowedAutoConnectionSlots(st *state.State, snapID string, ssi []*sna
 		} else if allowed {
 			filtered = append(filtered, slot)
 		} else {
-			logger.Debugf("Interface %s was configured to be disallowed auto-connection, skipping connection",
-				slot.Interface)
+			logger.Debugf("slot %v interface %v disallowed auto-connection, skipping connection", slot, slot.Interface)
 		}
 	}
 	return filtered, nil

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1678,13 +1678,6 @@ func getAllowOptionAsString(inter string, tr *config.Transaction) (string, error
 }
 
 func isSnapSlotAutoConnectAllowed(st *state.State, snapID string, slot *snap.SlotInfo, tr *config.Transaction) (bool, error) {
-	if slot.Snap.InstanceKey != "" {
-		// Disallow auto connecting to parallel installed slot snaps
-		// TODO:parallel-installs: figure out the policy for auto
-		// connections and parallel installed slot side snaps
-		return false, nil
-	}
-
 	// Until we decide that we want to support other interfaces, do a
 	// quick allow check for x11 only.
 	if slot.Interface != "x11" {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -984,6 +984,21 @@ func filterUbuntuCoreSlots(candidates []*snap.SlotInfo, arities []interfaces.Sid
 	return candidates, arities
 }
 
+func filterOutParallelInstallsSlots(candidates []*snap.SlotInfo, arities []interfaces.SideArity) ([]*snap.SlotInfo, []interfaces.SideArity) {
+	var withoutParallelInstalled []*snap.SlotInfo
+	var withoutParallelInstalledArities []interfaces.SideArity
+
+	for i, candSlot := range candidates {
+		if candSlot.Snap.InstanceKey != "" {
+			continue
+		}
+		withoutParallelInstalled = append(withoutParallelInstalled, candSlot)
+		withoutParallelInstalledArities = append(withoutParallelInstalledArities, arities[i])
+	}
+
+	return withoutParallelInstalled, withoutParallelInstalledArities
+}
+
 // addAutoConnections adds to newconns any applicable auto-connections
 // from the given plugs to corresponding candidates slots after
 // filtering them with optional filter and against preexisting
@@ -1008,6 +1023,13 @@ func (c *autoConnectChecker) addAutoConnections(task *state.Task, newconns map[s
 		// want to ignore any candidates in ubuntu-core and
 		// simply go with those from the new core snap.
 		candSlots, arities = filterUbuntuCoreSlots(candSlots, arities)
+
+		// Filter out slots from parallel installed snaps.
+		// TODO:parallel-installs: figure out the policy for auto connections
+		// and parallel installed slot side snaps. Note, this could be applied
+		// earlier, but doing it here ensures that the policy is applied in a
+		// centralized fashion.
+		candSlots, arities = filterOutParallelInstallsSlots(candSlots, arities)
 
 		applicable := candSlots
 		// candidate arity check

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -999,12 +999,12 @@ func filterOutParallelInstallsSlots(candidates []*snap.SlotInfo, arities []inter
 	return withoutParallelInstalled, withoutParallelInstalledArities
 }
 
-// addAutoConnections adds to newconns any applicable auto-connections
-// from the given plugs to corresponding candidates slots after
-// filtering them with optional filter and against preexisting
-// conns. cannotAutoConnectLog is called to build a log message in
-// case no applicable pair was found. conflictError is called
-// to handle checkAutoconnectConflicts errors.
+// addAutoConnections adds to newconns any applicable auto-connections from the
+// given plugs to corresponding candidates slots after filtering them with
+// optional filter and against preexisting conns. Candidate slots from parallel
+// installed snaps are filtered-out. cannotAutoConnectLog is called to build a
+// log message in case no applicable pair was found. conflictError is called to
+// handle checkAutoconnectConflicts errors.
 func (c *autoConnectChecker) addAutoConnections(task *state.Task, newconns map[string]*interfaces.ConnRef, plugs []*snap.PlugInfo,
 	filter func([]*snap.SlotInfo) []*snap.SlotInfo, conns map[string]*schema.ConnState,
 	cannotAutoConnectLog func(plug *snap.PlugInfo, candRefs []string) string,

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1002,9 +1002,10 @@ func filterOutParallelInstallsSlots(candidates []*snap.SlotInfo, arities []inter
 // addAutoConnections adds to newconns any applicable auto-connections from the
 // given plugs to corresponding candidates slots after filtering them with
 // optional filter and against preexisting conns. Candidate slots from parallel
-// installed snaps are filtered-out. cannotAutoConnectLog is called to build a
-// log message in case no applicable pair was found. conflictError is called to
-// handle checkAutoconnectConflicts errors.
+// installed snaps are filtered-out and are not used for establishing
+// connections. cannotAutoConnectLog is called to build a log message in case no
+// applicable pair was found. conflictError is called to handle
+// checkAutoconnectConflicts errors.
 func (c *autoConnectChecker) addAutoConnections(task *state.Task, newconns map[string]*interfaces.ConnRef, plugs []*snap.PlugInfo,
 	filter func([]*snap.SlotInfo) []*snap.SlotInfo, conns map[string]*schema.ConnState,
 	cannotAutoConnectLog func(plug *snap.PlugInfo, candRefs []string) string,

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -990,7 +990,11 @@ func filterUbuntuCoreSlots(candidates []*snap.SlotInfo, arities []interfaces.Sid
 // conns. cannotAutoConnectLog is called to build a log message in
 // case no applicable pair was found. conflictError is called
 // to handle checkAutoconnectConflicts errors.
-func (c *autoConnectChecker) addAutoConnections(task *state.Task, newconns map[string]*interfaces.ConnRef, plugs []*snap.PlugInfo, filter func([]*snap.SlotInfo) []*snap.SlotInfo, conns map[string]*schema.ConnState, cannotAutoConnectLog func(plug *snap.PlugInfo, candRefs []string) string, conflictError func(*state.Retry, error) error) error {
+func (c *autoConnectChecker) addAutoConnections(task *state.Task, newconns map[string]*interfaces.ConnRef, plugs []*snap.PlugInfo,
+	filter func([]*snap.SlotInfo) []*snap.SlotInfo, conns map[string]*schema.ConnState,
+	cannotAutoConnectLog func(plug *snap.PlugInfo, candRefs []string) string,
+	conflictError func(*state.Retry, error) error,
+) error {
 	for _, plug := range plugs {
 		candSlots, arities := c.repo.AutoConnectCandidateSlots(plug.Snap.InstanceName(), plug.Name, c.check)
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3195,7 +3195,20 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	c.Check(newConns, DeepEquals, []string{"consumer:plug producer:slot"})
 }
 
-func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnap(c *C) {
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnapInstallingConsumer(c *C) {
+	s.testDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnap(c, installingConsumer)
+}
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnapInstallingProducer(c *C) {
+	s.testDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnap(c, installingProducer)
+}
+
+const (
+	installingConsumer = iota
+	installingProducer
+)
+
+func (s *interfaceManagerSuite) testDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnap(c *C, scenario int) {
 	// The auto-connect task will not auto-connect to parallel installed slot snaps.
 	s.MockModel(c, nil)
 
@@ -3204,20 +3217,35 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInst
 	// Add an OS snap.
 	s.mockSnap(c, coreSnapYaml)
 	// Add a parallel-installed producer snap with a "slot" slot of the "test" interface.
-	s.mockSnapInstance(c, "producer_instance", fmt.Sprintf(producerYamlTemplate, "producer"))
+	prodSnapInfo := s.mockSnapInstance(c, "producer_instance", fmt.Sprintf(producerYamlTemplate, "producer"))
 	// Add a consumer snap with an unconnected plug (interface "test")
-	snapInfo := s.mockSnap(c, consumerYaml)
+	consSnapInfo := s.mockSnap(c, consumerYaml)
 
 	// Initialize the manager. This registers all snaps.
 	mgr := s.manager(c)
 
-	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
-		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.SnapName(),
-			Revision: snapInfo.Revision,
-		},
-	})
+	var change *state.Change
+	switch scenario {
+	case installingConsumer:
+		// setup-snap-security task as if we're installing the "consumer"
+		change = s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+			SideInfo: &snap.SideInfo{
+				RealName: consSnapInfo.SnapName(),
+				Revision: consSnapInfo.Revision,
+			},
+		})
+	case installingProducer:
+		// setup-snap-security task as if we're installing the "producer_instance"
+		change = s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+			SideInfo: &snap.SideInfo{
+				RealName: prodSnapInfo.SnapName(),
+				Revision: prodSnapInfo.Revision,
+			},
+			InstanceKey: "instance",
+		})
+	}
+
+	// Run the change and let it finish
 	s.settle(c)
 
 	s.state.Lock()
@@ -3266,6 +3294,61 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInst
 	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
 		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
 		SlotRef: interfaces.SlotRef{Snap: "producer_instance", Name: "slot"}}})
+}
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsParallelInstalledPlugSnap(c *C) {
+	// The auto-connect task will auto-connect plugs of a parallel installed snap
+	// to compatible slots of regular (non-parallel installed) snaps.
+	s.MockModel(c, nil)
+
+	// Mock the interface that will be used by the test
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	// Add an OS snap.
+	s.mockSnap(c, coreSnapYaml)
+	// Add a regular producer snap with a "slot" slot of the "test" interface.
+	s.mockSnap(c, producerYaml)
+	// Add a parallel-installed consumer snap with a "plug" plug of the "test" interface.
+	snapInfo := s.mockSnapInstance(c, "consumer_instance", fmt.Sprintf(consumerYamlTemplate, "consumer"))
+
+	// Initialize the manager. This registers all snaps.
+	mgr := s.manager(c)
+
+	// Run the setup-snap-security task for the parallel-installed consumer.
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+		InstanceKey: "instance",
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	// Ensure that the parallel-installed consumer's plug was auto-connected
+	// to the regular producer's slot.
+	var conns map[string]any
+	err := s.state.Get("conns", &conns)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer_instance:plug producer:slot": map[string]any{
+			"interface": "test", "auto": true,
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
+		},
+	})
+
+	// Ensure that the connection exists in the repository.
+	repo := mgr.Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, HasLen, 1)
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer_instance", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 }
 
 // The auto-connect task will auto-connect slots with viable multiple candidates.

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3195,6 +3195,79 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	c.Check(newConns, DeepEquals, []string{"consumer:plug producer:slot"})
 }
 
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectParallelInstalledSlotSnap(c *C) {
+	// The auto-connect task will not auto-connect to parallel installed slot snaps.
+	s.MockModel(c, nil)
+
+	// Mock the interface that will be used by the test
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	// Add an OS snap.
+	s.mockSnap(c, coreSnapYaml)
+	// Add a parallel-installed producer snap with a "slot" slot of the "test" interface.
+	s.mockSnapInstance(c, "producer_instance", fmt.Sprintf(producerYamlTemplate, "producer"))
+	// Add a consumer snap with an unconnected plug (interface "test")
+	snapInfo := s.mockSnap(c, consumerYaml)
+
+	// Initialize the manager. This registers all snaps.
+	mgr := s.manager(c)
+
+	// Run the setup-snap-security task and let it finish.
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			Revision: snapInfo.Revision,
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	// Ensure that no auto-connections were made - the only slot candidate
+	// was from a parallel installed snap which is disallowed.
+	var conns map[string]any
+	err := s.state.Get("conns", &conns)
+	if !errors.Is(err, state.ErrNoState) {
+		c.Assert(err, IsNil)
+		c.Check(conns, HasLen, 0)
+	}
+
+	// Ensure that no connections exist in the repository.
+	repo := mgr.Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, HasLen, 0)
+
+	// A manual connection to the parallel installed snap is possible.
+	connectChange := s.state.NewChange("connect", "manual connect")
+	ts, err := ifacestate.Connect(s.state, "consumer", "plug", "producer_instance", "slot")
+	c.Assert(err, IsNil)
+	c.Assert(ts.Tasks(), HasLen, 5)
+	ts.Tasks()[2].Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "consumer",
+		},
+	})
+	connectChange.AddAll(ts)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+
+	c.Assert(connectChange.Err(), IsNil)
+	c.Assert(connectChange.Status(), Equals, state.DoneStatus)
+
+	// Connection is established
+	ifaces = repo.Interfaces()
+	c.Assert(ifaces.Connections, HasLen, 1)
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer_instance", Name: "slot"}}})
+}
+
 // The auto-connect task will auto-connect slots with viable multiple candidates.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiplePlugs(c *C) {
 	s.MockModel(c, nil)


### PR DESCRIPTION
Disallow establishing auto-connections to parallel installed slot snaps.

Related: SNAPDENG-36763

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
