### PR TITLE
packaging/opensuse: default to /var/lib/snapd/snap and sync from downstream

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -98,6 +98,14 @@
 %global with_multilib 1
 %endif
 
+%global with_go_unit_tests 1
+%ifnarch x86_64
+# disable Go unit tests on architectures other than x86_64. Those run on
+# virtualized systems with very little resources and often amplify races in
+# checks emplyed by unit tests themselves.
+%global with_go_unit_tests 0
+%endif
+
 %ifarch %arm
 # libsnap-confine-private/unit-tests fails on ARM under valgrind
 %bcond_with valgrind
@@ -119,6 +127,7 @@ Source1:        snapd-rpmlintrc
 BuildRequires:  autoconf
 BuildRequires:  autoconf-archive
 BuildRequires:  automake
+BuildRequires:  m4
 BuildRequires:  distribution-release
 BuildRequires:  fakeroot
 BuildRequires:  glibc-devel-static
@@ -354,11 +363,13 @@ export CGO_LDFLAGS="$LDFLAGS"
 
 %make_build -C %{indigo_srcdir}/cmd -k check
 %make_build -C %{indigo_srcdir}/data -k check
+%if %{with_go_unit_tests}
 # Use the common packaging helper for testing.
 export SNAPD_SKIP_SLOW_TESTS=1
 %make_build -C %{indigo_srcdir} -f %{indigo_srcdir}/packaging/snapd.mk \
             GOPATH=%{indigo_gopath}:$GOPATH SNAPD_DEFINES_DIR=%{_builddir} \
             check
+%endif
 
 %install
 # Install all systemd and dbus units, and env files.
@@ -601,6 +612,7 @@ fi
 %{_datadir}/fish/vendor_conf.d/snapd.fish
 %{_datadir}/snapd/snapcraft-logo-bird.svg
 %{_environmentdir}/990-snapd.conf
+%dir %{_prefix}/lib/dracut/dracut.conf.d
 %{_prefix}/lib/dracut/dracut.conf.d/50-snapd.conf
 %{_libexecdir}/snapd/complete.sh
 %{_libexecdir}/snapd/etelpmoc.sh
@@ -637,7 +649,6 @@ fi
 %{_unitdir}/snapd.mounts-pre.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
-%ghost /tmp/snap-private-tmp
 
 # When apparmor is enabled there are some additional entries.
 %if %{with apparmor}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -51,6 +51,7 @@
 # adding global with_alt_snap_mount_dir 1 then.
 %global snap_mount_dir /snap
 %global alt_snap_mount_dir %{_localstatedir}/lib/snapd/snap
+%global with_alt_snap_mount_dir 1
 
 %global selinuxtype targeted
 
@@ -442,13 +443,12 @@ rm -fv %{buildroot}%{_unitdir}/snapd.failure.service
 %apparmor_reload /etc/apparmor.d/%{apparmor_snapconfine_profile}
 %endif
 
-# TODO: starting with 2.74 default to %{alt_snap_mount_dir}
 if test ! -e %{snap_mount_dir} && test ! -e %{alt_snap_mount_dir} ; then
     # neither location exists, it's likely a new installation, but we
     # need one of the directories to exist for snapd and snap-confine
     # to be able to figure out the desired configuration at runtime
-    echo "Using %{snap_mount_dir} as snap mount directory"
-    mkdir -p -m 755 %{snap_mount_dir} || :
+    echo "Using %{alt_snap_mount_dir} as snap mount directory"
+    mkdir -p -m 755 %{alt_snap_mount_dir} || :
 fi
 
 %service_add_post %{systemd_services_list}

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -887,6 +887,7 @@ pkg_dependencies_opensuse(){
         udisks2
         upower
         uuidd
+        xdelta3
         xdg-user-dirs
         xdg-utils
         zsh

--- a/tests/main/classic-confinement-perms/task.yaml
+++ b/tests/main/classic-confinement-perms/task.yaml
@@ -14,16 +14,12 @@ systems:
 prepare: |
     tests.session -u test prepare
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # Arch linux and Centos, we still want to verify if the basics
-            # do work if the user symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            tests.cleanup defer rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
     # owned by root
     echo foo > root-foo.file
     # as user, accessing a user owned file

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -14,22 +14,12 @@ environment:
 prepare: |
     snap pack "$TESTSLIB/snaps/$CLASSIC_SNAP/"
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # Arch linux and Centos, we still want to verify if the basics
-            # do work if the user symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
-
-restore: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     echo "Check that classic snaps work only with --classic"

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -9,23 +9,12 @@ details: |
 systems: [-ubuntu-core-*]
 
 prepare: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
-
-
-restore: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     snap install --classic test-snapd-hello-classic

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -164,19 +164,12 @@ execute: |
             # MATCH 'is-reexecd: false' < snap-yes-reexec.out
             # MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
             case "$SPREAD_SYSTEM" in
-                arch-linux-*|fedora-*|centos-*)
+                arch-linux-*|fedora-*|centos-*|opensuse-*)
                     # no /snap -> /var/lib/snapd/snap symlink by default
                     MATCH 'is-reexecd: false' < snap-yes-reexec.out
                     MATCH 'self-exe: /usr/bin/snap' < snap-yes-reexec.out
 
                     MATCH 'is-reexecd: false' < snap-force-reexec.out
