### PR TITLE
spread: use LXD 5.21/candidate branch for older ubuntu systems

### DIFF
--- a/tests/lib/tools/lxd-state
+++ b/tests/lib/tools/lxd-state
@@ -8,7 +8,11 @@ show_help() {
 
 prepare_snap(){
     echo "lxd-state: installing lxd snap"
-    snap install lxd --channel="$LXD_SNAP_CHANNEL"
+    channel="${LXD_SNAP_CHANNEL}"
+    if os.query is_ubuntu_le 20.04; then
+        channel="5.21/${channel#*/}"
+    fi
+    snap install lxd --channel="$channel"
 
     if tests.pkgs is-installed lxd; then
         echo "lxd-state: remove the lxd pkg (some images carry them) to ensure we use the snap"

--- a/tests/lib/tools/lxd-state
+++ b/tests/lib/tools/lxd-state
@@ -10,6 +10,7 @@ prepare_snap(){
     echo "lxd-state: installing lxd snap"
     channel="${LXD_SNAP_CHANNEL}"
     if os.query is_ubuntu_le 20.04; then
+        # LXD 6 is not supported on older systems. Use 5.21 instead.
         channel="5.21/${channel#*/}"
     fi
     snap install lxd --channel="$channel"


### PR DESCRIPTION
LXD 6.0 isn't supported on older Ubuntu systems. Use 5.21/candidate instead
