### PR TITLE
tests/regression/lp-1813365: pass PATH from spread.yaml to command

### DIFF
--- a/tests/regression/lp-1813365/task.yaml
+++ b/tests/regression/lp-1813365/task.yaml
@@ -30,5 +30,6 @@ restore: |
     rm -f /tmp/logger.log
 
 execute: |
-    su -l -c "PATH=\$PATH:/usr/lib/python $(pwd)/helper" test
+    # Ensure that we pass the PATH defined in spread.yaml so python is found
+    su -l -c "PATH=$PATH $(pwd)/helper" test
     not test -e /tmp/logger.log


### PR DESCRIPTION
Pass PATH from spread.yaml instead of adding a path to the default one when using su to run a command, to help maintainability.