### PR TITLE
many: support --wait-for timeouts when accessing confdb

### DIFF
--- a/client/confdb.go
+++ b/client/confdb.go
@@ -25,9 +25,14 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 )
 
-func (c *Client) ConfdbGetViaView(viewID string, requests []string, constraints map[string]any) (changeID string, err error) {
+type ConfdbOptions struct {
+	AccessTimeout *time.Duration
+}
+
+func (c *Client) ConfdbGetViaView(viewID string, requests []string, constraints map[string]any, opts *ConfdbOptions) (changeID string, err error) {
 	query := url.Values{}
 	query.Add("keys", strings.Join(requests, ","))
 
@@ -40,16 +45,25 @@ func (c *Client) ConfdbGetViaView(viewID string, requests []string, constraints 
 		query.Add("constraints", string(data))
 	}
 
+	if opts != nil && opts.AccessTimeout != nil {
+		query.Add("access-timeout", opts.AccessTimeout.String())
+	}
+
 	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
 	return c.doAsync("GET", endpoint, query, nil, nil)
 }
 
-func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]any) (changeID string, err error) {
-	type setBody struct {
-		Values map[string]any `json:"values"`
+func (c *Client) ConfdbSetViaView(viewID string, values map[string]any, opts *ConfdbOptions) (changeID string, err error) {
+	body := map[string]any{
+		"values": values,
 	}
 
-	body := setBody{Values: requestValues}
+	if opts != nil && opts.AccessTimeout != nil {
+		body["options"] = map[string]any{
+			"access-timeout": opts.AccessTimeout.String(),
+		}
+	}
+
 	bodyRaw, err := json.Marshal(body)
 	if err != nil {
 		return "", err

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -23,7 +23,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/url"
+	"time"
 
+	"github.com/snapcore/snapd/client"
 	. "gopkg.in/check.v1"
 )
 
@@ -35,7 +37,7 @@ func (cs *clientSuite) TestConfdbGet(c *C) {
 		"type": "async"
 	}`
 
-	chgID, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo", "bar"}, nil)
+	chgID, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo", "bar"}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(chgID, Equals, "123")
 	c.Check(cs.reqs[0].Method, Equals, "GET")
@@ -52,7 +54,7 @@ func (cs *clientSuite) TestConfdbGetWithConstraints(c *C) {
 	}`
 
 	constraints := map[string]any{"bar": "value1", "baz": "value2"}
-	chgID, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo"}, constraints)
+	chgID, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo"}, constraints, nil)
 	c.Assert(err, IsNil)
 	c.Assert(chgID, Equals, "123")
 	c.Assert(cs.reqs[0].Method, Equals, "GET")
@@ -72,7 +74,12 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "123"}`
 
-	chgID, err := cs.cli.ConfdbSetViaView("a/b/c", map[string]any{"foo": "bar", "baz": json.Number("1")})
+	timeout := 10 * time.Second
+	opts := &client.ConfdbOptions{
+		AccessTimeout: &timeout,
+	}
+
+	chgID, err := cs.cli.ConfdbSetViaView("a/b/c", map[string]any{"foo": "bar", "baz": json.Number("1")}, opts)
 	c.Check(err, IsNil)
 	c.Check(chgID, Equals, "123")
 	c.Assert(cs.reqs, HasLen, 1)
@@ -86,5 +93,5 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	res := make(map[string]any)
 	err = json.Unmarshal(data, &res)
 	c.Assert(err, IsNil)
-	c.Check(res, DeepEquals, map[string]any{"values": map[string]any{"foo": "bar", "baz": float64(1)}})
+	c.Check(string(data), Equals, `{"options":{"access-timeout":"10s"},"values":{"baz":1,"foo":"bar"}}`)
 }

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 
@@ -78,6 +79,7 @@ type cmdGet struct {
 	List     bool     `short:"l"`
 	Default  string   `long:"default" unquote:"false"`
 	With     []string `long:"with" value-name:"<param>=<constraint>"`
+	WaitFor  string   `long:"wait-for"`
 }
 
 func init() {
@@ -101,6 +103,8 @@ func init() {
 			"default": i18n.G("A strictly typed default value to be used when none is found"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"with": i18n.G("Parameter constraints for filtering confdb queries"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"wait-for": i18n.G("Maximum duration to wait for confdb access (e.g. 10s)"),
 		}, []argDesc{
 			{
 				name: "<snap>",
@@ -278,12 +282,18 @@ func (x *cmdGet) Execute(args []string) error {
 		// first argument is a confdbViewID, use the confdb API
 		conf, err = x.getConfdb(snapName, confKeys)
 	} else {
-		if x.Default != "" {
-			return fmt.Errorf(`cannot use --default in non-confdb read`)
+		var flag string
+		switch {
+		case x.WaitFor != "":
+			flag = "wait-for"
+		case x.Default != "":
+			flag = "default"
+		case len(x.With) > 0:
+			flag = "with"
 		}
 
-		if len(x.With) > 0 {
-			return fmt.Errorf(`cannot use --with in non-confdb read`)
+		if flag != "" {
+			return fmt.Errorf("cannot use --%s in non-confdb read", flag)
 		}
 
 		conf, err = x.client.Conf(snapName, confKeys)
@@ -318,13 +328,25 @@ func (x *cmdGet) getConfdb(confdbViewID string, confKeys []string) (map[string]a
 		return nil, fmt.Errorf("cannot use --default with more than one confdb request")
 	}
 
-	opts := clientutil.ConfdbOptions{Typed: x.Typed}
-	constraints, err := clientutil.ParseConfdbConstraints(x.With, opts)
+	parseOpts := clientutil.ConfdbOptions{Typed: x.Typed}
+	constraints, err := clientutil.ParseConfdbConstraints(x.With, parseOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	chgID, err := x.client.ConfdbGetViaView(confdbViewID, confKeys, constraints)
+	var opts *client.ConfdbOptions
+	if x.WaitFor != "" {
+		timeout, err := time.ParseDuration(x.WaitFor)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse --wait-for value %s: %v", x.WaitFor, err)
+		}
+
+		opts = &client.ConfdbOptions{
+			AccessTimeout: &timeout,
+		}
+	}
+
+	chgID, err := x.client.ConfdbGetViaView(confdbViewID, confKeys, constraints, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -1070,3 +1070,57 @@ func (s *confdbSuite) TestForbidWithWithNonConfdbGet(c *check.C) {
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
 }
+
+func (s *confdbSuite) TestConfdbGetWaitFor(c *check.C) {
+	restore := snapset.MockIsStdinTTY(true)
+	defer restore()
+
+	restore = s.mockConfdbFlag(c)
+	defer restore()
+
+	var reqs int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch reqs {
+		case 0:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
+
+			q := r.URL.Query()
+			c.Check(q.Get("access-timeout"), Equals, "5s")
+
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": "cba"}}}}`)
+		default:
+			err := fmt.Errorf("expected to get 2 requests, now on %d (%v)", reqs+1, r)
+			w.WriteHeader(500)
+			fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+			c.Error(err)
+		}
+
+		reqs++
+	})
+
+	rest, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", "foo/bar/baz", "abc", "--wait-for", "5s"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, "cba\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *confdbSuite) TestForbidWaitForWithNonConfdbGet(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		err := fmt.Errorf("expected to get no requests (%v)", r)
+		w.WriteHeader(500)
+		fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+		c.Error(err)
+	})
+
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", ":foo", "--wait-for", "5s", "bar"})
+	c.Assert(err, ErrorMatches, "cannot use --wait-for in non-confdb read")
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "")
+}

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -21,10 +21,13 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
 )
@@ -59,8 +62,9 @@ type cmdSet struct {
 		ConfValues []string `required:"1"`
 	} `positional-args:"yes" required:"yes"`
 
