### PR TITLE
core-initrd: increase mount burst from 5 to 128

### DIFF
--- a/core-initrd/26.04/factory/usr/lib/systemd/system.conf.d/mount-burst.conf
+++ b/core-initrd/26.04/factory/usr/lib/systemd/system.conf.d/mount-burst.conf
@@ -1,0 +1,2 @@
+[Manager]
+ManagerEnvironment=SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=128


### PR DESCRIPTION
On my VM it makes core-initrd for 26 go from more than 4 seconds to less than 3 seconds. We should probably apply something similar to core-base.
