### PR TITLE
interfaces: conditionally deny /proc/self/mountinfo 

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -671,6 +671,15 @@ func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppS
 	content = make(map[string]osutil.FileState, len(runnables))
 	snapInfo := appSet.Info()
 
+	// add base snippets to the spec, unless it's an unjailed classic snap. These
+	// will be present in the final profile if no interface overrides them with a
+	// more specific snippet of the same key
+	if !opts.Classic || opts.JailMode {
+		for key, snippet := range basePrioritizedSnippets {
+			spec.AddBasePrioritizedSnippet(snippet, key)
+		}
+	}
+
 	// Add profile for apps and hooks.
 	for _, r := range runnables {
 		b.addContent(r.SecurityTag, snapInfo, r.CommandName, opts, spec.SnippetForTag(r.SecurityTag), content, spec)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1227,25 +1227,27 @@ const commonPrefix = `
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"`
 
+const mountInfoSnippet = "\ndeny @{PROC}/self/mountinfo r,\ndeny @{PROC}/@{pid}/mountinfo r,\n"
+
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.
 	opts:    interfaces.ConfinementOptions{},
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted) {\n\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted) {\n" + mountInfoSnippet + "\n}\n",
 }, {
 	// Snippets are injected in the space between "{" and "}"
 	opts:    interfaces.ConfinementOptions{},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
 }, {
 	// DevMode switches apparmor to non-enforcing (complain) mode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
 }, {
 	// JailMode switches apparmor to enforcing mode even in the presence of DevMode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
 }, {
 	// Classic confinement (without jailmode) uses apparmor in complain mode by default and ignores all snippets.
 	opts:    interfaces.ConfinementOptions{Classic: true},
@@ -1270,6 +1272,7 @@ profile "snap.samba.smbd" flags=(attach_disconnected,mediate_deleted) {
   # snapd snap is installed and executes the snap application.
   @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
 
+` + mountInfoSnippet + `
 snippet
 }
 `,
@@ -1362,8 +1365,15 @@ func (s *backendSuite) TestUnconfinedFlag(c *C) {
 		if opts.Classic {
 			prefix = "\n#classic" + commonPrefix
 		}
-		contents := fmt.Sprintf(prefix+"\nprofile \"snap.samba.smbd\" flags=(%s) {\n\n}\n",
-			strings.Join(flags, ","))
+		var body string
+		if opts.Classic && !opts.JailMode {
+			// Classic mode ignores all snippets, including base snippets
+			body = "\n\n"
+		} else {
+			body = "\n" + mountInfoSnippet + "\n"
+		}
+		contents := fmt.Sprintf(prefix+"\nprofile \"snap.samba.smbd\" flags=(%s) {%s}\n",
+			strings.Join(flags, ","), body)
 		c.Check(profile, testutil.FileEquals, contents, Commentf("scenario %d: %#v", i, opts))
 		stat, err := os.Stat(profile)
 		c.Assert(err, IsNil)
@@ -1519,7 +1529,7 @@ func (s *backendSuite) TestParallelInstallCombineSnippets(c *C) {
 @{PROFILE_DBUS}="snap_2esamba_5ffoo_2esmbd"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"
 profile "snap.samba_foo.smbd" flags=(attach_disconnected,mediate_deleted) {
-
+` + mountInfoSnippet + `
 }
 `
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "samba_foo", ifacetest.SambaYamlV1, 1)
@@ -1558,7 +1568,7 @@ func (s *backendSuite) TestTemplateVarsWithHook(c *C) {
 @{PROFILE_DBUS}="snap_2efoo_2ehook_2econfigure"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"
 profile "snap.foo.hook.configure" flags=(attach_disconnected,mediate_deleted) {
-
+` + mountInfoSnippet + `
 }
 `
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.HookYaml, 1)
@@ -1597,7 +1607,7 @@ func (s *backendSuite) TestTemplateVarsWithComponentHook(c *C) {
 @{PROFILE_DBUS}="snap_2esnap_2bcomp_2ehook_2einstall"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"
 profile "snap.snap+comp.hook.install" flags=(attach_disconnected,mediate_deleted) {
-
+` + mountInfoSnippet + `
 }
 `
 	info := s.InstallSnapWithComponents(c, interfaces.ConfinementOptions{}, "", ifacetest.SnapWithComponentsYaml, 1, []string{ifacetest.ComponentYaml})

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -106,3 +106,7 @@ func (b *Backend) SetupSnapConfineReexec(info *snap.Info) error {
 func (s *Specification) SnippetsForTag(tag string) []string {
 	return s.snippetsForTag(tag)
 }
+
+func NewSnippetKey(key string) SnippetKey {
+	return newSnippetKey(key)
+}

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -172,6 +172,8 @@ type Specification struct {
 	// is smaller than the old one.
 	prioritizedSnippets map[string]map[SnippetKey]prioritizedSnippets
 
+	baseSnippets map[SnippetKey]string
+
 	// dedupSnippets are just like snippets but are added only once to the
 	// resulting policy in an effort to avoid certain expensive to de-duplicate
 	// rules by apparmor_parser.
@@ -336,12 +338,44 @@ func (spec *Specification) AddPrioritizedSnippet(snippet string, key SnippetKey,
 	}
 }
 
+// AddBasePrioritizedSnippet adds a new apparmor snippet to all apps and hooks,
+// identified by a key. If any other prioritized snippet exists for that key, it
+// will take priority over this. This is useful to add snippets which should be
+// present on all profiles, unless a more specific snippet is added by an
+// interface. The key must have been previously registered using RegisterSnippetKey().
+func (spec *Specification) AddBasePrioritizedSnippet(snippet string, key SnippetKey) {
+	if _, ok := registeredKeys[key]; !ok {
+		logger.Panicf("snippet key %q is not registered", key.String())
+	} else if _, ok := spec.baseSnippets[key]; ok {
+		logger.Panicf("already registered a snippet for key %q (one base snippet per key expected)", key.String())
+	}
+
+	if spec.baseSnippets == nil {
+		spec.baseSnippets = make(map[SnippetKey]string)
+	}
+
+	spec.baseSnippets[key] = snippet
+}
+
 func (spec *Specification) composeSnippetsForTag(tag string) []string {
 	// Compose the normal and the prioritized snippets in a single string array
 	composedSnippets := append([]string(nil), spec.snippets[tag]...)
+
+	prioKeys := make(map[SnippetKey]bool)
 	for key := range spec.prioritizedSnippets[tag] {
+		prioKeys[key] = true
 		composedSnippets = append(composedSnippets, spec.prioritizedSnippets[tag][key].list...)
 	}
+
+	for key, sn := range spec.baseSnippets {
+		if prioKeys[key] {
+			// any prioritized snippet overrides a base snippet of the same key
+			continue
+		}
+
+		composedSnippets = append(composedSnippets, sn)
+	}
+
 	sort.Strings(composedSnippets)
 	return composedSnippets
 }

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -773,12 +773,35 @@ func (s *specSuite) TestRegisterSameSnippetKeyTwice(c *C) {
 	c.Assert(func() { apparmor.RegisterSnippetKey("testkey1") }, PanicMatches, "priority key testkey1 is already registered")
 }
 
+func (s *specSuite) TestAddBasePrioritizedSnippet(c *C) {
+	restoreScope := apparmor.SetSpecScope(s.spec, []string{"snap.demo.app"})
+	defer restoreScope()
+
+	s.spec.AddBasePrioritizedSnippet("#foo#", key1)
+
+	// it's there, if no prioritized snippet is added
+	snippets := s.spec.SnippetForTag("snap.demo.app")
+	c.Assert(snippets, testutil.Contains, "#foo#")
+
+	// but a snippet of any priority is enough to override the base snippet
+	s.spec.AddPrioritizedSnippet("#bar#", key1, 0)
+	snippets = s.spec.SnippetForTag("snap.demo.app")
+
+	c.Assert(snippets, testutil.Contains, "#bar#")
+	c.Assert(snippets, Not(testutil.Contains), "#foo#")
+}
+
+func (s *specSuite) TestBasePrioritizedSnippetInvalid(c *C) {
+	key := apparmor.NewSnippetKey("unregistered-key")
+	c.Assert(func() { s.spec.AddBasePrioritizedSnippet("#foo#", key) }, PanicMatches, "snippet key \"unregistered-key\" is not registered")
+
+	s.spec.AddBasePrioritizedSnippet("#foo#", key1)
+	c.Assert(func() { s.spec.AddBasePrioritizedSnippet("#foo#", key1) }, PanicMatches, `already registered a snippet for key "testkey1" \(one base snippet per key expected\)`)
+}
+
 func (s *specSuite) TestMoreSnippets(c *C) {
 	keylist := apparmor.RegisteredSnippetKeys()
-	c.Assert(keylist, testutil.Contains, "testkey1")
-	c.Assert(keylist, testutil.Contains, "testkey2")
-	c.Assert(len(keylist), Equals, 2)
-
+	c.Assert(keylist, testutil.DeepUnsortedMatches, []string{"testkey1", "testkey2", "mount-info"})
 }
 
 func (s *specSuite) TestInterfaceForMetadataTag(c *C) {

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1155,3 +1155,18 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 ###SNIPPETS###
 }
 `
+
+var MountInfoKey = RegisterSnippetKey("mount-info")
+
+// basePrioritizedSnippets holds snippets that are added to the base template
+// if no more specific snippet is added by an interface.
+var basePrioritizedSnippets = map[SnippetKey]string{
+	// Go (1.25+) reads /proc/self/mountinfo to implement container-aware
+	// GOMAXPROCS (see also: https://github.com/golang/go/issues/77911) which we
+	// can't blanket allow so deny to silence log. Specific interfaces can override
+	// using AddPrioritizedSnippet with any priority.
+	MountInfoKey: `
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`,
+}

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -469,8 +469,7 @@ func (s *AllSuite) TestAppArmorUnconfinedSlots(c *C) {
 
 func (s *AllSuite) TestPrioritizedSnippets(c *C) {
 	keys := apparmor.RegisteredSnippetKeys()
-	c.Assert(len(keys), Equals, 1)
-	c.Assert(keys, testutil.Contains, "desktop-file-access")
+	c.Assert(keys, testutil.DeepUnsortedMatches, []string{"desktop-file-access", "mount-info"})
 }
 
 type conflictsWithOtherConnectedInterfacesDefiner interface {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -110,7 +110,6 @@ deny @{PROC}/@{pid}/attr/{,apparmor/}current r,
 # when using the chromium content api file chooser due to a (harmless) glib
 # warning and the noisy AppArmor denial.
 owner @{PROC}/@{pid}/mounts r,
-owner @{PROC}/@{pid}/mountinfo r,
 
 # Since snapd still uses SECCOMP_RET_KILL, we have added a workaround rule to
 # allow mknod on character devices since chromium unconditionally performs
@@ -410,6 +409,7 @@ func (iface *browserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	} else {
 		spec.SetSuppressPtraceTrace()
 	}
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 	return nil
 }
 

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -228,3 +228,28 @@ func (s *BrowserSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 func (s *BrowserSupportInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+func (s *BrowserSupportInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.other.app2")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.other.app2")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}

--- a/interfaces/builtin/classic_support.go
+++ b/interfaces/builtin/classic_support.go
@@ -19,6 +19,11 @@
 
 package builtin
 
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+)
+
 const classicSupportSummary = `special permissions for the classic snap`
 
 const classicSupportBaseDeclarationPlugs = `
@@ -64,7 +69,6 @@ capability sys_admin,
 /{,usr/}bin/mount ixr,
 /{,usr/}bin/mountpoint ixr,
 /run/mount/utab rw,
-@{PROC}/[0-9]*/mountinfo r,
 # parallel-installs: SNAP_{DATA,COMMON} are remapped, need to use SNAP_NAME, for
 # completeness allow SNAP_INSTANCE_NAME too
 mount options=(rw bind) /home/ -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/,
@@ -118,15 +122,28 @@ umount
 umount2
 `
 
+type classicSupportInterface struct {
+	commonInterface
+}
+
+func (iface *classicSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(classicSupportPlugAppArmor)
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
+	return nil
+}
+
 func init() {
-	registerIface(&commonInterface{
-		name:                  "classic-support",
-		summary:               classicSupportSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationPlugs:  classicSupportBaseDeclarationPlugs,
-		baseDeclarationSlots:  classicSupportBaseDeclarationSlots,
-		connectedPlugAppArmor: classicSupportPlugAppArmor,
-		connectedPlugSecComp:  classicSupportPlugSecComp,
+	registerIface(&classicSupportInterface{
+		commonInterface: commonInterface{
+			name:                 "classic-support",
+			summary:              classicSupportSummary,
+			implicitOnCore:       true,
+			implicitOnClassic:    true,
+			baseDeclarationPlugs: classicSupportBaseDeclarationPlugs,
+			baseDeclarationSlots: classicSupportBaseDeclarationSlots,
+			// handled by AppArmorConnectedPlug
+			connectedPlugAppArmor: "",
+			connectedPlugSecComp:  classicSupportPlugSecComp,
+		},
 	})
 }

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -96,3 +96,28 @@ func (s *ClassicSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 func (s *ClassicSupportInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+func (s *ClassicSupportInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.other.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.other.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -96,7 +96,6 @@ const fwupdPermanentSlotAppArmor = `
   /run/udev/data/* r,
   /run/mount/utab r,
 
-  owner @{PROC}/@{pid}/mountinfo r,
   owner @{PROC}/@{pid}/mounts r,
 
   /dev/tpm* rw,
@@ -445,6 +444,7 @@ func (iface *fwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 	}
 	snippet := strings.Replace(fwupdConnectedPlugAppArmor, old, new, -1)
 	spec.AddSnippet(snippet)
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 	return nil
 }
 

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -306,3 +306,28 @@ func (s *FwupdInterfaceSuite) TestStaticInfo(c *C) {
 	c.Assert(si.Summary, Equals, "allows operating as the fwupd service")
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "fwupd")
 }
+
+func (s *FwupdInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.uefi-fw-tools.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.appSlot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.uefi-fw-tools.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -111,7 +111,6 @@ capability sys_admin,
 capability dac_override,  # for various overlayfs accesses
 
 # for setting up mounts
-@{PROC}/[0-9]*/mountinfo r,
 @{PROC}/filesystems r,
 
 # runc needs this
@@ -448,6 +447,7 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 		spec.AddSnippet(greengrassSupportProcessModeConnectedPlugAppArmor)
 	}
 
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 	return nil
 }
 

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -97,7 +97,6 @@ func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.processModePlug, s.processModePlugInfo = MockConnectedPlug(c, ggProcessModeMockPlugSnapInfoYaml, nil, "greengrass-support-no-container")
 
 	s.containerModePlug, s.containerModePlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support-legacy-container")
