### PR TITLE
interfaces/builtin: add vsock interface for VM guest services

### DIFF
--- a/interfaces/builtin/vsock_guest.go
+++ b/interfaces/builtin/vsock_guest.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const vsockGuestSummary = `allows access to vsock sockets for VM guest to host/hypervisor communication`
+
+const vsockGuestBaseDeclarationSlots = `
+  vsock-guest:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const vsockGuestConnectedPlugAppArmor = `
+# Description: Allow access to vsock sockets for communication between
+# a VM guest and the host or hypervisor (AF_VSOCK).
+network vsock,
+/dev/vsock rw,
+`
+
+const vsockGuestConnectedPlugSecComp = `
+# Description: Allow access to vsock sockets for VM guest to host communication.
+# socket AF_VSOCK is already permitted by the default seccomp template.
+bind
+listen
+accept
+accept4
+`
+
+var vsockGuestConnectedPlugUDev = []string{
+	`KERNEL=="vsock"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "vsock-guest",
+		summary:               vsockGuestSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  vsockGuestBaseDeclarationSlots,
+		connectedPlugAppArmor: vsockGuestConnectedPlugAppArmor,
+		connectedPlugSecComp:  vsockGuestConnectedPlugSecComp,
+		connectedPlugUDev:     vsockGuestConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/vsock_guest_test.go
+++ b/interfaces/builtin/vsock_guest_test.go
@@ -1,0 +1,129 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type vsockGuestInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&vsockGuestInterfaceSuite{
+	iface: builtin.MustInterface("vsock-guest"),
+})
+
+const vsockGuestConsumerYaml = `name: consumer
+version: 0
+apps:
+  app:
+    plugs: [vsock-guest]
+`
+
+const vsockGuestCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  vsock-guest:
+`
+
+func (s *vsockGuestInterfaceSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.plug, s.plugInfo = MockConnectedPlug(c, vsockGuestConsumerYaml, nil, "vsock-guest")
+	s.slot, s.slotInfo = MockConnectedSlot(c, vsockGuestCoreYaml, nil, "vsock-guest")
+}
+
+func (s *vsockGuestInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "vsock-guest")
+}
+
+func (s *vsockGuestInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *vsockGuestInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *vsockGuestInterfaceSuite) TestAppArmorSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "network vsock,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/vsock rw,")
+}
+
+func (s *vsockGuestInterfaceSuite) TestUDevSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), testutil.Contains, "# vsock-guest\nKERNEL==\"vsock\", TAG+=\"snap_consumer_app\"")
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *vsockGuestInterfaceSuite) TestSecCompSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := seccomp.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "bind\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "listen\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "accept\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "accept4\n")
+}
+
+func (s *vsockGuestInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to vsock sockets for VM guest to host/hypervisor communication`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "vsock-guest")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *vsockGuestInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *vsockGuestInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -299,6 +299,9 @@ apps:
   vcio:
     command: bin/run
     plugs: [ vcio ]
+  vsock-guest:
+    command: bin/run
+    plugs: [ vsock-guest ]
   x11:
     command: bin/run
     plugs: [ x11 ]


### PR DESCRIPTION
A customer would like to use open-vm-tools heavily relies on the vsock interface for communication between hypervisor and guest. They were using `custom-device` interface to access `dev` files like `/dev/vsock` and `/dev/vmci`.

However, they also realized that they are getting denial due to missing `vsock` support. The `custom-device` interface does not allow adding `network vsock`. This PR aims to solve this problem.

Denied Messages:

```
Log: apparmor="DENIED" operation="create" class="net" profile="snap.vmware-tools-probe.probe" pid=34906 comm="python3" family="vsock" sock_type="stream" protocol=0 requested="create" denied="create"
```

```
Log: apparmor="DENIED" operation="create" class="net" profile="snap.vmware-tools-probe.probe" pid=34906 comm="python3" family="vsock" sock_type="dgram" protocol=0 requested="create" denied="create"
```

Internal reference: LP#2147028