### PR TITLE
cmd/snap-update-ns/change: fix mount ns updates in presence of synthetic bind mounts touching same target paths

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -651,6 +651,22 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 		// mount entries of a directory that was hidden with a tmpfs, but this
 		// fact was lost.
 		if current[i].XSnapdSynthetic() && desiredIDs[current[i].XSnapdNeededBy()] {
+			// Don't reuse a synthetic entry, created as a prerequisite of a
+			// previously constructed writable mimic, if a different,
+			// non-synthetic desired entry targets the same mountpoint. This
+			// handles the case where a writable mimic created a synthetic
+			// self-rebind of an existing directory, but a content interface
+			// mount should replace it. All children of the replaced mount point
+			// are also skipped from reuse, as they were mounted on top of the
+			// old content and need to be rebuilt.
+			// This problem should no longer be possible in snaps using bare or
+			// core26+ bases.
+			if entry, ok := desiredMap[dir]; ok && !current[i].Equal(entry) {
+				logger.Debugf("not reusing synthetic entry %q, non-synthetic desired entry %q exists for same mountpoint",
+					current[i], entry)
+				skipDir = strings.TrimSuffix(dir, "/") + "/"
+				continue
+			}
 			logger.Debugf("reusing synthetic entry %q", current[i])
 			reuse[mountId] = true
 			continue

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -659,8 +659,6 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 			// mount should replace it. All children of the replaced mount point
 			// are also skipped from reuse, as they were mounted on top of the
 			// old content and need to be rebuilt.
-			// This problem should no longer be possible in snaps using bare or
-			// core26+ bases.
 			if entry, ok := desiredMap[dir]; ok && !current[i].Equal(entry) {
 				logger.Debugf("not reusing synthetic entry %q, non-synthetic desired entry %q exists for same mountpoint",
 					current[i], entry)

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -651,14 +651,25 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 		// mount entries of a directory that was hidden with a tmpfs, but this
 		// fact was lost.
 		if current[i].XSnapdSynthetic() && desiredIDs[current[i].XSnapdNeededBy()] {
-			// Don't reuse a synthetic entry, created as a prerequisite of a
-			// previously constructed writable mimic, if a different,
-			// non-synthetic desired entry targets the same mountpoint. This
-			// handles the case where a writable mimic created a synthetic
-			// self-rebind of an existing directory, but a content interface
-			// mount should replace it. All children of the replaced mount point
-			// are also skipped from reuse, as they were mounted on top of the
-			// old content and need to be rebuilt.
+			// Don't reuse a synthetic entry (current[i]), created as a
+			// prerequisite of a previously constructed writable mimic, if a
+			// different, non-synthetic desired entry (entry below) targets the
+			// same mountpoint (dir). This handles the case where a writable
+			// mimic created a synthetic self-rebind of an existing directory,
+			// but a content interface mount should replace it. For instance,
+			// assume this state:
+			// - $SNAP/foo <-- used as content target, but did not exist
+			// - $SNAP/bar <-- as a result we have a mimic over $SNAP, $SNAP/bar is a tmpfs mount
+			//
+			// Next, a content connection, which uses target $SNAP/bar is
+			// established, the following needs to happen:
+			// - $SNAP/foo <-- keep (decided here)
+			// - $SNAP/bar <-- not reused, tmpfs needs to be unmounted (decided here)
+			// - $SNAP/bar <-- mount relevant content (decided later)
+			//
+			// All children of the replaced mount point are also skipped from
+			// reuse, as they were mounted on top of the old content and need to
+			// be rebuilt.
 			if entry, ok := desiredMap[dir]; ok && !current[i].Equal(entry) {
 				logger.Debugf("not reusing synthetic entry %q, non-synthetic desired entry %q exists for same mountpoint",
 					current[i], entry)

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -543,6 +543,71 @@ func (s *changeSuite) TestNeededChangesRepeatedDir(c *C) {
 	})
 }
 
+// This models the scenario from LP: #2144666 where a snap has two content
+// plugs: provider-1 (target doesn't exist in snap, triggering a writable mimic)
+// and provider-2 (target exists in snap as an empty directory). The mimic
+// creates synthetic self-rebinds for all existing directories, including
+// provider-2. When provider-2's content interface is subsequently connected,
+// the synthetic self-rebind must be replaced with the real content mount.
+func (s *changeSuite) TestNeededChangesSyntheticNotReusedWhenContentMountDesired(c *C) {
+	// The provider-2 target directory exists on the filesystem (it lives on
+	// the tmpfs from the mimic that is being kept).
+	restore := update.MockIsDirectory(func(path string) bool {
+		return path == "/snap/name/42/provider-2"
+	})
+	defer restore()
+
+	// After connecting provider-1, a writable mimic was created over
+	// /snap/name/42. The current profile reflects the mimic state: a tmpfs,
+	// synthetic self-rebinds for pre-existing directories (provider-2, bin,
+	// meta), and the non-synthetic content mount for provider-1.
+	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
+		{Name: "tmpfs", Dir: "/snap/name/42", Type: "tmpfs",
+			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/provider-2", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/bin", Dir: "/snap/name/42/bin",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/meta", Dir: "/snap/name/42/meta",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/snap/provider-1/x1", Dir: "/snap/name/42/provider-1",
+			Options: []string{"bind", "ro"}},
+	}}
+
+	// Now provider-2 is also connected. The desired profile contains both
+	// content mounts.
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
+		{Name: "/snap/provider-1/x1", Dir: "/snap/name/42/provider-1",
+			Options: []string{"bind", "ro"}},
+		{Name: "/snap/provider-2/x1", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro"}},
+	}}
+
+	changes := update.NeededChanges(current, desired)
+
+	c.Assert(changes, DeepEquals, []*update.Change{
+		// Keep/Unmount phase (reverse of current profile order):
+		// provider-1 content mount is unchanged.
+		{Entry: osutil.MountEntry{Name: "/snap/provider-1/x1", Dir: "/snap/name/42/provider-1",
+			Options: []string{"bind", "ro"}}, Action: update.Keep},
+		// meta and bin synthetic rebinds still support provider-1.
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/meta", Dir: "/snap/name/42/meta",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/bin", Dir: "/snap/name/42/bin",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}}, Action: update.Keep},
+		// The synthetic self-rebind of provider-2 must NOT be reused: a
+		// real content mount wants the same directory.
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/provider-2", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1"), osutil.XSnapdDetach()}}, Action: update.Unmount},
+		// The mimic tmpfs still supports provider-1.
+		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/snap/name/42", Type: "tmpfs",
+			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}}, Action: update.Keep},
+		// Mount phase: real content mount for provider-2.
+		{Entry: osutil.MountEntry{Name: "/snap/provider-2/x1", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro"}}, Action: update.Mount},
+	})
+}
+
 func (s *changeSuite) TestRuntimeUsingSymlinks(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer func() {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -608,6 +608,68 @@ func (s *changeSuite) TestNeededChangesSyntheticNotReusedWhenContentMountDesired
 	})
 }
 
