### PR TITLE
tests: fix upgrade-from-release

### DIFF
--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -44,7 +44,7 @@ execute: |
     # TODO: add automatic package lookup - manual list maintenance is impractical
     declare -A EXPECTED_SNAPD_VERSIONS=(
         ["26.04"]='2.74.1\+ubuntu26.04'
-        ["25.10"]='2.73\+ubuntu25.10'
+        ["25.10"]='2.74.1\+ubuntu25.10'
         ["24.04"]='2.62\+24.04'
         ["22.04"]='2.55.3\+22.04'
         ["20.04"]='2.44.3\+20.04'


### PR DESCRIPTION
upgrade-from-release has been failing on 25.10:

```
grep error: pattern not found, got:
Listing...
error: unsuccessful run
snapd/questing,now 2.71.1+ubuntu25.10.1 amd64 [installed,upgradable to: 2.74.1+ubuntu25.10.4]
-----
.
2026-04-21 07:42:21 Debug output for openstack:ubuntu-25.10-64:tests/main/upgrade-from-release (apr210736-949518) 
```