### PR TITLE
cmd/snap: report file-access "hidden" when prompting running

### DIFF
--- a/cmd/snap/cmd_routine_file_access.go
+++ b/cmd/snap/cmd_routine_file_access.go
@@ -106,14 +106,19 @@ func (x *cmdRoutineFileAccess) Execute(args []string) error {
 		}
 	}
 
-	// XXX: should features.AppArmorPrompting.IsEnabled() be used instead of
-	// querying the API for /v2/system-info?
-	sysInfo, err := x.client.SysInfo()
-	if err != nil {
-		return fmt.Errorf("cannot get system info: %w", err)
+	var promptingRunning bool
+	// Avoid checking prompting unless it is relevant, i.e. has an interface
+	// which is mediated by prompting.
+	if hasHome {
+		// XXX: should features.AppArmorPrompting.IsEnabled() be used instead of
+		// querying the API for /v2/system-info?
+		sysInfo, err := x.client.SysInfo()
+		if err != nil {
+			return err
+		}
+		promptingFeatureInfo, ok := sysInfo.Features[features.AppArmorPrompting.String()]
+		promptingRunning = ok && promptingFeatureInfo.Supported && promptingFeatureInfo.Enabled
 	}
-	promptingFeatureInfo, ok := sysInfo.Features[features.AppArmorPrompting.String()]
-	promptingRunning := ok && promptingFeatureInfo.Supported && promptingFeatureInfo.Enabled
 
 	access, err := x.checkAccess(snap, hasHome, hasRemovableMedia, promptingRunning, path)
 	if err != nil {

--- a/cmd/snap/cmd_routine_file_access.go
+++ b/cmd/snap/cmd_routine_file_access.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 )
 
@@ -105,7 +106,16 @@ func (x *cmdRoutineFileAccess) Execute(args []string) error {
 		}
 	}
 
-	access, err := x.checkAccess(snap, hasHome, hasRemovableMedia, path)
+	// XXX: should features.AppArmorPrompting.IsEnabled() be used instead of
+	// querying the API for /v2/system-info?
+	sysInfo, err := x.client.SysInfo()
+	if err != nil {
+		return fmt.Errorf("cannot get system info: %w", err)
+	}
+	promptingFeatureInfo, ok := sysInfo.Features[features.AppArmorPrompting.String()]
+	promptingRunning := ok && promptingFeatureInfo.Supported && promptingFeatureInfo.Enabled
+
+	access, err := x.checkAccess(snap, hasHome, hasRemovableMedia, promptingRunning, path)
 	if err != nil {
 		return err
 	}
@@ -143,7 +153,7 @@ func pathHasPrefix(path, prefix []string) bool {
 	return true
 }
 
-func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemovableMedia bool, path string) (FileAccess, error) {
+func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemovableMedia, promptingRunning bool, path string) (FileAccess, error) {
 	// Classic confinement snaps run in the host system namespace,
 	// so can see everything.
 	if snap.Confinement == client.ClassicConfinement {
@@ -204,8 +214,10 @@ func (x *cmdRoutineFileAccess) checkAccess(snap *client.Snap, hasHome, hasRemova
 		}
 		// If the home interface is connected, the snap has
 		// access to other files in home, except top-level dot
-		// files.
-		if hasHome {
+		// files. If prompting is running, then the file access
+		// should be proxied, so we don't get a prompt to use a
+		// file which has been chosen via a portal.
+		if hasHome && !promptingRunning {
 			if len(pathInHome) == 0 || !strings.HasPrefix(pathInHome[0], ".") {
 				return FileAccessReadWrite, nil
 			}

--- a/cmd/snap/cmd_routine_file_access.go
+++ b/cmd/snap/cmd_routine_file_access.go
@@ -32,6 +32,12 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
+// `snap routine file-access` is called whenever a snap uses the portal API to
+// open a path, so that the document portal knows whether the snap has direct
+// access to the file, or whether the portal needs to proxy access to it.
+//
+// Concretely, the command is called here:
+// https://github.com/flatpak/xdg-desktop-portal/blob/c6f217875485e28799a524b643c34474a289ba4f/document-portal/document-portal.c#L747-L788
 type cmdRoutineFileAccess struct {
 	clientMixin
 	FileAccessOptions struct {
@@ -128,11 +134,20 @@ func (x *cmdRoutineFileAccess) Execute(args []string) error {
 	return nil
 }
 
+// FileAccess corresponds to the XDG desktop portal's concept of file access
+// modes.
 type FileAccess string
 
 const (
-	FileAccessHidden    FileAccess = "hidden"
-	FileAccessReadOnly  FileAccess = "read-only"
+	// FileAccessHidden means that the XDG desktop portal needs to proxy access
+	// to the file.
+	FileAccessHidden FileAccess = "hidden"
+	// FileAccessReadOnly means that applications may read the file directly
+	// without the XDG desktop portal needing to proxy access to it.
+	FileAccessReadOnly FileAccess = "read-only"
+	// FileAccessReadWrite means that applications may read or write to the
+	// file directly without the XDG desktop portal needing to proxy access to
+	// it.
 	FileAccessReadWrite FileAccess = "read-write"
 )
 

--- a/cmd/snap/cmd_routine_file_access_test.go
+++ b/cmd/snap/cmd_routine_file_access_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil/user"
 )
 
@@ -52,7 +53,7 @@ func (s *SnapRoutineFileAccessSuite) SetUpTest(c *C) {
 	}))
 }
 
-func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRemovableMedia bool) {
+func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRemovableMedia, promptingSupported, promptingEnabled bool) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/snaps/hello":
@@ -101,6 +102,21 @@ func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRe
 				"type":   "sync",
 				"result": result,
 			})
