### PR TITLE
tests: Revert "tests: disable second special character case for prompting integration tests"

### DIFF
--- a/tests/main/apparmor-prompting-integration-tests/special_characters.json
+++ b/tests/main/apparmor-prompting-integration-tests/special_characters.json
@@ -23,6 +23,23 @@
           "permissions": [ "read" ]
         }
       }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": "${BASE_PATH}/foo\\\\\\*\\\\\\?\\(\\)\\\\\\[\\\\\\]\\\\\\{\\\\\\}\\\\\\\\\\\\\\\\",
+          "path": "${BASE_PATH}/foo\\\\\\*\\\\\\?\\(\\)\\\\\\[\\\\\\]\\\\\\{\\\\\\}\\\\\\\\",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/foo\\*\\?()\\[\\]\\{\\}\\\\",
+          "permissions": [ "read" ]
+        }
+      }
     }
   ]
 }

--- a/tests/main/apparmor-prompting-integration-tests/special_characters.sh
+++ b/tests/main/apparmor-prompting-integration-tests/special_characters.sh
@@ -21,10 +21,8 @@ echo "$SECOND_CONTENT" | tee "${TEST_DIR}/foo*?()[]{}\\"
 echo "Attempt to read the first file"
 FIRST_OUTPUT="$(snap run --shell prompt-requester.home -c "cat ${TEST_DIR}/'[アニメ][ゲーム動画].mkv'")"
 
-echo "Skip reading the second file as there's an issue with the prompting-client.scripted parsing the sequence"
-# TODO: actually do the second read
-#echo "Attempt to read the second file"
-#SECOND_OUTPUT="$(snap run --shell prompt-requester.home -c "cat ${TEST_DIR}/'foo*?()[]{}\\'")"
+echo "Attempt to read the second file"
+SECOND_OUTPUT="$(snap run --shell prompt-requester.home -c "cat ${TEST_DIR}/'foo*?()[]{}\\'")"
 
 # Wait for the client to write its result and exit
 for i in $(seq "$TIMEOUT") ; do
@@ -51,8 +49,7 @@ if [ "$FIRST_OUTPUT" != "$FIRST_CONTENT" ] ; then
 	exit 1
 fi
 
-# TODO: actually check the second output
-#if [ "$SECOND_OUTPUT" != "$SECOND_CONTENT" ] ; then
-#	echo "test script failed"
-#	exit 1
-#fi
+if [ "$SECOND_OUTPUT" != "$SECOND_CONTENT" ] ; then
+	echo "test script failed"
+	exit 1
+fi


### PR DESCRIPTION
This PR is a follow-up to #16854 which re-enables the second `special_characters` test case for the `apparmor-prompting-integration-tests` spread test.

This is blocked until https://github.com/canonical/prompting-client/issues/305 is resolved.

This work is tracked internally by: https://warthogs.atlassian.net/browse/SNAPDENG-36784