+// This is a variation of
+// TestNeededChangesSyntheticNotReusedWhenContentMountDesired which assumes that
+// 2 things have changed in the desired profile:
+// - provider-1 is disconnected (only present in the current profile)
+// - provider-2 is listed in the desired profile
+func (s *changeSuite) TestNeededChangesMimicTornDownWhenNeededByEntryNotDesired(c *C) {
+	// At planning time the mimic is still mounted, so provider-2's target
+	// directory exists on the tmpfs.
+	restore := update.MockIsDirectory(func(path string) bool {
+		return path == "/snap/name/42/provider-2"
+	})
+	defer restore()
+
+	// After connecting provider-1, a writable mimic was created over
+	// /snap/name/42. The current profile reflects the mimic state.
+	// This is the same starting point as
+	// TestNeededChangesSyntheticNotReusedWhenContentMountDesired.
+	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
+		{Name: "tmpfs", Dir: "/snap/name/42", Type: "tmpfs",
+			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/provider-2", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/bin", Dir: "/snap/name/42/bin",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/var/lib/snapd/hostfs/snap/name/42/meta", Dir: "/snap/name/42/meta",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1")}},
+		{Name: "/snap/provider-1/x1", Dir: "/snap/name/42/provider-1",
+			Options: []string{"bind", "ro"}},
+	}}
+
+	// Provider-1 is disconnected, provider-2 is now connected.
+	// The needed-by target (/snap/name/42/provider-1) is no longer in
+	// the desired profile, so the synthetic reuse block is never entered.
+	// The tmpfs at /snap/name/42 fails the normal reuse check (no desired
+	// entry at that Dir), setting skipDir which cascades to all children.
+	// The entire mimic tree is torn down and provider-2 is freshly mounted.
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
+		{Name: "/snap/provider-2/x1", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro"}},
+	}}
+
+	changes := update.NeededChanges(current, desired)
+
+	c.Assert(changes, DeepEquals, []*update.Change{
+		// Unmount phase (reverse of current profile order):
+		// Everything is unmounted because nothing is reused.
+		{Entry: osutil.MountEntry{Name: "/snap/provider-1/x1", Dir: "/snap/name/42/provider-1",
+			Options: []string{"bind", "ro", osutil.XSnapdDetach()}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/meta", Dir: "/snap/name/42/meta",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1"), osutil.XSnapdDetach()}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/bin", Dir: "/snap/name/42/bin",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1"), osutil.XSnapdDetach()}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "/var/lib/snapd/hostfs/snap/name/42/provider-2", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1"), osutil.XSnapdDetach()}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/snap/name/42", Type: "tmpfs",
+			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/snap/name/42/provider-1"), osutil.XSnapdDetach()}}, Action: update.Unmount},
+		// Mount phase: provider-2 content mount is freshly created.
+		{Entry: osutil.MountEntry{Name: "/snap/provider-2/x1", Dir: "/snap/name/42/provider-2",
+			Options: []string{"bind", "ro"}}, Action: update.Mount},
+	})
+}
+
 func (s *changeSuite) TestRuntimeUsingSymlinks(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer func() {

--- a/tests/main/interfaces-content-mimic-missing-target/task.yaml
+++ b/tests/main/interfaces-content-mimic-missing-target/task.yaml
@@ -34,14 +34,14 @@ execute: |
     echo "Connect provider-2 to the plug whose target DOES exist in the snap"
     snap connect test-snapd-consumer:provider-2 test-snapd-provider-2:provider
 
-    echo "Verify content from provider-2 is NOT visible"
+    echo "Verify content from provider-2 is visible"
     #shellcheck disable=SC2016
-    not test-snapd-consumer.app -c 'cat $SNAP/provider-2/content' |& MATCH '/provider-2/content: No such file or directory'
+    test-snapd-consumer.app -c 'cat $SNAP/provider-2/content' | MATCH "content of test-snapd-provider-2"
 
-    echo "Discard the snap's mount namespace so that we start from scratch"
+    echo "Discard the snap's mount namespace and verify both remain visible from scratch"
     snapd.tool exec snap-discard-ns test-snapd-consumer
 
-    echo "Both content files are now visible"
+    echo "Both content files are still visible after namespace recreation"
     #shellcheck disable=SC2016
     test-snapd-consumer.app -c 'cat $SNAP/provider-1/content' | MATCH "content of test-snapd-provider-1"
     #shellcheck disable=SC2016

--- a/tests/main/layout-content-delayed-effects/task.yaml
+++ b/tests/main/layout-content-delayed-effects/task.yaml
@@ -212,16 +212,11 @@ execute: |
     wait || true
 
     # join it to observe updated content
-    # TODO: the output should be:
-    # > content mod v1;content p2;special content mod v3;
-    # however due to a buggy mount ns update new content is not, or shows up at
-    # connected-content-v2-2, the previously visible content from p2 and p2 is
-    # messed up as well
     # shellcheck disable=SC2016
     snap run --shell test-snapd-content-consumer-c1.app -c \
          'cat $SNAP/connected-content{,-2,-v2}/special-content-file' | \
          tr '\n' ';' | \
-         MATCH '^.*;special content mod v2;$'
+         MATCH '^.*;special content mod v3;$'
 
     # discard and observe correct content'
     snapd.tool exec snap-discard-ns test-snapd-content-consumer-c1


### PR DESCRIPTION
Fix how synthetic bind mounts are handled when a mount namespace is
being updated. Specifically correctly handle a scenario in which a
synthesized bind mount refers to the same path as a content interface
target.

As identified in LP#2144666, a writable mimic constructed in response to
one content connection resulted in a tmpfs mount at the mountpoint of
another, noot yet established, content connection. Subsequently, when
the other plug was connected, snap-update-ns incorrectly identified an
existing tmpfs mount as desired and did not perform the actual mount
from the content provider snap.

This problem should be entirely avoided once snapd to require presence
of content targets in snaps using bare or core26+ bases.

Related: SNAPDENG-36606 SNAPDENG-36625