### PR TITLE
seclog: setup snapd security logger and log login events (part 3)

### DIFF
--- a/cmd/snapd/export_test.go
+++ b/cmd/snapd/export_test.go
@@ -47,7 +47,7 @@ func MockCheckRunningConditionsRetryDelay(d time.Duration) (restore func()) {
 	}
 }
 
-func MockOpenAuditWriter(f func() (io.WriteCloser, error)) (restore func()) {
+func MockOpenAuditWriter(f func() (*seclog.AuditWriter, error)) (restore func()) {
 	oldOpenAuditWriter := openAuditWriter
 	openAuditWriter = f
 	return func() {

--- a/cmd/snapd/export_test.go
+++ b/cmd/snapd/export_test.go
@@ -20,11 +20,15 @@
 package main
 
 import (
+	"io"
 	"time"
+
+	"github.com/snapcore/snapd/seclog"
 )
 
 var (
-	Run = run
+	Run                  = run
+	SetupSecurityLogging = setupSecurityLogging
 )
 
 func MockSyscheckCheckSystem(f func() error) (restore func()) {
@@ -40,5 +44,21 @@ func MockCheckRunningConditionsRetryDelay(d time.Duration) (restore func()) {
 	checkRunningConditionsRetryDelay = d
 	return func() {
 		checkRunningConditionsRetryDelay = oldCheckRunningConditionsRetryDelay
+	}
+}
+
+func MockOpenAuditWriter(f func() (io.WriteCloser, error)) (restore func()) {
+	oldOpenAuditWriter := openAuditWriter
+	openAuditWriter = f
+	return func() {
+		openAuditWriter = oldOpenAuditWriter
+	}
+}
+
+func MockNewSlogLogger(f func(io.Writer, string, seclog.Level) seclog.SecurityLogger) (restore func()) {
+	oldNewSlogLogger := newSlogLogger
+	newSlogLogger = f
+	return func() {
+		newSlogLogger = oldNewSlogLogger
 	}
 }

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -57,8 +57,7 @@ func init() {
 
 func main() {
 	// Set up security logging via the audit subsystem.
-	teardown := setupSecurityLogging()
-	defer teardown()
+	teardownSecurityLogging := setupSecurityLogging()
 
 	// When preseeding re-exec is not used
 	if snapdenv.Preseeding() {
@@ -74,7 +73,13 @@ func main() {
 	// TODO look into signal.NotifyContext
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	if err := run(ch); err != nil {
+	err := run(ch)
+
+	// Tear down security logging explicitly so that the "disabled" log
+	// entry is written before any os.Exit call
+	teardownSecurityLogging()
+
+	if err != nil {
 		if errors.Is(err, daemon.ErrRestartSocket) {
 			// Note that we don't prepend: "error: " here because
 			// ErrRestartSocket is not an error as such.

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -56,15 +56,15 @@ func init() {
 }
 
 func main() {
-	// Set up security logging via the audit subsystem.
-	teardownSecurityLogging := setupSecurityLogging()
-
 	// When preseeding re-exec is not used
 	if snapdenv.Preseeding() {
 		logger.Noticef("running for preseeding")
 	} else {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
+
+	// Set up security logging via the audit subsystem.
+	teardownSecurityLogging := setupSecurityLogging()
 
 	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"argon2-proc"})
 

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/syscheck"
@@ -41,6 +42,13 @@ import (
 
 var (
 	syscheckCheckSystem = syscheck.CheckSystem
+	openAuditWriter     = seclog.OpenAuditWriter
+	newSlogLogger       = seclog.NewSlogLogger
+)
+
+const (
+	secLogAppID                 = "canonical.snapd.snapd"
+	secLogMinLevel seclog.Level = seclog.LevelInfo
 )
 
 func init() {
@@ -48,6 +56,10 @@ func init() {
 }
 
 func main() {
+	// Set up security logging via the audit subsystem.
+	teardown := setupSecurityLogging()
+	defer teardown()
+
 	// When preseeding re-exec is not used
 	if snapdenv.Preseeding() {
 		logger.Noticef("running for preseeding")
@@ -80,6 +92,21 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "cannot run daemon: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func setupSecurityLogging() (teardown func()) {
+	auditWriter, err := openAuditWriter()
+	if err != nil {
+		logger.Noticef("cannot set up security logger: %v", err)
+		return func() {}
+	}
+	sl := newSlogLogger(auditWriter, secLogAppID, secLogMinLevel)
+	seclog.Setup(sl)
+	seclog.LogLoggerEnabled()
+	return func() {
+		seclog.LogLoggerDisabled()
+		auditWriter.Close()
 	}
 }
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -83,6 +84,17 @@ type userResponseData struct {
 
 var isEmailish = regexp.MustCompile(`.@.*\..`).MatchString
 
+// loginError logs a login failure to the security audit log and returns resp
+// unchanged. It is a convenience wrapper so that each error return path in
+// loginUser can log with a single call.
+func loginError(resp *apiError, snapdUser seclog.SnapdUser, code string) *apiError {
+	seclog.LogLoginFailure(snapdUser, seclog.Reason{
+		Code:    code,
+		Message: resp.Message,
+	})
+	return resp
+}
+
 func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	var loginData struct {
 		Username string `json:"username"`
@@ -93,7 +105,8 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&loginData); err != nil {
-		return BadRequest("cannot decode login data from request body: %v", err)
+		return loginError(BadRequest("cannot decode login data from request body: %v", err),
+			seclog.SnapdUser{}, seclog.ReasonInvalidAuthData)
 	}
 
 	if loginData.Email == "" && isEmailish(loginData.Username) {
@@ -108,12 +121,23 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	// the "username" needs to look a lot like an email address
 	if !isEmailish(loginData.Email) {
-		return &apiError{
+		return loginError(&apiError{
 			Status:  400,
 			Message: "please use a valid email address.",
 			Kind:    client.ErrorKindInvalidAuthData,
 			Value:   map[string][]string{"email": {"invalid"}},
-		}
+		}, seclog.SnapdUser{
+			StoreUserName:  loginData.Username,
+			StoreUserEmail: loginData.Email,
+		}, seclog.ReasonInvalidAuthData)
+	}
+
+	// Build the user identity for security audit logging. At this
+	// point we know the email and optional username; the numeric ID
+	// is only available after successful authentication.
+	snapdUser := seclog.SnapdUser{
+		StoreUserName:  loginData.Username,
+		StoreUserEmail: loginData.Email,
 	}
 
 	overlord := c.d.overlord
@@ -122,35 +146,39 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	macaroon, discharge, err := theStore.LoginUser(loginData.Email, loginData.Password, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
-		return &apiError{
+		return loginError(&apiError{
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorRequired,
-		}
+		}, snapdUser, seclog.ReasonTwoFactorRequired)
 	case store.Err2faFailed:
-		return &apiError{
+		return loginError(&apiError{
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorFailed,
-		}
+		}, snapdUser, seclog.ReasonTwoFactorFailed)
 	default:
 		switch err := err.(type) {
 		case store.InvalidAuthDataError:
-			return &apiError{
+			return loginError(&apiError{
 				Status:  400,
 				Message: err.Error(),
 				Kind:    client.ErrorKindInvalidAuthData,
 				Value:   err,
-			}
+			}, snapdUser, seclog.ReasonInvalidAuthData)
 		case store.PasswordPolicyError:
-			return &apiError{
+			return loginError(&apiError{
 				Status:  401,
 				Message: err.Error(),
 				Kind:    client.ErrorKindPasswordPolicy,
 				Value:   err,
-			}
+			}, snapdUser, seclog.ReasonPasswordPolicy)
 		}
-		return Unauthorized(err.Error())
+		reason := seclog.ReasonInternal
+		if err == store.ErrInvalidCredentials {
+			reason = seclog.ReasonInvalidCredentials
+		}
+		return loginError(Unauthorized(err.Error()), snapdUser, reason)
 	case nil:
 		// continue
 	}
@@ -172,8 +200,14 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	st.Unlock()
 	if err != nil {
-		return InternalError("cannot persist authentication details: %v", err)
+		return loginError(InternalError("cannot persist authentication details: %v", err), snapdUser, seclog.ReasonInternal)
 	}
+
+	snapdUser.ID = int64(user.ID)
+	snapdUser.StoreUserName = user.Username
+	snapdUser.StoreUserEmail = user.Email
+	snapdUser.Expiration = user.Expiration
+	seclog.LogLoginSuccess(snapdUser)
 
 	result := userResponseData{
 		ID:         user.ID,

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -84,10 +84,10 @@ type userResponseData struct {
 
 var isEmailish = regexp.MustCompile(`.@.*\..`).MatchString
 
-// loginError logs a login failure to the security audit log and returns resp
+// apiLoginError logs a login failure to the security audit log and returns resp
 // unchanged. It is a convenience wrapper so that each error return path in
 // loginUser can log with a single call.
-func loginError(resp *apiError, snapdUser seclog.SnapdUser, code string) *apiError {
+func apiLoginError(resp *apiError, snapdUser seclog.SnapdUser, code string) *apiError {
 	seclog.LogLoginFailure(snapdUser, seclog.Reason{
 		Code:    code,
 		Message: resp.Message,
@@ -105,7 +105,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&loginData); err != nil {
-		return loginError(BadRequest("cannot decode login data from request body: %v", err),
+		return apiLoginError(BadRequest("cannot decode login data from request body: %v", err),
 			seclog.SnapdUser{}, seclog.ReasonInvalidAuthData)
 	}
 
@@ -121,7 +121,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	// the "username" needs to look a lot like an email address
 	if !isEmailish(loginData.Email) {
-		return loginError(&apiError{
+		return apiLoginError(&apiError{
 			Status:  400,
 			Message: "please use a valid email address.",
 			Kind:    client.ErrorKindInvalidAuthData,
@@ -132,9 +132,9 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		}, seclog.ReasonInvalidAuthData)
 	}
 
-	// Build the user identity for security audit logging. At this
-	// point we know the email and optional username; the numeric ID
-	// is only available after successful authentication.
+	// Build the user identity for security audit logging. At this point we know
+	// their claimed email and optional username; the numeric ID is only
+	// available after successful authentication.
 	snapdUser := seclog.SnapdUser{
 		StoreUserName:  loginData.Username,
 		StoreUserEmail: loginData.Email,
@@ -146,13 +146,13 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	macaroon, discharge, err := theStore.LoginUser(loginData.Email, loginData.Password, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
-		return loginError(&apiError{
+		return apiLoginError(&apiError{
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorRequired,
 		}, snapdUser, seclog.ReasonTwoFactorRequired)
 	case store.Err2faFailed:
-		return loginError(&apiError{
+		return apiLoginError(&apiError{
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorFailed,
@@ -160,14 +160,14 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	default:
 		switch err := err.(type) {
 		case store.InvalidAuthDataError:
-			return loginError(&apiError{
+			return apiLoginError(&apiError{
 				Status:  400,
 				Message: err.Error(),
 				Kind:    client.ErrorKindInvalidAuthData,
 				Value:   err,
 			}, snapdUser, seclog.ReasonInvalidAuthData)
 		case store.PasswordPolicyError:
-			return loginError(&apiError{
+			return apiLoginError(&apiError{
 				Status:  401,
 				Message: err.Error(),
 				Kind:    client.ErrorKindPasswordPolicy,
@@ -178,7 +178,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		if err == store.ErrInvalidCredentials {
 			reason = seclog.ReasonInvalidCredentials
 		}
-		return loginError(Unauthorized(err.Error()), snapdUser, reason)
+		return apiLoginError(Unauthorized(err.Error()), snapdUser, reason)
 	case nil:
 		// continue
 	}
@@ -200,7 +200,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	st.Unlock()
 	if err != nil {
-		return loginError(InternalError("cannot persist authentication details: %v", err), snapdUser, seclog.ReasonInternal)
+		return apiLoginError(InternalError("cannot persist authentication details: %v", err), snapdUser, seclog.ReasonInternal)
 	}
 
 	snapdUser.ID = int64(user.ID)

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -99,7 +99,7 @@ func (s *userSuite) SetUpTest(c *check.C) {
 	s.loginUserDischarge = ""
 
 	s.seclogBuf = &bytes.Buffer{}
-	seclog.Setup(seclogtest.NewMockSecurityLogger(s.seclogBuf))
+	seclog.Setup(seclogtest.MockSecurityLogger(s.seclogBuf))
 	s.AddCleanup(func() { seclog.Setup(seclog.NewNopLogger()) })
 }
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -53,6 +55,8 @@ type userSuite struct {
 
 	mockUserHome      string
 	trivialUserLookup func(username string) (*user.User, error)
+
+	seclogBuf *bytes.Buffer
 }
 
 func (s *userSuite) LoginUser(username, password, otp string) (string, string, error) {
@@ -93,6 +97,10 @@ func (s *userSuite) SetUpTest(c *check.C) {
 
 	s.loginUserStoreMacaroon = ""
 	s.loginUserDischarge = ""
+
+	s.seclogBuf = &bytes.Buffer{}
+	seclog.Setup(seclogtest.NewMockSecurityLogger(s.seclogBuf))
+	s.AddCleanup(func() { seclog.Setup(seclog.NewNopLogger()) })
 }
 
 func mkUserLookup(userHomeDir string) func(string) (*user.User, error) {
@@ -149,6 +157,10 @@ func (s *userSuite) TestLoginUser(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(snapdMacaroon.Id(), check.Equals, "1")
 	c.Check(snapdMacaroon.Location(), check.Equals, "snapd")
+
+	// security log was called with the right user details
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
 }
 
 func (s *userSuite) TestLoginUserWithUsername(c *check.C) {
@@ -191,6 +203,11 @@ func (s *userSuite) TestLoginUserWithUsername(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(snapdMacaroon.Id(), check.Equals, "1")
 	c.Check(snapdMacaroon.Location(), check.Equals, "snapd")
+
+	// security log was called with the right user details
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
 }
 
 func (s *userSuite) TestLoginUserNoEmailWithExistentLocalUser(c *check.C) {
@@ -239,6 +256,11 @@ func (s *userSuite) TestLoginUserNoEmailWithExistentLocalUser(c *check.C) {
 	c.Check(user.Discharges, check.IsNil)
 	c.Check(user.StoreMacaroon, check.Equals, s.loginUserStoreMacaroon)
 	c.Check(user.StoreDischarges, check.DeepEquals, []string{"the-discharge-macaroon-serialized-data"})
+
+	// security log was called with the right user details
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@test.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
 }
 
 func (s *userSuite) TestLoginUserWithExistentLocalUser(c *check.C) {
@@ -287,6 +309,11 @@ func (s *userSuite) TestLoginUserWithExistentLocalUser(c *check.C) {
 	c.Check(user.Discharges, check.IsNil)
 	c.Check(user.StoreMacaroon, check.Equals, s.loginUserStoreMacaroon)
 	c.Check(user.StoreDischarges, check.DeepEquals, []string{"the-discharge-macaroon-serialized-data"})
+
+	// security log was called with the right user details
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@test.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
 }
 
 func (s *userSuite) TestLoginUserNewEmailWithExistentLocalUser(c *check.C) {
@@ -336,6 +363,11 @@ func (s *userSuite) TestLoginUserNewEmailWithExistentLocalUser(c *check.C) {
 	c.Check(user.Discharges, check.IsNil)
 	c.Check(user.StoreMacaroon, check.Equals, s.loginUserStoreMacaroon)
 	c.Check(user.StoreDischarges, check.DeepEquals, []string{"the-discharge-macaroon-serialized-data"})
+
+	// security log was called with the right user details
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_success")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "new.email@test.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
 }
 
 func (s *userSuite) TestLogoutUser(c *check.C) {
@@ -375,6 +407,9 @@ func (s *userSuite) TestLoginUserBadRequest(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 400)
 	c.Check(rspe.Message, check.Not(check.Equals), "")
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
 }
 
 func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
@@ -387,6 +422,10 @@ func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 400)
 	c.Check(rspe.Message, testutil.Contains, "please use a valid email address")
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "notemail")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
 }
 
 func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
@@ -400,6 +439,10 @@ func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 401)
 	c.Check(rspe.Message, testutil.Contains, "error-from-login-user")
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInternal)
 }
 
 func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
@@ -413,6 +456,10 @@ func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 401)
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindTwoFactorRequired)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonTwoFactorRequired)
 }
 
 func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
@@ -426,6 +473,10 @@ func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 401)
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindTwoFactorFailed)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonTwoFactorFailed)
 }
 
 func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
@@ -439,6 +490,10 @@ func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, check.Equals, 401)
 	c.Check(rspe.Message, check.Equals, "invalid credentials")
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidCredentials)
 }
 
 func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
@@ -453,6 +508,10 @@ func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
 	c.Check(rspe.Status, check.Equals, 400)
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindInvalidAuthData)
 	c.Check(rspe.Value, check.DeepEquals, s.err)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
 }
 
 func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
@@ -467,6 +526,32 @@ func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
 	c.Check(rspe.Status, check.Equals, 401)
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindPasswordPolicy)
 	c.Check(rspe.Value, check.DeepEquals, s.err)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonPasswordPolicy)
+}
+
+func (s *userSuite) TestLoginUserPersistError(c *check.C) {
+	s.expectLoginAccess()
+
+	s.loginUserStoreMacaroon = "user-macaroon"
+	s.loginUserDischarge = "the-discharge-macaroon-serialized-data"
+	buf := bytes.NewBufferString(`{"username": "username", "email": "email@.com", "password": "password"}`)
+	req, err := http.NewRequest("POST", "/v2/login", buf)
+	c.Assert(err, check.IsNil)
+
+	// Pass a user whose ID does not exist in the auth state, so
+	// auth.UpdateUser returns ErrInvalidUser.
+	fakeUser := &auth.UserState{ID: 99999, Username: "username", Email: "email@.com"}
+	rspe := s.errorReq(c, req, fakeUser, actionIsExpected)
+	c.Check(rspe.Status, check.Equals, 500)
+	c.Check(rspe.Message, check.Matches, "cannot persist authentication details: .*")
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
+	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInternal)
 }
 
 func (s *userSuite) TestPostCreateUser(c *check.C) {

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -7,21 +7,23 @@ details: |
     when store credentials are available, that a successful login produces
     an "authn_login_success" event in the audit log.
 
-# ubuntu-core: auditd is not available as a distro package
-systems: [-ubuntu-core-*]
-
 prepare: |
-    # Ensure auditd (which provides ausearch) is installed and running.
-    if ! command -v ausearch; then
-        #shellcheck source=tests/lib/pkgdb.sh
-        . "$TESTSLIB/pkgdb.sh"
-        distro_install_package auditd
-        systemctl enable --now auditd.service
+    if ! systemctl is-active systemd-journald-audit.socket; then
+        touch audit-socket-was-inactive
+        systemctl stop systemd-journald.service
+        systemctl start systemd-journald-audit.socket
+        systemctl restart systemd-journald.service
     fi
+    systemctl restart snapd.service
 
 restore: |
+    if [ -f audit-socket-was-inactive ]; then
+        systemctl stop systemd-journald-audit.socket
+        systemctl restart systemd-journald.service
+        rm -f audit-socket-was-inactive
+    fi
+
     snap logout || true
-    rm -f stamp content
 
 execute: |
     # Pin snapd journal search position to the current journal position
@@ -29,81 +31,60 @@ execute: |
         "$TESTSTOOLS"/journal-state start_new_log
     }
 
-    # Assert that snapd.service logs since the pinned position do not match expression
+    # Assert that journal logs since the pinned position do not match expression
+    # Usage: journal_nomatch <expression> [-u <unit>]
     journal_nomatch() {
-        expression="$1"
-        ! "$TESTSTOOLS"/journal-state match-log "$expression" -n 1 -u snapd.service >/dev/null 2>&1
+        local expression="$1"; shift
+        ! "$TESTSTOOLS"/journal-state match-log "$expression" -n 1 "$@" >/dev/null 2>&1
     }
 
-    # Assert that snapd.service logs since the pinned position match expression
+    # Assert that journal logs since the pinned position match expression
+    # Usage: journal_match <expression> [-u <unit>]
     journal_match() {
-        expression="$1"
-        "$TESTSTOOLS"/journal-state match-log "$expression" -n 3 -u snapd.service >/dev/null 2>&1
+        local expression="$1"; shift
+        "$TESTSTOOLS"/journal-state match-log "$expression" -n 3 "$@" >/dev/null 2>&1
     }
 
-    # Pin audit search position to after the latest existing 1121 events
-    audit_pin() {
-        rm -f stamp content
-        ausearch --checkpoint stamp -m 1121 --raw >/dev/null 2>&1 || true
-    }
-
-    # Dump all content since pinned position into file with provided name
-    audit_dump() {
-        filename=$1
-        ausearch --start checkpoint --checkpoint stamp -m 1121 --raw > "$filename" 2>&1 || true
-    }
-
-    # Wait for snapd to become active and responsive to API calls, retrying if necessary.
+    # Wait for snapd to become active and responsive to API calls.
     wait_snapd_ready() {
-        local retries="${1:-3}"
-        local delay="${2:-1}"
         local attempt=1
         local output
 
-        while (( attempt <= retries )); do
+        while (( attempt <= 10 )); do
             if output="$(snap debug api /v2/snaps 2>&1)"; then
-                echo "snapd ready" >&2
                 return 0
             fi
-
-            echo "snapd API not ready yet, retrying ($attempt/$retries): $output" >&2
-            sleep "$delay"
+            sleep 1
             ((attempt++))
         done
 
-        echo "snapd API did not become ready after $retries attempts" >&2
+        echo "snapd API did not become ready after 3 attempts" >&2
         echo "last error: $output" >&2
         return 1
     }
 
     echo "Checking that the security logger is disabled in snapd stop and enabled on snapd start"
-    audit_pin
     journal_pin
     systemctl restart snapd.service
     wait_snapd_ready
-    journal_match "security logger disabled"
-    journal_match "security logger enabled"
+    journal_match "security logger disabled" -u snapd.service
+    journal_match "security logger enabled" -u snapd.service
 
     echo "Checking that restart produces disable/enable audit events"
-    audit_dump content
-    MATCH 'sys_logging_disabled' < content
-    MATCH 'sys_logging_enabled' < content
+    journal_match '"level":"INFO","description":"Security logging enabled","app_id":"canonical.snapd.snapd","type":"security","category":"SYS","event":"sys_logging_enabled"'
+    journal_match '"level":"CRITICAL","description":"Security logging disabled","app_id":"canonical.snapd.snapd","type":"security","category":"SYS","event":"sys_logging_disabled"'
 
     echo "Checking that a failed login attempt produces an audit event"
-    audit_pin
     echo '{"email":"someemail@testing.com","password":"wrong-password"}' | \
         snap debug api -X POST -H 'Content-Type: application/json' /v2/login || true
-    audit_dump content
-    MATCH 'authn_login_failure' < content
-    MATCH 'invalid-credentials' < content
-    MATCH 'someemail@testing.com' < content
 
+    journal_match '"level":"WARN","description":"User <unknown>:someemail@testing.com:<unknown> login failure: invalid-credentials:invalid credentials","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_failure","user":{"snapd-user-id":0,"store-user-name":"","store-user-email":"someemail@testing.com","expiration":"never"},"error":{"code":"invalid-credentials","message":"invalid credentials"}'
+
+
+    # SPREAD_STORE_USER and SPREAD_STORE_PASSWORD are only available when running off master
     if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ]; then
         echo "Checking that a successful login produces an audit event"
-        audit_pin
         expect -d -f "$TESTSLIB"/successful_login.exp
-        audit_dump content
-        MATCH 'authn_login_success' < content
-        MATCH "$SPREAD_STORE_USER" < content
-        snap logout
+
+        journal_match '"level":"INFO","description":"User [^ ]* login success","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_success","user":\{"snapd-user-id":[0-9]+,"store-user-name":"[^"]*","store-user-email":"[^"]*","expiration":"[^"]*"\}'
     fi

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -38,28 +38,10 @@ execute: |
         "$TESTSTOOLS"/journal-state match-log "$expression" -n 3 "$@" >/dev/null 2>&1
     }
 
-    # Wait for snapd to become active and responsive to API calls.
-    wait_snapd_ready() {
-        local attempt=1
-        local output
-
-        while (( attempt <= 10 )); do
-            if output="$(snap debug api /v2/snaps 2>&1)"; then
-                return 0
-            fi
-            sleep 1
-            ((attempt++))
-        done
-
-        echo "snapd API did not become ready after 3 attempts" >&2
-        echo "last error: $output" >&2
-        return 1
-    }
-
     echo "Checking that the security logger is disabled in snapd stop and enabled on snapd start"
     journal_pin
     systemctl restart snapd.service
-    wait_snapd_ready
+    snap wait system seed.loaded
     journal_match "security logger disabled" -u snapd.service
     journal_match "security logger enabled" -u snapd.service
 

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -31,13 +31,6 @@ execute: |
         "$TESTSTOOLS"/journal-state start_new_log
     }
 
-    # Assert that journal logs since the pinned position do not match expression
-    # Usage: journal_nomatch <expression> [-u <unit>]
-    journal_nomatch() {
-        local expression="$1"; shift
-        ! "$TESTSTOOLS"/journal-state match-log "$expression" -n 1 "$@" >/dev/null 2>&1
-    }
-
     # Assert that journal logs since the pinned position match expression
     # Usage: journal_match <expression> [-u <unit>]
     journal_match() {

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -8,6 +8,20 @@ details: |
     an "authn_login_success" event in the audit log.
 
 prepare: |
+    # Enable the kernel audit subsystem if it isn't already enabled.
+    python3 -c "
+    import socket, struct
+    NETLINK_AUDIT = 9
+    AUDIT_SET = 1001
+    NLM_F_REQUEST = 1
+    # audit_status struct: mask=1 (AUDIT_STATUS_ENABLED), enabled=1, rest zeroed
+    status = struct.pack('IIIIIIiii', 1, 1, 0, 0, 0, 0, 0, 0, 0)
+    hdr = struct.pack('IHHII', 16 + len(status), AUDIT_SET, NLM_F_REQUEST, 1, 0)
+    s = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_AUDIT)
+    s.sendto(hdr + status, (0, 0))
+    s.close()
+    "
+
     if ! systemctl is-active systemd-journald-audit.socket; then
         touch audit-socket-was-inactive
         systemctl stop systemd-journald.service

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -1,0 +1,109 @@
+summary: Checks that security audit events are written to the kernel audit log
+
+details: |
+    The snapd daemon writes structured security audit events via the kernel
+    audit subsystem (AUDIT_TRUSTED_APP, type 1121). This test verifies that
+    a failed login attempt produces an "authn_login_failure" event and,
+    when store credentials are available, that a successful login produces
+    an "authn_login_success" event in the audit log.
+
+# ubuntu-core: auditd is not available as a distro package
+systems: [-ubuntu-core-*]
+
+prepare: |
+    # Ensure auditd (which provides ausearch) is installed and running.
+    if ! command -v ausearch; then
+        #shellcheck source=tests/lib/pkgdb.sh
+        . "$TESTSLIB/pkgdb.sh"
+        distro_install_package auditd
+        systemctl enable --now auditd.service
+    fi
+
+restore: |
+    snap logout || true
+    rm -f stamp content
+
+execute: |
+    # Pin snapd journal search position to the current journal position
+    journal_pin() {
+        "$TESTSTOOLS"/journal-state start_new_log
+    }
+
+    # Assert that snapd.service logs since the pinned position do not match expression
+    journal_nomatch() {
+        expression="$1"
+        ! "$TESTSTOOLS"/journal-state match-log "$expression" -n 1 -u snapd.service >/dev/null 2>&1
+    }
+
+    # Assert that snapd.service logs since the pinned position match expression
+    journal_match() {
+        expression="$1"
+        "$TESTSTOOLS"/journal-state match-log "$expression" -n 3 -u snapd.service >/dev/null 2>&1
+    }
+
+    # Pin audit search position to after the latest existing 1121 events
+    audit_pin() {
+        rm -f stamp content
+        ausearch --checkpoint stamp -m 1121 --raw >/dev/null 2>&1 || true
+    }
+
+    # Dump all content since pinned position into file with provided name
+    audit_dump() {
+        filename=$1
+        ausearch --start checkpoint --checkpoint stamp -m 1121 --raw > "$filename" 2>&1 || true
+    }
+
+    # Wait for snapd to become active and responsive to API calls, retrying if necessary.
+    wait_snapd_ready() {
+        local retries="${1:-3}"
+        local delay="${2:-1}"
+        local attempt=1
+        local output
+
+        while (( attempt <= retries )); do
+            if output="$(snap debug api /v2/snaps 2>&1)"; then
+                echo "snapd ready" >&2
+                return 0
+            fi
+
+            echo "snapd API not ready yet, retrying ($attempt/$retries): $output" >&2
+            sleep "$delay"
+            ((attempt++))
+        done
+
+        echo "snapd API did not become ready after $retries attempts" >&2
+        echo "last error: $output" >&2
+        return 1
+    }
+
+    echo "Checking that the security logger is disabled in snapd stop and enabled on snapd start"
+    audit_pin
+    journal_pin
+    systemctl restart snapd.service
+    wait_snapd_ready
+    journal_match "security logger disabled"
+    journal_match "security logger enabled"
+
+    echo "Checking that restart produces disable/enable audit events"
+    audit_dump content
+    MATCH 'sys_logging_disabled' < content
+    MATCH 'sys_logging_enabled' < content
+
+    echo "Checking that a failed login attempt produces an audit event"
+    audit_pin
+    echo '{"email":"someemail@testing.com","password":"wrong-password"}' | \
+        snap debug api -X POST -H 'Content-Type: application/json' /v2/login || true
+    audit_dump content
+    MATCH 'authn_login_failure' < content
+    MATCH 'invalid-credentials' < content
+    MATCH 'someemail@testing.com' < content
+
+    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ]; then
+        echo "Checking that a successful login produces an audit event"
+        audit_pin
+        expect -d -f "$TESTSLIB"/successful_login.exp
+        audit_dump content
+        MATCH 'authn_login_success' < content
+        MATCH "$SPREAD_STORE_USER" < content
+        snap logout
+    fi


### PR DESCRIPTION
### Implement security logging: Part 3
- Setup/graceful-close security logger for snapd.
- Use seclog for logging login success and failure.
- Spread test

See complete implementation for reference: https://github.com/ernestl/snapd/pull/5/changes

The audit log, as persisted by auditd, can be inspected with:

```
sudo tail -f /var/log/audit/audit.log
or ausearch -m 1121 --raw
```

To have journald also log audit messages:
```
sudo systemctl enable systemd-journald-audit.socket
sudo systemctl restart systemd-journald.service
journalctl -f
```
Example output: 
```
type=TRUSTED_APP msg=audit(1777146066.014:297): pid=11855 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg='{"datetime":"2026-04-25T19:41:06.014896849Z","level":"WARN","description":"User unknown:someemail@testing.com:unknown login failure: invalid-credentials:invalid credentials","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_failure","user":{"snapd-user-id":0,"store-user-name":"","store-user-email":"someemail@testing.com","expiration":"never"},"error":{"code":"invalid-credentials","message":"invalid credentials"}}'
```

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35756
Spec: https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0