### PR TITLE
tests: update url used for test-predictor client

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -646,7 +646,7 @@ jobs:
             echo "Results sent successfully"
 
             echo "Getting predictions for failed tests"
-            wget -q -O predict https://raw.githubusercontent.com/canonical/snapd-testing/master/ai/test-predictor/client/predict
+            wget -q -O predict https://raw.githubusercontent.com/canonical/snapd-testing/master/ai/test-predictor/src/client/predict
             chmod +x predict
             ./predict results.json
         else


### PR DESCRIPTION
The client was moved to scr/client
