### PR TITLE
hacking: suppress prompt while installing ubuntu deps

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -49,7 +49,7 @@ Build dependencies can automatically be resolved using `build-dep` on Ubuntu:
 
     cd ~/snapd
     ln -sfn packaging/ubuntu-16.04 debian
-    sudo apt build-dep .
+    sudo apt build-dep -y .
 
 > [!NOTE]
 > The `debian` symbolic link is intentionally not part of the tree, and is explicitly listed in the .gitignore file.


### PR DESCRIPTION
Should fix [Error executing openstack:ubuntu-24.04-64:tests/smoke/hacking-md](https://github.com/canonical/snapd/actions/runs/25115309605/job/73605807823?pr=16992#step:25:1442)
