### PR TITLE
interfaces/builtin: add apparmor-observe interface

### DIFF
--- a/interfaces/builtin/apparmor_observe.go
+++ b/interfaces/builtin/apparmor_observe.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const apparmorObserveSummary = `allows querying AppArmor access decisions`
+
+const apparmorObserveBaseDeclarationSlots = `
+  apparmor-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const apparmorObserveConnectedPlugAppArmor = `
+# Description: Allow use of AppArmor's access query interface.
+# The query interface is writable because callers write a query to .access
+# and then read the kernel's response back from the same file.
+/sys/kernel/security/apparmor/.access rw,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "apparmor-observe",
+		summary:               apparmorObserveSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  apparmorObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: apparmorObserveConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/apparmor_observe_test.go
+++ b/interfaces/builtin/apparmor_observe_test.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type AppArmorObserveInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&AppArmorObserveInterfaceSuite{
+	iface: builtin.MustInterface("apparmor-observe"),
+})
+
+const apparmorObserveConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [apparmor-observe]
+`
+
+const apparmorObserveCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  apparmor-observe:
+`
+
+func (s *AppArmorObserveInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, apparmorObserveConsumerYaml, nil, "apparmor-observe")
+	s.slot, s.slotInfo = MockConnectedSlot(c, apparmorObserveCoreYaml, nil, "apparmor-observe")
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "apparmor-observe")
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestAppArmorSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/kernel/security/apparmor/.access rw,`)
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows querying AppArmor access decisions`)
+	c.Assert(si.BaseDeclarationPlugs, Equals, "")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "apparmor-observe")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *AppArmorObserveInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -14,6 +14,9 @@ apps:
   allegro-vcu:
     command: bin/run
     plugs: [ allegro-vcu ]
+  apparmor-observe:
+    command: bin/run
+    plugs: [ apparmor-observe ]
   audio-playback:
     command: bin/run
     plugs: [ audio-playback ]


### PR DESCRIPTION
This allows apparmor-insight, or programs that use libapparmor, to access the unprivileged .access interface to run userspace queries.