-	Typed  bool `short:"t"`
-	String bool `short:"s"`
+	Typed   bool   `short:"t"`
+	String  bool   `short:"s"`
+	WaitFor string `long:"wait-for"`
 }
 
 func init() {
@@ -74,6 +78,8 @@ func init() {
 			"t": i18n.G("Parse the value strictly as JSON document"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"s": i18n.G("Parse the value as a string"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"wait-for": i18n.G("Maximum duration to wait for confdb access (e.g. 10s)"),
 		}), []argDesc{
 			{
 				name: "<snap>",
@@ -112,8 +118,23 @@ func (x *cmdSet) Execute([]string) error {
 			return err
 		}
 
-		chgID, err = x.client.ConfdbSetViaView(confdbViewID, patchValues)
+		var opts *client.ConfdbOptions
+		if x.WaitFor != "" {
+			timeout, err := time.ParseDuration(x.WaitFor)
+			if err != nil {
+				return fmt.Errorf("cannot parse --wait-for value %s: %v", x.WaitFor, err)
+			}
+
+			opts = &client.ConfdbOptions{
+				AccessTimeout: &timeout,
+			}
+		}
+
+		chgID, err = x.client.ConfdbSetViaView(confdbViewID, patchValues, opts)
 	} else {
+		if x.WaitFor != "" {
+			return fmt.Errorf("cannot use --wait-for in non-confdb write")
+		}
 		chgID, err = x.client.SetConf(snapName, patchValues)
 	}
 

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -261,7 +261,7 @@ func (s *confdbSuite) TestConfdbSetMany(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
-func (s *confdbSuite) TestConfdbSetInvalidAspectID(c *check.C) {
+func (s *confdbSuite) TestConfdbSetInvalidID(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
@@ -321,4 +321,66 @@ func (s *confdbSuite) TestSetEmptyKey(c *check.C) {
 
 	_, err = snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "some-snap", "="})
 	c.Assert(err, check.ErrorMatches, "configuration keys cannot be empty")
+}
+
+func (s *confdbSuite) TestConfdbSetWaitFor(c *check.C) {
+	restore := s.mockConfdbFlag(c)
+	defer restore()
+
+	var reqs int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch reqs {
+		case 0:
+			c.Check(r.Method, check.Equals, "PUT")
+			c.Check(r.URL.Path, check.Equals, "/v2/confdb/foo/bar/baz")
+
+			raw, err := io.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+
+			var body struct {
+				Values  map[string]any `json:"values"`
+				Options struct {
+					AccessTimeout string `json:"access-timeout"`
+				} `json:"options"`
+			}
+
+			c.Assert(json.Unmarshal(raw, &body), check.IsNil)
+			c.Check(body.Values, check.DeepEquals, map[string]any{"abc": "cba"})
+			c.Check(body.Options.AccessTimeout, check.Equals, "5s")
+
+			w.WriteHeader(202)
+			fmt.Fprintln(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintf(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}\n`)
+		default:
+			err := fmt.Errorf("expected to get 2 requests, now on %d (%v)", reqs+1, r)
+			w.WriteHeader(500)
+			fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+			c.Error(err)
+		}
+
+		reqs++
+	})
+
+	rest, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "foo/bar/baz", `abc="cba"`, "--wait-for", "5s"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *confdbSuite) TestForbidWaitForWithNonConfdbSet(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		err := fmt.Errorf("expected to get no requests (%v)", r)
+		w.WriteHeader(500)
+		fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+		c.Error(err)
+	})
+
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "some-snap", "abc=1", "--wait-for", "5s"})
+	c.Assert(err, check.ErrorMatches, "cannot use --wait-for in non-confdb write")
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_unset.go
+++ b/cmd/snap/cmd_unset.go
@@ -21,9 +21,12 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 )
 
@@ -54,6 +57,7 @@ type cmdUnset struct {
 		Snap     installedSnapName
 		ConfKeys []string `required:"1"`
 	} `positional-args:"yes" required:"yes"`
+	WaitFor string `long:"wait-for"`
 }
 
 func init() {
@@ -61,7 +65,11 @@ func init() {
 		longUnsetHelp += longConfdbUnsetHelp
 	}
 
-	addCommand("unset", shortUnsetHelp, longUnsetHelp, func() flags.Commander { return &cmdUnset{} }, waitDescs, []argDesc{
+	addCommand("unset", shortUnsetHelp, longUnsetHelp, func() flags.Commander { return &cmdUnset{} }, waitDescs.also(
+		map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"wait-for": i18n.G("Maximum duration to wait for confdb access (e.g. 10s)"),
+		}), []argDesc{
 		{
 			name: "<snap>",
 			// TRANSLATORS: This should not start with a lowercase letter.
@@ -100,8 +108,24 @@ func (x *cmdUnset) Execute(args []string) error {
 			return err
 		}
 
-		id, err = x.client.ConfdbSetViaView(confdbViewID, patchValues)
+		var opts *client.ConfdbOptions
+		if x.WaitFor != "" {
+			timeout, err := time.ParseDuration(x.WaitFor)
+			if err != nil {
+				return fmt.Errorf("cannot parse --wait-for value %s: %v", x.WaitFor, err)
+			}
+
+			opts = &client.ConfdbOptions{
+				AccessTimeout: &timeout,
+			}
+		}
+
+		id, err = x.client.ConfdbSetViaView(confdbViewID, patchValues, opts)
 	} else {
+		if x.WaitFor != "" {
+			return fmt.Errorf("cannot use --wait-for in non-confdb write")
+		}
+
 		id, err = x.client.SetConf(snapName, patchValues)
 	}
 

--- a/cmd/snap/cmd_unset_test.go
+++ b/cmd/snap/cmd_unset_test.go
@@ -20,7 +20,9 @@
 package main_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"gopkg.in/check.v1"
@@ -98,6 +100,77 @@ func (s *confdbSuite) TestConfdbUnsetInvalidConfdbID(c *check.C) {
 	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "foo//bar", "abc"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "confdb-schema view id must conform to format: <account-id>/<confdb-schema>/<view>")
+}
+
+func (s *confdbSuite) TestConfdbUnsetWaitFor(c *check.C) {
+	restore := s.mockConfdbFlag(c)
+	defer restore()
+
+	var reqs int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch reqs {
+		case 0:
+			c.Check(r.Method, check.Equals, "PUT")
+			c.Check(r.URL.Path, check.Equals, "/v2/confdb/foo/bar/baz")
+
+			raw, err := io.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+
+			var body struct {
+				Values  map[string]any `json:"values"`
+				Options struct {
+					AccessTimeout string `json:"access-timeout"`
+				} `json:"options"`
+			}
+
+			c.Assert(json.Unmarshal(raw, &body), check.IsNil)
+			c.Check(body.Values, check.DeepEquals, map[string]any{"abc": nil})
+			c.Check(body.Options.AccessTimeout, check.Equals, "5s")
+
+			w.WriteHeader(202)
+			fmt.Fprintln(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintf(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}\n`)
+		default:
+			err := fmt.Errorf("expected to get 2 requests, now on %d (%v)", reqs+1, r)
+			w.WriteHeader(500)
+			fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+			c.Error(err)
+		}
+
+		reqs++
+	})
+
+	rest, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "foo/bar/baz", "abc", "--wait-for", "5s"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *confdbSuite) TestForbidWaitForWithNonConfdbUnset(c *check.C) {
+	restore := s.mockConfdbFlag(c)
+	defer restore()
+
+	var reqs int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch reqs {
+		default:
+			err := fmt.Errorf("expected to get no requests, now on %d (%v)", reqs+1, r)
+			w.WriteHeader(500)
+			fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+			c.Error(err)
+		}
+
+		reqs++
+	})
+
+	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "some-snap", "abc", "--wait-for", "5s"})
+	c.Assert(err, check.ErrorMatches, "cannot use --wait-for in non-confdb write")
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
 }
 
 func (s *confdbSuite) TestUnsetEmptyKey(c *check.C) {

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -95,11 +95,11 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	if timeoutStr := query.Get("access-timeout"); timeoutStr != "" {
 		timeout, err := time.ParseDuration(timeoutStr)
 		if err != nil {
-			return BadRequest("cannot get confdb: invalid access-timeout: %q", timeoutStr)
+			return BadRequest("cannot read confdb: invalid access-timeout: %q", timeoutStr)
 		}
 
 		if timeout < 0 {
-			return BadRequest("cannot get confdb: access timeout must be non-negative")
+			return BadRequest("cannot read confdb: access timeout must be non-negative")
 		}
 
 		var cancel context.CancelFunc
@@ -163,18 +163,18 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 
 	if len(action.Values) == 0 {
-		return BadRequest("cannot set confdb: request body contains no values")
+		return BadRequest("cannot write confdb: request body contains no values")
 	}
 
 	ctx := r.Context()
 	if action.Options.AccessTimeout != "" {
 		timeout, err := time.ParseDuration(action.Options.AccessTimeout)
 		if err != nil {
-			return BadRequest("cannot set confdb: invalid access-timeout: %q", action.Options.AccessTimeout)
+			return BadRequest("cannot write confdb: invalid access-timeout: %q", action.Options.AccessTimeout)
 		}
 
 		if timeout < 0 {
-			return BadRequest("cannot set confdb: access timeout must be non-negative")
+			return BadRequest("cannot write confdb: access timeout must be non-negative")
 		}
 
 		var cancel context.CancelFunc

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -19,10 +19,12 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
@@ -64,10 +66,10 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	vars := muxVars(r)
 	account, schemaName, viewName := vars["account"], vars["confdb-schema"], vars["view"]
+	query := r.URL.Query()
 
-	keysStr := r.URL.Query().Get("keys")
 	var keys []string
-	if keysStr != "" {
+	if keysStr := query.Get("keys"); keysStr != "" {
 		keys = strutil.CommaSeparatedList(keysStr)
 	}
 
@@ -89,10 +91,23 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 		return toAPIError(err)
 	}
 
-	// Allow both root and snap API admins admin access to confdb data
-
-	// TODO: set timeout parsed from URL query parameter
 	ctx := r.Context()
+	if timeoutStr := query.Get("access-timeout"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			return BadRequest("cannot get confdb: invalid access-timeout: %q", timeoutStr)
+		}
+
+		if timeout < 0 {
+			return BadRequest("cannot get confdb: access timeout must be non-negative")
+		}
+
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	// Allow both root and snap API admins admin access to confdb data
 	chgID, err := confdbstateReadConfdb(ctx, st, view, keys, constraints, confdb.AdminAccess)
 	if err != nil {
 		return toAPIError(err)
@@ -135,7 +150,10 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	account, schemaName, viewName := vars["account"], vars["confdb-schema"], vars["view"]
 
 	type setAction struct {
-		Values map[string]any `json:"values"`
+		Values  map[string]any `json:"values"`
+		Options struct {
+			AccessTimeout string `json:"access-timeout"`
+		}
 	}
 
 	var action setAction
@@ -147,16 +165,30 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	if len(action.Values) == 0 {
 		return BadRequest("cannot set confdb: request body contains no values")
 	}
+
+	ctx := r.Context()
+	if action.Options.AccessTimeout != "" {
+		timeout, err := time.ParseDuration(action.Options.AccessTimeout)
+		if err != nil {
+			return BadRequest("cannot set confdb: invalid access-timeout: %q", action.Options.AccessTimeout)
+		}
+
+		if timeout < 0 {
+			return BadRequest("cannot set confdb: access timeout must be non-negative")
+		}
+
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	// TODO: apply some size restrictions to the value (so someone can't pass
 	// a massive string, for instance)
-
 	view, err := confdbstateGetView(st, account, schemaName, viewName)
 	if err != nil {
 		return toAPIError(err)
 	}
 
-	// TODO: set timeout parsed from URL query parameter
-	ctx := r.Context()
 	changeID, err := confdbstateWriteConfdb(ctx, st, view, action.Values)
 	if err != nil {
 		return toAPIError(err)

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -384,7 +384,7 @@ func (s *confdbSuite) TestSetEmpty(c *C) {
 
 		rspe := s.errorReq(c, req, nil, actionIsExpected)
 		c.Assert(rspe.Status, Equals, 400)
-		c.Assert(rspe.Message, Equals, "cannot set confdb: request body contains no values")
+		c.Assert(rspe.Message, Equals, "cannot write confdb: request body contains no values")
 		c.Assert(called, Equals, false)
 	}
 }
@@ -702,11 +702,11 @@ func (s *confdbSuite) TestReadAccessTimeout(c *C) {
 		},
 		{
 			timeout: "-10m",
-			error:   "cannot get confdb: access timeout must be non-negative",
+			error:   "cannot read confdb: access timeout must be non-negative",
 		},
 		{
 			timeout: "invalid",
-			error:   "cannot get confdb: invalid access-timeout: \"invalid\"",
+			error:   "cannot read confdb: invalid access-timeout: \"invalid\"",
 		},
 	}
 
@@ -773,11 +773,11 @@ func (s *confdbSuite) TestWriteAccessTimeout(c *C) {
 		},
 		{
 			timeout: `-10m`,
-			error:   "cannot set confdb: access timeout must be non-negative",
+			error:   "cannot write confdb: access timeout must be non-negative",
 		},
 		{
 			timeout: `invalid`,
-			error:   "cannot set confdb: invalid access-timeout: \"invalid\"",
+			error:   "cannot write confdb: invalid access-timeout: \"invalid\"",
 		},
 	}
 

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -124,7 +124,10 @@ func (s *confdbSuite) TestGetView(c *C) {
 			return s.schema.View(viewName), nil
 		})
 
-		restoreLoad := daemon.MockConfdbstateReadConfdb(func(_ context.Context, _ *state.State, view *confdb.View, requests []string, _ map[string]any, access confdb.Access) (string, error) {
+		restoreLoad := daemon.MockConfdbstateReadConfdb(func(ctx context.Context, _ *state.State, view *confdb.View, requests []string, _ map[string]any, access confdb.Access) (string, error) {
+			_, ok := ctx.Deadline()
+			c.Check(ok, Equals, false)
+
 			c.Assert(view.Name, Equals, "wifi-setup")
 			c.Assert(requests, DeepEquals, []string{"ssid"})
 			c.Assert(access, Equals, confdb.AdminAccess)
@@ -331,8 +334,11 @@ func (s *confdbSuite) TestSetView(c *C) {
 		cmt := Commentf("%s test", t.name)
 
 		var called bool
-		restoreSet := daemon.MockConfdbstateWriteConfdb(func(_ context.Context, _ *state.State, view *confdb.View, values map[string]any) (string, error) {
+		restoreSet := daemon.MockConfdbstateWriteConfdb(func(ctx context.Context, _ *state.State, view *confdb.View, values map[string]any) (string, error) {
 			called = true
+			_, ok := ctx.Deadline()
+			c.Check(ok, Equals, false)
+
 			c.Assert(view.Name, Equals, "wifi-setup", cmt)
 			c.Assert(values, DeepEquals, map[string]any{"ssid": t.value}, cmt)
 			return "123", nil
@@ -650,6 +656,155 @@ func (s *confdbSuite) TestGetBadConstraints(c *C) {
 		rspe := s.errorReq(c, req, nil, actionIsExpected)
 		c.Check(rspe.Status, Equals, 400, cmt)
 		c.Check(rspe.Message, Matches, tc.err, cmt)
+	}
+}
+
+func (s *confdbSuite) TestReadAccessTimeout(c *C) {
+	s.setFeatureFlag(c)
+
+	restore := daemon.MockConfdbstateGetView(func(_ *state.State, _, _, _ string) (*confdb.View, error) {
+		return s.schema.View("wifi-setup"), nil
+	})
+	defer restore()
+
+	restore = daemon.MockConfdbstateReadConfdb(func(ctx context.Context, _ *state.State, _ *confdb.View, _ []string, _ map[string]any, _ confdb.Access) (string, error) {
+		deadline, ok := ctx.Deadline()
+		c.Assert(ok, Equals, true)
+		c.Check(time.Until(deadline) <= 10*time.Second, Equals, true)
+		return "123", nil
+	})
+	defer restore()
+
+	type testcase struct {
+		timeout  string
+		error    string
+		ctxCheck func(ctx context.Context)
+	}
+
+	tcs := []testcase{
+		{
+			timeout: "10s",
+			ctxCheck: func(ctx context.Context) {
+				deadline, ok := ctx.Deadline()
+				c.Assert(ok, Equals, true)
+				c.Check(time.Until(deadline) <= 10*time.Second, Equals, true)
+			},
+		},
+		{
+			// this might seen useless but it could be used to do an attempt at read
+			// that would exit immediately if it had to wait
+			timeout: "0s",
+			ctxCheck: func(ctx context.Context) {
+				deadline, ok := ctx.Deadline()
+				c.Assert(ok, Equals, true)
+				c.Check(time.Until(deadline) <= 0, Equals, true)
+			},
+		},
+		{
+			timeout: "-10m",
+			error:   "cannot get confdb: access timeout must be non-negative",
+		},
+		{
+			timeout: "invalid",
+			error:   "cannot get confdb: invalid access-timeout: \"invalid\"",
+		},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=ssid&access-timeout="+tc.timeout, nil)
+		c.Assert(err, IsNil)
+		req.RemoteAddr = "pid=100;uid=1000;socket=;"
+
+		if tc.error == "" {
+			restore = daemon.MockConfdbstateReadConfdb(func(ctx context.Context, _ *state.State, _ *confdb.View, _ []string, _ map[string]any, _ confdb.Access) (string, error) {
+				tc.ctxCheck(ctx)
+				return "123", nil
+			})
+
+			rspe := s.asyncReq(c, req, nil, actionIsExpected)
+			c.Check(rspe.Status, Equals, 202)
+			c.Check(rspe.Change, Equals, "123")
+			restore()
+		} else {
+			rspe := s.errorReq(c, req, nil, actionIsExpected)
+			c.Check(rspe.Status, Equals, 400)
+			c.Check(rspe.Message, Matches, tc.error)
+		}
+	}
+}
+
+func (s *confdbSuite) TestWriteAccessTimeout(c *C) {
+	s.setFeatureFlag(c)
+
+	restore := daemon.MockConfdbstateGetView(func(_ *state.State, _, _, _ string) (*confdb.View, error) {
+		return s.schema.View("wifi-setup"), nil
+	})
+	defer restore()
+
+	restore = daemon.MockConfdbstateWriteConfdb(func(ctx context.Context, _ *state.State, _ *confdb.View, _ map[string]any) (string, error) {
+		deadline, ok := ctx.Deadline()
+		c.Assert(ok, Equals, true)
+		c.Check(time.Until(deadline) <= 10*time.Second, Equals, true)
+		return "123", nil
+	})
+	defer restore()
+
+	type testcase struct {
+		timeout  string
+		error    string
+		ctxCheck func(ctx context.Context)
+	}
+
+	tcs := []testcase{
+		{
+			timeout: `10s`,
+			ctxCheck: func(ctx context.Context) {
+				deadline, ok := ctx.Deadline()
+				c.Assert(ok, Equals, true)
+				c.Check(time.Until(deadline) <= 10*time.Second, Equals, true)
+			},
+		},
+		{
+			timeout: `0s`,
+			ctxCheck: func(ctx context.Context) {
+				_, ok := ctx.Deadline()
+				c.Assert(ok, Equals, true)
+			},
+		},
+		{
+			timeout: `-10m`,
+			error:   "cannot set confdb: access timeout must be non-negative",
+		},
+		{
+			timeout: `invalid`,
+			error:   "cannot set confdb: invalid access-timeout: \"invalid\"",
+		},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("testcase %d/%d", i+1, len(tcs))
+		body := fmt.Sprintf(`{"values": {"ssid": "foo"}, "options": {"access-timeout": %q}}`, tc.timeout)
+
+		req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", bytes.NewBufferString(body))
+		c.Assert(err, IsNil, cmt)
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "pid=100;uid=1000;socket=;"
+
+		if tc.error == "" {
+			restore = daemon.MockConfdbstateWriteConfdb(func(ctx context.Context, _ *state.State, _ *confdb.View, _ map[string]any) (string, error) {
+				tc.ctxCheck(ctx)
+				return "123", nil
+			})
+
+			rspe := s.asyncReq(c, req, nil, actionIsExpected)
+			c.Check(rspe.Status, Equals, 202, cmt)
+			c.Check(rspe.Change, Equals, "123", cmt)
+			restore()
+		} else {
+			rspe := s.errorReq(c, req, nil, actionIsExpected)
+			c.Check(rspe.Status, Equals, 400, cmt)
+			c.Check(rspe.Message, Matches, tc.error, cmt)
+		}
 	}
 }
 

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -251,11 +252,15 @@ func waitForAccess(ctx context.Context, st *state.State, view *confdb.View, accK
 		// for testing purposes only
 		close(blockingSignals["wait-for-access"])
 	}
+	logger.Debugf("%s access (id: %s) is blocking", accKind, accessID)
 
 	select {
 	case <-wait:
+		logger.Debugf("%s access (id: %s) was unblocked", accKind, accessID)
 		st.Lock()
+
 	case <-ctx.Done():
+		logger.Debugf("%s access (id: %s) timed out/cancelled", accKind, accessID)
 		// if the waiting was cancelled or timed out, clean up the pending state
 		st.Lock()
 		txs, updateTxs, err := getOngoingTxs(st, account, schema)
@@ -312,7 +317,7 @@ func WriteConfdb(ctx context.Context, st *state.State, view *confdb.View, values
 	// and a change to verify its changes and commit
 	tx, err := NewTransaction(st, account, schema)
 	if err != nil {
-		return "", fmt.Errorf("cannot modify confdb through view %s: cannot create transaction: %v", view.ID(), err)
+		return "", fmt.Errorf("cannot write confdb view %s: cannot create transaction: %v", view.ID(), err)
 	}
 
 	err = setViaView(tx, view, values)
@@ -342,7 +347,10 @@ func WriteConfdb(ctx context.Context, st *state.State, view *confdb.View, values
 // WriteConfdbFromSnap takes a hook context and a map of requests to values that
 // are written through the provided view. It will block until the writing change
 // completes.
-func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values map[string]any) (err error) {
+func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values map[string]any, opts *client.ConfdbOptions) (err error) {
+	if opts == nil {
+		opts = &client.ConfdbOptions{}
+	}
 	account, schema := view.Schema().Account, view.Schema().Name
 
 	// check if we're already running in the context of a committing transaction
@@ -352,11 +360,11 @@ func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values m
 		t, _ := hookCtx.Task()
 		tx, _, saveTxChanges, err := GetStoredTransaction(t)
 		if err != nil {
-			return fmt.Errorf("cannot access confdb through view %s: cannot get transaction: %v", view.ID(), err)
+			return fmt.Errorf("cannot write confdb view %s: cannot get transaction: %v", view.ID(), err)
 		}
 
 		if tx.ConfdbAccount != account || tx.ConfdbName != schema {
-			return fmt.Errorf("cannot access confdb through view %s: ongoing transaction for %s/%s", view.ID(), tx.ConfdbAccount, tx.ConfdbName)
+			return fmt.Errorf("cannot write confdb view %s: ongoing transaction for %s/%s", view.ID(), tx.ConfdbAccount, tx.ConfdbName)
 		}
 
 		// update the commit task to save transaction changes made by the hook
@@ -368,11 +376,19 @@ func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values m
 		return setViaView(tx, view, values)
 	}
 
-	// get --wait-for timeout from context state, if any is set
+	var timeout *time.Duration
+	if opts.AccessTimeout != nil {
+		timeout = opts.AccessTimeout
+	} else if hookCtx.Timeout() != time.Duration(0) {
+		// default to the hook timeout, if running in a hook
+		dur := hookCtx.Timeout()
+		timeout = &dur
+	}
+
 	ctx := context.Background()
-	if hookCtx.Timeout() != time.Duration(0) {
+	if timeout != nil {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, hookCtx.Timeout())
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
 		defer cancel()
 	}
 
@@ -392,7 +408,7 @@ func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values m
 	// and a change to verify its changes and commit
 	tx, err := NewTransaction(st, account, schema)
 	if err != nil {
-		return fmt.Errorf("cannot modify confdb through view %s: cannot create transaction: %v", view.ID(), err)
+		return fmt.Errorf("cannot write confdb view %s: cannot create transaction: %v", view.ID(), err)
 	}
 
 	err = setViaView(tx, view, values)
@@ -445,7 +461,7 @@ func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values m
 	select {
 	case <-waitChan:
 	case <-time.After(transactionTimeout):
-		return fmt.Errorf("cannot set confdb %s: timed out after %s", view.ID(), transactionTimeout)
+		return fmt.Errorf("cannot write confdb view %s: timed out (%s) waiting for change %s", view.ID(), transactionTimeout, chg.ID())
 	}
 
 	return nil
@@ -458,7 +474,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 	}
 
 	if len(custodianPlugs) == 0 {
-		return nil, nil, nil, fmt.Errorf("cannot commit changes to confdb made through view %s: no custodian snap connected", view.ID())
+		return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: no custodian snap connected", view.ID())
 	}
 
 	paths := tx.AlteredPaths()
@@ -499,7 +515,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		}
 
 		if hookPrefix == "save-view-" && mightAffectEph && !saveViewHookPresent {
-			return nil, nil, nil, fmt.Errorf("cannot access %s: write might change ephemeral data but no custodians has a save-view hook", view.ID())
+			return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: write might change ephemeral data but no custodians has a save-view hook", view.ID())
 		}
 	}
 
@@ -696,7 +712,11 @@ func CanHookSetConfdb(ctx *hookstate.Context) bool {
 // tasks to load the confdb as needed, unless no custodian defined relevant
 // hooks. Blocks until the confdb has been loaded into the Transaction. If no
 // tasks need to run to load the confdb, returns without blocking.
-func ReadConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, paths []string, constraints map[string]any) (tx *Transaction, err error) {
+func ReadConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, paths []string, constraints map[string]any, opts *client.ConfdbOptions) (tx *Transaction, err error) {
+	if opts == nil {
+		opts = &client.ConfdbOptions{}
+	}
+
 	st := hookCtx.State()
 	account, schema := view.Schema().Account, view.Schema().Name
 
@@ -706,22 +726,31 @@ func ReadConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, paths []s
 		t, _ := hookCtx.Task()
 		tx, _, _, err := GetStoredTransaction(t)
 		if err != nil {
-			return nil, fmt.Errorf("cannot load confdb view %s: cannot get transaction: %v", view.ID(), err)
+			return nil, fmt.Errorf("cannot read confdb view %s: cannot get transaction: %v", view.ID(), err)
 		}
 
 		if tx.ConfdbAccount != account || tx.ConfdbName != schema {
 			// TODO: this should be enabled at some point
-			return nil, fmt.Errorf("cannot load confdb %s/%s: ongoing transaction for %s/%s", account, schema, tx.ConfdbAccount, tx.ConfdbName)
+			return nil, fmt.Errorf("cannot read confdb view %s: ongoing transaction for %s/%s", view.ID(), tx.ConfdbAccount, tx.ConfdbName)
 		}
 
 		// we're reading the tx that this hook is modifying, just return that
 		return tx, nil
 	}
 
+	var timeout *time.Duration
+	if opts.AccessTimeout != nil {
+		timeout = opts.AccessTimeout
+	} else if hookCtx.Timeout() != time.Duration(0) {
+		// default to the hook timeout, if running in a hook
+		dur := hookCtx.Timeout()
+		timeout = &dur
+	}
+
 	ctx := context.Background()
-	if hookCtx.Timeout() != time.Duration(0) {
+	if timeout != nil {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, hookCtx.Timeout())
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
 		defer cancel()
 	}
 
@@ -740,7 +769,7 @@ func ReadConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, paths []s
 	// and a change to load/modify data
 	tx, err = NewTransaction(st, account, schema)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load confdb view %s: cannot create transaction: %v", view.ID(), err)
+		return nil, fmt.Errorf("cannot read confdb view %s: cannot create transaction: %v", view.ID(), err)
 	}
 
 	ts, clearTxTask, err := createLoadConfdbTasks(st, tx, view, paths, constraints)
@@ -791,7 +820,7 @@ func ReadConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, paths []s
 	case <-waitChan:
 	case <-time.After(transactionTimeout):
 		hookCtx.Lock()
-		return nil, fmt.Errorf("cannot load confdb %s/%s in change %s: timed out after %s", account, schema, chg.ID(), transactionTimeout)
+		return nil, fmt.Errorf("cannot read confdb view %s: timed out (%s) waiting for change %s", view.ID(), transactionTimeout, chg.ID())
 	}
 
 	hookCtx.Lock()
@@ -865,7 +894,7 @@ func ReadConfdb(ctx context.Context, st *state.State, view *confdb.View, request
 
 	tx, err := NewTransaction(st, account, schema)
 	if err != nil {
-		return "", fmt.Errorf("cannot access confdb view %s: cannot create transaction: %v", view.ID(), err)
+		return "", fmt.Errorf("cannot read confdb view %s: cannot create transaction: %v", view.ID(), err)
 	}
 
 	ts, clearTxTask, err := createLoadConfdbTasks(st, tx, view, requests, constraints)
@@ -918,7 +947,7 @@ func createLoadConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, 
 	}
 
 	if len(custodians) == 0 {
-		return nil, nil, fmt.Errorf("cannot load confdb through view %s: no custodian snap connected", view.ID())
+		return nil, nil, fmt.Errorf("cannot read confdb view %s: no custodian snap connected", view.ID())
 	}
 
 	ts := state.NewTaskSet()
@@ -956,7 +985,7 @@ func createLoadConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, 
 
 		// there must be least one load-view hook if we're accessing ephemeral data
 		if hookPrefix == "load-view-" && mightAffectEph && !loadViewHookPresent {
-			return nil, nil, fmt.Errorf("cannot schedule tasks to access %s: read might cover ephemeral data but no custodian has a load-view hook", view.ID())
+			return nil, nil, fmt.Errorf("cannot schedule tasks to read view %s: read might cover ephemeral data but no custodian has a load-view hook", view.ID())
 		}
 	}
 

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
@@ -778,7 +779,7 @@ func (s *confdbTestSuite) testConfdbTasksNoCustodian(c *C) {
 
 	// a non-custodian snap modifies a confdb
 	_, _, _, err = confdbstate.CreateChangeConfdbTasks(s.state, tx, view, "test-snap-1")
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot commit changes to confdb made through view %s/network/%s: no custodian snap connected", s.devAccID, view.Name))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot write confdb view %s/network/%s: no custodian snap connected", s.devAccID, view.Name))
 }
 
 type confdbHooks uint8
@@ -1073,7 +1074,7 @@ func (s *confdbTestSuite) TestWriteConfdbFromSnapCreatesNewChange(c *C) {
 	s.state.Unlock()
 
 	ctx.Lock()
-	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"})
+	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"}, nil)
 	c.Assert(err, IsNil)
 
 	// this is called automatically by hooks or manually for daemon/
@@ -1105,7 +1106,7 @@ func (s *confdbTestSuite) TestGetTransactionFromNonConfdbHookAddsConfdbTx(c *C) 
 
 		if hooksup.Hook == "install" {
 			ctx.Lock()
-			err := confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"})
+			err := confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"}, nil)
 			ctx.Unlock()
 			c.Assert(err, IsNil)
 			return nil, nil
@@ -1231,7 +1232,7 @@ func (s *confdbTestSuite) TestWriteConfdbFromChangeViewHook(c *C) {
 
 	ctx.Lock()
 	view := s.dbSchema.View("setup-wifi")
-	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	c.Assert(err, IsNil)
 	// accessed an ongoing transaction
 	data, err := tx.Get(parsePath(c, "wifi.ssid"), nil)
@@ -1241,7 +1242,7 @@ func (s *confdbTestSuite) TestWriteConfdbFromChangeViewHook(c *C) {
 	// change-view hooks can also write to the transaction
 	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{
 		"ssid": "bar",
-	})
+	}, nil)
 	c.Assert(err, IsNil)
 
 	// accessed an ongoing transaction so save the changes made by the hook
@@ -1290,9 +1291,9 @@ func (s *confdbTestSuite) TestGetDifferentTransactionThanOngoing(c *C) {
 
 	ctx.Lock()
 	view := confdb.View("foo")
-	err = confdbstate.WriteConfdbFromSnap(ctx, view, nil)
+	err = confdbstate.WriteConfdbFromSnap(ctx, view, nil, nil)
 	ctx.Unlock()
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot access confdb through view foo/bar/foo: ongoing transaction for %s/network`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot write confdb view foo/bar/foo: ongoing transaction for %s/network`, s.devAccID))
 }
 
 func (s *confdbTestSuite) TestConfdbLoadDisconnectedCustodianSnap(c *C) {
@@ -1328,7 +1329,7 @@ func (s *confdbTestSuite) testConfdbLoadNoCustodian(c *C) {
 
 	// a non-custodian snap modifies a confdb
 	_, _, err = confdbstate.CreateLoadConfdbTasks(s.state, tx, view, []string{"ssid"}, nil)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot load confdb through view %s/network/setup-wifi: no custodian snap connected", s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read confdb view %s/network/setup-wifi: no custodian snap connected", s.devAccID))
 }
 
 func checkLoadConfdbTasks(c *C, chg *state.Change, taskKinds []string, hooksups []*hookstate.HookSetup) {
@@ -1539,7 +1540,7 @@ func (s *confdbTestSuite) testReadConfdbFromSnap(c *C, ctx *hookstate.Context) *
 	s.state.Set("confdb-databags", map[string]map[string]confdb.JSONDatabag{s.devAccID: {"network": bag}})
 
 	view := s.dbSchema.View("setup-wifi")
-	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(s.state.Changes(), HasLen, 1)
 
@@ -1580,7 +1581,7 @@ func (s *confdbTestSuite) TestGetTransactionInConfdbHook(c *C) {
 	c.Assert(err, IsNil)
 
 	view := s.dbSchema.View("setup-wifi")
-	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	c.Assert(err, IsNil)
 	// reads synchronously without creating new change or tasks
 	c.Assert(s.state.Changes(), HasLen, 1)
@@ -1621,7 +1622,7 @@ func (s *confdbTestSuite) TestGetTransactionNoConfdbHooks(c *C) {
 	view := s.dbSchema.View("setup-wifi")
 	s.state.Unlock()
 	ctx.Lock()
-	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	ctx.Unlock()
 	s.state.Lock()
 	c.Assert(err, IsNil)
@@ -1665,9 +1666,16 @@ func (s *confdbTestSuite) TestGetTransactionTimesOut(c *C) {
 	ctx.Lock()
 	defer ctx.Unlock()
 
-	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, nil, nil)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot load confdb %s/network in change 1: timed out after 0s", s.devAccID))
+	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, nil, nil, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read confdb view %s/network/setup-wifi: timed out \\(0s\\) waiting for change 1", s.devAccID))
 	c.Assert(tx, IsNil)
+
+	s.state.Unlock()
+	s.o.Settle(testutil.HostScaledTimeout(2 * time.Second))
+	s.state.Lock()
+
+	err = confdbstate.WriteConfdbFromSnap(ctx, view, nil, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot write confdb view %s/network/setup-wifi: timed out \\(0s\\) waiting for change 2", s.devAccID))
 }
 
 func (s *confdbTestSuite) checkGetConfdbTasks(c *C, chg *state.Change, executedHooks *[]string) {
@@ -1999,13 +2007,13 @@ func (s *confdbTestSuite) TestWriteAffectingEphemeralMustDefineSaveViewHook(c *C
 	// can't write an ephemeral path w/o a save-view hook
 	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{
 		"eph": "foo",
-	})
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot access %s/network/setup-wifi: write might change ephemeral data but no custodians has a save-view hook", s.devAccID))
+	}, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot write confdb view %s/network/setup-wifi: write might change ephemeral data but no custodians has a save-view hook", s.devAccID))
 
 	// but we can if the path can't touch any ephemeral data
 	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{
 		"ssid": "foo",
-	})
+	}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -2023,23 +2031,23 @@ func (s *confdbTestSuite) TestReadCoveringEphemeralMustDefineLoadViewHook(c *C) 
 	ctx.Lock()
 	view := s.dbSchema.View("setup-wifi")
 	// can't read an ephemeral path w/o a load-view hook
-	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"eph"}, nil)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot schedule tasks to access %s/network/setup-wifi: read might cover ephemeral data but no custodian has a load-view hook", s.devAccID))
+	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"eph"}, nil, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot schedule tasks to read view %s/network/setup-wifi: read might cover ephemeral data but no custodian has a load-view hook", s.devAccID))
 
 	// so we don't block on the read
 	restore := confdbstate.MockTransactionTimeout(0)
 	defer restore()
 
 	// but if the path isn't ephemeral it's fine
