### PR TITLE
fdestate: remove check for unchanged authentication options

### DIFF
--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -442,14 +442,6 @@ func (m *FDEManager) doChangeAuth(t *state.Task, _ *tomb.Tomb) (err error) {
 		return fmt.Errorf("internal error: wrong data type under changeAuthOptionsKey: %T", cached)
 	}
 
-	if opts.old == opts.new {
-		// optimally, this check should be done in ChangeAuth before the change
-		// is created but it is done here to avoid breaking the API, as on success
-		// it expects an async response with a change ID, and if we have an empty
-		// change, it stays at "Hold" status forever, so it is more for convenience.
-		return nil
-	}
-
 	changeOneKeyslot := func(keyslot Keyslot, old, new string) error {
 		kd, err := keyslot.KeyData()
 		if err != nil {

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -684,6 +684,7 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeys(c *C) {
 		keyslots        []fdestate.KeyslotRef
 		authMode        device.AuthMode
 		noOpt           bool
+		sameAuth        bool
 		errOn           []string
 		expectedChanges []string
 		expectedUndos   []string
@@ -766,6 +767,19 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeys(c *C) {
 			authMode:    device.AuthModeNone,
 			expectedErr: `internal error: unexpected auth-mode "none"`,
 		},
+		{
+			keyslots:        []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}},
+			authMode:        device.AuthModePassphrase,
+			sameAuth:        true,
+			expectedChanges: []string{"/dev/disk/by-uuid/data:default"},
+		},
+		{
+			keyslots:    []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}},
+			authMode:    device.AuthModePassphrase,
+			sameAuth:    true,
+			errOn:       []string{"change:/dev/disk/by-uuid/data:default"},
+			expectedErr: `cannot change passphrase for \(container-role: "system-data", name: "default"\): change error on /dev/disk/by-uuid/data:default`,
+		},
 	}
 	for idx, tc := range tcs {
 		task := s.st.NewTask("fde-change-auth", "test")
@@ -775,6 +789,9 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeys(c *C) {
 		old, new := "old", "new"
 		if tc.authMode == device.AuthModePIN {
 			old, new = "1234", "4321"
+		}
+		if tc.sameAuth {
+			old, new = "same", "same"
 		}
 		if !tc.noOpt {
 			s.st.Unlock()

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -863,33 +863,6 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeys(c *C) {
 	}
 }
 
-func (s *fdeMgrSuite) TestDoChangeAuthKeysNoop(c *C) {
-	const onClassic = true
-	s.startedManager(c, onClassic)
-
-	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
-		panic("unexpected")
-	})()
-
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	task := s.st.NewTask("fde-change-auth", "test")
-	task.Set("keyslots", []fdestate.KeyslotRef{})
-	task.Set("auth-mode", device.AuthModePassphrase)
-
-	s.st.Unlock()
-	defer fdestate.MockChangeAuthOptionsInCache(s.st, "old", "old")()
-	s.st.Lock()
-
-	chg := s.st.NewChange("sample", "...")
-	chg.AddTask(task)
-
-	s.settle(c)
-
-	c.Check(chg.Status(), Equals, state.DoneStatus)
-}
-
 func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 	const onClassic = true
 	s.startedManager(c, onClassic)


### PR DESCRIPTION
This fixes an issue replacing passphrase/pin, where a wrong old secret doesn't return a response error.

To reproduce in an active TPM/FDE system:

```sh
echo '{"action": "change-passphrase", "new-passphrase": "wrong-old-passphrase", "old-passphrase": "wrong-old-passphrase" }' | snap debug api -H "Content-Type: application/json" -X POST /v2/system-volumes

# output
{
  "change": "48",
  "result": null,
  "status": "Accepted",
  "status-code": 202,
  "type": "async",
}

snap debug api /v2/changes/48

# output, here I would expect an error
{
  "result": {
    "id": "48",
    "kind": "fde-change-passphrase",
    "ready": true,
    "ready-time": "2026-04-23T13:27:33.206842696+02:00",
    "spawn-time": "2026-04-23T13:27:33.18068195+02:00",
    "status": "Done",
    "summary": "Change passphrase",
    "tasks": [
      {
        "id": "911",
        "kind": "fde-change-auth",
        "progress": {
          "done": 1,
          "label": "",
          "total": 1
        },
        "ready-time": "2026-04-23T13:27:33.206837207+02:00",
        "spawn-time": "2026-04-23T13:27:33.1806602+02:00",
        "status": "Done",
        "summary": "Change passphrase protected key slots"
      }
    ]
  },
  "status": "OK",
  "status-code": 200,
  "type": "sync",
}
```

The system is not affected by the change, so it means internally it still rejects correctly the wrong passphrase


JIRA: [SNAPDENG-36363](https://warthogs.atlassian.net/browse/SNAPDENG-36363)




[SNAPDENG-36363]: https://warthogs.atlassian.net/browse/SNAPDENG-36363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