+		case "/v2/system-info":
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/system-info")
+			sysInfo := client.SysInfo{
+				Features: map[string]features.FeatureInfo{
+					features.AppArmorPrompting.String(): {
+						Supported: promptingSupported,
+						Enabled:   promptingEnabled,
+					},
+				},
+			}
+			EncodeResponseBody(c, w, map[string]any{
+				"type":   "sync",
+				"result": sysInfo,
+			})
 		default:
 			c.Fatalf("unexpected request: %v", r)
 		}
@@ -136,7 +152,7 @@ func (s *SnapRoutineFileAccessSuite) checkBasicAccess(c *C) {
 }
 
 func (s *SnapRoutineFileAccessSuite) TestAccessDefault(c *C) {
-	s.setUpClient(c, false, false, false)
+	s.setUpClient(c, false, false, false, false, false)
 	s.checkBasicAccess(c)
 
 	// No access to root
@@ -150,7 +166,7 @@ func (s *SnapRoutineFileAccessSuite) TestAccessDefault(c *C) {
 }
 
 func (s *SnapRoutineFileAccessSuite) TestAccessClassicConfinement(c *C) {
-	s.setUpClient(c, true, false, false)
+	s.setUpClient(c, true, false, false, false, false)
 
 	// Classic confinement snaps run in the host file system
 	// namespace, so have access to everything.
@@ -162,7 +178,7 @@ func (s *SnapRoutineFileAccessSuite) TestAccessClassicConfinement(c *C) {
 }
 
 func (s *SnapRoutineFileAccessSuite) TestAccessHomeInterface(c *C) {
-	s.setUpClient(c, false, true, false)
+	s.setUpClient(c, false, true, false, false, false)
 	s.checkBasicAccess(c)
 
 	// Access to non-hidden files in the home directory
@@ -172,8 +188,41 @@ func (s *SnapRoutineFileAccessSuite) TestAccessHomeInterface(c *C) {
 	s.checkAccess(c, filepath.Join(s.fakeHome, ".config"), "hidden\n")
 }
 
+func (s *SnapRoutineFileAccessSuite) TestAccessHomeInterfaceAppArmorPromptingUnsupportedOrDisabled(c *C) {
+	// Prompting supported but not enabled
+	s.setUpClient(c, false, true, false, true, false)
+	s.checkBasicAccess(c)
+
+	// Access to non-hidden files in the home directory
+	s.checkAccess(c, s.fakeHome, "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/foo.txt"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/.hidden"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, ".config"), "hidden\n")
+
+	// Prompting enabled but not supported
+	s.setUpClient(c, false, true, false, false, true)
+	s.checkBasicAccess(c)
+
+	// Access to non-hidden files in the home directory
+	s.checkAccess(c, s.fakeHome, "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/foo.txt"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/.hidden"), "read-write\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, ".config"), "hidden\n")
+}
+
+func (s *SnapRoutineFileAccessSuite) TestAccessHomeInterfaceAppArmorPromptingSupportedAndEnabled(c *C) {
+	s.setUpClient(c, false, true, false, true, true)
+	s.checkBasicAccess(c)
+
+	// Access to non-hidden files in the home directory
+	s.checkAccess(c, s.fakeHome, "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/foo.txt"), "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, "Documents/.hidden"), "hidden\n")
+	s.checkAccess(c, filepath.Join(s.fakeHome, ".config"), "hidden\n")
+}
+
 func (s *SnapRoutineFileAccessSuite) TestAccessRemovableMedia(c *C) {
-	s.setUpClient(c, false, false, true)
+	s.setUpClient(c, false, false, true, false, false)
 	s.checkBasicAccess(c)
 
 	s.checkAccess(c, "/mnt", "read-write\n")


### PR DESCRIPTION
`snap routine file-access` is used by the xdg-document-portal to decide whether files can be accessed directly or whether they should be proxied.

When a user selects a file via the document portal, that intent is explicit. Thus, if prompting is enabled, we do not want to present the user with another prompt when they try to access the file they just selected.

Therefore, we need `snap routine file-access` to report that files accessible via the "home" interface are "hidden" when prompting is enabled.

This commit does so by checking /v2/system-info and using prompting support and enablement to decide whether prompting is running, and then using that value to decide whether to return "read-write" or "hidden" for paths granted by the home interface.

This issue was originally raised by @3v1n0.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36467
