### PR TITLE
seclog: add seclog with nop implementation (part 1)

### DIFF
--- a/seclog/nop.go
+++ b/seclog/nop.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+// nopLogger provides a no-operation [SecurityLogger] implementation.
+type nopLogger struct{}
+
+// Ensure [nopLogger] implements [SecurityLogger].
+var _ SecurityLogger = (*nopLogger)(nil)
+
+func NewNopLogger() SecurityLogger {
+	return nopLogger{}
+}
+
+// LogAny implements [SecurityLogger.LogAny].
+func (nopLogger) LogAny(event Event, description string, attrs ...Attr) {
+}

--- a/seclog/nop.go
+++ b/seclog/nop.go
@@ -25,6 +25,7 @@ type nopLogger struct{}
 // Ensure [nopLogger] implements [SecurityLogger].
 var _ SecurityLogger = (*nopLogger)(nil)
 
+// NewNopLogger returns a [SecurityLogger] that silently discards all events.
 func NewNopLogger() SecurityLogger {
 	return nopLogger{}
 }

--- a/seclog/nop_test.go
+++ b/seclog/nop_test.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type NopSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&NopSuite{})
+
+func (s *NopSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+}
+
+func (s *NopSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *NopSuite) TestLogLoggerEnabled(c *C) {
+	logger := seclog.NewNopLogger()
+	c.Assert(logger, NotNil)
+
+	// nop logger discards all messages without error
+	logger.LogAny(
+		seclog.Event{Category: "SYS", Name: "sys_logging_enabled", Level: seclog.LevelInfo},
+		"Security logging enabled",
+	)
+}
+
+func (s *NopSuite) TestLogLoggerDisabled(c *C) {
+	logger := seclog.NewNopLogger()
+	c.Assert(logger, NotNil)
+
+	// nop logger discards all messages without error
+	logger.LogAny(
+		seclog.Event{Category: "SYS", Name: "sys_logging_disabled", Level: seclog.LevelCritical},
+		"Security logging disabled",
+	)
+}
+
+func (s *NopSuite) TestLogLoginSuccess(c *C) {
+	logger := seclog.NewNopLogger()
+	c.Assert(logger, NotNil)
+
+	// nop logger discards all messages without error
+	logger.LogAny(
+		seclog.Event{Category: "AUTHN", Name: "authn_login_success", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "user", Value: seclog.SnapdUser{StoreUserEmail: "user@gmail.com"}},
+	)
+}
+
+func (s *NopSuite) TestLogLoginFailure(c *C) {
+	logger := seclog.NewNopLogger()
+	c.Assert(logger, NotNil)
+
+	// nop logger discards all messages without error
+	logger.LogAny(
+		seclog.Event{Category: "AUTHN", Name: "authn_login_failure", Level: seclog.LevelWarn},
+		"test",
+		seclog.Attr{Key: "user", Value: seclog.SnapdUser{StoreUserEmail: "user@gmail.com"}},
+		seclog.Attr{Key: "error", Value: seclog.Reason{}},
+	)
+}

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -27,6 +27,9 @@ import (
 	"github.com/snapcore/snapd/logger"
 )
 
+// unknown is the placeholder for empty fields in descriptions.
+const unknown = "<unknown>"
+
 // Level is the importance or severity of a log event.
 // The higher the level, the more severe the event.
 type Level int
@@ -40,9 +43,7 @@ const (
 	LevelCritical Level = 5
 )
 