-	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot load confdb %s/network in change 1: timed out after 0s", s.devAccID))
+	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read confdb view %s: timed out \\(0s\\) waiting for change 1", view.ID()))
 	ctx.Unlock()
 
 	s.state.Lock()
 	defer s.state.Unlock()
 	// can't read an ephemeral path w/o a load-view hook
 	_, err = confdbstate.ReadConfdb(context.Background(), s.state, view, []string{"eph"}, nil, confdb.AdminAccess)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot schedule tasks to access %s/network/setup-wifi: read might cover ephemeral data but no custodian has a load-view hook", s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot schedule tasks to read view %s/network/setup-wifi: read might cover ephemeral data but no custodian has a load-view hook", s.devAccID))
 
 	// but reading a non-ephemeral path succeeds
 	_, err = confdbstate.ReadConfdb(context.Background(), s.state, view, []string{"ssid"}, nil, confdb.AdminAccess)
@@ -2060,13 +2068,13 @@ func (s *confdbTestSuite) TestBadPathHookChecks(c *C) {
 	defer ctx.Unlock()
 	view := s.dbSchema.View("setup-wifi")
 
-	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"foo"}, nil)
+	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"foo"}, nil, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "foo" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 
 	_, err = confdbstate.ReadConfdb(context.Background(), s.state, view, []string{"foo"}, nil, confdb.AdminAccess)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "foo" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 
