### PR TITLE
interfaces/builtin: add MODE support to custom-device udev-tagging rules

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -129,7 +129,7 @@ func (iface *customDeviceInterface) validatePaths(attrName string, paths []strin
 func (iface *customDeviceInterface) validateUDevModeValue(value any) error {
 	stringValue, ok := value.(string)
 	if !ok {
-		return fmt.Errorf(`value "%v" is not a string, octal mode must be quoted e.g. " mode: '0644' "`, value)
+		return fmt.Errorf("value \"%v\" is not a string, octal mode must be quoted e.g. `mode: '0644'`", value)
 	}
 
 	if !customDeviceUDevFileModeRegexp.MatchString(stringValue) {

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -70,6 +70,10 @@ var (
 
 	// Validating regexp for udev tag values (all but kernel devices)
 	customDeviceUDevValueRegexp = regexp.MustCompile(`^[^"{}\\]+$`)
+
+	// must be 3 or 4 digit octal values as string (e.g. [0]644) with no
+	// preceding or following characters.
+	customDeviceUDevFileModeRegexp = regexp.MustCompile(`^[0-7]{3,4}$`)
 )
 
 // customDeviceInterface allows sharing customDevice between snaps
@@ -116,6 +120,19 @@ func (iface *customDeviceInterface) validatePaths(attrName string, paths []strin
 		if err := iface.validateFilePath(path, attrName); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (iface *customDeviceInterface) validateUDevModeValue(value any) error {
+	stringValue, ok := value.(string)
+	if !ok {
+		return fmt.Errorf(`value "%v" is not a string, octal mode must be quoted e.g. " mode: '0644' "`, value)
+	}
+
+	if !customDeviceUDevFileModeRegexp.MatchString(stringValue) {
+		return fmt.Errorf(`value "%v" is not a valid octal file mode string e.g. "[0]644"`, stringValue)
 	}
 
 	return nil
@@ -187,6 +204,8 @@ func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]any,
 				break
 			}
 			kernelVal = value.(string)
+		case "mode":
+			err = iface.validateUDevModeValue(value)
 		case "attributes", "environment":
 			err = iface.validateUDevValueMap(value)
 		case "for-device":
@@ -455,6 +474,10 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 
 		if subsystem, ok := udevTaggingRule["subsystem"].(string); ok {
 			fmt.Fprintf(rule, `, SUBSYSTEM=="%s"`, subsystem)
+		}
+
+		if mode, ok := udevTaggingRule["mode"].(string); ok {
+			fmt.Fprintf(rule, `, MODE="%s"`, mode)
 		}
 
 		environment := iface.extractStringMapAttribute(udevTaggingRule, "environment")

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -72,8 +72,9 @@ var (
 	customDeviceUDevValueRegexp = regexp.MustCompile(`^[^"{}\\]+$`)
 
 	// must be 3 or 4 digit octal values as string (e.g. [0]644) with no
-	// preceding or following characters.
-	customDeviceUDevFileModeRegexp = regexp.MustCompile(`^[0-7]{3,4}$`)
+	// preceding or following characters. If 4 digits, first digit must be 0
+	// since the first digit is not relevant to device nodes.
+	customDeviceUDevFileModeRegexp = regexp.MustCompile(`^(0?)[0-7]{3}$`)
 )
 
 // customDeviceInterface allows sharing customDevice between snaps

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -346,6 +346,41 @@ apps:
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: foo\n      for-device: 1234",
 			`custom-device "udev-tagging" invalid "for-device" tag: "for-device" must be a string, but got int64: 1234`,
 		},
+		// mode validation: non-string
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: 660",
+			`custom-device "udev-tagging" invalid "mode" tag: value "660" is not a string, octal mode must be quoted e\.g\. " mode: '0644' "`,
+		},
+		// mode validation: too short (2 digits)
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"66\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "66" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
+		// mode validation: too long (5 digits)
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"06660\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "06660" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
+		// mode validation: non-octal digit (8 is not octal)
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"688\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "688" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
+		// mode validation: non-octal digit (9 is not octal)
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"0699\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "0699" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
+		// mode validation: alphabetic characters
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"rw-\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "rw-" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
+		// mode validation: leading/trailing spaces
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \" 660\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value " 660" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
 	}
 
 	for _, testData := range data {
@@ -727,6 +762,73 @@ apps:
 # custom-device
 KERNEL=="msr[0-9]*", SUBSYSTEM=="msr", TAG+="snap_consumer_app"
 TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`[1:], dirs.DistroLibExecDir))
+}
+
+func (s *CustomDeviceInterfaceSuite) TestUDevSpecMode(c *C) {
+	const slotYamlTemplate = `name: provider
+version: 0
+slots:
+ hwdev:
+  interface: custom-device
+  custom-device: mydev
+  devices:
+    - /dev/mydev
+  udev-tagging:
+    - kernel: mydev
+      %s
+apps:
+ app:
+  slots: [hwdev]
+`
+	data := []struct {
+		taggingYaml  string
+		expectedMode string
+	}{
+		// 3-digit octal, no leading zero
+		{
+			`mode: "660"`,
+			`MODE="660"`,
+		},
+		// 4-digit octal with leading zero
+		{
+			`mode: "0660"`,
+			`MODE="0660"`,
+		},
+		// world-writable 3-digit
+		{
+			`mode: "666"`,
+			`MODE="666"`,
+		},
+		// world-writable 4-digit
+		{
+			`mode: "0666"`,
+			`MODE="0666"`,
+		},
+		// restrictive owner-only
+		{
+			`mode: "600"`,
+			`MODE="600"`,
+		},
+		// execute bits included
+		{
+			`mode: "755"`,
+			`MODE="755"`,
+		},
+	}
+
+	for _, testData := range data {
+		testLabel := Commentf("tagging yaml: %s", testData.taggingYaml)
+		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+		c.Assert(err, IsNil, testLabel)
+		spec := udev.NewSpecification(appSet)
+		snapYaml := fmt.Sprintf(slotYamlTemplate, testData.taggingYaml)
+		slot, _ := MockConnectedSlot(c, snapYaml, nil, "hwdev")
+		c.Assert(spec.AddConnectedPlug(s.iface, s.plug, slot), IsNil, testLabel)
+		snippets := spec.Snippets()
+
+		all := strings.Join(snippets, "\n")
+		c.Check(all, testutil.Contains, testData.expectedMode, testLabel)
+	}
 }
 
 func (s *CustomDeviceInterfaceSuite) TestAutoConnect(c *C) {

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -834,6 +834,32 @@ apps:
 		all := strings.Join(snippets, "\n")
 		c.Check(all, testutil.Contains, testData.expectedMode, testLabel)
 	}
+
+	// Verify that mode coexists correctly with other tagging attributes
+	// without garbling the output.
+	const combinedTaggingYaml = `mode: "0660"
+      subsystem: input
+      attributes:
+        attr1: one
+        attr2: two
+      environment:
+        env1: first
+        env2: second|other`
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	snapYaml := fmt.Sprintf(slotYamlTemplate, combinedTaggingYaml)
+	slot, _ := MockConnectedSlot(c, snapYaml, nil, "hwdev")
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, slot), IsNil)
+	snippets := spec.Snippets()
+	all := strings.Join(snippets, "\n")
+	c.Check(all, testutil.Contains, `KERNEL=="mydev"`)
+	c.Check(all, testutil.Contains, `SUBSYSTEM=="input"`)
+	c.Check(all, testutil.Contains, `MODE="0660"`)
+	c.Check(all, testutil.Contains, `ATTR{attr1}=="one"`)
+	c.Check(all, testutil.Contains, `ATTR{attr2}=="two"`)
+	c.Check(all, testutil.Contains, `ENV{env1}=="first"`)
+	c.Check(all, testutil.Contains, `ENV{env2}=="second|other"`)
 }
 
 func (s *CustomDeviceInterfaceSuite) TestAutoConnect(c *C) {

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -371,6 +371,11 @@ apps:
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"0699\"",
 			`custom-device "udev-tagging" invalid "mode" tag: value "0699" is not a valid octal file mode string e\.g\. "\[0\]644"`,
 		},
+		// mode validation: non-zero leading digit in 4-digit form
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"1660\"",
+			`custom-device "udev-tagging" invalid "mode" tag: value "1660" is not a valid octal file mode string e\.g\. "\[0\]644"`,
+		},
 		// mode validation: alphabetic characters
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: \"rw-\"",

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -349,7 +349,7 @@ apps:
 		// mode validation: non-string
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: \"null\"\n      mode: 660",
-			`custom-device "udev-tagging" invalid "mode" tag: value "660" is not a string, octal mode must be quoted e\.g\. " mode: '0644' "`,
+			"custom-device \"udev-tagging\" invalid \"mode\" tag: value \"660\" is not a string, octal mode must be quoted e\\.g\\. `mode: '0644'`",
 		},
 		// mode validation: too short (2 digits)
 		{


### PR DESCRIPTION
Add support for a mode key in udev-tagging rules of the custom-device interface, allowing gadget snaps to set device node permissions via udev.

This is to allow non-privileged users to run userspace applications which need device access. 
In my specific use-case, I am trying to use a Xilinx video encode/decode accelerator running on an FPGA. At the moment, the user needs root access to encode/decode video, and there is no way to grant group access or otherwise provide a user the ability to use the hardware without root access. I am open to discuss alternative solutions but this seemed simplest and leverages the existing udev functionality to achieve custom permissions.

Example user space program: https://github.com/Xilinx/vcu-ctrl-sw

**Changes:**

- Add customDeviceUDevFileModeRegexp to validate mode values as 3- or 4-digit octal strings (e.g. 644 or 0644)
- Add validateUDevModeValue() which enforces string typing and octal format using the above regexp matcher
- Handle mode key in validateUDevTaggingRule() switch block
- Emit `MODE="<value>"` into the resulting udev rule to assign the permissions.

**Tests:**

**Unhappy:** non-string integer value, too-short (2 digit), too-long (5 digit), non-octal digits (8, 9), alphabetic input, leading spaces, *4 digits and not beginning with 0*

**Happy:** all valid 3- and 4-digit octal forms (644, 0644, 660, 0660, 666,
 0666, 600, 755) verified to produce correct MODE= assignment in the
 generated udev snippet *and not garble other entries*

~~Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?~~ Done.