-
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestName(c *C) {
@@ -274,4 +273,29 @@ func (s *GreengrassSupportInterfaceSuite) TestPermanentPlugServiceSnippets(c *C)
 		c.Assert(err, IsNil)
 		c.Check(snips, DeepEquals, t.exp)
 	}
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.other.app2")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.other.app2")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, `owner @{PROC}/@{pid}/mountinfo r,`)
+	c.Assert(snippet, testutil.Contains, `owner @{PROC}/self/mountinfo r,`)
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
 }

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -632,8 +632,6 @@ func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
   capability sys_admin,  # for mount
 
   owner @{PROC}/@{pid}/mounts r,
-  owner @{PROC}/@{pid}/mountinfo r,
-  owner @{PROC}/self/mountinfo r,
 
   /{,usr/}bin/mount ixr,
   /{,usr/}bin/umount ixr,
@@ -688,6 +686,7 @@ func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 	})
 
 	spec.AddSnippet(mountControlSnippet.String())
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 	return nil
 }
 

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -496,3 +496,28 @@ func (s *MountControlInterfaceSuite) TestMountOptionsAreValid(c *C) {
 		c.Check(libmount.ValidateMountOptions(opt), IsNil)
 	}
 }
+
+func (s *MountControlInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.consumer.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -19,6 +19,15 @@
 
 package builtin
 
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+)
+
+type mountObserveInterface struct {
+	commonInterface
+}
+
 const mountObserveSummary = `allows reading mount table and quota information`
 
 const mountObserveBaseDeclarationSlots = `
@@ -44,7 +53,6 @@ const mountObserveConnectedPlugAppArmor = `
 @{PROC}/1/mounts r,
 
 owner @{PROC}/@{pid}/mounts r,