-	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"foo": "bar"})
+	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"foo": "bar"}, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot set "foo" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 }
 
@@ -2574,7 +2582,7 @@ func (s *confdbTestSuite) TestSnapctlWriteOngoingRead(c *C) {
 
 	secondAccess := func() {
 		ctx.Lock()
-		err := confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"})
+		err := confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"}, nil)
 		ctx.Unlock()
 		c.Assert(err, IsNil)
 	}
@@ -2597,7 +2605,7 @@ func (s *confdbTestSuite) TestSnapctlReadOngoingWrite(c *C) {
 
 	secondAccess := func() {
 		ctx.Lock()
-		_, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+		_, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 		ctx.Unlock()
 		c.Assert(err, IsNil)
 	}
@@ -2691,10 +2699,64 @@ func (s *confdbTestSuite) TestSnapctlReadAndWriteUseHookTimeout(c *C) {
 	ctx.Lock()
 	defer ctx.Unlock()
 
-	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil)
+	_, err = confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read %s: timed out waiting for access", view.ID()))
 
-	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"})
+	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"}, nil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot write %s: timed out waiting for access", view.ID()))
+}
+
+func (s *confdbTestSuite) TestConfdbFromSnapCustomTimeouts(c *C) {
+	s.state.Lock()
+	s.setupConfdbScenario(c, map[string]confdbHooks{"custodian-snap": allHooks}, nil)
+	_, restore := s.mockConfdbHooks()
+	defer restore()
+
+	view := s.dbSchema.View("setup-wifi")
+
+	mockHandler := hooktest.NewMockHandler()
+	setup := &hookstate.HookSetup{Snap: "test-snap", Hook: "change-view-setup"}
+	hookCtx, err := hookstate.NewContext(nil, s.state, setup, mockHandler, "")
+	c.Assert(err, IsNil)
+
+	// set ongoing write transaction so the next one blocks
+	ref := s.devAccID + "/network"
+	ongoingTxs := make(map[string]*confdbstate.ConfdbTransactions)
+	ongoingTxs[ref] = &confdbstate.ConfdbTransactions{
+		WriteTxID: "10",
+	}
+	s.state.Set("confdb-ongoing-txs", ongoingTxs)
+	s.state.Unlock()
+
+	hookCtx.Lock()
+	defer hookCtx.Unlock()
+	t := time.Millisecond
+	opts := &client.ConfdbOptions{AccessTimeout: &t}
+
+	doneChan := make(chan struct{})
+	go func() {
+		_, err = confdbstate.ReadConfdbFromSnap(hookCtx, view, []string{"ssid"}, nil, opts)
+		close(doneChan)
+	}()
+
+	select {
+	case <-doneChan:
+	case <-time.After(testutil.HostScaledTimeout(2 * time.Second)):
+		c.Fatal("expected access to block but timed out")
+	}
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot read %s: timed out waiting for access", view.ID()))
+
+	doneChan = make(chan struct{})
+	go func() {
+		err = confdbstate.WriteConfdbFromSnap(hookCtx, view, map[string]any{"ssid": "foo"}, opts)
+		close(doneChan)
+	}()
+
+	select {
+	case <-doneChan:
+	case <-time.After(testutil.HostScaledTimeout(2 * time.Second)):
+		c.Fatal("expected access to block but timed out")
+	}
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot write %s: timed out waiting for access", view.ID()))
 }
 
