### PR TITLE
interfaces/builtin/microceph_support.go: do not log sudo attempt

### DIFF
--- a/interfaces/builtin/microceph_support.go
+++ b/interfaces/builtin/microceph_support.go
@@ -54,6 +54,8 @@ const microcephSupportConnectedPlugAppArmor = `
 /sys/bus/rbd/supported_features r,                         # display enabled features
 /sys/bus/rbd/devices/** rwk,                               # manage individual block devs
 
+# Avoid logging known attempts calling sudo
+deny /usr/bin/sudo x,
 `
 
 func init() {


### PR DESCRIPTION
osd in microceph attempts to call sudo, which is denied. But that is known, and it spams the logs. Explicitly denying without "audit" will make it silent.

Requested from https://forum.snapcraft.io/t/suppress-audit-logging/51065
