### PR TITLE
overlord: restore mocked version

### DIFF
--- a/overlord/hookstate/ctlcmd/version_test.go
+++ b/overlord/hookstate/ctlcmd/version_test.go
@@ -53,7 +53,8 @@ func (s *versionSuite) SetUpTest(c *C) {
 }
 
 func (s *setSuite) TestVersion(c *C) {
-	snapdtool.MockVersion("2.71+g123123-happy")
+	restore := snapdtool.MockVersion("2.71+g123123-happy")
+	defer restore()
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"version"}, 0, nil)
 	c.Check(err, IsNil)
 	c.Check(string(stdout), DeepEquals,

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -318,13 +318,14 @@ func (s *patchSuite) TestError(c *C) {
 func (s *patchSuite) testMaybeResetPatchLevel6(c *C, snapdVersion, lastVersion string, expectedPatches []int) {
 	var sequence []int
 
-	snapdtool.MockVersion(snapdVersion)
+	restore := snapdtool.MockVersion(snapdVersion)
+	defer restore()
 
 	p60 := generatePatchFunc(60, &sequence)
 	p61 := generatePatchFunc(61, &sequence)
 	p62 := generatePatchFunc(62, &sequence)
 
-	restore := patch.Mock(6, 2, map[int][]patch.PatchFunc{
+	restore = patch.Mock(6, 2, map[int][]patch.PatchFunc{
 		6: {p60, p61, p62},
 	})
 


### PR DESCRIPTION
This is harmless (perhaps) but it's easier to fix than to prove.

