### PR TITLE
o/devicestate: filter seed-refresh based on model and seed presence

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/swfeats"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/naming"
@@ -1770,10 +1771,16 @@ func removeRecoverySystemTask(st *state.State, label string) *state.Task {
 // that, after finalize records the new system, the two most recently created
 // seed-refresh systems remain tracked.
 func SeedRefreshTasks(st *state.State, dctx snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+	triggers := seedRefreshTriggers(st, dctx)
+
 	var snapsups, compsups []string
 	added := make(map[string]bool, len(candidates))
 	for _, candidate := range candidates {
-		if !seedRefreshIncludesSnap(dctx, candidate.InstanceName) {
+		ok, err := triggers(candidate.InstanceName)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !ok {
 			continue
 		}
 		added[candidate.InstanceName] = true
@@ -1838,7 +1845,13 @@ func SeedRefreshTasks(st *state.State, dctx snapstate.DeviceContext, candidates 
 // snap isn't part of the seed refresh, otherwise returns the seed refresh task
 // set.
 func UpdateSeedRefreshChange(chg *state.Change, dctx snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, error) {
-	if !seedRefreshIncludesSnap(dctx, candidate.InstanceName) {
+	triggers := seedRefreshTriggers(chg.State(), dctx)
+
+	ok, err := triggers(candidate.InstanceName)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 
@@ -1866,20 +1879,69 @@ func appendSeedRefreshCandidate(create *state.Task, snapSetupTasks, compSetupTas
 	return setTaskRecoverySystemSetup(create, setup)
 }
 
-func seedRefreshIncludesSnap(dctx snapstate.DeviceContext, instanceName string) bool {
-	// TODO:SEEDREFRESH: consider the intersections of snaps in the model and
-	// snaps currently present in the seed, not all snaps in the model.
-	if instanceName == "snapd" {
-		return true
-	}
-
+// seedRefreshTriggers returns a closure that reports whether the given snap
+// should trigger a seed refresh. The seed is lazily loaded, and only opened
+// when required.
+func seedRefreshTriggers(st *state.State, dctx snapstate.DeviceContext) func(string) (bool, error) {
+	required := make(map[string]bool)
+	optional := make(map[string]bool)
 	for _, sn := range dctx.Model().AllSnaps() {
-		if sn.SnapName() == instanceName {
-			return true
+		if sn.Presence == "required" {
+			required[sn.SnapName()] = true
+		} else {
+			optional[sn.SnapName()] = true
 		}
 	}
 
-	return false
+	// snapd should always be considered a part of the model. this is really a
+	// compatibility thing, and maybe should not be here since seed-refresh
+	// isn't gonna work on old models anyways.
+	required["snapd"] = true
+
+	var optionalInSeed map[string]bool
+
+	return func(instanceName string) (bool, error) {
+		if required[instanceName] {
+			return true, nil
+		}
+
+		if !optional[instanceName] {
+			return false, nil
+		}
+
+		if optionalInSeed == nil {
+			currentSystem, err := currentSeededSystem(st)
+			if err != nil {
+				return false, err
+			}
+
+			current, err := seedOpen(dirs.SnapSeedDir, currentSystem.System)
+			if err != nil {
+				return false, err
+			}
+			if err := current.LoadAssertions(nil, nil); err != nil {
+				return false, err
+			}
+
+			copier, ok := current.(seed.Copier)
+			if !ok {
+				// this would only happen if the seed is pre-core20
+				return false, fmt.Errorf("internal error: seed %q does not support listing optional containers", currentSystem.System)
+			}
+
+			oc, err := copier.OptionalContainers()
+			if err != nil {
+				return false, err
+			}
+
+			optionalInSeed = make(map[string]bool, len(oc.Snaps))
+			for _, sn := range oc.Snaps {
+				optionalInSeed[sn] = true
+			}
+		}
+
+		return optionalInSeed[instanceName], nil
+	}
 }
 
 func findSeedRefreshTasks(chg *state.Change) (*snapstate.SeedRefreshTaskSet, error) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2119,6 +2119,45 @@ func (s *startOfOperationTimeSuite) TestStartOfOperationErrorIfPreseed(c *C) {
 	c.Assert(err, ErrorMatches, `internal error: unexpected call to StartOfOperationTime in preseed mode`)
 }
 
+func (s *deviceMgrSuite) TestCreateSeedRefreshTasksSkipsOpeningSeed(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make sure that we don't attempt to open the seed
+	restore := devicestate.MockSeedOpen(func(seedDir, label string) (seed.Seed, error) {
+		c.Fatalf("unexpected call to seed.Open: %s %s", seedDir, label)
+		return nil, nil
+	})
+	defer restore()
+
+	download := s.state.NewTask("fake-download", "...")
+	otherDwnload := s.state.NewTask("fake-download", "...")
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+	})
+
+	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
+		// proves that required snaps don't make us open the seed
+		{
+			InstanceName:     "snap-1",
+			SnapSetupTaskIDs: []string{download.ID()},
+		},
+		// proves that non-model snaps don't make us open the seed
+		{
+			InstanceName:     "snap-not-in-model",
+			SnapSetupTaskIDs: []string{otherDwnload.ID()},
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
+}
+
 func (s *deviceMgrSuite) TestCreateSeedRefreshTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -2131,7 +2170,14 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasks(c *C) {
 	tSnap1 := s.state.NewTask("fake-download", "...")
 	tSnap2 := s.state.NewTask("fake-download", "...")
 	tComp1 := s.state.NewTask("fake-download-component", "...")
-	dctx := s.seedRefreshDeviceContext(c, "snap-1", "snap-2")
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+		{"name": "snap-2", "presence": "optional"},
+	}, "snap-2")
 
 	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
 		{
@@ -2174,6 +2220,42 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasks(c *C) {
 	c.Check(boundary, Equals, restart.RestartBoundaryDirectionDo)
 }
 
+func (s *deviceMgrSuite) TestCreateSeedRefreshTasksComponentExclusive(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restore := devicestate.MockTimeNow(func() time.Time {
+		return time.Date(2026, 2, 27, 8, 45, 0, 0, time.UTC)
+	})
+	defer restore()
+
+	compTask1 := s.state.NewTask("fake-download-component", "...")
+	compTask2 := s.state.NewTask("fake-download-component", "...")
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+	})
+
+	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
+		{
+			InstanceName:          "snap-1",
+			ComponentSetupTaskIDs: []string{compTask1.ID(), compTask2.ID()},
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
+
+	var setup devicestate.RecoverySystemSetup
+	c.Assert(seedTS.Create.Get("recovery-system-setup", &setup), IsNil)
+	c.Check(setup.SnapSetupTasks, HasLen, 0)
+	c.Check(setup.ComponentSetupTasks, DeepEquals, []string{compTask1.ID(), compTask2.ID()})
+}
+
 func (s *deviceMgrSuite) TestCreateSeedRefreshTasksUsesNextAvailableLabel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -2190,7 +2272,13 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksUsesNextAvailableLabel(c *C) 
 	c.Assert(os.MkdirAll(filepath.Join(systemsDir, labelBase+"-2"), 0755), IsNil)
 
 	tSnap := s.state.NewTask("fake-download", "...")
-	dctx := s.seedRefreshDeviceContext(c, "snap-1")
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+	})
 
 	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
 		{
@@ -2232,7 +2320,13 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
 		{System: "old-seed-refresh-1", SeedRefresh: true},
 		{System: "old-seed-refresh-2", SeedRefresh: true},
 	})
-	dctx := s.seedRefreshDeviceContext(c, "snap-1")
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+	})
 	tSnap := s.state.NewTask("fake-download", "...")
 
 	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
@@ -2261,7 +2355,14 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChange(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	dctx := s.seedRefreshDeviceContext(c, "snap-1", "snap-2")
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+		{"name": "snap-2", "presence": "optional"},
+	}, "snap-2", "snap-3")
 	chg := s.state.NewChange("seed-refresh", "...")
 	snap1Task := s.state.NewTask("fake-download", "...")
 	snap2Task := s.state.NewTask("fake-download", "...")
@@ -2314,11 +2415,120 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChange(c *C) {
 	c.Check(setup.ComponentSetupTasks, DeepEquals, []string{"comp-1", "comp-2", "comp-3"})
 }
 
+func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeComponentExclusive(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+		{"name": "snap-2", "presence": "optional"},
+	}, "snap-2")
+	chg := s.state.NewChange("seed-refresh", "...")
+	snap1Task := s.state.NewTask("fake-download", "...")
+	compTask1 := s.state.NewTask("fake-download-component", "...")
+	compTask2 := s.state.NewTask("fake-download-component", "...")
+	create := s.state.NewTask("create-recovery-system", "...")
+	create.Set("recovery-system-setup", &devicestate.RecoverySystemSetup{
+		Label:               "20260227",
+		Directory:           filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", "20260227"),
+		SnapSetupTasks:      []string{snap1Task.ID()},
+		ComponentSetupTasks: []string{compTask1.ID()},
+	})
+	finalize := s.state.NewTask("finalize-recovery-system", "...")
+	finalize.Set("recovery-system-setup-task", create.ID())
+	chg.AddTask(create)
+	chg.AddTask(finalize)
+
+	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+		InstanceName:          "snap-2",
+		ComponentSetupTaskIDs: []string{compTask2.ID(), compTask1.ID()},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+
+	var setup devicestate.RecoverySystemSetup
+	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
+	c.Check(setup.SnapSetupTasks, DeepEquals, []string{snap1Task.ID()})
+	c.Check(setup.ComponentSetupTasks, DeepEquals, []string{compTask1.ID(), compTask2.ID()})
+}
+
+func (s *deviceMgrSuite) TestCreateSeedRefreshTasksSkipsOptionalSnapNotInCurrentSeed(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1", "presence": "optional"},
+	})
+
+	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
+		{
+			InstanceName:     "snap-1",
+			SnapSetupTaskIDs: []string{s.state.NewTask("fake-download", "...").ID()},
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(seedTS, IsNil)
+	c.Check(added, IsNil)
+}
+
+func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeSkipsOptionalSnapNotInCurrentSeed(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+		{"name": "snap-2", "presence": "optional"},
+	})
+	chg := s.state.NewChange("seed-refresh", "...")
+	snap1Task := s.state.NewTask("fake-download", "...")
+	snap2Task := s.state.NewTask("fake-download", "...")
+	create := s.state.NewTask("create-recovery-system", "...")
+	create.Set("recovery-system-setup", &devicestate.RecoverySystemSetup{
+		Label:          "20260227",
+		Directory:      filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", "20260227"),
+		SnapSetupTasks: []string{snap1Task.ID()},
+	})
+	finalize := s.state.NewTask("finalize-recovery-system", "...")
+	finalize.Set("recovery-system-setup-task", create.ID())
+	chg.AddTask(create)
+	chg.AddTask(finalize)
+
+	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+		InstanceName:     "snap-2",
+		SnapSetupTaskIDs: []string{snap2Task.ID()},
+	})
+	c.Assert(err, IsNil)
+	c.Check(seedTS, IsNil)
+
+	var setup devicestate.RecoverySystemSetup
+	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
+	c.Check(setup.SnapSetupTasks, DeepEquals, []string{snap1Task.ID()})
+}
+
 func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeUsesPendingSeedRefreshTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	dctx := s.seedRefreshDeviceContext(c, "snap-1", "snap-2")
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+		{"name": "snap-2"},
+	})
 	chg := s.state.NewChange("seed-refresh", "...")
 
 	oldSnapTask := s.state.NewTask("fake-download", "...")
