### PR TITLE
github: add GOTRACEBACK=all to unit tests running in CI

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -52,6 +52,7 @@ jobs:
       GOROOT: ""
       GO_BUILD_TAGS: ${{ inputs.go-build-tags }}
       CC: ${{ inputs.c-compiler }}
+      GOTRACEBACK: all
       
     steps:
     - name: Checkout code


### PR DESCRIPTION
There have been some instances of a seg fault:
- https://github.com/canonical/snapd/actions/runs/24790674528/job/72547895774#step:14:919
- https://github.com/canonical/snapd/actions/runs/24851982273/job/72755559748?pr=16926#step:14:943

