### PR TITLE
cmd: introduce snap-rehash utility to emulate c_rehash

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -347,7 +347,8 @@ parts:
             lib/snapd/snap-update-ns
             lib/snapd/snapctl
             lib/snapd/snapd-apparmor
-            lib/snapd/snap-gpio-helper)
+            lib/snapd/snap-gpio-helper
+            lib/snapd/snap-rehash)
       if [ -f fips-build ]; then
         # build FIPS dispatcher
         CMDS+=(lib/snapd/snap-fips-dispatch)

--- a/cmd/snap-rehash/main.go
+++ b/cmd/snap-rehash/main.go
@@ -1,0 +1,137 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Command snap-rehash creates OpenSSL-compatible SHA-1 hash links for
+// certificate files in a directory. This is a separate binary from snapd
+// because the snapd daemon operates in FIPS 140-3 mode (when enabled) which
+// forbids use of the SHA-1 algorithm. This tool does not configure FIPS
+// crypto and uses plain SHA-1 for the hash-based directory lookup that
+// OpenSSL's c_rehash(1) would normally produce.
+package main
+
+import (
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// sha1HashForCertFile computes the SHA-1 digest of all DER-encoded
+// certificate blocks found in the file at path. For PEM files with
+// multiple CERTIFICATE blocks, it hashes them all in order. For raw
+// DER files, it hashes the single certificate.
+func sha1HashForCertFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha1.New()
+
+	if block, _ := pem.Decode(data); block != nil {
+		// PEM-encoded: hash all CERTIFICATE blocks in order.
+		rest := data
+		found := false
+		for {
+			block, next := pem.Decode(rest)
+			if block == nil {
+				break
+			}
+			rest = next
+			if block.Type != "CERTIFICATE" {
+				continue
+			}
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return "", fmt.Errorf("cannot parse PEM certificate block: %v", err)
+			}
+			h.Write(cert.Raw)
+			found = true
+		}
+		if !found {
+			return "", fmt.Errorf("no CERTIFICATE PEM block found")
+		}
+	} else {
+		// DER-encoded: single certificate.
+		cert, err := x509.ParseCertificate(data)
+		if err != nil {
+			return "", fmt.Errorf("cannot parse DER certificate: %v", err)
+		}
+		h.Write(cert.Raw)
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// rehashDirectory creates SHA-1 hash links for all .crt files in dir, emulating
+// the behaviour of OpenSSL's c_rehash(1). Each certificate file gets a
+// hard link named <hash>.N where <hash> is the first 8 hex characters of
+// the SHA-1 digest of the certificate chain's DER encoding and N is a
+// collision suffix starting at 0.
+func rehashDirectory(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot read directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".crt") {
+			continue
+		}
+
+		// Skip the combined bundle file.
+		if entry.Name() == "ca-certificates.crt" {
+			continue
+		}
+
+		certPath := filepath.Join(dir, entry.Name())
+		hash, err := sha1HashForCertFile(certPath)
+		if err != nil {
+			return fmt.Errorf("cannot hash certificate %q: %v", entry.Name(), err)
+		}
+
+		prefix := hash[:8]
+		for suffix := 0; ; suffix++ {
+			linkName := filepath.Join(dir, fmt.Sprintf("%s.%d", prefix, suffix))
+			if err := os.Link(certPath, linkName); err != nil {
+				if os.IsExist(err) {
+					continue
+				}
+				return fmt.Errorf("cannot create hash link for %q: %v", entry.Name(), err)
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: snap-rehash <directory>\n")
+		os.Exit(1)
+	}
+
+	if err := rehashDirectory(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/snap-rehash/main.go
+++ b/cmd/snap-rehash/main.go
@@ -32,8 +32,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
+
+	"github.com/snapcore/snapd/strutil"
 )
+
+var allowedSuffixes = []string{"pem", "crt", "cer"}
+
+var certificatePEMBlockTypePattern = regexp.MustCompile(`^(X509 |TRUSTED |)?CERTIFICATE$`)
+
+func isCertificatePEMBlockType(blockType string) bool {
+	return certificatePEMBlockTypePattern.MatchString(blockType)
+}
 
 // sha1HashForCertFile computes the SHA-1 digest of all DER-encoded
 // certificate blocks found in the file at path. For PEM files with
@@ -57,9 +67,12 @@ func sha1HashForCertFile(path string) (string, error) {
 				break
 			}
 			rest = next
-			if block.Type != "CERTIFICATE" {
+
+			// TODO: block type 'X509 CRL' if we ever need this
+			if !isCertificatePEMBlockType(block.Type) {
 				continue
 			}
+
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				return "", fmt.Errorf("cannot parse PEM certificate block: %v", err)
@@ -82,8 +95,8 @@ func sha1HashForCertFile(path string) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-// rehashDirectory creates SHA-1 hash links for all .crt files in dir, emulating
-// the behaviour of OpenSSL's c_rehash(1). Each certificate file gets a
+// rehashDirectory creates SHA-1 hash links for all supported certificate files
+// in dir, emulating the behaviour of OpenSSL's c_rehash(1). Each certificate file gets a
 // hard link named <hash>.N where <hash> is the first 8 hex characters of
 // the SHA-1 digest of the certificate chain's DER encoding and N is a
 // collision suffix starting at 0.
@@ -94,7 +107,14 @@ func rehashDirectory(dir string) error {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".crt") {
+		if entry.IsDir() {
+			continue
+		}
+
+		// TODO: we could support .crl files like openssl's c_rehash does,
+		// but currently we have no .crl files in the bases
+		extension := filepath.Ext(entry.Name())[1:]
+		if !strutil.ListContains(allowedSuffixes, extension) {
 			continue
 		}
 

--- a/cmd/snap-rehash/main_test.go
+++ b/cmd/snap-rehash/main_test.go
@@ -79,6 +79,38 @@ func expectedHash(pemData []byte) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
+func (s *rehashSuite) TestRehashInvalidPEMNoCertificateBlock(c *C) {
+	dir := c.MkDir()
+
+	// A PEM file that contains only a PRIVATE KEY block, no CERTIFICATE.
+	keyBlock := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not a real key")})
+	c.Assert(os.WriteFile(filepath.Join(dir, "nocert.crt"), keyBlock, 0o644), IsNil)
+
+	err := rehashDirectory(dir)
+	c.Check(err, ErrorMatches, `cannot hash certificate "nocert.crt": no CERTIFICATE PEM block found`)
+}
+
+func (s *rehashSuite) TestRehashInvalidPEMCertificateData(c *C) {
+	dir := c.MkDir()
+
+	// A PEM file with a CERTIFICATE block containing garbage bytes.
+	badCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("garbage")})
+	c.Assert(os.WriteFile(filepath.Join(dir, "corrupt.crt"), badCert, 0o644), IsNil)
+
+	err := rehashDirectory(dir)
+	c.Check(err, ErrorMatches, `cannot hash certificate "corrupt.crt": cannot parse PEM certificate block: .*`)
+}
+
+func (s *rehashSuite) TestRehashInvalidDERData(c *C) {
+	dir := c.MkDir()
+
+	// Raw bytes that are not valid DER or PEM.
+	c.Assert(os.WriteFile(filepath.Join(dir, "junk.crt"), []byte{0x30, 0x00, 0x01}, 0o644), IsNil)
+
+	err := rehashDirectory(dir)
+	c.Check(err, ErrorMatches, `cannot hash certificate "junk.crt": cannot parse DER certificate: .*`)
+}
+
 func (s *rehashSuite) TestRehashCreatesHashLinks(c *C) {
 	dir := c.MkDir()
 
@@ -100,6 +132,22 @@ func (s *rehashSuite) TestRehashCreatesHashLinks(c *C) {
 	c.Check(err, IsNil)
 	_, err = os.Stat(filepath.Join(dir, hashB+".0"))
 	c.Check(err, IsNil)
+}
+
+func (s *rehashSuite) TestRehashLinkCreationError(c *C) {
+	dir := c.MkDir()
+
+	certA, err := makeTestCert("A")
+	c.Assert(err, IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.crt"), certA, 0o644), IsNil)
+
+	// Make the directory read-only so os.Link fails with permission denied
+	// (not EEXIST), which exercises the non-collision error return.
+	c.Assert(os.Chmod(dir, 0o555), IsNil)
+	defer os.Chmod(dir, 0o755)
+
+	err = rehashDirectory(dir)
+	c.Check(err, ErrorMatches, `cannot create hash link for "a.crt": .*permission denied`)
 }
 
 func (s *rehashSuite) TestRehashSkipsCACertificatesBundle(c *C) {

--- a/cmd/snap-rehash/main_test.go
+++ b/cmd/snap-rehash/main_test.go
@@ -1,0 +1,182 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type rehashSuite struct{}
+
+var _ = Suite(&rehashSuite{})
+
+func makeTestCert(cn string) ([]byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+func expectedHash(pemData []byte) string {
+	h := sha1.New()
+	rest := pemData
+	for {
+		block, next := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = next
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, _ := x509.ParseCertificate(block.Bytes)
+		h.Write(cert.Raw)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func (s *rehashSuite) TestRehashCreatesHashLinks(c *C) {
+	dir := c.MkDir()
+
+	certA, err := makeTestCert("A")
+	c.Assert(err, IsNil)
+	certB, err := makeTestCert("B")
+	c.Assert(err, IsNil)
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.crt"), certA, 0o644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.crt"), certB, 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	hashA := expectedHash(certA)[:8]
+	hashB := expectedHash(certB)[:8]
+
+	_, err = os.Stat(filepath.Join(dir, hashA+".0"))
+	c.Check(err, IsNil)
+	_, err = os.Stat(filepath.Join(dir, hashB+".0"))
+	c.Check(err, IsNil)
+}
+
+func (s *rehashSuite) TestRehashSkipsCACertificatesBundle(c *C) {
+	dir := c.MkDir()
+
+	certA, err := makeTestCert("A")
+	c.Assert(err, IsNil)
+
+	// Write something named ca-certificates.crt — it must be skipped.
+	c.Assert(os.WriteFile(filepath.Join(dir, "ca-certificates.crt"), certA, 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	// No hash links should exist.
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, IsNil)
+	for _, e := range entries {
+		c.Check(e.Name(), Equals, "ca-certificates.crt")
+	}
+}
+
+func (s *rehashSuite) TestRehashCollisionUsesSuffix(c *C) {
+	dir := c.MkDir()
+
+	certA, err := makeTestCert("A")
+	c.Assert(err, IsNil)
+	certB, err := makeTestCert("B")
+	c.Assert(err, IsNil)
+
+	hashA := expectedHash(certA)[:8]
+
+	// Write a.crt
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.crt"), certA, 0o644), IsNil)
+	// Write b.crt but also pre-create the hash link for b that collides with a's prefix
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.crt"), certB, 0o644), IsNil)
+
+	// Create a pre-existing file that occupies the .0 slot for a's hash
+	c.Assert(os.WriteFile(filepath.Join(dir, hashA+".0"), []byte("occupied"), 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	// a.crt should get suffix .1 since .0 is already taken
+	_, err = os.Stat(filepath.Join(dir, hashA+".1"))
+	c.Check(err, IsNil)
+}
+
+func (s *rehashSuite) TestRehashSkipsNonCrtFiles(c *C) {
+	dir := c.MkDir()
+
+	certA, err := makeTestCert("A")
+	c.Assert(err, IsNil)
+
+	// Write with .pem extension — should be skipped.
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.pem"), certA, 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, IsNil)
+	// Only the original file should exist.
+	c.Check(entries, HasLen, 1)
+}
+
+func (s *rehashSuite) TestRehashSkipsDirectories(c *C) {
+	dir := c.MkDir()
+
+	// Create a directory with .crt suffix — must be skipped.
+	c.Assert(os.MkdirAll(filepath.Join(dir, "subdir.crt"), 0o755), IsNil)
+
+	err := rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 1)
+	c.Check(entries[0].Name(), Equals, "subdir.crt")
+}

--- a/cmd/snap-rehash/main_test.go
+++ b/cmd/snap-rehash/main_test.go
@@ -43,6 +43,10 @@ type rehashSuite struct{}
 var _ = Suite(&rehashSuite{})
 
 func makeTestCert(cn string) ([]byte, error) {
+	return makeTestCertWithPEMBlockType(cn, "CERTIFICATE")
+}
+
+func makeTestCertWithPEMBlockType(cn, blockType string) ([]byte, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
@@ -58,7 +62,7 @@ func makeTestCert(cn string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+	return pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), nil
 }
 
 func expectedHash(pemData []byte) string {
@@ -70,13 +74,41 @@ func expectedHash(pemData []byte) string {
 			break
 		}
 		rest = next
-		if block.Type != "CERTIFICATE" {
+		if !isCertificatePEMBlockType(block.Type) {
 			continue
 		}
 		cert, _ := x509.ParseCertificate(block.Bytes)
 		h.Write(cert.Raw)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func (s *rehashSuite) TestRehashAcceptsTrustedCertificatePEMBlock(c *C) {
+	dir := c.MkDir()
+
+	certData, err := makeTestCertWithPEMBlockType("trusted", "TRUSTED CERTIFICATE")
+	c.Assert(err, IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "trusted.crt"), certData, 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(filepath.Join(dir, expectedHash(certData)[:8]+".0"))
+	c.Check(err, IsNil)
+}
+
+func (s *rehashSuite) TestRehashAcceptsX509CertificatePEMBlock(c *C) {
+	dir := c.MkDir()
+
+	certData, err := makeTestCertWithPEMBlockType("x509", "X509 CERTIFICATE")
+	c.Assert(err, IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "x509.crt"), certData, 0o644), IsNil)
+
+	err = rehashDirectory(dir)
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(filepath.Join(dir, expectedHash(certData)[:8]+".0"))
+	c.Check(err, IsNil)
 }
 
 func (s *rehashSuite) TestRehashInvalidPEMNoCertificateBlock(c *C) {
@@ -196,14 +228,14 @@ func (s *rehashSuite) TestRehashCollisionUsesSuffix(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (s *rehashSuite) TestRehashSkipsNonCrtFiles(c *C) {
+func (s *rehashSuite) TestRehashSkipsUnsupportedSuffixes(c *C) {
 	dir := c.MkDir()
 
 	certA, err := makeTestCert("A")
 	c.Assert(err, IsNil)
 
-	// Write with .pem extension — should be skipped.
-	c.Assert(os.WriteFile(filepath.Join(dir, "a.pem"), certA, 0o644), IsNil)
+	// Write with an unsupported extension — it should be skipped.
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.txt"), certA, 0o644), IsNil)
 
 	err = rehashDirectory(dir)
 	c.Assert(err, IsNil)

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -17,6 +17,7 @@ export DH_GOLANG_EXCLUDES=tests
 export DH_GOLANG_BUILDPKG = $(strip $(addprefix $(DH_GOPKG)/, \
     cmd/snap \
     cmd/snap-exec \
+    cmd/snap-rehash \
     cmd/snap-seccomp \
     cmd/snap-update-ns \
     cmd/snapctl \

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -12,6 +12,7 @@ data/info /usr/lib/snapd/
 etc/apparmor.d/usr.lib.snapd.snap-confine.real
 usr/bin/snap
 usr/bin/snap-exec /usr/lib/snapd/
+usr/bin/snap-rehash /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -6,6 +6,7 @@ usr/bin/snap-repair /usr/lib/snapd/
 usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
+usr/bin/snap-rehash /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-bootstrap /usr/lib/snapd/
 usr/bin/snap-preseed /usr/lib/snapd/


### PR DESCRIPTION
Came up from a discussion at https://github.com/canonical/snapd/pull/16914 

In FIPS 140-3, SHA1 is mostly forbidden to use, and we should avoid using any SHA1 from the snapd binary. Move the generation of this to a separate binary.

The snap-rehash binary is 2.7mb is size due to the inclusion/usage of the crypto library, and this unfortunately increases the snapd snap binary with 1mb.