### PR TITLE
tests/main/disk-space-awareness: ensure consistent state before and after the test, bump size

### DIFF
--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -11,18 +11,26 @@ environment:
   TMPFSMOUNT: /var/lib/snapd
   # filling tmpfs mounted under /var/lib/snapd triggers OOM
   SNAPD_NO_MEMORY_LIMIT: 1
-  SUFFICIENT_SIZE: 200M
+  SUFFICIENT_SIZE: 300M
 
 prepare: |
   systemctl stop snapd.{socket,service}
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
 
+  # purge removes the snap mount directory, which needs to be restored
+  snapd.tool exec snap-mgmt --purge
+  mkdir -p "$SNAP_MOUNT_DIR"
   # mount /var/lib/snapd on a tmpfs
   mount -t tmpfs tmpfs -o size="$SUFFICIENT_SIZE",mode=0755 "$TMPFSMOUNT"
 
   systemctl start snapd.{socket,service}
+  snap wait system seed.loaded
 
 restore: |
   systemctl stop snapd.{socket,service}
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+  snapd.tool exec snap-mgmt --purge
+  mkdir -p "$SNAP_MOUNT_DIR"
   umount -l "$TMPFSMOUNT"
   systemctl start snapd.{socket,service}
 


### PR DESCRIPTION
Ensure that the state before and after the state is consistent. Specifically, mount units created during suite prepare are carried over to the test, thus mounting a tmpfs on top of /var/lib/snapd creates a discrepancy between e.g. unit files under /etc/systemd/system and actual snapd state. Adding purge ensures that the system state and snapd state match again.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