@@ -2875,10 +2937,10 @@ func (s *confdbTestSuite) TestSnapctlConfdbErrorUnblocksNextAccess(c *C) {
 	var accErr error
 	for _, accFunc := range []func(){
 		func() {
-			_, accErr = confdbstate.ReadConfdbFromSnap(hookCtx, view, []string{"ssid"}, nil)
+			_, accErr = confdbstate.ReadConfdbFromSnap(hookCtx, view, []string{"ssid"}, nil, nil)
 		},
 		func() {
-			accErr = confdbstate.WriteConfdbFromSnap(hookCtx, view, map[string]any{"ssid": "foo"})
+			accErr = confdbstate.WriteConfdbFromSnap(hookCtx, view, map[string]any{"ssid": "foo"}, nil)
 		},
 	} {
 		accErr = nil
@@ -2975,7 +3037,7 @@ func (s *confdbTestSuite) TestReadConfdbFromSnapNoHooksToRun(c *C) {
 	doneChan := make(chan struct{})
 	go func() {
 		hookCtx.Lock()
-		tx, readErr = confdbstate.ReadConfdbFromSnap(hookCtx, view, []string{"ssid"}, nil)
+		tx, readErr = confdbstate.ReadConfdbFromSnap(hookCtx, view, []string{"ssid"}, nil, nil)
 		hookCtx.Unlock()
 		close(doneChan)
 	}()

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/osutil/user"
@@ -190,7 +191,7 @@ func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid strin
 	return restore
 }
 
-func MockConfdbstateWriteConfdb(f func(*hookstate.Context, *confdb.View, map[string]any) error) (restore func()) {
+func MockConfdbstateWriteConfdb(f func(*hookstate.Context, *confdb.View, map[string]any, *client.ConfdbOptions) error) (restore func()) {
 	old := confdbstateWriteConfdb
 	confdbstateWriteConfdb = f
 	return func() {
@@ -206,7 +207,7 @@ func MockConfdbstateGetView(f func(st *state.State, account, confdbName, viewNam
 	}
 }
 
-func MockConfdbstateReadConfdb(f func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error)) (restore func()) {
+func MockConfdbstateReadConfdb(f func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error)) (restore func()) {
 	old := confdbstateReadConfdb
 	confdbstateReadConfdb = f
 	return func() {

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -25,7 +25,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/features"
@@ -55,15 +57,16 @@ type getCommand struct {
 	View          bool     `long:"view" description:"return confdb values from the view declared in the plug"`
 	Previous      bool     `long:"previous" description:"return confdb values disregarding changes from the current transaction"`
 	With          []string `long:"with" value-name:"<param>=<constraint>" description:"parameter constraints for filtering confdb queries"`
+	Default       string   `long:"default" unquote:"false" description:"a default value to be used when no value is set"`
+	WaitFor       string   `long:"wait-for" description:"maximum duration to wait for confdb access (e.g. 10s)"`
 
 	Positional struct {
 		PlugOrSlotSpec string   `positional-args:"true" positional-arg-name:":<plug|slot>"`
 		Keys           []string `positional-arg-name:"<keys>" description:"option keys"`
 	} `positional-args:"yes"`
 
-	Document bool   `short:"d" description:"always return document, even with single key"`
-	Typed    bool   `short:"t" description:"strict typing with nulls and quoted strings"`
-	Default  string `long:"default" unquote:"false" description:"a default value to be used when no value is set"`
+	Document bool `short:"d" description:"always return document, even with single key"`
+	Typed    bool `short:"t" description:"strict typing with nulls and quoted strings"`
 }
 
 var shortGetHelp = i18n.G("Print either configuration options or interface connection settings")
@@ -442,14 +445,27 @@ func (c *getCommand) getConfdbValues(ctx *hookstate.Context, plugName string, re
 		return err
 	}
 
-	opts := clientutil.ConfdbOptions{Typed: c.Typed}
-	constraints, err := clientutil.ParseConfdbConstraints(c.With, opts)
+	parseOpts := clientutil.ConfdbOptions{Typed: c.Typed}
+	constraints, err := clientutil.ParseConfdbConstraints(c.With, parseOpts)
 	if err != nil {
 		return err
 	}
 
-	// TODO: add --wait-for timeout to options and cache in hookstate context
-	tx, err := confdbstateReadConfdb(ctx, view, requests, constraints)
+	opts := &client.ConfdbOptions{}
+	if c.WaitFor != "" {
+		timeout, err := time.ParseDuration(c.WaitFor)
+		if err != nil {
+			return fmt.Errorf("cannot parse --wait-for value %s: %v", c.WaitFor, err)
+		}
+
+		if timeout < 0 {
+			return fmt.Errorf("--wait-for value must be non-negative")
+		}
+
+		opts.AccessTimeout = &timeout
+	}
+
+	tx, err := confdbstateReadConfdb(ctx, view, requests, constraints, opts)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
@@ -634,7 +636,7 @@ func (s *confdbSuite) TestConfdbGetSingleView(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		c.Assert(requests, DeepEquals, []string{"ssid"})
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
@@ -658,7 +660,7 @@ func (s *confdbSuite) TestConfdbGetManyViews(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		c.Assert(requests, DeepEquals, []string{"ssid", "password"})
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
@@ -687,7 +689,7 @@ func (s *confdbSuite) TestConfdbGetNoRequest(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		c.Assert(requests, IsNil)
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
@@ -850,7 +852,7 @@ func (s *confdbSuite) TestConfdbGetPrevious(c *C) {
 	err = tx.Set(parsePath(c, "wifi.ssid"), "bar")
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		return tx, nil
 	})
 	defer restore()
@@ -921,7 +923,7 @@ func (s *confdbSuite) TestConfdbGetDifferentViewThanOngoingTx(c *C) {
 	defer restore()
 
 	stdout, stderr, err := ctlcmd.Run(ctx, []string{"get", "--view", ":other", "ssid"}, 0, nil)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot load confdb %[1]s/other: ongoing transaction for %[1]s/network`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot read confdb view %[1]s/other/other: ongoing transaction for %[1]s/network`, s.devAccID))
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 }
@@ -1017,7 +1019,7 @@ func (s *confdbSuite) TestConfdbAccessUnconnectedPlug(c *C) {
 
 	err = tx.Set(parsePath(c, "wifi.ssid"), "foo")
 	c.Assert(err, IsNil)
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		c.Fatal("should not allow access to confdb")
 		return tx, nil
 	})
@@ -1077,7 +1079,7 @@ func (s *confdbSuite) TestConfdbDefaultIfNoData(c *C) {
 
 	err = tx.Set(parsePath(c, "wifi.ssid"), "foo")
 	c.Assert(err, IsNil)
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		return tx, nil
 	})
 	defer restore()
@@ -1098,7 +1100,7 @@ func (s *confdbSuite) TestConfdbDefaultNoFallbackIfTyped(c *C) {
 
 	err = tx.Set(parsePath(c, "wifi.ssid"), "foo")
 	c.Assert(err, IsNil)
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		return tx, nil
 	})
 	defer restore()
@@ -1117,7 +1119,7 @@ func (s *confdbSuite) TestConfdbDefaultWithOtherFlags(c *C) {
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(*hookstate.Context, *confdb.View, []string, map[string]any, *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		return tx, nil
 	})
 	defer restore()
@@ -1191,7 +1193,7 @@ func (s *confdbSuite) TestConfdbGetWithConstraints(c *C) {
 	s.state.Unlock()
 
 	var gotConstraints map[string]any
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(_ *hookstate.Context, _ *confdb.View, _ []string, constraints map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(_ *hookstate.Context, _ *confdb.View, _ []string, constraints map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		gotConstraints = constraints
 		return tx, nil
 	})
@@ -1315,7 +1317,7 @@ func (s *confdbSuite) TestConfdbGetTypedConstraints(c *C) {
 		s.state.Unlock()
 
 		var gotConstraints map[string]any
-		restore := ctlcmd.MockConfdbstateReadConfdb(func(_ *hookstate.Context, _ *confdb.View, _ []string, constraints map[string]any) (*confdbstate.Transaction, error) {
+		restore := ctlcmd.MockConfdbstateReadConfdb(func(_ *hookstate.Context, _ *confdb.View, _ []string, constraints map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 			gotConstraints = constraints
 			return tx, nil
 		})
@@ -1354,7 +1356,7 @@ func (s *confdbSuite) TestConfdbGetSecretVisibility(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any, _ *client.ConfdbOptions) (*confdbstate.Transaction, error) {
 		c.Assert(requests, DeepEquals, []string{"password"})
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
@@ -1366,4 +1368,71 @@ func (s *confdbSuite) TestConfdbGetSecretVisibility(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "password" through %s/network/read-wifi: unauthorized access`, s.devAccID))
 	c.Check(stderr, IsNil)
 	c.Assert(stdout, IsNil)
+}
+
+func (s *confdbSuite) TestConfdbValidWaitFor(c *C) {
+	restore := ctlcmd.MockConfdbstateReadConfdb(func(ctx *hookstate.Context, view *confdb.View, requests []string, _ map[string]any, opts *client.ConfdbOptions) (*confdbstate.Transaction, error) {
+		c.Assert(opts, NotNil)
+		c.Assert(opts.AccessTimeout, NotNil)
+		c.Assert(*(opts.AccessTimeout), Equals, 5*time.Second)
+
+		tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
+		c.Assert(err, IsNil)
+		err = tx.Set(parsePath(c, "wifi.ssid"), "test-ssid")
+		c.Assert(err, IsNil)
+		return tx, nil
+	})
+	defer restore()
+
+	restore = ctlcmd.MockConfdbstateWriteConfdb(func(ctx *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
+		return nil
+	})
+	defer restore()
+
+	cmds := [][]string{
+		{"get", "--view", ":read-wifi", "--wait-for", "5s", "ssid"},
+		{"set", "--view", ":write-wifi", "--wait-for", "5s", "ssid=test-ssid"},
+		{"unset", "--view", ":write-wifi", "--wait-for", "0s", "ssid"},
+	}
+
+	for _, cmd := range cmds {
+		cmt := Commentf("testcase %q", cmd[0])
+		_, stderr, err := ctlcmd.Run(s.mockContext, cmd, 0, nil)
+		c.Assert(err, IsNil, cmt)
+		c.Check(stderr, IsNil, cmt)
+	}
+}
+
+func (s *confdbSuite) TestConfdbInvalidWaitFor(c *C) {
+	cmds := [][]string{
+		{"get", "--view", ":read-wifi", "--wait-for", "invalid", "ssid"},
+		{"set", "--view", ":write-wifi", "--wait-for", "invalid", "ssid=test-ssid"},
+		{"unset", "--view", ":write-wifi", "--wait-for", "invalid", "ssid"},
+	}
+
+	for _, cmd := range cmds {
+		cmt := Commentf("testcase %q", cmd[0])
+
+		stdout, stderr, err := ctlcmd.Run(s.mockContext, cmd, 0, nil)
+		c.Check(err, ErrorMatches, `cannot parse --wait-for value invalid: .*`, cmt)
+		c.Check(stdout, IsNil, cmt)
+		c.Check(stderr, IsNil, cmt)
+	}
+}
+
+func (s *confdbSuite) TestConfdbNegativeWaitFor(c *C) {
+	cmds := [][]string{
+		{"get", "--view", ":read-wifi", "--wait-for", `"-10s"`, "ssid"},
+		{"set", "--view", ":write-wifi", "--wait-for", `"-1ms"`, "ssid=test-ssid"},
+		{"unset", "--view", ":write-wifi", "--wait-for", `"-2h"`, "ssid"},
+	}
+
+	for _, cmd := range cmds {
+		cmt := Commentf("testcase %q", cmd[0])
+
+		stdout, stderr, err := ctlcmd.Run(s.mockContext, cmd, 0, nil)
+		c.Check(err, ErrorMatches, `--wait-for value must be non-negative`, cmt)
+		c.Check(stdout, IsNil, cmt)
+		c.Check(stderr, IsNil, cmt)
+	}
 }

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -24,7 +24,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
@@ -41,7 +43,8 @@ var confdbstateWriteConfdb = confdbstate.WriteConfdbFromSnap
 type setCommand struct {
 	baseCommand
 
-	View bool `long:"view" description:"return confdb values from the view declared in the plug"`
+	View    bool   `long:"view" description:"return confdb values from the view declared in the plug"`
+	WaitFor string `long:"wait-for" description:"maximum duration to wait for confdb access (e.g. 10s)"`
 
 	Positional struct {
 		PlugOrSlotSpec string   `positional-arg-name:":<plug|slot>"`
@@ -130,7 +133,20 @@ func (s *setCommand) Execute(args []string) error {
 			return fmt.Errorf(i18n.G("cannot set %s plug: %w"), s.Positional.PlugOrSlotSpec, err)
 		}
 
-		return setConfdbValues(context, name, requests)
+		copts := &client.ConfdbOptions{}
+		if s.WaitFor != "" {
+			timeout, err := time.ParseDuration(s.WaitFor)
+			if err != nil {
+				return fmt.Errorf("cannot parse --wait-for value %s: %v", s.WaitFor, err)
+			}
+
+			if timeout < 0 {
+				return fmt.Errorf("--wait-for value must be non-negative")
+			}
+
+			copts.AccessTimeout = &timeout
+		}
+		return setConfdbValues(context, name, requests, copts)
 	}
 
 	return s.setInterfaceSetting(context, name)
@@ -244,7 +260,7 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	return nil
 }
 
-func setConfdbValues(ctx *hookstate.Context, plugName string, values map[string]any) error {
+func setConfdbValues(ctx *hookstate.Context, plugName string, values map[string]any, opts *client.ConfdbOptions) error {
 	ctx.Lock()
 	defer ctx.Unlock()
 
@@ -267,6 +283,5 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, values map[string]
 		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 
-	// TODO: add --wait-for timeout to options and cache in hookstate context
-	return confdbstateWriteConfdb(ctx, view, values)
+	return confdbstateWriteConfdb(ctx, view, values, opts)
 }

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -412,7 +413,7 @@ func parsePath(c *C, path string) []confdb.Accessor {
 
 func (s *confdbSuite) TestConfdbSetSingleViewNewTransaction(c *C) {
 	var called bool
-	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any) error {
+	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
 		called = true
 		c.Assert(values, DeepEquals, map[string]any{
 			"ssid": "other-ssid",
@@ -429,7 +430,7 @@ func (s *confdbSuite) TestConfdbSetSingleViewNewTransaction(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbSetManyViews(c *C) {
-	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any) error {
+	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
 		c.Assert(values, DeepEquals, map[string]any{
 			"ssid":     "other-ssid",
 			"password": "other-secret",
@@ -470,7 +471,7 @@ func (s *confdbSuite) TestConfdbSetInvalid(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbSetExclamationMark(c *C) {
-	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any) error {
+	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
 		c.Assert(values, DeepEquals, map[string]any{"password": nil})
 		return nil
 	})
@@ -486,7 +487,7 @@ func (s *confdbSuite) TestConfdbModifyHooks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any) error {
+	restore := ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
 		c.Assert(values, DeepEquals, map[string]any{"password": "thing"})
 		return nil
 	})

--- a/overlord/hookstate/ctlcmd/unset.go
+++ b/overlord/hookstate/ctlcmd/unset.go
@@ -23,7 +23,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -31,7 +33,8 @@ import (
 
 type unsetCommand struct {
 	baseCommand
-	View bool `long:"view" description:"unset confdb values in the view declared in the plug"`
+	View    bool   `long:"view" description:"unset confdb values in the view declared in the plug"`
+	WaitFor string `long:"wait-for" description:"maximum duration to wait for confdb access (e.g. 10s)"`
 
 	Positional struct {
 		ConfKeys []string
@@ -111,5 +114,19 @@ func (s *unsetCommand) Execute(args []string) error {
 		confs[key] = nil
 	}
 
-	return setConfdbValues(context, plugName, confs)
+	opts := &client.ConfdbOptions{}
+	if s.WaitFor != "" {
+		timeout, err := time.ParseDuration(s.WaitFor)
+		if err != nil {
+			return fmt.Errorf("cannot parse --wait-for value %s: %v", s.WaitFor, err)
+		}
+
+		if timeout < 0 {
+			return fmt.Errorf("--wait-for value must be non-negative")
+		}
+
+		opts.AccessTimeout = &timeout
+	}
+
+	return setConfdbValues(context, plugName, confs, opts)
 }

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -163,7 +164,7 @@ func (s *unsetSuite) TestCommandWithoutContext(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbUnsetManyViews(c *C) {
-	ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any) error {
+	ctlcmd.MockConfdbstateWriteConfdb(func(_ *hookstate.Context, _ *confdb.View, values map[string]any, _ *client.ConfdbOptions) error {
 		c.Assert(values, DeepEquals, map[string]any{
 			"ssid":     nil,
 			"password": nil,


### PR DESCRIPTION
Adds support for configurable access timeouts for snap, snapctl and the API. The timeout applies to time spent waiting on other accesses to finish, it doesn't apply to the whole transaction as a whole.

https://warthogs.atlassian.net/browse/SNAPDENG-35593