### PR TITLE
tests/lib: add helper function for base channel selection

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -499,6 +499,19 @@ nested_get_image_channel() {
     fi
 }
 
+nested_get_base_channel() {
+    if nested_is_core_26_system; then
+        # TODO: use $CORE_CHANNEL for the risk when core26 is released
+        if [ "$NESTED_USE_CLOUD_INIT" = "true" ]; then
+            echo "cloud-init/edge"
+        else
+            echo "edge"
+        fi
+    else
+        echo "${CORE_CHANNEL:-edge}"
+    fi
+}
+
 nested_get_kernel_channel() {
     echo "${NESTED_KERNEL_CHANNEL}"
 }
@@ -897,10 +910,10 @@ nested_prepare_base() {
             fi
             return
         fi
-        
+
         if [ ! -f "$NESTED_ASSETS_DIR/$output_name" ]; then
             echo "Repacking $snap_name snap"
-            snap download --channel="$CORE_CHANNEL" --basename="$snap_name" "$snap_name"
+            snap download --channel="$(nested_get_base_channel)" --basename="$snap_name" "$snap_name"
             repack_core_snap_with_tweaks "${snap_name}.snap" "new-${snap_name}.snap"
             rm -f "$snap_name".snap "$snap_name".assert
 
@@ -1025,9 +1038,7 @@ nested_create_core_vm() {
             # cloud-init is included in the snap or not. This won't have any
             # effect if using an unasserted snap.
             local BASE_CHANNEL=""
-            if nested_is_core_26_system && [ "$NESTED_USE_CLOUD_INIT" = "true" ]; then
-                BASE_CHANNEL="--snap core26=$image_channel/cloud-init"
-            fi
+            BASE_CHANNEL=$(nested_get_base_channel)
 
             declare -a UBUNTU_IMAGE_PRESEED_ARGS
             if [ -n "$NESTED_UBUNTU_IMAGE_PRESEED_KEY" ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1406,7 +1406,7 @@ setup_reflash_magic() {
     journalctl -u snapd
     snap model --verbose
     # remove the above debug lines once the mentioned bug is fixed
-    snap install "--channel=${CORE_CHANNEL:-edge}" "$core_name"
+    snap install "--channel=$(nested_get_base_channel)" "$core_name"
     # TODO set up a trap to clean this up properly?
     local UNPACK_DIR
     UNPACK_DIR="$(mktemp -d "/tmp/$core_name-unpack.XXXXXXXX")"


### PR DESCRIPTION
Add nested_get_base_channel() function to centralize logic for determining the appropriate base snap channel. This function handles special cases for core26 systems and cloud-init configurations, and replaces direct usage of CORE_CHANNEL variable throughout the codebase.