-                    ;;
-                opensuse-*)
-                    # snap mount dir is /snap
-                    MATCH 'is-reexecd: true' < snap-yes-reexec.out
-                    MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
-
-                    MATCH 'is-reexecd: true' < snap-force-reexec.out
                     ;;
                 amazon-linux-*)
                     # has /snap -> /var/lib/snapd symlink
@@ -208,15 +201,9 @@ execute: |
                 *)
                     # arch and opensuse have AppArmor installed
                     MATCH 'apparmor-parser: (/usr)?/sbin/apparmor_parser' < snap-apparmor-default.out
-                    case "$SPREAD_SYSTEM" in
-                        opensuse-*)
-                            MATCH 'internal: true' < snap-apparmor-force-reexec.out
-                            ;;
-                        *)
-                            # arch has no /snap -> /var/lib/snapd/snap symlink
-                            MATCH 'internal: false' < snap-apparmor-force-reexec.out
-                            ;;
-                    esac
+                    # no /snap -> /var/lib/snapd/snap symlink on Arch or openSUSE
+                    MATCH 'internal: false' < snap-apparmor-force-reexec.out
+                    ;;
             esac
             MATCH 'internal: false' < snap-apparmor-default.out
 

--- a/tests/main/graphical-user-daemons/task.yaml
+++ b/tests/main/graphical-user-daemons/task.yaml
@@ -13,14 +13,8 @@ restore: |
     snap set system experimental.user-daemons=false
 
 execute: |
-    case "$SPREAD_SYSTEM" in
-        amazon-*|arch-*|centos-*|fedora-*)
-            SNAP_BIN="/var/lib/snapd/snap/bin"
-            ;;
-        *)
-            SNAP_BIN="/snap/bin"
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    SNAP_BIN="$SNAP_MOUNT_DIR/bin"
 
     echo "Test that the non-daemon apps have binaries"
     test -L "$SNAP_BIN"/test-snapd-graphical-user-daemons.normal

--- a/tests/main/interfaces-classic-content-slot/task.yaml
+++ b/tests/main/interfaces-classic-content-slot/task.yaml
@@ -17,23 +17,12 @@ environment:
     CONSUMER_SNAP: test-snapd-content-plug-to-classic-slot
 
 prepare: |
-    # Classic confinement needs to be enabled with a symlink on Fedora, Arch linux and Centos
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # Arch linux and Centos, we still want to verify if the basics
-            # do work if the user symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
-
-restore: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     echo "Install classic snap with content slot - no automatic pull for classic"

--- a/tests/main/migrate-snap-mount-dir/task.yaml
+++ b/tests/main/migrate-snap-mount-dir/task.yaml
@@ -14,6 +14,18 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     echo "$SNAP_MOUNT_DIR" > start-mount-dir
 
