### PR TITLE
spread: remove dead syntax

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -755,29 +755,23 @@ backends:
             exec image-garden discard "$SPREAD_SYSTEM_ADDRESS"
         systems:
             - ubuntu-core-16-64:
-                  image: ubuntu-16.04-64
                   username: root
                   password: root
                   # Disable due to ENOSPC.
                   manual: true
             - ubuntu-core-18-64:
-                  image: ubuntu-18.04-64
                   username: root
                   password: root
             - ubuntu-core-20-64:
-                  image: ubuntu-20.04-64
                   username: root
                   password: root
             - ubuntu-core-22-64:
-                  image: ubuntu-22.04-64
                   username: root
                   password: root
             - ubuntu-core-24-64:
-                  image: ubuntu-24.04-64
                   username: root
                   password: root
             - ubuntu-core-26-64:
-                  image: ubuntu-26.04-64
                   username: root
                   password: root
             - ubuntu-16.04-64:


### PR DESCRIPTION
We somehow got those image: elements under the adhoc backend used by garden and they are harmless but also not really doing anything because spread doesn't implement this. Let's remove it to avoid any confusion.
