### PR TITLE
seclog: add slog implementation and audit sink (part 2)

### DIFF
--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -60,7 +60,7 @@ func (realNetlinkOps) Close(fd int) error {
 
 var netlink netlinkOps = realNetlinkOps{}
 
-// OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
+// OpenAuditWriter opens a netlink audit socket and returns an [io.WriteCloser]
 // that sends each written payload as an AUDIT_TRUSTED_APP.
 func OpenAuditWriter() (io.WriteCloser, error) {
 	// SOCK_CLOEXEC prevents the fd from leaking to child processes.
@@ -71,11 +71,7 @@ func OpenAuditWriter() (io.WriteCloser, error) {
 	return &AuditWriter{fd: fd}, nil
 }
 
-// AuditWriter sends messages to the kernel audit subsystem via a netlink
-// socket. Each Write call sends the payload as an AUDIT_TRUSTED_APP.
-//
-// The writer is safe for sequential use; concurrent use requires external
-// synchronization.
+// AuditWriter implements [io.WriteCloser].
 type AuditWriter struct {
 	fd  int
 	seq atomic.Uint32
@@ -83,12 +79,14 @@ type AuditWriter struct {
 
 // Write sends payload as an AUDIT_TRUSTED_APP netlink message.
 // The returned byte count reflects only the original payload length.
+// Concurrent use requires external synchronization.
 func (aw *AuditWriter) Write(payload []byte) (int, error) {
 	msg := aw.buildMessage(payload)
 	addr := &syscall.SockaddrNetlink{
 		Family: syscall.AF_NETLINK,
 		Pid:    0, // kernel
 	}
+	// TODO: request and handle ACK from kernel audit subsystem
 	if err := netlink.Sendto(aw.fd, msg, 0, addr); err != nil {
 		return 0, fmt.Errorf("cannot send audit message: %v", err)
 	}

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -33,31 +33,31 @@ const (
 	auditTrustedApp = 1121
 )
 
-// netlinkOps abstracts the syscall operations needed to open,
-// send to, and close a netlink socket. Production code uses [realNetlinkOps];
+// syscallOps abstracts the syscall operations needed to open,
+// send to, and close a netlink socket. Production code uses [realSyscallOps];
 // tests can substitute a recording or stubbing implementation.
-type netlinkOps interface {
+type syscallOps interface {
 	Socket(domain, typ, proto int) (int, error)
 	Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error
 	Close(fd int) error
 }
 
-// realNetlinkOps delegates every operation to the corresponding syscall.
-type realNetlinkOps struct{}
+// realSyscallOps delegates every operation to the corresponding syscall.
+type realSyscallOps struct{}
 
-func (realNetlinkOps) Socket(domain, typ, proto int) (int, error) {
+func (realSyscallOps) Socket(domain, typ, proto int) (int, error) {
 	return syscall.Socket(domain, typ, proto)
 }
 
-func (realNetlinkOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
+func (realSyscallOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
 	return syscall.Sendto(fd, payload, flags, to)
 }
 
-func (realNetlinkOps) Close(fd int) error {
+func (realSyscallOps) Close(fd int) error {
 	return syscall.Close(fd)
 }
 
-var netlink netlinkOps = realNetlinkOps{}
+var sys syscallOps = realSyscallOps{}
 
 // AuditWriter implements [io.WriteCloser].
 type AuditWriter struct {
@@ -69,7 +69,7 @@ type AuditWriter struct {
 // that sends each written payload as an AUDIT_TRUSTED_APP.
 func OpenAuditWriter() (*AuditWriter, error) {
 	// SOCK_CLOEXEC prevents the fd from leaking to child processes.
-	fd, err := netlink.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, syscall.NETLINK_AUDIT)
+	fd, err := sys.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, syscall.NETLINK_AUDIT)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open audit socket: %v", err)
 	}
@@ -86,7 +86,7 @@ func (aw *AuditWriter) Write(payload []byte) (int, error) {
 		Pid:    0, // kernel
 	}
 	// TODO: request and handle ACK from kernel audit subsystem
-	if err := netlink.Sendto(aw.fd, msg, 0, addr); err != nil {
+	if err := sys.Sendto(aw.fd, msg, 0, addr); err != nil {
 		return 0, fmt.Errorf("cannot send audit message: %v", err)
 	}
 	return len(payload), nil
@@ -94,7 +94,7 @@ func (aw *AuditWriter) Write(payload []byte) (int, error) {
 
 // Close closes the underlying netlink socket.
 func (aw *AuditWriter) Close() error {
-	return netlink.Close(aw.fd)
+	return sys.Close(aw.fd)
 }
 
 // buildMessage constructs a raw netlink message containing the given payload.

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -62,7 +62,7 @@ var sys syscallOps = realSyscallOps{}
 // AuditWriter implements [io.WriteCloser].
 type AuditWriter struct {
 	fd  int
-	seq atomic.Uint32
+	seq uint32
 }
 
 // OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
@@ -133,9 +133,9 @@ func nlmsgAlign(size uint32) uint32 {
 // nextSeq returns the next non-zero sequence number, skipping zero on
 // wrap to allow unambiguous ACK matching (mirrors audit-userspace).
 func (aw *AuditWriter) nextSeq() uint32 {
-	s := aw.seq.Add(1)
+	s := atomic.AddUint32(&aw.seq, 1)
 	if s == 0 {
-		s = aw.seq.Add(1)
+		s = atomic.AddUint32(&aw.seq, 1)
 	}
 	return s
 }

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -21,7 +21,6 @@ package seclog
 
 import (
 	"fmt"
-	"io"
 	"sync/atomic"
 	"syscall"
 
@@ -60,9 +59,9 @@ func (realNetlinkOps) Close(fd int) error {
 
 var netlink netlinkOps = realNetlinkOps{}
 
-// OpenAuditWriter opens a netlink audit socket and returns an [io.WriteCloser]
+// OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
 // that sends each written payload as an AUDIT_TRUSTED_APP.
-func OpenAuditWriter() (io.WriteCloser, error) {
+func OpenAuditWriter() (*AuditWriter, error) {
 	// SOCK_CLOEXEC prevents the fd from leaking to child processes.
 	fd, err := netlink.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, syscall.NETLINK_AUDIT)
 	if err != nil {

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -1,0 +1,127 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/snapcore/snapd/arch"
+)
+
+const (
+	// AUDIT_TRUSTED_APP is the audit message type for trusted application messages.
+	// See https://github.com/linux-audit/audit-userspace/blob/a54613b2b6233669972d55f1f5463ae4757700be/lib/audit-records.h#L75
+	auditTrustedApp = 1121
+)
+
+// netlinkOps abstracts the syscall operations needed to open,
+// send to, and close a netlink socket. Production code uses [realNetlinkOps];
+// tests can substitute a recording or stubbing implementation.
+type netlinkOps interface {
+	Socket(domain, typ, proto int) (int, error)
+	Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error
+	Close(fd int) error
+}
+
+// realNetlinkOps delegates every operation to the corresponding syscall.
+type realNetlinkOps struct{}
+
+func (realNetlinkOps) Socket(domain, typ, proto int) (int, error) {
+	return syscall.Socket(domain, typ, proto)
+}
+
+func (realNetlinkOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
+	return syscall.Sendto(fd, payload, flags, to)
+}
+
+func (realNetlinkOps) Close(fd int) error {
+	return syscall.Close(fd)
+}
+
+var netlink netlinkOps = realNetlinkOps{}
+
+// OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
+// that sends each written payload as an AUDIT_TRUSTED_APP.
+func OpenAuditWriter() (io.WriteCloser, error) {
+	// SOCK_CLOEXEC prevents the fd from leaking to child processes.
+	fd, err := netlink.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, syscall.NETLINK_AUDIT)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open audit socket: %v", err)
+	}
+	return &AuditWriter{fd: fd}, nil
+}
+
+// AuditWriter sends messages to the kernel audit subsystem via a netlink
+// socket. Each Write call sends the payload as an AUDIT_TRUSTED_APP.
+//
+// The writer is safe for sequential use; concurrent use requires external
+// synchronization.
+type AuditWriter struct {
+	fd  int
+	seq atomic.Uint32
+}
+
+// Write sends payload as an AUDIT_TRUSTED_APP netlink message.
+// The returned byte count reflects only the original payload length.
+func (aw *AuditWriter) Write(payload []byte) (int, error) {
+	msg := aw.buildMessage(payload)
+	addr := &syscall.SockaddrNetlink{
+		Family: syscall.AF_NETLINK,
+		Pid:    0, // kernel
+	}
+	if err := netlink.Sendto(aw.fd, msg, 0, addr); err != nil {
+		return 0, fmt.Errorf("cannot send audit message: %v", err)
+	}
+	return len(payload), nil
+}
+
+// Close closes the underlying netlink socket.
+func (aw *AuditWriter) Close() error {
+	return netlink.Close(aw.fd)
+}
+
+// buildMessage constructs a raw netlink message containing the given payload.
+// The header layout follows struct nlmsghdr from
+// https://github.com/torvalds/linux/blob/254f49634ee16a731174d2ae34bc50bd5f45e731/include/uapi/linux/netlink.h#L45
+func (aw *AuditWriter) buildMessage(payload []byte) []byte {
+	totalLen := syscall.SizeofNlMsghdr + uint32(len(payload))
+	buf := make([]byte, nlmsgAlign(totalLen))
+
+	// Write header in native byte order (netlink uses host endianness).
+	// TODO: Upgrade from fire-and-forget to use NLM_F_ACK and handle
+	// acknowledgments.
+	arch.Endian().PutUint32(buf[0:4], totalLen)
+	arch.Endian().PutUint16(buf[4:6], auditTrustedApp)
+	arch.Endian().PutUint16(buf[6:8], syscall.NLM_F_REQUEST) // fire-and-forget, no ACK
+	arch.Endian().PutUint32(buf[8:12], aw.seq.Add(1))
+	arch.Endian().PutUint32(buf[12:16], 0)
+
+	// Write payload.
+	copy(buf[syscall.SizeofNlMsghdr:], payload)
+	return buf
+}
+
+// nlmsgAlign rounds up to the nearest 4-byte boundary per NLMSG_ALIGN.
+func nlmsgAlign(size uint32) uint32 {
+	return (size + 3) &^ 3
+}

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -59,6 +59,12 @@ func (realNetlinkOps) Close(fd int) error {
 
 var netlink netlinkOps = realNetlinkOps{}
 
+// AuditWriter implements [io.WriteCloser].
+type AuditWriter struct {
+	fd  int
+	seq atomic.Uint32
+}
+
 // OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
 // that sends each written payload as an AUDIT_TRUSTED_APP.
 func OpenAuditWriter() (*AuditWriter, error) {
@@ -68,12 +74,6 @@ func OpenAuditWriter() (*AuditWriter, error) {
 		return nil, fmt.Errorf("cannot open audit socket: %v", err)
 	}
 	return &AuditWriter{fd: fd}, nil
-}
-
-// AuditWriter implements [io.WriteCloser].
-type AuditWriter struct {
-	fd  int
-	seq atomic.Uint32
 }
 
 // Write sends payload as an AUDIT_TRUSTED_APP netlink message.

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -60,9 +60,11 @@ func (realSyscallOps) Close(fd int) error {
 var sys syscallOps = realSyscallOps{}
 
 // AuditWriter implements [io.WriteCloser].
+// It must be created via [OpenAuditWriter]; the zero value is not usable.
 type AuditWriter struct {
-	fd  int
-	seq uint32
+	fd     int
+	seq    uint32
+	opened bool
 }
 
 // OpenAuditWriter opens a netlink audit socket and returns an [AuditWriter]
@@ -73,13 +75,16 @@ func OpenAuditWriter() (*AuditWriter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open audit socket: %v", err)
 	}
-	return &AuditWriter{fd: fd}, nil
+	return &AuditWriter{fd: fd, opened: true}, nil
 }
 
 // Write sends payload as an AUDIT_TRUSTED_APP netlink message.
 // The returned byte count reflects only the original payload length.
 // Concurrent use requires external synchronization.
 func (aw *AuditWriter) Write(payload []byte) (int, error) {
+	if !aw.opened {
+		return 0, fmt.Errorf("cannot send audit message: not open")
+	}
 	msg := aw.buildMessage(payload)
 	addr := &syscall.SockaddrNetlink{
 		Family: syscall.AF_NETLINK,
@@ -94,6 +99,10 @@ func (aw *AuditWriter) Write(payload []byte) (int, error) {
 
 // Close closes the underlying netlink socket.
 func (aw *AuditWriter) Close() error {
+	if !aw.opened {
+		return fmt.Errorf("cannot close audit writer: not open")
+	}
+	aw.opened = false
 	return sys.Close(aw.fd)
 }
 

--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -101,16 +101,23 @@ func (aw *AuditWriter) Close() error {
 // The header layout follows struct nlmsghdr from
 // https://github.com/torvalds/linux/blob/254f49634ee16a731174d2ae34bc50bd5f45e731/include/uapi/linux/netlink.h#L45
 func (aw *AuditWriter) buildMessage(payload []byte) []byte {
-	totalLen := syscall.SizeofNlMsghdr + uint32(len(payload))
-	buf := make([]byte, nlmsgAlign(totalLen))
+	// The kernel forcibly null-terminates the payload data. We include an extra
+	// byte to avoid overwriting message data.
+	totalLen := nlmsgAlign(syscall.SizeofNlMsghdr + uint32(len(payload)) + 1)
+	buf := make([]byte, totalLen)
 
 	// Write header in native byte order (netlink uses host endianness).
+	//   [0:4]   uint32 Length of message including header
+	//   [4:6]   uint16 Message content type
+	//   [6:8]   uint16 Flags
+	//   [8:12]  uint32 Sequence number
+	//   [12:16] uint32 Sending process port ID
 	// TODO: Upgrade from fire-and-forget to use NLM_F_ACK and handle
 	// acknowledgments.
 	arch.Endian().PutUint32(buf[0:4], totalLen)
 	arch.Endian().PutUint16(buf[4:6], auditTrustedApp)
-	arch.Endian().PutUint16(buf[6:8], syscall.NLM_F_REQUEST) // fire-and-forget, no ACK
-	arch.Endian().PutUint32(buf[8:12], aw.seq.Add(1))
+	arch.Endian().PutUint16(buf[6:8], syscall.NLM_F_REQUEST)
+	arch.Endian().PutUint32(buf[8:12], aw.nextSeq())
 	arch.Endian().PutUint32(buf[12:16], 0)
 
 	// Write payload.
@@ -121,4 +128,14 @@ func (aw *AuditWriter) buildMessage(payload []byte) []byte {
 // nlmsgAlign rounds up to the nearest 4-byte boundary per NLMSG_ALIGN.
 func nlmsgAlign(size uint32) uint32 {
 	return (size + 3) &^ 3
+}
+
+// nextSeq returns the next non-zero sequence number, skipping zero on
+// wrap to allow unambiguous ACK matching (mirrors audit-userspace).
+func (aw *AuditWriter) nextSeq() uint32 {
+	s := aw.seq.Add(1)
+	if s == 0 {
+		s = aw.seq.Add(1)
+	}
+	return s
 }

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -21,7 +21,6 @@ package seclog_test
 
 import (
 	"fmt"
-	"slices"
 	"syscall"
 
 	. "gopkg.in/check.v1"
@@ -49,7 +48,7 @@ func (m *mockSyscallOps) Socket(domain, typ, proto int) (int, error) {
 }
 
 func (m *mockSyscallOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
-	m.sendtoData = slices.Clone(payload)
+	m.sendtoData = append([]byte(nil), payload...)
 	return m.sendtoErr
 }
 

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -1,0 +1,222 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog_test
+
+import (
+	"fmt"
+	"slices"
+	"syscall"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/seclog"
+)
+
+type AuditSuite struct{}
+
+var _ = Suite(&AuditSuite{})
+
+// mockNetlinkOps records calls and returns configurable results.
+type mockNetlinkOps struct {
+	socketFD   int
+	socketErr  error
+	sendtoData []byte
+	sendtoErr  error
+	closedFDs  []int
+	closeErr   error
+}
+
+func (m *mockNetlinkOps) Socket(domain, typ, proto int) (int, error) {
+	return m.socketFD, m.socketErr
+}
+
+func (m *mockNetlinkOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
+	m.sendtoData = slices.Clone(payload)
+	return m.sendtoErr
+}
+
+func (m *mockNetlinkOps) Close(fd int) error {
+	m.closedFDs = append(m.closedFDs, fd)
+	return m.closeErr
+}
+
+// Ensure mockNetlinkOps satisfies the interface.
+var _ seclog.NetlinkOps = (*mockNetlinkOps)(nil)
+
+func (s *AuditSuite) TestOpenSuccess(c *C) {
+	mock := &mockNetlinkOps{
+		socketFD: 42,
+	}
+	restore := seclog.MockNetlinkOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+	c.Assert(writer, NotNil)
+}
+
+func (s *AuditSuite) TestOpenSocketError(c *C) {
+	mock := &mockNetlinkOps{
+		socketErr: fmt.Errorf("permission denied"),
+	}
+	restore := seclog.MockNetlinkOps(mock)
+	defer restore()
+
+	_, err := seclog.OpenAuditWriter()
+	c.Assert(err, ErrorMatches, "cannot open audit socket: permission denied")
+}
+
+func (s *AuditSuite) TestWriteSuccess(c *C) {
+	mock := &mockNetlinkOps{
+		socketFD: 7,
+	}
+	restore := seclog.MockNetlinkOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+
+	n, err := writer.Write([]byte("hello"))
+	c.Assert(err, IsNil)
+	c.Check(n, Equals, 5)
+	// The mock captured the raw netlink message.
+	c.Check(len(mock.sendtoData) > syscall.SizeofNlMsghdr, Equals, true)
+}
+
+func (s *AuditSuite) TestWriteSendtoError(c *C) {
+	mock := &mockNetlinkOps{
+		socketFD:  7,
+		sendtoErr: fmt.Errorf("no buffer space"),
+	}
+	restore := seclog.MockNetlinkOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+
+	_, err = writer.Write([]byte("test"))
+	c.Assert(err, ErrorMatches, "cannot send audit message: no buffer space")
+}
+
+func (s *AuditSuite) TestClose(c *C) {
+	mock := &mockNetlinkOps{
+		socketFD: 7,
+	}
+	restore := seclog.MockNetlinkOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+
+	closer, ok := writer.(interface{ Close() error })
+	c.Assert(ok, Equals, true)
+	err = closer.Close()
+	c.Assert(err, IsNil)
+	c.Check(mock.closedFDs, DeepEquals, []int{7})
+}
+
+func (s *AuditSuite) TestBuildMessageHeaderLayout(c *C) {
+	aw := &seclog.AuditWriter{}
+
+	payload := []byte("hello")
+	msg := seclog.AuditWriterBuildMessage(aw, payload)
+
+	// Total length: 16 (header) + 5 (payload) = 21, aligned to 24.
+	c.Assert(len(msg), Equals, 24)
+
+	// nlmsghdr fields in native byte order.
+	totalLen := arch.Endian().Uint32(msg[0:4])
+	c.Check(totalLen, Equals, uint32(21))
+
+	msgType := arch.Endian().Uint16(msg[4:6])
+	c.Check(msgType, Equals, uint16(seclog.AuditTrustedApp))
+
+	flags := arch.Endian().Uint16(msg[6:8])
+	c.Check(flags, Equals, uint16(syscall.NLM_F_REQUEST))
+
+	seq := arch.Endian().Uint32(msg[8:12])
+	c.Check(seq, Equals, uint32(1))
+
+	portID := arch.Endian().Uint32(msg[12:16])
+	c.Check(portID, Equals, uint32(0))
+
+	// Payload follows header.
+	c.Check(string(msg[syscall.SizeofNlMsghdr:syscall.SizeofNlMsghdr+5]), Equals, "hello")
+
+	// Padding bytes after payload should be zero.
+	c.Check(msg[21], Equals, byte(0))
+	c.Check(msg[22], Equals, byte(0))
+	c.Check(msg[23], Equals, byte(0))
+}
+
+func (s *AuditSuite) TestBuildMessageSequenceIncrements(c *C) {
+	aw := &seclog.AuditWriter{}
+
+	msg1 := seclog.AuditWriterBuildMessage(aw, []byte("a"))
+	msg2 := seclog.AuditWriterBuildMessage(aw, []byte("b"))
+	msg3 := seclog.AuditWriterBuildMessage(aw, []byte("c"))
+
+	seq1 := arch.Endian().Uint32(msg1[8:12])
+	seq2 := arch.Endian().Uint32(msg2[8:12])
+	seq3 := arch.Endian().Uint32(msg3[8:12])
+
+	c.Check(seq1, Equals, uint32(1))
+	c.Check(seq2, Equals, uint32(2))
+	c.Check(seq3, Equals, uint32(3))
+}
+
+func (s *AuditSuite) TestBuildMessageAlignedPayload(c *C) {
+	aw := &seclog.AuditWriter{}
+
+	// Payload of exactly 4 bytes: total = 20 which is already aligned.
+	msg := seclog.AuditWriterBuildMessage(aw, []byte("abcd"))
+	c.Check(len(msg), Equals, 20)
+
+	totalLen := arch.Endian().Uint32(msg[0:4])
+	c.Check(totalLen, Equals, uint32(20))
+}
+
+func (s *AuditSuite) TestBuildMessageEmptyPayload(c *C) {
+	aw := &seclog.AuditWriter{}
+
+	msg := seclog.AuditWriterBuildMessage(aw, []byte{})
+
+	// 16-byte header, already aligned.
+	c.Check(len(msg), Equals, 16)
+
+	totalLen := arch.Endian().Uint32(msg[0:4])
+	c.Check(totalLen, Equals, uint32(16))
+}
+
+func (s *AuditSuite) TestNlmsgAlignAlreadyAligned(c *C) {
+	c.Check(seclog.NlmsgAlign(0), Equals, uint32(0))
+	c.Check(seclog.NlmsgAlign(4), Equals, uint32(4))
+	c.Check(seclog.NlmsgAlign(8), Equals, uint32(8))
+	c.Check(seclog.NlmsgAlign(16), Equals, uint32(16))
+}
+
+func (s *AuditSuite) TestNlmsgAlignRoundsUp(c *C) {
+	c.Check(seclog.NlmsgAlign(1), Equals, uint32(4))
+	c.Check(seclog.NlmsgAlign(2), Equals, uint32(4))
+	c.Check(seclog.NlmsgAlign(3), Equals, uint32(4))
+	c.Check(seclog.NlmsgAlign(5), Equals, uint32(8))
+	c.Check(seclog.NlmsgAlign(17), Equals, uint32(20))
+}

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -34,8 +34,8 @@ type AuditSuite struct{}
 
 var _ = Suite(&AuditSuite{})
 
-// mockNetlinkOps records calls and returns configurable results.
-type mockNetlinkOps struct {
+// mockSyscallOps records calls and returns configurable results.
+type mockSyscallOps struct {
 	socketFD   int
 	socketErr  error
 	sendtoData []byte
@@ -44,28 +44,28 @@ type mockNetlinkOps struct {
 	closeErr   error
 }
 
-func (m *mockNetlinkOps) Socket(domain, typ, proto int) (int, error) {
+func (m *mockSyscallOps) Socket(domain, typ, proto int) (int, error) {
 	return m.socketFD, m.socketErr
 }
 
-func (m *mockNetlinkOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
+func (m *mockSyscallOps) Sendto(fd int, payload []byte, flags int, to syscall.Sockaddr) error {
 	m.sendtoData = slices.Clone(payload)
 	return m.sendtoErr
 }
 
-func (m *mockNetlinkOps) Close(fd int) error {
+func (m *mockSyscallOps) Close(fd int) error {
 	m.closedFDs = append(m.closedFDs, fd)
 	return m.closeErr
 }
 
-// Ensure mockNetlinkOps satisfies the interface.
-var _ seclog.NetlinkOps = (*mockNetlinkOps)(nil)
+// Ensure mockSyscallOps satisfies the interface.
+var _ seclog.SyscallOps = (*mockSyscallOps)(nil)
 
 func (s *AuditSuite) TestOpenSuccess(c *C) {
-	mock := &mockNetlinkOps{
+	mock := &mockSyscallOps{
 		socketFD: 42,
 	}
-	restore := seclog.MockNetlinkOps(mock)
+	restore := seclog.MockSyscallOps(mock)
 	defer restore()
 
 	writer, err := seclog.OpenAuditWriter()
@@ -74,10 +74,10 @@ func (s *AuditSuite) TestOpenSuccess(c *C) {
 }
 
 func (s *AuditSuite) TestOpenSocketError(c *C) {
-	mock := &mockNetlinkOps{
+	mock := &mockSyscallOps{
 		socketErr: fmt.Errorf("permission denied"),
 	}
-	restore := seclog.MockNetlinkOps(mock)
+	restore := seclog.MockSyscallOps(mock)
 	defer restore()
 
 	_, err := seclog.OpenAuditWriter()
@@ -85,10 +85,10 @@ func (s *AuditSuite) TestOpenSocketError(c *C) {
 }
 
 func (s *AuditSuite) TestWriteSuccess(c *C) {
-	mock := &mockNetlinkOps{
+	mock := &mockSyscallOps{
 		socketFD: 7,
 	}
-	restore := seclog.MockNetlinkOps(mock)
+	restore := seclog.MockSyscallOps(mock)
 	defer restore()
 
 	writer, err := seclog.OpenAuditWriter()
@@ -102,11 +102,11 @@ func (s *AuditSuite) TestWriteSuccess(c *C) {
 }
 
 func (s *AuditSuite) TestWriteSendtoError(c *C) {
-	mock := &mockNetlinkOps{
+	mock := &mockSyscallOps{
 		socketFD:  7,
 		sendtoErr: fmt.Errorf("no buffer space"),
 	}
-	restore := seclog.MockNetlinkOps(mock)
+	restore := seclog.MockSyscallOps(mock)
 	defer restore()
 
 	writer, err := seclog.OpenAuditWriter()
@@ -117,10 +117,10 @@ func (s *AuditSuite) TestWriteSendtoError(c *C) {
 }
 
 func (s *AuditSuite) TestClose(c *C) {
-	mock := &mockNetlinkOps{
+	mock := &mockSyscallOps{
 		socketFD: 7,
 	}
-	restore := seclog.MockNetlinkOps(mock)
+	restore := seclog.MockSyscallOps(mock)
 	defer restore()
 
 	writer, err := seclog.OpenAuditWriter()

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -126,9 +126,7 @@ func (s *AuditSuite) TestClose(c *C) {
 	writer, err := seclog.OpenAuditWriter()
 	c.Assert(err, IsNil)
 
-	closer, ok := writer.(interface{ Close() error })
-	c.Assert(ok, Equals, true)
-	err = closer.Close()
+	err = writer.Close()
 	c.Assert(err, IsNil)
 	c.Check(mock.closedFDs, DeepEquals, []int{7})
 }

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -130,6 +130,43 @@ func (s *AuditSuite) TestClose(c *C) {
 	c.Check(mock.closedFDs, DeepEquals, []int{7})
 }
 
+func (s *AuditSuite) TestCloseNotOpen(c *C) {
+	mock := &mockSyscallOps{
+		socketFD: 7,
+	}
+	restore := seclog.MockSyscallOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+
+	err = writer.Close()
+	c.Assert(err, IsNil)
+
+	// Second close must fail.
+	err = writer.Close()
+	c.Assert(err, ErrorMatches, "cannot close audit writer: not open")
+	// Only one fd was closed.
+	c.Check(mock.closedFDs, DeepEquals, []int{7})
+}
+
+func (s *AuditSuite) TestWriteAfterClose(c *C) {
+	mock := &mockSyscallOps{
+		socketFD: 7,
+	}
+	restore := seclog.MockSyscallOps(mock)
+	defer restore()
+
+	writer, err := seclog.OpenAuditWriter()
+	c.Assert(err, IsNil)
+
+	err = writer.Close()
+	c.Assert(err, IsNil)
+
+	_, err = writer.Write([]byte("test"))
+	c.Assert(err, ErrorMatches, "cannot send audit message: not open")
+}
+
 func (s *AuditSuite) TestBuildMessageHeaderLayout(c *C) {
 	aw := &seclog.AuditWriter{}
 

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -137,12 +137,12 @@ func (s *AuditSuite) TestBuildMessageHeaderLayout(c *C) {
 	payload := []byte("hello")
 	msg := seclog.AuditWriterBuildMessage(aw, payload)
 
-	// Total length: 16 (header) + 5 (payload) = 21, aligned to 24.
+	// Total length: NLMSG_SPACE(5 + 1) = align(22) = 24.
 	c.Assert(len(msg), Equals, 24)
 
 	// nlmsghdr fields in native byte order.
 	totalLen := arch.Endian().Uint32(msg[0:4])
-	c.Check(totalLen, Equals, uint32(21))
+	c.Check(totalLen, Equals, uint32(24))
 
 	msgType := arch.Endian().Uint16(msg[4:6])
 	c.Check(msgType, Equals, uint16(seclog.AuditTrustedApp))
@@ -159,8 +159,9 @@ func (s *AuditSuite) TestBuildMessageHeaderLayout(c *C) {
 	// Payload follows header.
 	c.Check(string(msg[syscall.SizeofNlMsghdr:syscall.SizeofNlMsghdr+5]), Equals, "hello")
 
-	// Padding bytes after payload should be zero.
+	// NUL byte for kernel null-termination.
 	c.Check(msg[21], Equals, byte(0))
+	// Padding bytes should be zero.
 	c.Check(msg[22], Equals, byte(0))
 	c.Check(msg[23], Equals, byte(0))
 }
@@ -181,15 +182,32 @@ func (s *AuditSuite) TestBuildMessageSequenceIncrements(c *C) {
 	c.Check(seq3, Equals, uint32(3))
 }
 
+func (s *AuditSuite) TestBuildMessageSequenceSkipsZero(c *C) {
+	aw := &seclog.AuditWriter{}
+
+	// Set sequence just before wraparound.
+	seclog.AuditWriterSetSeq(aw, ^uint32(0)) // math.MaxUint32
+
+	msg1 := seclog.AuditWriterBuildMessage(aw, []byte("x"))
+	msg2 := seclog.AuditWriterBuildMessage(aw, []byte("y"))
+
+	seq1 := arch.Endian().Uint32(msg1[8:12])
+	seq2 := arch.Endian().Uint32(msg2[8:12])
+
+	// Should skip 0 and go to 1, then 2.
+	c.Check(seq1, Equals, uint32(1))
+	c.Check(seq2, Equals, uint32(2))
+}
+
 func (s *AuditSuite) TestBuildMessageAlignedPayload(c *C) {
 	aw := &seclog.AuditWriter{}
 
-	// Payload of exactly 4 bytes: total = 20 which is already aligned.
+	// Payload of exactly 4 bytes: NLMSG_SPACE(4 + 1) = align(21) = 24.
 	msg := seclog.AuditWriterBuildMessage(aw, []byte("abcd"))
-	c.Check(len(msg), Equals, 20)
+	c.Check(len(msg), Equals, 24)
 
 	totalLen := arch.Endian().Uint32(msg[0:4])
-	c.Check(totalLen, Equals, uint32(20))
+	c.Check(totalLen, Equals, uint32(24))
 }
 
 func (s *AuditSuite) TestBuildMessageEmptyPayload(c *C) {
@@ -197,11 +215,11 @@ func (s *AuditSuite) TestBuildMessageEmptyPayload(c *C) {
 
 	msg := seclog.AuditWriterBuildMessage(aw, []byte{})
 
-	// 16-byte header, already aligned.
-	c.Check(len(msg), Equals, 16)
+	// NLMSG_SPACE(0 + 1) = align(17) = 20.
+	c.Check(len(msg), Equals, 20)
 
 	totalLen := arch.Endian().Uint32(msg[0:4])
-	c.Check(totalLen, Equals, uint32(16))
+	c.Check(totalLen, Equals, uint32(20))
 }
 
 func (s *AuditSuite) TestNlmsgAlignAlreadyAligned(c *C) {

--- a/seclog/export_audit_linux_test.go
+++ b/seclog/export_audit_linux_test.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+import (
+	"github.com/snapcore/snapd/testutil"
+)
+
+type NetlinkOps = netlinkOps
+
+var NlmsgAlign = nlmsgAlign
+
+const AuditTrustedApp = auditTrustedApp
+
+func AuditWriterBuildMessage(aw *AuditWriter, payload []byte) []byte {
+	return aw.buildMessage(payload)
+}
+
+func MockNetlinkOps(ops netlinkOps) (restore func()) {
+	return testutil.Mock(&netlink, ops)
+}

--- a/seclog/export_audit_linux_test.go
+++ b/seclog/export_audit_linux_test.go
@@ -20,6 +20,8 @@
 package seclog
 
 import (
+	"sync/atomic"
+
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,7 +36,7 @@ func AuditWriterBuildMessage(aw *AuditWriter, payload []byte) []byte {
 }
 
 func AuditWriterSetSeq(aw *AuditWriter, val uint32) {
-	aw.seq.Store(val)
+	atomic.StoreUint32(&aw.seq, val)
 }
 
 func MockSyscallOps(ops syscallOps) (restore func()) {

--- a/seclog/export_audit_linux_test.go
+++ b/seclog/export_audit_linux_test.go
@@ -33,6 +33,10 @@ func AuditWriterBuildMessage(aw *AuditWriter, payload []byte) []byte {
 	return aw.buildMessage(payload)
 }
 
+func AuditWriterSetSeq(aw *AuditWriter, val uint32) {
+	aw.seq.Store(val)
+}
+
 func MockSyscallOps(ops syscallOps) (restore func()) {
 	return testutil.Mock(&sys, ops)
 }

--- a/seclog/export_audit_linux_test.go
+++ b/seclog/export_audit_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type NetlinkOps = netlinkOps
+type SyscallOps = syscallOps
 
 var NlmsgAlign = nlmsgAlign
 
@@ -33,6 +33,6 @@ func AuditWriterBuildMessage(aw *AuditWriter, payload []byte) []byte {
 	return aw.buildMessage(payload)
 }
 
-func MockNetlinkOps(ops netlinkOps) (restore func()) {
-	return testutil.Mock(&netlink, ops)
+func MockSyscallOps(ops syscallOps) (restore func()) {
+	return testutil.Mock(&sys, ops)
 }

--- a/seclog/nop.go
+++ b/seclog/nop.go
@@ -30,6 +30,6 @@ func NewNopLogger() SecurityLogger {
 	return nopLogger{}
 }
 
-// LogAny implements [SecurityLogger.LogAny].
-func (nopLogger) LogAny(event Event, description string, attrs ...Attr) {
+// LogEvent implements [SecurityLogger.LogEvent].
+func (nopLogger) LogEvent(event Event, description string, attrs ...Attr) {
 }

--- a/seclog/nop_test.go
+++ b/seclog/nop_test.go
@@ -45,7 +45,7 @@ func (s *NopSuite) TestLogLoggerEnabled(c *C) {
 	c.Assert(logger, NotNil)
 
 	// nop logger discards all messages without error
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "SYS", Name: "sys_logging_enabled", Level: seclog.LevelInfo},
 		"Security logging enabled",
 	)
@@ -56,7 +56,7 @@ func (s *NopSuite) TestLogLoggerDisabled(c *C) {
 	c.Assert(logger, NotNil)
 
 	// nop logger discards all messages without error
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "SYS", Name: "sys_logging_disabled", Level: seclog.LevelCritical},
 		"Security logging disabled",
 	)
@@ -67,7 +67,7 @@ func (s *NopSuite) TestLogLoginSuccess(c *C) {
 	c.Assert(logger, NotNil)
 
 	// nop logger discards all messages without error
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "AUTHN", Name: "authn_login_success", Level: seclog.LevelInfo},
 		"test",
 		seclog.Attr{Key: "user", Value: seclog.SnapdUser{StoreUserEmail: "user@gmail.com"}},
@@ -79,7 +79,7 @@ func (s *NopSuite) TestLogLoginFailure(c *C) {
 	c.Assert(logger, NotNil)
 
 	// nop logger discards all messages without error
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "AUTHN", Name: "authn_login_failure", Level: seclog.LevelWarn},
 		"test",
 		seclog.Attr{Key: "user", Value: seclog.SnapdUser{StoreUserEmail: "user@gmail.com"}},

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -145,7 +145,7 @@ type Attr struct {
 // optional [Attr] values, so new event types can be added without
 // changing the interface.
 type SecurityLogger interface {
-	LogAny(event Event, description string, attrs ...Attr)
+	LogEvent(event Event, description string, attrs ...Attr)
 }
 
 var (
@@ -172,7 +172,7 @@ func LogLoggerEnabled() {
 	lock.Lock()
 	defer lock.Unlock()
 
-	globalLogger.LogAny(
+	globalLogger.LogEvent(
 		Event{Category: "SYS", Name: "sys_logging_enabled", Level: LevelInfo},
 		"Security logging enabled",
 	)
@@ -185,7 +185,7 @@ func LogLoggerDisabled() {
 	lock.Lock()
 	defer lock.Unlock()
 
-	globalLogger.LogAny(
+	globalLogger.LogEvent(
 		Event{Category: "SYS", Name: "sys_logging_disabled", Level: LevelCritical},
 		"Security logging disabled",
 	)
@@ -196,7 +196,7 @@ func LogLoginSuccess(user SnapdUser) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	globalLogger.LogAny(
+	globalLogger.LogEvent(
 		Event{Category: "AUTHN", Name: "authn_login_success", Level: LevelInfo},
 		fmt.Sprintf("User %s login success", user.String()),
 		Attr{Key: "user", Value: user},
@@ -208,7 +208,7 @@ func LogLoginFailure(user SnapdUser, reason Reason) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	globalLogger.LogAny(
+	globalLogger.LogEvent(
 		Event{Category: "AUTHN", Name: "authn_login_failure", Level: LevelWarn},
 		fmt.Sprintf("User %s login failure: %s", user.String(), reason.String()),
 		Attr{Key: "user", Value: user},

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -167,10 +167,12 @@ func Setup(l SecurityLogger) {
 
 // LogLoggerEnabled logs that the security logger has been enabled.
 func LogLoggerEnabled() {
-	logger.Noticef("security logger enabled")
-
 	lock.Lock()
 	defer lock.Unlock()
+
+	if _, ok := globalLogger.(nopLogger); !ok {
+		logger.Noticef("security logger enabled")
+	}
 
 	globalLogger.LogEvent(
 		Event{Category: "SYS", Name: "sys_logging_enabled", Level: LevelInfo},
@@ -180,10 +182,12 @@ func LogLoggerEnabled() {
 
 // LogLoggerDisabled logs that the security logger has been disabled.
 func LogLoggerDisabled() {
-	logger.Noticef("security logger disabled")
-
 	lock.Lock()
 	defer lock.Unlock()
+
+	if _, ok := globalLogger.(nopLogger); !ok {
+		logger.Noticef("security logger disabled")
+	}
 
 	globalLogger.LogEvent(
 		Event{Category: "SYS", Name: "sys_logging_disabled", Level: LevelCritical},

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -195,3 +195,23 @@ func (s *SecLogSuite) TestLogLoggerDisabledLogsToStandardLogger(c *C) {
 
 	c.Check(logBuf.String(), testutil.Contains, "security logger disabled")
 }
+
+func (s *SecLogSuite) TestLogLoggerEnabledNopSkipsNoticef(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	seclog.Setup(seclog.NewNopLogger())
+	seclog.LogLoggerEnabled()
+
+	c.Check(logBuf.String(), Not(testutil.Contains), "security logger enabled")
+}
+
+func (s *SecLogSuite) TestLogLoggerDisabledNopSkipsNoticef(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	seclog.Setup(seclog.NewNopLogger())
+	seclog.LogLoggerDisabled()
+
+	c.Check(logBuf.String(), Not(testutil.Contains), "security logger disabled")
+}

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -45,8 +45,8 @@ func MockSecurityLogger(buf *bytes.Buffer) seclog.SecurityLogger {
 	return &mockLogger{buf: buf}
 }
 
-// LogAny implements [seclog.SecurityLogger.LogAny].
-func (m *mockLogger) LogAny(event seclog.Event, description string, attrs ...seclog.Attr) {
+// LogEvent implements [seclog.SecurityLogger.LogEvent].
+func (m *mockLogger) LogEvent(event seclog.Event, description string, attrs ...seclog.Attr) {
 	fmt.Fprintf(m.buf, "%s %s", event.Name, description)
 	for _, a := range attrs {
 		fmt.Fprintf(m.buf, " [%s=%#v]", a.Key, a.Value)

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -79,21 +79,6 @@ func (l *slogLogger) LogEvent(event Event, description string, attrs ...Attr) {
 	)
 }
 
-// LogValue implements [slog.LogValuer], allowing SnapdUser to be
-// used directly as a structured log attribute value.
-func (u SnapdUser) LogValue() slog.Value {
-	expiration := "never"
-	if !u.Expiration.IsZero() {
-		expiration = u.Expiration.UTC().Format(time.RFC3339Nano)
-	}
-	return slog.GroupValue(
-		slog.Int64("snapd-user-id", u.ID),
-		slog.String("store-user-name", u.StoreUserName),
-		slog.String("store-user-email", u.StoreUserEmail),
-		slog.String("expiration", expiration),
-	)
-}
-
 // newJsonHandler returns a slog JSON handler configured for security logs.
 //
 // It writes newline-delimited JSON to writer and enforces a schema for the
@@ -176,4 +161,19 @@ func (h *errorAwareHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 func (h *errorAwareHandler) WithGroup(name string) slog.Handler {
 	return &errorAwareHandler{inner: h.inner.WithGroup(name)}
+}
+
+// LogValue implements [slog.LogValuer], allowing SnapdUser to be
+// used directly as a structured log attribute value.
+func (u SnapdUser) LogValue() slog.Value {
+	expiration := "never"
+	if !u.Expiration.IsZero() {
+		expiration = u.Expiration.UTC().Format(time.RFC3339Nano)
+	}
+	return slog.GroupValue(
+		slog.Int64("snapd-user-id", u.ID),
+		slog.String("store-user-name", u.StoreUserName),
+		slog.String("store-user-email", u.StoreUserEmail),
+		slog.String("expiration", expiration),
+	)
 }

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -156,16 +156,16 @@ func (h *errorAwareHandler) Enabled(ctx context.Context, l slog.Level) bool {
 func (h *errorAwareHandler) Handle(ctx context.Context, r slog.Record) error {
 	if err := h.inner.Handle(ctx, r); err != nil {
 		n := h.consecutiveFails.Add(1)
-		if n <= writeFailureThreshold {
-			logger.Noticef("security log write failed: %v", err)
+		if n < writeFailureThreshold {
+			logger.Noticef("WARNING: security log write failed: %v", err)
 		}
 		if n == writeFailureThreshold {
-			logger.Noticef("security log write failed %d times, suppressing further errors", writeFailureThreshold)
+			logger.Noticef("WARNING: security log write failed %d times, further failures will not be reported", writeFailureThreshold)
 		}
 		return err
 	}
-	if h.consecutiveFails.Swap(0) >= writeFailureThreshold {
-		logger.Noticef("security log write recovered")
+	if n := h.consecutiveFails.Swap(0); n >= writeFailureThreshold {
+		logger.Noticef("security log write recovered following %d failures", n)
 	}
 	return nil
 }

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -1,0 +1,179 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// go1.21 is required for log/slog which was added in Go 1.21.
+// See https://go.dev/doc/go1.21#slog
+// The noslog tag allows excluding the slog-based logger entirely.
+//go:build go1.21 && !noslog
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/snapcore/snapd/logger"
+)
+
+// NewSlogLogger creates a new security logger backed by log/slog that
+// writes structured JSON to writer. Events at or above minLevel are
+// emitted; lower-level events are silently discarded.
+func NewSlogLogger(writer io.Writer, appID string, minLevel Level) SecurityLogger {
+	var handler slog.Handler = newJsonHandler(writer, slog.Level(minLevel))
+
+	logger := &slogLogger{
+		// always include app_id and type
+		logger: slog.New(handler).With(
+			slog.String("app_id", appID),
+			slog.String("type", "security"),
+		),
+	}
+	return logger
+}
+
+// Ensure [slogLogger] implements [SecurityLogger].
+var _ SecurityLogger = (*slogLogger)(nil)
+
+// slogLogger implements [SecurityLogger] and is constructed by
+// [NewSlogLogger]. It wraps a [slog.Logger] and provides the required
+// methods. The logger emits structured JSON with a predefined schema for
+// built-in attributes.
+type slogLogger struct {
+	logger *slog.Logger
+}
+
+// LogAny implements [SecurityLogger.LogAny].
+func (l *slogLogger) LogAny(event Event, description string, attrs ...Attr) {
+	slogAttrs := make([]slog.Attr, 0, len(attrs)+2)
+	slogAttrs = append(slogAttrs,
+		slog.Attr{Key: "category", Value: slog.StringValue(event.Category)},
+		slog.Attr{Key: "event", Value: slog.StringValue(event.Name)},
+	)
+	for _, a := range attrs {
+		slogAttrs = append(slogAttrs, slog.Any(a.Key, a.Value))
+	}
+	l.logger.LogAttrs(
+		context.Background(),
+		slog.Level(event.Level),
+		description,
+		slogAttrs...,
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing SnapdUser to be
+// used directly as a structured log attribute value.
+func (u SnapdUser) LogValue() slog.Value {
+	expiration := "never"
+	if !u.Expiration.IsZero() {
+		expiration = u.Expiration.UTC().Format(time.RFC3339Nano)
+	}
+	return slog.GroupValue(
+		slog.Int64("snapd-user-id", u.ID),
+		slog.String("store-user-name", u.StoreUserName),
+		slog.String("store-user-email", u.StoreUserEmail),
+		slog.String("expiration", expiration),
+	)
+}
+
+// newJsonHandler returns a slog JSON handler configured for security logs.
+//
+// It writes newline-delimited JSON to writer and enforces a schema for the
+// built-in attributes:
+//   - time:     key "datetime", formatted in UTC using [time.RFC3339Nano]
+//   - level:    rendered as a string via [Level.String]
+//   - message:  key "description"
+//
+// [NewSlogLogger] adds additional built-in attributes to the logger context:
+//   - app_id:   always included with the value provided to [NewSlogLogger]
+//   - type:     always included with the value "security"
+//
+// Additional attributes are preserved verbatim, including nested groups. The
+// handler logs at or above the minLevel threshold. It does not close or sync
+// writer.
+func newJsonHandler(writer io.Writer, minLevel slog.Leveler) slog.Handler {
+	options := &slog.HandlerOptions{
+		Level: minLevel,
+		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+			switch attr.Key {
+			case slog.TimeKey:
+				// use "datetime" instead of default "time"
+				attr.Key = "datetime"
+				if t, ok := attr.Value.Any().(time.Time); ok {
+					// convert to formatted string
+					attr.Value = slog.StringValue(t.UTC().Format(time.RFC3339Nano))
+				}
+			case slog.LevelKey:
+				if l, ok := attr.Value.Any().(slog.Level); ok {
+					attr.Value = slog.StringValue(Level(l).String())
+				}
+			case slog.MessageKey:
+				// use "description" instead of default "msg"
+				attr.Key = "description"
+			}
+			return attr
+		},
+	}
+
+	return &errorAwareHandler{inner: slog.NewJSONHandler(writer, options)}
+}
+
+// writeFailureThreshold is the number of consecutive write failures
+// after which error reporting is suppressed.
+const writeFailureThreshold = 3
+
+// errorAwareHandler wraps a [slog.Handler] and reports write failures
+// via the snapd logger. After [writeFailureThreshold] consecutive
+// failures, further error messages are suppressed until a write
+// succeeds.
+type errorAwareHandler struct {
+	inner            slog.Handler
+	consecutiveFails atomic.Int32
+}
+
+func (h *errorAwareHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.inner.Enabled(ctx, l)
+}
+
+func (h *errorAwareHandler) Handle(ctx context.Context, r slog.Record) error {
+	if err := h.inner.Handle(ctx, r); err != nil {
+		n := h.consecutiveFails.Add(1)
+		if n <= writeFailureThreshold {
+			logger.Noticef("security log write failed: %v", err)
+		}
+		if n == writeFailureThreshold {
+			logger.Noticef("security log write failed %d times, suppressing further errors", writeFailureThreshold)
+		}
+		return err
+	}
+	if h.consecutiveFails.Swap(0) >= writeFailureThreshold {
+		logger.Noticef("security log write recovered")
+	}
+	return nil
+}
+
+func (h *errorAwareHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &errorAwareHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *errorAwareHandler) WithGroup(name string) slog.Handler {
+	return &errorAwareHandler{inner: h.inner.WithGroup(name)}
+}

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -72,7 +72,7 @@ func (l *slogLogger) LogAny(event Event, description string, attrs ...Attr) {
 		slogAttrs = append(slogAttrs, slog.Any(a.Key, a.Value))
 	}
 	l.logger.LogAttrs(
-		context.Background(),
+		context.TODO(),
 		slog.Level(event.Level),
 		description,
 		slogAttrs...,

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -61,8 +61,8 @@ type slogLogger struct {
 	logger *slog.Logger
 }
 
-// LogAny implements [SecurityLogger.LogAny].
-func (l *slogLogger) LogAny(event Event, description string, attrs ...Attr) {
+// LogEvent implements [SecurityLogger.LogEvent].
+func (l *slogLogger) LogEvent(event Event, description string, attrs ...Attr) {
 	slogAttrs := make([]slog.Attr, 0, len(attrs)+2)
 	slogAttrs = append(slogAttrs,
 		slog.Attr{Key: "category", Value: slog.StringValue(event.Category)},

--- a/seclog/slog_nop.go
+++ b/seclog/slog_nop.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// Fallback for environments where log/slog is not available (Go < 1.21
+// or the noslog build tag is set). NewSlogLogger returns a nop logger
+// so that callers compile unconditionally.
+//go:build !go1.21 || noslog
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog
+
+import "io"
+
+// NewSlogLogger returns a nop logger when log/slog is not available.
+// The writer, appID and minLevel parameters are accepted for API
+// compatibility but are ignored.
+func NewSlogLogger(_ io.Writer, _ string, _ Level) SecurityLogger {
+	return NewNopLogger()
+}

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -62,8 +62,8 @@ func (s *SlogSuite) TestNewSlogLogger(c *C) {
 	c.Check(logger, NotNil)
 }
 
-// baseAttrs represents the non-optional attributes that is present in
-// every record
+// baseAttrs represents the non-optional attributes that are present in
+// every record.
 type baseAttrs struct {
 	Datetime    time.Time `json:"datetime"`
 	Level       string    `json:"level"`

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -286,10 +286,10 @@ func (s *SlogSuite) TestWriteFailureSuppressedAfterThreshold(c *C) {
 	}
 
 	output := logBuf.String()
-	// First 3 failures are reported individually.
-	c.Check(strings.Count(output, "security log write failed: disk full"), Equals, 3)
+	// First 2 failures are reported individually.
+	c.Check(strings.Count(output, "security log write failed: disk full"), Equals, 2)
 	// The suppression message appears exactly once.
-	c.Check(strings.Count(output, "suppressing further errors"), Equals, 1)
+	c.Check(strings.Count(output, "further failures will not be reported"), Equals, 1)
 }
 
 func (s *SlogSuite) TestWriteRecoveryIsLogged(c *C) {
@@ -309,7 +309,7 @@ func (s *SlogSuite) TestWriteRecoveryIsLogged(c *C) {
 	w.failing = false
 	sl.LogEvent(evt, "recovered")
 
-	c.Check(logBuf.String(), testutil.Contains, "security log write recovered")
+	c.Check(logBuf.String(), testutil.Contains, "security log write recovered following 4 failures")
 	c.Check(w.buf.Len() > 0, Equals, true)
 }
 

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -1,0 +1,333 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build go1.21 && !noslog
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seclog_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SlogSuite struct {
+	testutil.BaseTest
+	buf   *bytes.Buffer
+	appID string
+}
+
+var _ = Suite(&SlogSuite{})
+
+func (s *SlogSuite) SetUpSuite(c *C) {
+	s.buf = &bytes.Buffer{}
+	s.appID = "canonical.snapd"
+}
+
+func (s *SlogSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.buf.Reset()
+}
+
+func (s *SlogSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *SlogSuite) TestNewSlogLogger(c *C) {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
+	c.Check(logger, NotNil)
+}
+
+// baseAttrs represents the non-optional attributes that is present in
+// every record
+type baseAttrs struct {
+	Datetime    time.Time `json:"datetime"`
+	Level       string    `json:"level"`
+	Description string    `json:"description"`
+	AppID       string    `json:"app_id"`
+	Type        string    `json:"type"`
+	Category    string    `json:"category"`
+}
+
+// orderedKeys extracts the top-level JSON object keys in order.
+func orderedKeys(data []byte) ([]string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	// consume opening '{'
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return nil, errors.New("expected '{' delimiter")
+	}
+	var keys []string
+	for decoder.More() {
+		token, err = decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return nil, errors.New("expected string key")
+		}
+		keys = append(keys, key)
+		// skip value
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
+
+func (s *SlogSuite) TestLogAny(c *C) {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
+	c.Assert(logger, NotNil)
+
+	type record struct {
+		baseAttrs
+		Event string `json:"event"`
+	}
+
+	logger.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"Something happened",
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(time.Since(obtained.Datetime) < time.Second, Equals, true)
+	c.Check(obtained.Level, Equals, "INFO")
+	c.Check(obtained.Description, Equals, "Something happened")
+	c.Check(obtained.AppID, Equals, s.appID)
+	c.Check(obtained.Type, Equals, "security")
+	c.Check(obtained.Category, Equals, "TEST")
+	c.Check(obtained.Event, Equals, "test_event")
+
+	// verify key order for human readability
+	keys, err := orderedKeys(s.buf.Bytes())
+	c.Assert(err, IsNil)
+	c.Check(keys, DeepEquals, []string{
+		"datetime", "level", "description",
+		"app_id", "type", "category", "event",
+	})
+}
+
+func (s *SlogSuite) TestLogAnyWithAttrs(c *C) {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
+	c.Assert(logger, NotNil)
+
+	type record struct {
+		baseAttrs
+		Event string `json:"event"`
+		User  struct {
+			ID             int64  `json:"snapd-user-id"`
+			StoreUserName  string `json:"store-user-name"`
+			StoreUserEmail string `json:"store-user-email"`
+			Expiration     string `json:"expiration"`
+		} `json:"user"`
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	user := seclog.SnapdUser{
+		ID:             42,
+		StoreUserEmail: "user@gmail.com",
+		StoreUserName:  "jdoe",
+	}
+	reason := seclog.Reason{Code: seclog.ReasonInvalidCredentials, Message: "invalid credentials"}
+	logger.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelWarn},
+		fmt.Sprintf("User %s caused an issue: %s", user.String(), reason.String()),
+		seclog.Attr{Key: "user", Value: user},
+		seclog.Attr{Key: "error", Value: reason},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(time.Since(obtained.Datetime) < time.Second, Equals, true)
+	c.Check(obtained.Level, Equals, "WARN")
+	c.Check(obtained.Description, Equals,
+		"User 42:user@gmail.com:jdoe caused an issue: invalid-credentials:invalid credentials")
+	c.Check(obtained.AppID, Equals, s.appID)
+	c.Check(obtained.Type, Equals, "security")
+	c.Check(obtained.Category, Equals, "TEST")
+	c.Check(obtained.Event, Equals, "test_event")
+	// SnapdUser is a LogValuer — verify structured output
+	c.Check(obtained.User.ID, Equals, int64(42))
+	c.Check(obtained.User.StoreUserEmail, Equals, "user@gmail.com")
+	c.Check(obtained.User.StoreUserName, Equals, "jdoe")
+	c.Check(obtained.User.Expiration, Equals, "never")
+	// Reason is a plain struct — verify JSON marshaling via slog.Any
+	c.Check(obtained.Error.Code, Equals, seclog.ReasonInvalidCredentials)
+	c.Check(obtained.Error.Message, Equals, "invalid credentials")
+
+	// verify key order for human readability
+	keys, err := orderedKeys(s.buf.Bytes())
+	c.Assert(err, IsNil)
+	c.Check(keys, DeepEquals, []string{
+		"datetime", "level", "description",
+		"app_id", "type", "category", "event", "user", "error",
+	})
+}
+
+func (s *SlogSuite) TestLogAnyWithLogValuer(c *C) {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
+	c.Assert(logger, NotNil)
+
+	type record struct {
+		User struct {
+			Expiration string `json:"expiration"`
+		} `json:"user"`
+	}
+
+	expiry := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	user := seclog.SnapdUser{
+		ID:         42,
+		Expiration: expiry,
+	}
+	logger.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "user", Value: user},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.User.Expiration, Equals, "2026-06-15T12:00:00Z")
+}
+
+func (s *SlogSuite) TestLevelFiltering(c *C) {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelWarn)
+	c.Assert(logger, NotNil)
+
+	// LevelInfo is below LevelWarn — should be filtered out
+	logger.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"Should be filtered",
+	)
+	c.Check(s.buf.Len(), Equals, 0)
+
+	// LevelWarn meets the threshold — should be emitted
+	logger.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelWarn},
+		"Should pass",
+	)
+	c.Check(s.buf.Len() > 0, Equals, true)
+}
+
+// failWriter is an io.Writer whose Write method can be toggled to fail.
+type failWriter struct {
+	buf     bytes.Buffer
+	failing bool
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	if w.failing {
+		return 0, fmt.Errorf("disk full")
+	}
+	return w.buf.Write(p)
+}
+
+func (s *SlogSuite) TestWriteFailureIsLogged(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	w := &failWriter{failing: true}
+	sl := seclog.NewSlogLogger(w, s.appID, seclog.LevelInfo)
+
+	sl.LogAny(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"should fail",
+	)
+
+	c.Check(logBuf.String(), testutil.Contains, "security log write failed: disk full")
+}
+
+func (s *SlogSuite) TestWriteFailureSuppressedAfterThreshold(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	w := &failWriter{failing: true}
+	sl := seclog.NewSlogLogger(w, s.appID, seclog.LevelInfo)
+
+	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
+	for i := 0; i < 5; i++ {
+		sl.LogAny(evt, fmt.Sprintf("attempt %d", i))
+	}
+
+	output := logBuf.String()
+	// First 3 failures are reported individually.
+	c.Check(strings.Count(output, "security log write failed: disk full"), Equals, 3)
+	// The suppression message appears exactly once.
+	c.Check(strings.Count(output, "suppressing further errors"), Equals, 1)
+}
+
+func (s *SlogSuite) TestWriteRecoveryIsLogged(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	w := &failWriter{failing: true}
+	sl := seclog.NewSlogLogger(w, s.appID, seclog.LevelInfo)
+
+	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
+	// Exceed the threshold.
+	for i := 0; i < 4; i++ {
+		sl.LogAny(evt, "fail")
+	}
+
+	// Recover.
+	w.failing = false
+	sl.LogAny(evt, "recovered")
+
+	c.Check(logBuf.String(), testutil.Contains, "security log write recovered")
+	c.Check(w.buf.Len() > 0, Equals, true)
+}
+
+func (s *SlogSuite) TestNoRecoveryMessageBelowThreshold(c *C) {
+	logBuf, restore := logger.MockLogger()
+	defer restore()
+
+	w := &failWriter{failing: true}
+	sl := seclog.NewSlogLogger(w, s.appID, seclog.LevelInfo)
+
+	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
+	// Fail twice (below threshold of 3).
+	sl.LogAny(evt, "fail 1")
+	sl.LogAny(evt, "fail 2")
+
+	// Recover — no recovery message expected since threshold was not reached.
+	w.failing = false
+	sl.LogAny(evt, "ok")
+
+	c.Check(strings.Contains(logBuf.String(), "security log write recovered"), Equals, false)
+}

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -104,7 +104,7 @@ func orderedKeys(data []byte) ([]string, error) {
 	return keys, nil
 }
 
-func (s *SlogSuite) TestLogAny(c *C) {
+func (s *SlogSuite) TestLogEvent(c *C) {
 	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
 	c.Assert(logger, NotNil)
 
@@ -113,7 +113,7 @@ func (s *SlogSuite) TestLogAny(c *C) {
 		Event string `json:"event"`
 	}
 
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"Something happened",
 	)
@@ -138,7 +138,7 @@ func (s *SlogSuite) TestLogAny(c *C) {
 	})
 }
 
-func (s *SlogSuite) TestLogAnyWithAttrs(c *C) {
+func (s *SlogSuite) TestLogEventWithAttrs(c *C) {
 	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
 	c.Assert(logger, NotNil)
 
@@ -163,7 +163,7 @@ func (s *SlogSuite) TestLogAnyWithAttrs(c *C) {
 		StoreUserName:  "jdoe",
 	}
 	reason := seclog.Reason{Code: seclog.ReasonInvalidCredentials, Message: "invalid credentials"}
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelWarn},
 		fmt.Sprintf("User %s caused an issue: %s", user.String(), reason.String()),
 		seclog.Attr{Key: "user", Value: user},
@@ -199,7 +199,7 @@ func (s *SlogSuite) TestLogAnyWithAttrs(c *C) {
 	})
 }
 
-func (s *SlogSuite) TestLogAnyWithLogValuer(c *C) {
+func (s *SlogSuite) TestLogEventWithLogValuer(c *C) {
 	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
 	c.Assert(logger, NotNil)
 
@@ -214,7 +214,7 @@ func (s *SlogSuite) TestLogAnyWithLogValuer(c *C) {
 		ID:         42,
 		Expiration: expiry,
 	}
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"test",
 		seclog.Attr{Key: "user", Value: user},
@@ -231,14 +231,14 @@ func (s *SlogSuite) TestLevelFiltering(c *C) {
 	c.Assert(logger, NotNil)
 
 	// LevelInfo is below LevelWarn — should be filtered out
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"Should be filtered",
 	)
 	c.Check(s.buf.Len(), Equals, 0)
 
 	// LevelWarn meets the threshold — should be emitted
-	logger.LogAny(
+	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelWarn},
 		"Should pass",
 	)
@@ -265,7 +265,7 @@ func (s *SlogSuite) TestWriteFailureIsLogged(c *C) {
 	w := &failWriter{failing: true}
 	sl := seclog.NewSlogLogger(w, s.appID, seclog.LevelInfo)
 
-	sl.LogAny(
+	sl.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"should fail",
 	)
@@ -282,7 +282,7 @@ func (s *SlogSuite) TestWriteFailureSuppressedAfterThreshold(c *C) {
 
 	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
 	for i := 0; i < 5; i++ {
-		sl.LogAny(evt, fmt.Sprintf("attempt %d", i))
+		sl.LogEvent(evt, fmt.Sprintf("attempt %d", i))
 	}
 
 	output := logBuf.String()
@@ -302,12 +302,12 @@ func (s *SlogSuite) TestWriteRecoveryIsLogged(c *C) {
 	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
 	// Exceed the threshold.
 	for i := 0; i < 4; i++ {
-		sl.LogAny(evt, "fail")
+		sl.LogEvent(evt, "fail")
 	}
 
 	// Recover.
 	w.failing = false
-	sl.LogAny(evt, "recovered")
+	sl.LogEvent(evt, "recovered")
 
 	c.Check(logBuf.String(), testutil.Contains, "security log write recovered")
 	c.Check(w.buf.Len() > 0, Equals, true)
@@ -322,12 +322,12 @@ func (s *SlogSuite) TestNoRecoveryMessageBelowThreshold(c *C) {
 
 	evt := seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo}
 	// Fail twice (below threshold of 3).
-	sl.LogAny(evt, "fail 1")
-	sl.LogAny(evt, "fail 2")
+	sl.LogEvent(evt, "fail 1")
+	sl.LogEvent(evt, "fail 2")
 
 	// Recover — no recovery message expected since threshold was not reached.
 	w.failing = false
-	sl.LogAny(evt, "ok")
+	sl.LogEvent(evt, "ok")
 
 	c.Check(strings.Contains(logBuf.String(), "security log write recovered"), Equals, false)
 }


### PR DESCRIPTION
### Implement security logging: Part 2

- Add slog implementation
- Add audit subsystem sink
- Failure threshold below which we print successive errors (as notices).

See complete implementation for reference: https://github.com/ernestl/snapd/pull/5/changes

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35756
Spec: https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0