+    if [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+        # openSUSE supports both locations, but defaults to /var/lib/snapd/snap
+        tests.systemd stop-unit snapd.service
+        echo "Ensure all snaps are gone"
+        snapd.tool exec snap-mgmt --purge
+
+        mkdir -p /snap
+
+        systemctl start snapd.service
+        snap wait system seed.loaded
+    fi
+
     snap set system experimental.user-daemons=true
     # although state reset should clean that up
     tests.cleanup defer snap unset system experimental.user-daemons

--- a/tests/main/parallel-install-classic/task.yaml
+++ b/tests/main/parallel-install-classic/task.yaml
@@ -32,26 +32,17 @@ prepare: |
 
     snap pack "$TESTSLIB/snaps/test-snapd-classic-confinement/"
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
     snap set system experimental.parallel-instances=true
 
 restore: |
     snap unset system experimental.parallel-instances
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic

--- a/tests/main/parallel-install-remove-after/task.yaml
+++ b/tests/main/parallel-install-remove-after/task.yaml
@@ -6,24 +6,15 @@ details: |
   should not prevent snaps from being unmounted when removed.
 
 prepare: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 restore: |
     snap unset system experimental.parallel-instances
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
 
 execute: |
     # install confined and classic snaps

--- a/tests/main/refresh-classic/task.yaml
+++ b/tests/main/refresh-classic/task.yaml
@@ -8,22 +8,12 @@ details: |
 systems: [-ubuntu-core-*]
 
 prepare: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
-
-restore: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     echo "Install a snap that needs classic confinement"

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -27,7 +27,7 @@ skip:
         [ "$STORE_TYPE" = "fake" ] && [ "$TRUST_TEST_KEYS" = "false" ]
     - reason: Classic snaps are not supported in this system
       if: |
-        [[ "$SNAP_NAME" =~ classic && "$SPREAD_SYSTEM" =~ ^(fedora-|arch-|centos-) ]]
+        [[ "$SNAP_NAME" =~ classic && "$SPREAD_SYSTEM" =~ ^(fedora-|arch-|centos-|opensuse-) ]]
 
 prepare: |
     flags=

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -5,9 +5,8 @@ details: |
     sure that other devices are still accessible (ie, the cgroup is not in
     effect).
 
-# Disabled on Fedora, Ubuntu Core and Arch because they don't support classic
-# confinement.
-systems: [-fedora-*, -ubuntu-core-*, -arch-*, -amazon-*, -centos-*]
+# Disabled on Ubuntu Core doesn't support classic confinement.
+systems: [-ubuntu-core-*]
 
 prepare: |
     # Create framebuffer device node and give it some content we can verify
@@ -15,6 +14,13 @@ prepare: |
     if [ ! -e /dev/fb0 ]; then
         mknod /dev/fb0 c 29 0
         touch /dev/fb0.spread
+    fi
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
     fi
 
     echo "Given a snap declaring a plug on framebuffer is installed in classic"

--- a/tests/main/security-group-policy/task.yaml
+++ b/tests/main/security-group-policy/task.yaml
@@ -30,16 +30,12 @@ skip:
 prepare: |
     LIBEXEC_DIR="$(os.paths libexec-dir)"
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # Arch linux and Centos, we still want to verify if the basics
-            # do work if the user symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            tests.cleanup defer rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
     NOMATCH snap-runners /etc/group
     groupadd snap-runners

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -20,7 +20,8 @@ prepare: |
     # still want to verify if the basics do work if the user symlinks /snap to
     # $SNAP_MOUNT_DIR themselves
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
         ln -sf "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -26,22 +26,12 @@ prepare: |
     snap disconnect test-snapd-file-access:home
     snap disconnect test-snapd-file-access:removable-media
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            ;;
-    esac
-
-restore: |
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            rm -f /snap
-            ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        # set up classic execution support
+        ln -sf "$SNAP_MOUNT_DIR" /snap
+        tests.cleanup defer rm -f /snap
+    fi
 
 execute: |
     access() {

--- a/tests/main/snapctl-is-connected-pid/task.yaml
+++ b/tests/main/snapctl-is-connected-pid/task.yaml
@@ -15,16 +15,12 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snap1
     "$TESTSTOOLS"/snaps-state install-local test-snap2
 
-    case "$SPREAD_SYSTEM" in
-        fedora-*|arch-*|centos-*)
-            # although classic snaps do not work out of the box on fedora,
-            # we still want to verify if the basics do work if the user
-            # symlinks /snap to $SNAP_MOUNT_DIR themselves
-            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-            ln -sf "$SNAP_MOUNT_DIR" /snap
-            tests.cleanup defer rm -f /snap
-        ;;
-    esac
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+        ln -s "$SNAP_MOUNT_DIR" /snap
+        # remove it when we are done
+        tests.cleanup defer rm -rf /snap
+    fi
 
 execute: |
     echo "The test-snap1 service is running"

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -54,7 +54,7 @@ prepare: |
     . "$TESTSLIB/systems.sh"
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if os.query is-fedora || os.query is-arch-linux; then
+    if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
         ln -sf "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -28,12 +28,11 @@ prepare: |
             classic-container-mgr-snap/meta/snap.yaml
         echo "confinement: classic" >> classic-container-mgr-snap/meta/snap.yaml
 
-        if os.query is-arch-linux || os.query is-fedora || os.query is-centos; then
-            # TODO:opensuse: detect the mount directory
-            # need to enable /snap symlink to install classic snaps
-            ln -s /var/lib/snapd/snap /snap
-            # remove it when we are done
-            tests.cleanup defer rm -rf /snap
+        SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+        if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
+            # set up classic execution support
+            ln -sf "$SNAP_MOUNT_DIR" /snap
+            tests.cleanup defer rm -f /snap
         fi
 
         snap pack classic-container-mgr-snap


### PR DESCRIPTION
Sync with downstream packaging and default to /var/lib/snapd/snap.

Related: SNAPDENG-36210