### PR TITLE
docs: add prompt and rule not found errors

### DIFF
--- a/docs/api/v2/components/errors/PromptingPromptNotFoundError.yaml
+++ b/docs/api/v2/components/errors/PromptingPromptNotFoundError.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Canonical Ltd
+# SPDX-License-Identifier: GPL-3.0-only
+
+type: object
+required:
+  - message
+  - kind
+properties:
+  message:
+    type: string
+    description: A human-readable error message explaining the error.
+    example: cannot find prompt with the given ID for the given user
+  kind:
+    type: string
+    description: A machine-readable string identifying the error type.
+    enum:
+      - interfaces-requests-prompt-not-found

--- a/docs/api/v2/components/errors/PromptingRuleNotFoundError.yaml
+++ b/docs/api/v2/components/errors/PromptingRuleNotFoundError.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Canonical Ltd
+# SPDX-License-Identifier: GPL-3.0-only
+
+type: object
+required:
+  - message
+  - kind
+properties:
+  message:
+    type: string
+    description: A human-readable error message explaining the error.
+    example: cannot find rule with the given ID
+  kind:
+    type: string
+    description: A machine-readable string identifying the error type.
+    enum:
+      - interfaces-requests-rule-not-found

--- a/docs/api/v2/components/responses/NotFound.yaml
+++ b/docs/api/v2/components/responses/NotFound.yaml
@@ -28,3 +28,5 @@ content:
             - $ref: '../errors/NotFoundError.yaml'
             - $ref: '../errors/UserNotFoundError.yaml'
             - $ref: '../errors/SnapNotInstalledError.yaml'
+            - $ref: '../errors/PromptingPromptNotFoundError.yaml'
+            - $ref: '../errors/PromptingRuleNotFoundError.yaml'


### PR DESCRIPTION
Small documentation improvements now that prompting API errors have been adjusted and tested in #16947.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36821