### PR TITLE
overlord, snap: omit snapd refresh suggestion for ISA-related assume errors

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -144,7 +144,12 @@ func validateInfoAndFlags(info *snap.Info, snapst *SnapState, flags Flags) error
 	// check assumes
 	err := naming.ValidateAssumes(info.Assumes, snapdtool.Version, featureSet, arch.DpkgArchitecture())
 	if err != nil {
-		return fmt.Errorf("snap %q assumes %w (try to refresh snapd)", info.InstanceName(), err)
+		askToRefreshSnapd := " (try to refresh snapd)"
+		isaErr := &naming.IsaError{}
+		if errors.As(err, &isaErr) {
+			askToRefreshSnapd = ""
+		}
+		return fmt.Errorf("snap %q assumes %w%s", info.InstanceName(), err, askToRefreshSnapd)
 	}
 
 	// check and create system-usernames

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -27,6 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -95,6 +96,8 @@ architectures:
 }
 
 func (s *checkSnapSuite) TestCheckSnapAssumes(c *C) {
+	s.AddCleanup(archtest.MockArchitecture("arm64"))
+
 	var assumesTests = []struct {
 		version string
 		assumes string
@@ -109,6 +112,9 @@ func (s *checkSnapSuite) TestCheckSnapAssumes(c *C) {
 		assumes: "[f1, f2]",
 		classic: true,
 		error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh snapd\)`,
+	}, {
+		assumes: "[isa-arm64-someisa]",
+		error:   `snap "foo" assumes isa-arm64-someisa: ISA specification is not supported for arch: arm64`,
 	},
 	}
 

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -315,6 +315,15 @@ func validateAssumedSnapdVersion(assumedVersion, currentVersion string) (bool, e
 
 var archIsISASupportedByCPU = arch.IsISASupportedByCPU
 
+type IsaError struct {
+	Flag string
+	Err  error
+}
+
+func (e *IsaError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Flag, e.Err)
+}
+
 // validateAssumedISAArch checks that, when a snap requires an ISA to be supported:
 //  1. compares the specified <arch> with the device's one. If they differ, it exits
 //     without error signaling that the flag is valid
@@ -338,7 +347,7 @@ func validateAssumedISAArch(flag string, currentArchitecture string) error {
 	}
 
 	if err := archIsISASupportedByCPU(tokens[2]); err != nil {
-		return fmt.Errorf("%s: %s", flag, err)
+		return &IsaError{Flag: flag, Err: err}
 	}
 
 	return nil

--- a/tests/regression/lp-1813365/task.yaml
+++ b/tests/regression/lp-1813365/task.yaml
@@ -30,5 +30,5 @@ restore: |
     rm -f /tmp/logger.log
 
 execute: |
-    su -l -c "$(pwd)/helper" test
+    su -l -c "PATH=\$PATH:/usr/lib/python $(pwd)/helper" test
     not test -e /tmp/logger.log


### PR DESCRIPTION
Remove "(try to refresh snapd)" suggestion from error messages when snap assumes fail due to ISA-related issues. ISA errors indicate architectural incompatibilities that cannot be resolved by refreshing snapd, so the suggestion is misleading in these cases.

Introduce IsaError type to distinguish ISA validation failures from other assume validation errors, allowing appropriate error message formatting.