### PR TITLE
github: use symlink for debian folder

### DIFF
--- a/.github/workflows/deb-builds.yaml
+++ b/.github/workflows/deb-builds.yaml
@@ -47,10 +47,10 @@ jobs:
         target_system="${{ inputs.os }}-${{ inputs.os-version }}"
         case "$target_system" in
             debian-sid)
-                cp -av packaging/debian-sid debian
+                ln -sfn packaging/debian-sid debian
                 ;;
             ubuntu-*)
-                cp -av packaging/ubuntu-16.04 debian
+                ln -sfn packaging/ubuntu-16.04 debian
                 ;;
             *)
                 echo "unsupported deb packaging for $target_system"


### PR DESCRIPTION
When building the deb, I now correctly see the 1337 version [`*** Setting version to '1337.2.75.2+g9167177.9167177-dirty' from changelog+git.`](https://github.com/canonical/snapd/actions/runs/24716032419/job/72292881974?pr=16948#step:8:111)

To ensure the artifact is correct, I downloaded the ubuntu-24.04 artifact and tested it locally
```
$ SPREAD_USE_PREBUILT_PACKAGES=true SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_SNAP_REEXEC=0 spread garden:ubuntu-24.04-64:tests/regression/lp-1871652
2026-04-21 12:07:08 Project content is packed for delivery (112.20MB).
2026-04-21 12:07:08 If killed, discard servers with: spread -reuse-pid=37452 -discard
2026-04-21 12:07:08 Allocating garden:ubuntu-24.04-64...
2026-04-21 12:07:09 Waiting for garden:ubuntu-24.04-64 to make SSH available at localhost:5744...
2026-04-21 12:07:09 Allocated garden:ubuntu-24.04-64.
2026-04-21 12:07:09 Connecting to garden:ubuntu-24.04-64...
2026-04-21 12:07:30 Connected to garden:ubuntu-24.04-64 at localhost:5744.
2026-04-21 12:07:30 Sending project content to garden:ubuntu-24.04-64...
2026-04-21 12:07:33 Preparing garden:ubuntu-24.04-64 (garden:ubuntu-24.04-64)...
2026-04-21 12:08:39 Preparing garden:ubuntu-24.04-64:tests/regression/ (garden:ubuntu-24.04-64)...
2026-04-21 12:09:41 Preparing garden:ubuntu-24.04-64:tests/regression/lp-1871652 (garden:ubuntu-24.04-64)...
2026-04-21 12:12:06 Executing garden:ubuntu-24.04-64:tests/regression/lp-1871652 (garden:ubuntu-24.04-64) (1/1)...
2026-04-21 12:12:08 Restoring garden:ubuntu-24.04-64:tests/regression/lp-1871652 (garden:ubuntu-24.04-64)...
2026-04-21 12:12:28 Restoring garden:ubuntu-24.04-64:tests/regression/ (garden:ubuntu-24.04-64)...
2026-04-21 12:12:36 Restoring garden:ubuntu-24.04-64 (garden:ubuntu-24.04-64)...
2026-04-21 12:12:37 Discarding garden:ubuntu-24.04-64...
2026-04-21 12:12:37 Successful tasks: 1
2026-04-21 12:12:37 Aborted tasks: 0
```