@@ -2375,21 +2585,72 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeUsesPendingSeedRefreshTasks(
 	c.Check(currentSetup.SnapSetupTasks, DeepEquals, []string{currentSnapTask.ID(), nextSnapTask.ID()})
 }
 
-func (s *deviceMgrSuite) seedRefreshDeviceContext(c *C, requiredSnaps ...string) snapstate.DeviceContext {
-	extras := map[string]any{
-		"architecture": "amd64",
-		"kernel":       "pc-kernel",
-		"gadget":       "pc",
-	}
-	if len(requiredSnaps) != 0 {
-		required := make([]any, len(requiredSnaps))
-		for i, snapName := range requiredSnaps {
-			required[i] = snapName
-		}
-		extras["required-snaps"] = required
+func seedRefreshSnapYAML(name, snapType string) string {
+	if snapType == "" {
+		snapType = "app"
 	}
 
-	model := s.makeModelAssertionInState(c, "canonical", "pc", extras)
+	base := ""
+	switch snapType {
+	case "app", "gadget":
+		base = "\nbase: core24"
+	}
+
+	return fmt.Sprintf("name: %s\nversion: 1\ntype: %s%s", name, snapType, base)
+}
+
+func (s *deviceMgrSuite) setupSeedRefreshSeedAndContext(c *C, snaps []map[string]string, optionals ...string) snapstate.DeviceContext {
+	seed20 := &seedtest.TestingSeed20{
+		SeedSnaps: seedtest.SeedSnaps{
+			StoreSigning: s.storeSigning,
+			Brands:       s.brands,
+		},
+		SeedDir: dirs.SnapSeedDir,
+	}
+	restore := seed.MockTrusted(seed20.StoreSigning.Trusted)
+	s.AddCleanup(restore)
+	assertstest.AddMany(seed20.StoreSigning.Database, s.brands.AccountsAndKeys("my-brand")...)
+
+	headers := make([]any, 0, len(snaps))
+	for _, sn := range snaps {
+		if sn["presence"] != "optional" {
+			var files [][]string
+			if sn["type"] == "gadget" {
+				files = [][]string{{"meta/gadget.yaml", mockGadgetUCYaml}}
+			}
+			seed20.MakeAssertedSnap(c, seedRefreshSnapYAML(sn["name"], sn["type"]), files, snap.R(1), "my-brand", seed20.StoreSigning.Database)
+		}
+
+		modelSnap := make(map[string]any, len(sn)+1)
+		for k, v := range sn {
+			modelSnap[k] = v
+		}
+		modelSnap["id"] = seed20.AssertedSnapID(sn["name"])
+
+		headers = append(headers, modelSnap)
+	}
+
+	var opts []*seedwriter.OptionsSnap
+	for _, name := range optionals {
+		seed20.MakeAssertedSnap(c, seedRefreshSnapYAML(name, "app"), nil, snap.R(1), "my-brand", seed20.StoreSigning.Database)
+		opts = append(opts, &seedwriter.OptionsSnap{Name: name})
+	}
+
+	model := seed20.MakeSeed(c, "20260226", "my-brand", "seed-refresh-model", map[string]any{
+		"display-name": "seed refresh model",
+		"architecture": "amd64",
+		"base":         "core24",
+		"grade":        "dangerous",
+		"snaps":        headers,
+	}, opts)
+
+	var seededSystems []devicestate.SeededSystem
+	err := s.state.Get("seeded-systems", &seededSystems)
+	if err != nil {
+		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+	}
+	s.state.Set("seeded-systems", append([]devicestate.SeededSystem{{System: "20260226"}}, seededSystems...))
+
 	return &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 }
 


### PR DESCRIPTION
This updates seed-refresh to only trigger seed-refresh on snaps that are both in the model and present in the system's current seed.

I will add a spread test for this, but https://github.com/canonical/snapd/pull/17078 refactored the spread tests for this feature some, and I'd like that to land first.