-// String returns a name for the level. If the level has a name, then that name
-// in uppercase is returned. Otherwise, a string of the form "UKNOWN(<number>)"
-// is returned.
+// String returns a name for the level.
 func (l Level) String() string {
 	switch l {
 	case LevelDebug:
@@ -61,9 +62,6 @@ func (l Level) String() string {
 }
 
 // SnapdUser represents the identity of a user for security log events.
-// The slog output schema is defined by [SnapdUser.LogValue], which
-// renders Expiration as "never" for zero values instead of emitting a
-// zero-value datetime.
 type SnapdUser struct {
 	ID             int64     `json:"snapd-user-id"`
 	StoreUserName  string    `json:"store-user-name"`
@@ -73,10 +71,8 @@ type SnapdUser struct {
 
 // String returns a colon-separated description of the user in the form
 // "<ID>:<StoreUserEmail>:<StoreUserName>". Fields that are unset use
-// "unknown" as a placeholder. A zero ID is treated as unset.
+// "<unknown>" as a placeholder. A zero ID means unset.
 func (u SnapdUser) String() string {
-	const unknown = "unknown"
-
 	id := unknown
 	if u.ID != 0 {
 		id = fmt.Sprintf("%d", u.ID)
@@ -115,8 +111,6 @@ type Reason struct {
 // "<Code>:<Message>". Fields that are unset use "unknown" as a
 // placeholder.
 func (r Reason) String() string {
-	const unknown = "unknown"
-
 	code := unknown
 	if r.Code != "" {
 		code = r.Code
@@ -156,7 +150,8 @@ type SecurityLogger interface {
 
 var (
 	globalLogger SecurityLogger = NewNopLogger()
-	lock         sync.Mutex
+	// lock guards globalLogger reads and writes.
+	lock sync.Mutex
 )
 
 // Setup activates the security logger, replacing any previously
@@ -172,10 +167,11 @@ func Setup(l SecurityLogger) {
 
 // LogLoggerEnabled logs that the security logger has been enabled.
 func LogLoggerEnabled() {
+	logger.Noticef("security logger enabled")
+
 	lock.Lock()
 	defer lock.Unlock()
 
-	logger.Noticef("security logger enabled")
 	globalLogger.LogAny(
 		Event{Category: "SYS", Name: "sys_logging_enabled", Level: LevelInfo},
 		"Security logging enabled",
@@ -184,10 +180,11 @@ func LogLoggerEnabled() {
 
 // LogLoggerDisabled logs that the security logger has been disabled.
 func LogLoggerDisabled() {
+	logger.Noticef("security logger disabled")
+
 	lock.Lock()
 	defer lock.Unlock()
 
-	logger.Noticef("security logger disabled")
 	globalLogger.LogAny(
 		Event{Category: "SYS", Name: "sys_logging_disabled", Level: LevelCritical},
 		"Security logging disabled",

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -41,27 +41,22 @@ const (
 )
 
 // String returns a name for the level. If the level has a name, then that name
-// in uppercase is returned. If the level is between named values, then an
-// integer is appended to the uppercased name.
+// in uppercase is returned. Otherwise, a string of the form "UKNOWN(<number>)"
+// is returned.
 func (l Level) String() string {
-	str := func(base string, val Level) string {
-		if val == 0 {
-			return base
-		}
-		return fmt.Sprintf("%s%+d", base, val)
-	}
-
-	switch {
-	case l < LevelInfo:
-		return str("DEBUG", l-LevelDebug)
-	case l < LevelWarn:
-		return str("INFO", l-LevelInfo)
-	case l < LevelError:
-		return str("WARN", l-LevelWarn)
-	case l < LevelCritical:
-		return str("ERROR", l-LevelError)
+	switch l {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	case LevelCritical:
+		return "CRITICAL"
 	default:
-		return str("CRITICAL", l-LevelCritical)
+		return fmt.Sprintf("UNKNOWN(%d)", int(l))
 	}
 }
 

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -1,0 +1,225 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/logger"
+)
+
+// Level is the importance or severity of a log event.
+// The higher the level, the more severe the event.
+type Level int
+
+// Log levels.
+const (
+	LevelDebug    Level = 1
+	LevelInfo     Level = 2
+	LevelWarn     Level = 3
+	LevelError    Level = 4
+	LevelCritical Level = 5
+)
+
+// String returns a name for the level. If the level has a name, then that name
+// in uppercase is returned. If the level is between named values, then an
+// integer is appended to the uppercased name.
+func (l Level) String() string {
+	str := func(base string, val Level) string {
+		if val == 0 {
+			return base
+		}
+		return fmt.Sprintf("%s%+d", base, val)
+	}
+
+	switch {
+	case l < LevelInfo:
+		return str("DEBUG", l-LevelDebug)
+	case l < LevelWarn:
+		return str("INFO", l-LevelInfo)
+	case l < LevelError:
+		return str("WARN", l-LevelWarn)
+	case l < LevelCritical:
+		return str("ERROR", l-LevelError)
+	default:
+		return str("CRITICAL", l-LevelCritical)
+	}
+}
+
+// SnapdUser represents the identity of a user for security log events.
+// The slog output schema is defined by [SnapdUser.LogValue], which
+// renders Expiration as "never" for zero values instead of emitting a
+// zero-value datetime.
+type SnapdUser struct {
+	ID             int64     `json:"snapd-user-id"`
+	StoreUserName  string    `json:"store-user-name"`
+	StoreUserEmail string    `json:"store-user-email"`
+	Expiration     time.Time `json:"expiration"`
+}
+
+// String returns a colon-separated description of the user in the form
+// "<ID>:<StoreUserEmail>:<StoreUserName>". Fields that are unset use
+// "unknown" as a placeholder. A zero ID is treated as unset.
+func (u SnapdUser) String() string {
+	const unknown = "unknown"
+
+	id := unknown
+	if u.ID != 0 {
+		id = fmt.Sprintf("%d", u.ID)
+	}
+
+	email := unknown
+	if u.StoreUserEmail != "" {
+		email = u.StoreUserEmail
+	}
+
+	name := unknown
+	if u.StoreUserName != "" {
+		name = u.StoreUserName
+	}
+
+	return id + ":" + email + ":" + name
+}
+
+// Reason codes are stable identifiers for security audit events.
+const (
+	ReasonInvalidCredentials = "invalid-credentials"
+	ReasonTwoFactorRequired  = "two-factor-required"
+	ReasonTwoFactorFailed    = "two-factor-failed"
+	ReasonInvalidAuthData    = "invalid-auth-data"
+	ReasonPasswordPolicy     = "password-policy"
+	ReasonInternal           = "internal"
+)
+
+// Reason describes why a security event happened.
+type Reason struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// String returns a colon-separated representation in the form
+// "<Code>:<Message>". Fields that are unset use "unknown" as a
+// placeholder.
+func (r Reason) String() string {
+	const unknown = "unknown"
+
+	code := unknown
+	if r.Code != "" {
+		code = r.Code
+	}
+
+	message := unknown
+	if r.Message != "" {
+		message = r.Message
+	}
+
+	return code + ":" + message
+}
+
+// Event describes a structured security audit event.
+//
+// A Version field may be added in the future if a log aggregator or
+// consumer requires explicit schema versioning.
+type Event struct {
+	Category string `json:"category"`
+	Name     string `json:"event"`
+	Level    Level  `json:"level"`
+}
+
+// Attr is a key-value pair attached to a security log event.
+type Attr struct {
+	Key   string
+	Value any
+}
+
+// SecurityLogger defines the interface for emitting structured security
+// audit events. Implementations receive a fully described [Event] and
+// optional [Attr] values, so new event types can be added without
+// changing the interface.
+type SecurityLogger interface {
+	LogAny(event Event, description string, attrs ...Attr)
+}
+
+var (
+	globalLogger SecurityLogger = NewNopLogger()
+	lock         sync.Mutex
+)
+
+// Setup activates the security logger, replacing any previously
+// configured logger.
+//
+// Setup is intended to be called once during early initialization.
+func Setup(l SecurityLogger) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger = l
+}
+
+// LogLoggerEnabled logs that the security logger has been enabled.
+func LogLoggerEnabled() {
+	lock.Lock()
+	defer lock.Unlock()
+
+	logger.Noticef("security logger enabled")
+	globalLogger.LogAny(
+		Event{Category: "SYS", Name: "sys_logging_enabled", Level: LevelInfo},
+		"Security logging enabled",
+	)
+}
+
+// LogLoggerDisabled logs that the security logger has been disabled.
+func LogLoggerDisabled() {
+	lock.Lock()
+	defer lock.Unlock()
+
+	logger.Noticef("security logger disabled")
+	globalLogger.LogAny(
+		Event{Category: "SYS", Name: "sys_logging_disabled", Level: LevelCritical},
+		"Security logging disabled",
+	)
+}
+
+// LogLoginSuccess logs a successful login using the global security logger.
+func LogLoginSuccess(user SnapdUser) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogAny(
+		Event{Category: "AUTHN", Name: "authn_login_success", Level: LevelInfo},
+		fmt.Sprintf("User %s login success", user.String()),
+		Attr{Key: "user", Value: user},
+	)
+}
+
+// LogLoginFailure logs a failed login attempt using the global security logger.
+func LogLoginFailure(user SnapdUser, reason Reason) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogAny(
+		Event{Category: "AUTHN", Name: "authn_login_failure", Level: LevelWarn},
+		fmt.Sprintf("User %s login failure: %s", user.String(), reason.String()),
+		Attr{Key: "user", Value: user},
+		Attr{Key: "error", Value: reason},
+	)
+}

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -46,7 +46,7 @@ func (s *SecLogSuite) SetUpTest(c *C) {
 	// No cleanup of the global logger is needed: every suite that
 	// uses seclog calls Setup in its own SetUpTest, replacing any
 	// leftover logger from a previous suite.
-	seclog.Setup(seclogtest.NewMockSecurityLogger(s.buf))
+	seclog.Setup(seclogtest.MockSecurityLogger(s.buf))
 }
 
 func (s *SecLogSuite) TearDownTest(c *C) {
@@ -76,8 +76,6 @@ func (s *SecLogSuite) TestString(c *C) {
 		"UNKNOWN(7)",
 	}
 
-	c.Assert(len(levels), Equals, len(expected))
-
 	obtained := make([]string, 0, len(levels))
 
 	for _, level := range levels {
@@ -93,17 +91,17 @@ func (s *SecLogSuite) TestSnapdUserString(c *C) {
 		ID: 42, StoreUserEmail: "a@b.com", StoreUserName: "jdoe",
 	}.String(), Equals, "42:a@b.com:jdoe")
 
-	// All fields zero/empty — all "unknown".
-	c.Check(seclog.SnapdUser{}.String(), Equals, "unknown:unknown:unknown")
+	// All fields zero/empty — all "<unknown>".
+	c.Check(seclog.SnapdUser{}.String(), Equals, "<unknown>:<unknown>:<unknown>")
 
 	// Only ID set.
-	c.Check(seclog.SnapdUser{ID: 7}.String(), Equals, "7:unknown:unknown")
+	c.Check(seclog.SnapdUser{ID: 7}.String(), Equals, "7:<unknown>:<unknown>")
 
 	// Only email set.
-	c.Check(seclog.SnapdUser{StoreUserEmail: "x@y.z"}.String(), Equals, "unknown:x@y.z:unknown")
+	c.Check(seclog.SnapdUser{StoreUserEmail: "x@y.z"}.String(), Equals, "<unknown>:x@y.z:<unknown>")
 
 	// Only username set.
-	c.Check(seclog.SnapdUser{StoreUserName: "root"}.String(), Equals, "unknown:unknown:root")
+	c.Check(seclog.SnapdUser{StoreUserName: "root"}.String(), Equals, "<unknown>:<unknown>:root")
 }
 
 func (s *SecLogSuite) TestReasonString(c *C) {
@@ -112,14 +110,14 @@ func (s *SecLogSuite) TestReasonString(c *C) {
 		Code: seclog.ReasonInvalidCredentials, Message: "bad password",
 	}.String(), Equals, "invalid-credentials:bad password")
 
-	// Both fields empty — all "unknown".
-	c.Check(seclog.Reason{}.String(), Equals, "unknown:unknown")
+	// Both fields empty — all "<unknown>".
+	c.Check(seclog.Reason{}.String(), Equals, "<unknown>:<unknown>")
 
 	// Only code set.
-	c.Check(seclog.Reason{Code: seclog.ReasonInternal}.String(), Equals, "internal:unknown")
+	c.Check(seclog.Reason{Code: seclog.ReasonInternal}.String(), Equals, "internal:<unknown>")
 
 	// Only message set.
-	c.Check(seclog.Reason{Message: "something broke"}.String(), Equals, "unknown:something broke")
+	c.Check(seclog.Reason{Message: "something broke"}.String(), Equals, "<unknown>:something broke")
 }
 
 func (s *SecLogSuite) TestSetupSuccess(c *C) {
@@ -134,7 +132,7 @@ func (s *SecLogSuite) TestSetupReplacesExistingLogger(c *C) {
 
 	// Replace with a second logger.
 	secondBuf := &bytes.Buffer{}
-	seclog.Setup(seclogtest.NewMockSecurityLogger(secondBuf))
+	seclog.Setup(seclogtest.MockSecurityLogger(secondBuf))
 
 	// New events go to the second logger, not the first.
 	s.buf.Reset()

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -1,0 +1,199 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SecLogSuite struct {
+	testutil.BaseTest
+	buf *bytes.Buffer
+}
+
+var _ = Suite(&SecLogSuite{})
+
+func TestSecLog(t *testing.T) { TestingT(t) }
+
+func (s *SecLogSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.buf = &bytes.Buffer{}
+	// No cleanup of the global logger is needed: every suite that
+	// uses seclog calls Setup in its own SetUpTest, replacing any
+	// leftover logger from a previous suite.
+	seclog.Setup(seclogtest.NewMockSecurityLogger(s.buf))
+}
+
+func (s *SecLogSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *SecLogSuite) TestString(c *C) {
+	levels := []seclog.Level{
+		seclog.LevelDebug - 1,
+		seclog.LevelDebug,
+		seclog.LevelInfo,
+		seclog.LevelWarn,
+		seclog.LevelError,
+		seclog.LevelError + 1,
+		seclog.LevelCritical,
+		seclog.LevelCritical + 2,
+	}
+
+	expected := []string{
+		"DEBUG-1",
+		"DEBUG",
+		"INFO",
+		"WARN",
+		"ERROR",
+		"CRITICAL",
+		"CRITICAL",
+		"CRITICAL+2",
+	}
+
+	c.Assert(len(levels), Equals, len(expected))
+
+	obtained := make([]string, 0, len(levels))
+
+	for _, level := range levels {
+		obtained = append(obtained, level.String())
+	}
+
+	c.Assert(expected, DeepEquals, obtained)
+}
+
+func (s *SecLogSuite) TestSnapdUserString(c *C) {
+	// All fields set.
+	c.Check(seclog.SnapdUser{
+		ID: 42, StoreUserEmail: "a@b.com", StoreUserName: "jdoe",
+	}.String(), Equals, "42:a@b.com:jdoe")
+
+	// All fields zero/empty — all "unknown".
+	c.Check(seclog.SnapdUser{}.String(), Equals, "unknown:unknown:unknown")
+
+	// Only ID set.
+	c.Check(seclog.SnapdUser{ID: 7}.String(), Equals, "7:unknown:unknown")
+
+	// Only email set.
+	c.Check(seclog.SnapdUser{StoreUserEmail: "x@y.z"}.String(), Equals, "unknown:x@y.z:unknown")
+
+	// Only username set.
+	c.Check(seclog.SnapdUser{StoreUserName: "root"}.String(), Equals, "unknown:unknown:root")
+}
+
+func (s *SecLogSuite) TestReasonString(c *C) {
+	// Both fields set.
+	c.Check(seclog.Reason{
+		Code: seclog.ReasonInvalidCredentials, Message: "bad password",
+	}.String(), Equals, "invalid-credentials:bad password")
+
+	// Both fields empty — all "unknown".
+	c.Check(seclog.Reason{}.String(), Equals, "unknown:unknown")
+
+	// Only code set.
+	c.Check(seclog.Reason{Code: seclog.ReasonInternal}.String(), Equals, "internal:unknown")
+
+	// Only message set.
+	c.Check(seclog.Reason{Message: "something broke"}.String(), Equals, "unknown:something broke")
+}
+
+func (s *SecLogSuite) TestSetupSuccess(c *C) {
+	seclog.LogLoginSuccess(seclog.SnapdUser{ID: 1, StoreUserName: "testuser"})
+	c.Check(s.buf.Len() > 0, Equals, true)
+}
+
+func (s *SecLogSuite) TestSetupReplacesExistingLogger(c *C) {
+	// The first logger was set up in SetUpTest; verify it receives events.
+	seclog.LogLoginSuccess(seclog.SnapdUser{ID: 1, StoreUserName: "first"})
+	c.Check(s.buf.String(), testutil.Contains, "authn_login_success")
+
+	// Replace with a second logger.
+	secondBuf := &bytes.Buffer{}
+	seclog.Setup(seclogtest.NewMockSecurityLogger(secondBuf))
+
+	// New events go to the second logger, not the first.
+	s.buf.Reset()
+	seclog.LogLoginSuccess(seclog.SnapdUser{ID: 2, StoreUserName: "second"})
+	c.Check(secondBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.buf.Len(), Equals, 0)
+}
+
+func (s *SecLogSuite) TestLogLoginSuccess(c *C) {
+	user := seclog.SnapdUser{
+		ID:             42,
+		StoreUserEmail: "user@example.com",
+		StoreUserName:  "jdoe",
+	}
+	seclog.LogLoginSuccess(user)
+
+	c.Check(s.buf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.buf.String(), testutil.Contains, "user@example.com")
+}
+
+func (s *SecLogSuite) TestLogLoginFailure(c *C) {
+	user := seclog.SnapdUser{
+		ID:             42,
+		StoreUserEmail: "user@example.com",
+		StoreUserName:  "jdoe",
+	}
+	seclog.LogLoginFailure(user, seclog.Reason{Code: seclog.ReasonInvalidCredentials, Message: "invalid credentials"})
+
+	c.Check(s.buf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.buf.String(), testutil.Contains, "user@example.com")
+	c.Check(s.buf.String(), testutil.Contains, seclog.ReasonInvalidCredentials)
+}
+
+func (s *SecLogSuite) TestLogLoggerEnabledLogsEvent(c *C) {
+	seclog.LogLoggerEnabled()
+
+	c.Check(s.buf.String(), testutil.Contains, "sys_logging_enabled")
+}
+
+func (s *SecLogSuite) TestLogLoggerEnabledLogsToStandardLogger(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	seclog.LogLoggerEnabled()
+
+	c.Check(logBuf.String(), testutil.Contains, "security logger enabled")
+}
+
+func (s *SecLogSuite) TestLogLoggerDisabledLogsEvent(c *C) {
+	seclog.LogLoggerDisabled()
+
+	c.Check(s.buf.String(), testutil.Contains, "sys_logging_disabled")
+}
+
+func (s *SecLogSuite) TestLogLoggerDisabledLogsToStandardLogger(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	seclog.LogLoggerDisabled()
+
+	c.Check(logBuf.String(), testutil.Contains, "security logger disabled")
+}

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -66,14 +66,14 @@ func (s *SecLogSuite) TestString(c *C) {
 	}
 
 	expected := []string{
-		"DEBUG-1",
+		"UNKNOWN(0)",
 		"DEBUG",
 		"INFO",
 		"WARN",
 		"ERROR",
 		"CRITICAL",
 		"CRITICAL",
-		"CRITICAL+2",
+		"UNKNOWN(7)",
 	}
 
 	c.Assert(len(levels), Equals, len(expected))

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package seclogtest provides helpers for testing code that emits
+// security audit events via the seclog package.
+package seclogtest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/snapcore/snapd/seclog"
+)
+
+// MockSecurityLogger implements seclog.SecurityLogger and writes event
+// names plus key identifying data to a buffer. This lets tests verify
+// that the right events are emitted without depending on slog or JSON.
+type MockSecurityLogger struct {
+	buf *bytes.Buffer
+}
+
+// Ensure MockSecurityLogger implements seclog.SecurityLogger.
+var _ seclog.SecurityLogger = (*MockSecurityLogger)(nil)
+
+// NewMockSecurityLogger returns a MockSecurityLogger that writes to the
+// given buffer.
+func NewMockSecurityLogger(buf *bytes.Buffer) *MockSecurityLogger {
+	return &MockSecurityLogger{buf: buf}
+}
+
+// LogAny implements [seclog.SecurityLogger.LogAny].
+func (m *MockSecurityLogger) LogAny(event seclog.Event, description string, attrs ...seclog.Attr) {
+	fmt.Fprintf(m.buf, "%s %s", event.Name, description)
+	for _, a := range attrs {
+		fmt.Fprintf(m.buf, " [%s=%#v]", a.Key, a.Value)
+	}
+	fmt.Fprintln(m.buf)
+}
+
+// NewMockSlogLogger returns a buffer and a constructor function matching the
+// seclog.NewSlogLogger signature. The constructor ignores its arguments and
+// returns a MockSecurityLogger backed by the buffer. This is intended for
+// mocking the newSlogLogger variable in tests.
+func NewMockSlogLogger() (*bytes.Buffer, func(io.Writer, string, seclog.Level) seclog.SecurityLogger) {
+	buf := &bytes.Buffer{}
+	fn := func(_ io.Writer, _ string, _ seclog.Level) seclog.SecurityLogger {
+		return NewMockSecurityLogger(buf)
+	}
+	return buf, fn
+}

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -29,24 +29,24 @@ import (
 	"github.com/snapcore/snapd/seclog"
 )
 
-// MockSecurityLogger implements seclog.SecurityLogger and writes event
+// mockLogger implements seclog.SecurityLogger and writes event
 // names plus key identifying data to a buffer. This lets tests verify
 // that the right events are emitted without depending on slog or JSON.
-type MockSecurityLogger struct {
+type mockLogger struct {
 	buf *bytes.Buffer
 }
 
-// Ensure MockSecurityLogger implements seclog.SecurityLogger.
-var _ seclog.SecurityLogger = (*MockSecurityLogger)(nil)
+// Ensure mockLogger implements seclog.SecurityLogger.
+var _ seclog.SecurityLogger = (*mockLogger)(nil)
 
-// NewMockSecurityLogger returns a MockSecurityLogger that writes to the
+// MockSecurityLogger returns a [seclog.SecurityLogger] that writes to the
 // given buffer.
-func NewMockSecurityLogger(buf *bytes.Buffer) *MockSecurityLogger {
-	return &MockSecurityLogger{buf: buf}
+func MockSecurityLogger(buf *bytes.Buffer) seclog.SecurityLogger {
+	return &mockLogger{buf: buf}
 }
 
 // LogAny implements [seclog.SecurityLogger.LogAny].
-func (m *MockSecurityLogger) LogAny(event seclog.Event, description string, attrs ...seclog.Attr) {
+func (m *mockLogger) LogAny(event seclog.Event, description string, attrs ...seclog.Attr) {
 	fmt.Fprintf(m.buf, "%s %s", event.Name, description)
 	for _, a := range attrs {
 		fmt.Fprintf(m.buf, " [%s=%#v]", a.Key, a.Value)
@@ -54,14 +54,14 @@ func (m *MockSecurityLogger) LogAny(event seclog.Event, description string, attr
 	fmt.Fprintln(m.buf)
 }
 
-// NewMockSlogLogger returns a buffer and a constructor function matching the
+// MockSlogLogger returns a buffer and a constructor function matching the
 // seclog.NewSlogLogger signature. The constructor ignores its arguments and
-// returns a MockSecurityLogger backed by the buffer. This is intended for
+// returns a mockLogger backed by the buffer. This is intended for
 // mocking the newSlogLogger variable in tests.
-func NewMockSlogLogger() (*bytes.Buffer, func(io.Writer, string, seclog.Level) seclog.SecurityLogger) {
+func MockSlogLogger() (*bytes.Buffer, func(io.Writer, string, seclog.Level) seclog.SecurityLogger) {
 	buf := &bytes.Buffer{}
-	fn := func(_ io.Writer, _ string, _ seclog.Level) seclog.SecurityLogger {
-		return NewMockSecurityLogger(buf)
+	fn := func(io.Writer, string, seclog.Level) seclog.SecurityLogger {
+		return MockSecurityLogger(buf)
 	}
 	return buf, fn
 }


### PR DESCRIPTION
### Implement security logging: Part 1

This PR introduces a dedicated security/audit logging subsystem:
- Stable schema enforced by the package +slog implementation. Can add event version when required without breaking compat.
- Generic interface between seclog API and implementations that can easily be used with typical slog alternatives.
- Snapd emits security audit events into the system audit pipeline rather than implementing persistence/rotation policy (handled by auditd/journald configuration). Events are sent fire-and-forget (no netlink ACK). We can implement ACK in the future.
- Deals seemlessly with absence of slog in go < 1.21, both with implementation and tests. Tests uses very mock implementation to avoid tying to slog specifically.

See complete implementation for reference: https://github.com/ernestl/snapd/pull/5/changes

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35756
Spec: https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0