### PR TITLE
many: update to apparmor 5.0.1

### DIFF
--- a/build-aux/snap/local/apparmor/af_names.h
+++ b/build-aux/snap/local/apparmor/af_names.h
@@ -1,8 +1,8 @@
 /*
   this file was generated on a Ubuntu noble install from the upstream
-  apparmor-4.1.7 release tarball as follows:
+  apparmor-5.0.0 release tarball as follows:
 
-  AA_VER=4.1.7
+  AA_VER=5.0.0
   TARBALL_NAME="apparmor-v${AA_VER}"
   wget \
   "https://gitlab.com/apparmor/apparmor/-/archive/v${AA_VER}/${TARBALL_NAME}.tar.gz"

--- a/build-aux/snap/local/apparmor/af_names.h
+++ b/build-aux/snap/local/apparmor/af_names.h
@@ -1,8 +1,8 @@
 /*
   this file was generated on a Ubuntu noble install from the upstream
-  apparmor-5.0.0 release tarball as follows:
+  apparmor-5.0.1-rc1 release tarball as follows:
 
-  AA_VER=5.0.0
+  AA_VER=5.0.1-rc1
   TARBALL_NAME="apparmor-v${AA_VER}"
   wget \
   "https://gitlab.com/apparmor/apparmor/-/archive/v${AA_VER}/${TARBALL_NAME}.tar.gz"

--- a/build-aux/snap/local/apparmor/af_names.h
+++ b/build-aux/snap/local/apparmor/af_names.h
@@ -1,8 +1,8 @@
 /*
   this file was generated on a Ubuntu noble install from the upstream
-  apparmor-5.0.1-rc1 release tarball as follows:
+  apparmor-5.0.1 release tarball as follows:
 
-  AA_VER=5.0.1-rc1
+  AA_VER=5.0.1
   TARBALL_NAME="apparmor-v${AA_VER}"
   wget \
   "https://gitlab.com/apparmor/apparmor/-/archive/v${AA_VER}/${TARBALL_NAME}.tar.gz"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -161,8 +161,8 @@ parts:
       - pkg-config
       - wget
       - libzstd-dev
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.1-rc1/apparmor-v5.0.1-rc1.tar.gz
-    source-checksum: sha256/b674d7507f9b1f0006654e574ffe425c96a26ac52ba320fec4661e789978809d
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.1/apparmor-v5.0.1.tar.gz
+    source-checksum: sha256/cea1fc638dccea42a0a972bfe6ee2a34cbf52ed98526c25a49bbed39450d2dcc
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -160,8 +160,9 @@ parts:
       - g++
       - pkg-config
       - wget
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v4.1.7/apparmor-v4.1.7.tar.gz
-    source-checksum: sha256/ded4cd419b8a05002a108a0912208e2098695752664c6a59464d2dda418e0452
+      - libzstd-dev
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0/apparmor-v5.0.0.tar.gz
+    source-checksum: sha256/37494c3640baeca9301879baa6f741272c57ac121ec1fc3bc42b4a27f5bb93be
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional
@@ -173,7 +174,7 @@ parts:
 
       cd "${CRAFT_PART_BUILD}"/libraries/libapparmor
       ./autogen.sh
-      ./configure --prefix=/usr --libdir="/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}" --disable-man-pages --disable-perl --disable-python --disable-ruby
+      ./configure --prefix=/usr --libdir="/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}" --disable-man-pages --disable-perl --disable-python --disable-ruby --disable-shared
       make -j"${CRAFT_PARALLEL_BUILD_COUNT}"
       make -C src install DESTDIR="${CRAFT_PART_INSTALL}"
       make -C include install DESTDIR="${CRAFT_PART_INSTALL}"
@@ -182,7 +183,7 @@ parts:
       # parser gets built to support as many as possible even if glibc in
       # the current build environment does not support them
       cp -a "${LOCAL_APPARMOR_DIR}"/af_names.h .
-      make -j"${CRAFT_PARALLEL_BUILD_COUNT}"
+      make -j"${CRAFT_PARALLEL_BUILD_COUNT}" WITH_STATIC_LINKING=1
       install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" apparmor_parser
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd/apparmor" parser.conf
       cd "${CRAFT_PART_BUILD}/profiles"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -161,8 +161,8 @@ parts:
       - pkg-config
       - wget
       - libzstd-dev
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.0/apparmor-v5.0.0.tar.gz
-    source-checksum: sha256/37494c3640baeca9301879baa6f741272c57ac121ec1fc3bc42b4a27f5bb93be
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.1-rc1/apparmor-v5.0.1-rc1.tar.gz
+    source-checksum: sha256/b674d7507f9b1f0006654e574ffe425c96a26ac52ba320fec4661e789978809d
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -82,11 +82,11 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 
 # Check if apparmor userspace library is available.
 AS_IF([test "x$enable_apparmor" = "xyes"], [
-    # Expect AppArmor4 when building as a snap under snapcraft
+    # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR4], [libapparmor = 4.1.7], [
-            AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor4 support])], [
-            AC_MSG_ERROR([unable to find apparmor4 for snap build of snapd])])], [
+        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.0], [
+            AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
+            AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [
       AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor support])])])
 ], [

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 AS_IF([test "x$enable_apparmor" = "xyes"], [
     # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.1-rc1], [
+        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.1], [
             AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
             AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 AS_IF([test "x$enable_apparmor" = "xyes"], [
     # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.0], [
+        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.1-rc1], [
             AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
             AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -549,7 +549,7 @@ func (s *parserFeatureTestSuite) TestProbeFeature(c *C) {
 	probeOneParserFeature(c, &knownProbes, parserPath, "xdp", `profile snap-test { network xdp,}`)
 
 	// Pretend we have all the features.
-	err := os.WriteFile(parserPath, []byte(fakeParserScript("4.1.7")), 0o755)
+	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.0")), 0o755)
 	c.Assert(err, IsNil)
 
 	// Did any feature probes got added to non-test code?

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -549,7 +549,7 @@ func (s *parserFeatureTestSuite) TestProbeFeature(c *C) {
 	probeOneParserFeature(c, &knownProbes, parserPath, "xdp", `profile snap-test { network xdp,}`)
 
 	// Pretend we have all the features.
-	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.0")), 0o755)
+	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.1-rc1")), 0o755)
 	c.Assert(err, IsNil)
 
 	// Did any feature probes got added to non-test code?

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -549,7 +549,7 @@ func (s *parserFeatureTestSuite) TestProbeFeature(c *C) {
 	probeOneParserFeature(c, &knownProbes, parserPath, "xdp", `profile snap-test { network xdp,}`)
 
 	// Pretend we have all the features.
-	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.1-rc1")), 0o755)
+	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.1")), 0o755)
 	c.Assert(err, IsNil)
 
 	// Did any feature probes got added to non-test code?


### PR DESCRIPTION
Switch the copy of apparmor bundled with snapd snap to the new 5.0.1 release release. This keeps the old ABI intact so our profiles should retain old semantics.

Disable support for building libapparmor.so and force static linking of libapparmor.a into apparmor_parser.

Note that early in the 5.x series, apparmor userspace depends on libzstd for loading compressed profiles.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35412