-owner @{PROC}/@{pid}/mountinfo r,
 owner @{PROC}/@{pid}/mountstats r,
 
 # some processes might read mount* from /proc/thread-self/ instead
@@ -67,6 +75,15 @@ owner @{PROC}/@{pid}/task/@{tid}/mountinfo r,
 /run/mount/utab r,
 `
 
+// this snippet replaces a base prioritized snipet which denies these rules
+// by default. See basePrioritizedSnippets in interfaces/apparmor/template.go
+// for an explanation. Any priority is enough to replace a base snippet.
+const mountInfoPriority = uint(1)
+const mountInfoSnippet = `
+owner @{PROC}/@{pid}/mountinfo r,
+owner @{PROC}/self/mountinfo r,
+`
+
 const mountObserveConnectedPlugSecComp = `
 # Description: Can query system mount and disk quota information. This is
 # restricted because it gives privileged read access to mount arguments and
@@ -83,13 +100,22 @@ statmount
 `
 
 func init() {
-	registerIface(&commonInterface{
-		name:                  "mount-observe",
-		summary:               mountObserveSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  mountObserveBaseDeclarationSlots,
-		connectedPlugAppArmor: mountObserveConnectedPlugAppArmor,
-		connectedPlugSecComp:  mountObserveConnectedPlugSecComp,
+	registerIface(&mountObserveInterface{
+		commonInterface: commonInterface{
+			name:                 "mount-observe",
+			summary:              mountObserveSummary,
+			implicitOnCore:       true,
+			implicitOnClassic:    true,
+			baseDeclarationSlots: mountObserveBaseDeclarationSlots,
+			// handled by AppArmorConnectedPlug
+			connectedPlugAppArmor: "",
+			connectedPlugSecComp:  mountObserveConnectedPlugSecComp,
+		},
 	})
+}
+
+func (iface *mountObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(mountObserveConnectedPlugAppArmor)
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
+	return nil
 }

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -84,3 +84,28 @@ func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 func (s *MountObserveInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+func (s *MountObserveInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.other.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.other.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}

--- a/interfaces/builtin/usb_gadget.go
+++ b/interfaces/builtin/usb_gadget.go
@@ -190,8 +190,6 @@ func (iface *usbGadgetInterface) AppArmorConnectedPlug(spec *apparmor.Specificat
   capability sys_admin,  # for mount
 
   owner @{PROC}/@{pid}/mounts r,
-  owner @{PROC}/@{pid}/mountinfo r,
-  owner @{PROC}/self/mountinfo r,
 
   /{,usr/}bin/mount ixr,
   /{,usr/}bin/umount ixr,
@@ -222,6 +220,7 @@ func (iface *usbGadgetInterface) AppArmorConnectedPlug(spec *apparmor.Specificat
 	}
 
 	spec.AddSnippet(usbGadgetSnippet.String())
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 	return nil
 }
 

--- a/interfaces/builtin/usb_gadget_test.go
+++ b/interfaces/builtin/usb_gadget_test.go
@@ -82,6 +82,7 @@ slots:
 func (s *UsbGadgetInterfaceSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.slot, s.slotInfo = MockConnectedSlot(c, usbGadgetCoreYaml, nil, "usb-gadget")
+	s.plug, s.plugInfo = MockConnectedPlug(c, usbGadgetConsumerYaml, nil, "usbg")
 	s.AddCleanup(systemd.MockSystemdVersion(210, nil))
 }
 
@@ -194,4 +195,31 @@ func (s *UsbGadgetInterfaceSuite) TestAutoConnect(c *C) {
 
 func (s *UsbGadgetInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *UsbGadgetInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	plug, _ := MockConnectedPlug(c, usbGadgetWithFFSConsumerYaml, nil, "usbg")
+
+	spec := apparmor.NewSpecification(plug.AppSet())
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	err := spec.AddConnectedPlug(s.iface, plug, s.slot)
+	c.Assert(err, IsNil)
+
+	snippet = spec.SnippetForTag("snap.consumer.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
 }

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -23,19 +23,7 @@ debug: |
 execute: |
     echo "Running a trivial command causes no DENIED messages"
     test-snapd-sh-core24.sh -c 'echo hello'
-    if os.query is-arch-linux && [ "$SNAP_REEXEC" != "1" ]; then
-        dmesg | grep DENIED > arch-denied.log
-        # due to Go 1.25 poking /proc/self/mountinfo we get a denial from
-        # snap-exec which executes under the profile of test-snapd-sh which looks like this (all in one line):
-        # [ 1698.601327] audit: type=1400 audit(1757424814.280:2967): apparmor="DENIED"
-        # operation="open" class="file" profile="snap.test-snapd-sh.sh"
-        # name="/proc/162399/mountinfo" pid=162399 comm="snap-exec"
-        # requested_mask="r" denied_mask="r" fsuid=0 ouid=0
-        MATCH 'apparmor="DENIED" operation="open" .* name="/proc/[0-9]+/mountinfo" .* comm="snap-exec"' < arch-denied.log
-        test "$(wc -l < arch-denied.log)" = "1"
-    else
-        dmesg | not grep DENIED
-    fi
+    dmesg | not grep DENIED
 
     echo "Test that snap run use environments"
     basic-run.echo-data | MATCH ^/var/snap


### PR DESCRIPTION
Extends the concept of prioritized snippets to have allow base prioritized snippets not specific to any security tag that can be added to a base template and are removed if any prioritized snippet of the same key is added by a plug.
This is used to add a deny rule for /proc/self/mountinfo which the Go runtime from 1.25+ tries to read, resulting in logged denials for both Go snaps and snap-exec. This rule is removed if any interface providing read access to this path is plugged.

https://warthogs.atlassian.net/browse/SNAPDENG-35488
https://warthogs.atlassian.net/browse/SNAPDENG-36466