### PR TITLE
i/b/bool-file: support deep SoC sysfs paths for LED brightness

### DIFF
--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -63,7 +63,7 @@ func (iface *boolFileInterface) StaticInfo() interfaces.StaticInfo {
 var boolFileGPIOValuePattern = regexp.MustCompile(
 	"^/sys/class/gpio/gpio[0-9]+/value$")
 var boolFileLedPattern = regexp.MustCompile(
-	"^/sys/devices/platform/leds/[^/]+/[^/]+/brightness$")
+	"^/sys/devices/platform/.+/leds/[^/]+/brightness$")
 var boolFileAllowedPathPatterns = []*regexp.Regexp{
 	// The brightness of standard LED class device
 	regexp.MustCompile("^/sys/class/leds/[^/]+/brightness$"),

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -201,6 +201,24 @@ func (s *BoolFileInterfaceSuite) TestAddConnectedPlugAdditionalSnippetsForLeds(c
 			"/sys/devices/platform/leds/leds/status-grn-led/trigger rw,",
 		},
 	})
+
+	// Make sure that deep SoC paths (e.g. I2C-connected LED controllers on ARM
+	// boards) also get the additional snippets. These resolve to paths with
+	// multiple bus hierarchy segments between platform/ and leds/.
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		return "/sys/devices/platform/soc@0/soc@0:bus@30800000/30a50000.i2c/i2c-3/3-003f/leds/DL25:red/brightness", nil
+	})
+	apparmorSpec3 := apparmor.NewSpecification(s.plug.AppSet())
+	err = apparmorSpec3.AddConnectedPlug(s.iface, s.plug, s.ledSlot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec3.Snippets(), DeepEquals, map[string][]string{
+		"snap.other.app": {
+			"/sys/devices/platform/soc@0/soc@0:bus@30800000/30a50000.i2c/i2c-3/3-003f/leds/DL25:red/brightness rwk,",
+			"/sys/devices/platform/soc@0/soc@0:bus@30800000/30a50000.i2c/i2c-3/3-003f/leds/DL25:red/delay_off rw,",
+			"/sys/devices/platform/soc@0/soc@0:bus@30800000/30a50000.i2c/i2c-3/3-003f/leds/DL25:red/delay_on rw,",
+			"/sys/devices/platform/soc@0/soc@0:bus@30800000/30a50000.i2c/i2c-3/3-003f/leds/DL25:red/trigger rw,",
+		},
+	})
 }
 
 func (s *BoolFileInterfaceSuite) TestPlugSnippetDereferencesSymlinks(c *C) {


### PR DESCRIPTION
The boolFileLedPattern only matched LEDs sitting directly under `sys/devices/platform/leds/`, which reflects simple GPIO-backed LEDs.

On ARM boards with I2C-connected LED controllers the full bus hierarchy appears in sysfs (e.g.  `platform/soc@0/.../i2c-3/3-003fleds/...`  and because of it customer reported that they cannot use the `bool_file` interface due to denials. This PR aims to address the issue. 

Internal reference: LP#2148544

