### PR TITLE
daemon, o/h/ctlcmd: move state to client change conversion to ctlcmd

### DIFF
--- a/daemon/api_accessories.go
+++ b/daemon/api_accessories.go
@@ -51,5 +51,5 @@ func getAccessoriesChange(c *Command, r *http.Request, user *auth.UserState) Res
 		return NotFound("cannot find change with id %q", chID)
 	}
 
-	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
+	return SyncResponse(ctlcmd.StateChangeToChangeInfo(chg))
 }

--- a/daemon/api_accessories.go
+++ b/daemon/api_accessories.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 )
 
 var (
@@ -50,5 +51,5 @@ func getAccessoriesChange(c *Command, r *http.Request, user *auth.UserState) Res
 		return NotFound("cannot find change with id %q", chID)
 	}
 
-	return SyncResponse(change2changeInfo(chg))
+	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
 }

--- a/daemon/api_accessories_test.go
+++ b/daemon/api_accessories_test.go
@@ -26,6 +26,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 )
 
 var _ = Suite(&accessoriesSuite{})
@@ -53,7 +54,7 @@ func (s *accessoriesSuite) TestChangeInfo(c *C) {
 	rsp := s.syncReq(c, req, nil, actionIsUnexpected)
 	c.Check(rsp.Type, Equals, daemon.ResponseTypeSync)
 	c.Check(rsp.Status, Equals, 200)
-	info, ok := rsp.Result.(*daemon.ChangeInfo)
+	info, ok := rsp.Result.(*ctlcmd.ChangeInfo)
 	c.Assert(ok, Equals, true)
 	c.Check(info.ID, Equals, chg1.ID())
 	c.Check(info.Kind, Equals, "install-themes")

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -295,7 +295,7 @@ func getChange(c *Command, r *http.Request, user *auth.UserState) Response {
 		return NotFound("cannot find change with id %q", chID)
 	}
 
-	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
+	return SyncResponse(ctlcmd.StateChangeToChangeInfo(chg))
 }
 
 func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -352,7 +352,7 @@ func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
 		if !filter(chg) {
 			continue
 		}
-		chgInfos = append(chgInfos, ctlcmd.StateChangeToClientChange(chg))
+		chgInfos = append(chgInfos, ctlcmd.StateChangeToChangeInfo(chg))
 	}
 	return SyncResponse(chgInfos)
 }
@@ -390,7 +390,7 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 	// actually ask to proceed with the abort
 	ensureStateSoon(state)
 
-	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
+	return SyncResponse(ctlcmd.StateChangeToChangeInfo(chg))
 }
 
 var (

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -38,8 +38,8 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
@@ -295,7 +295,7 @@ func getChange(c *Command, r *http.Request, user *auth.UserState) Response {
 		return NotFound("cannot find change with id %q", chID)
 	}
 
-	return SyncResponse(change2changeInfo(chg))
+	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
 }
 
 func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -347,12 +347,12 @@ func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
 	state.Lock()
 	defer state.Unlock()
 	chgs := state.Changes()
-	chgInfos := make([]*changeInfo, 0, len(chgs))
+	chgInfos := make([]*ctlcmd.ChangeInfo, 0, len(chgs))
 	for _, chg := range chgs {
 		if !filter(chg) {
 			continue
 		}
-		chgInfos = append(chgInfos, change2changeInfo(chg))
+		chgInfos = append(chgInfos, ctlcmd.StateChangeToClientChange(chg))
 	}
 	return SyncResponse(chgInfos)
 }
@@ -390,125 +390,7 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 	// actually ask to proceed with the abort
 	ensureStateSoon(state)
 
-	return SyncResponse(change2changeInfo(chg))
-}
-
-type changeInfo struct {
-	ID      string      `json:"id"`
-	Kind    string      `json:"kind"`
-	Summary string      `json:"summary"`
-	Status  string      `json:"status"`
-	Tasks   []*taskInfo `json:"tasks,omitempty"`
-	Ready   bool        `json:"ready"`
-	Err     string      `json:"err,omitempty"`
-
-	SpawnTime time.Time  `json:"spawn-time,omitzero"`
-	ReadyTime *time.Time `json:"ready-time,omitempty"`
-
-	Data map[string]*json.RawMessage `json:"data,omitempty"`
-}
-
-type taskInfo struct {
-	ID       string           `json:"id"`
-	Kind     string           `json:"kind"`
-	Summary  string           `json:"summary"`
-	Status   string           `json:"status"`
-	Log      []string         `json:"log,omitempty"`
-	Progress taskInfoProgress `json:"progress"`
-
-	SpawnTime time.Time  `json:"spawn-time,omitzero"`
-	ReadyTime *time.Time `json:"ready-time,omitempty"`
-
-	Data map[string]*json.RawMessage `json:"data,omitempty"`
-}
-
-type taskInfoProgress struct {
-	Label string `json:"label"`
-	Done  int    `json:"done"`
-	Total int    `json:"total"`
-}
-
-func change2changeInfo(chg *state.Change) *changeInfo {
-	status := chg.Status()
-	chgInfo := &changeInfo{
-		ID:      chg.ID(),
-		Kind:    chg.Kind(),
-		Summary: chg.Summary(),
-		Status:  status.String(),
-		Ready:   status.Ready(),
-
-		SpawnTime: chg.SpawnTime(),
-	}
-	readyTime := chg.ReadyTime()
-	if !readyTime.IsZero() {
-		chgInfo.ReadyTime = &readyTime
-	}
-	if err := chg.Err(); err != nil {
-		chgInfo.Err = err.Error()
-	}
-
-	tasks := chg.Tasks()
-	taskInfos := make([]*taskInfo, len(tasks))
-	for j, t := range tasks {
-		label, done, total := t.Progress()
-
-		taskInfo := &taskInfo{
-			ID:      t.ID(),
-			Kind:    t.Kind(),
-			Summary: t.Summary(),
-			Status:  t.Status().String(),
-			Log:     t.Log(),
-			Progress: taskInfoProgress{
-				Label: label,
-				Done:  done,
-				Total: total,
-			},
-			SpawnTime: t.SpawnTime(),
-		}
-		readyTime := t.ReadyTime()
-		if !readyTime.IsZero() {
-			taskInfo.ReadyTime = &readyTime
-		}
-		if data, err := taskApiData(t); err == nil {
-			taskInfo.Data = data
-		}
-		taskInfos[j] = taskInfo
-	}
-	chgInfo.Tasks = taskInfos
-
-	var data map[string]*json.RawMessage
-	if chg.Get("api-data", &data) == nil {
-		chgInfo.Data = data
-	}
-
-	return chgInfo
-}
-
-var snapstateSnapsAffectedByTask = snapstate.SnapsAffectedByTask
-
-// taskApiData returns a map similar to change data which is currently
-// only filled with affected snap names.
-// Example: {"snap-names": ["snap-1", "snap-2"]}
-//
-// Note: This helper could be extended if needed to allow per-task custom
-// data similar to change "api-data".
-func taskApiData(t *state.Task) (map[string]*json.RawMessage, error) {
-	affectedSnaps, err := snapstateSnapsAffectedByTask(t)
-	if err != nil {
-		return nil, err
-	}
-	if len(affectedSnaps) == 0 {
-		return nil, nil
-	}
-	raw, err := json.Marshal(affectedSnaps)
-	if err != nil {
-		return nil, err
-	}
-	var affected json.RawMessage = raw
-	data := map[string]*json.RawMessage{
-		"affected-snaps": &affected,
-	}
-	return data, nil
+	return SyncResponse(ctlcmd.StateChangeToClientChange(chg))
 }
 
 var (

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -44,9 +44,11 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -1007,27 +1009,29 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 	st.Lock()
-	ids := setupChanges(st)
-	chg := st.Change(ids[0])
+
+	chg1 := st.NewChange("install", "install...")
+	chg1.Set("snap-names", []string{"funky-snap-name"})
+	t1 := st.NewTask("download", "1...")
+	t1.Set("snap-setup", &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap"}})
+	chg1.AddTask(t1)
+	t1.Logf("l11")
+	t1.Logf("l12")
+
+	t2 := st.NewTask("activate", "2...")
+	chg1.AddTask(t2)
+	t2.SetStatus(state.ErrorStatus)
+	t2.Errorf("activate failed")
+
+	chg := st.Change(chg1.ID())
 	chg.Set("api-data", map[string]int{"n": 42})
 	st.Unlock()
 
-	restore = daemon.MockSnapstateSnapsAffectedByTask(func(t *state.Task) ([]string, error) {
-		switch t.Kind() {
-		case "download":
-			// Mock affected snaps
-			return []string{"some-snap"}, nil
-		case "activate":
-			// Error should be ignored
-			return nil, fmt.Errorf("boom")
-		default:
-			return nil, nil
-		}
-	})
-	defer restore()
+	// Existing mock function would make task 1 (download) report some-snap as affected snap,
+	// and task 2 (activate) report an error which should be ignored. task 3 (unlink) has no error
 
 	// Execute
-	req, err := http.NewRequest("GET", "/v2/changes/"+ids[0], nil)
+	req, err := http.NewRequest("GET", "/v2/changes/"+chg1.ID(), nil)
 	c.Assert(err, check.IsNil)
 	rsp := s.syncReq(c, req, nil, actionIsExpected)
 	rec := httptest.NewRecorder()
@@ -1042,7 +1046,7 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	c.Check(body["result"], check.DeepEquals, map[string]any{
-		"id":         ids[0],
+		"id":         chg1.ID(),
 		"kind":       "install",
 		"summary":    "install...",
 		"status":     "Do",
@@ -1050,7 +1054,7 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"tasks": []any{
 			map[string]any{
-				"id":         ids[2],
+				"id":         t1.ID(),
 				"kind":       "download",
 				"summary":    "1...",
 				"status":     "Do",
@@ -1060,12 +1064,14 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 				"data":       map[string]any{"affected-snaps": []any{"some-snap"}},
 			},
 			map[string]any{
-				"id":         ids[3],
+				"id":         t2.ID(),
 				"kind":       "activate",
 				"summary":    "2...",
-				"status":     "Do",
-				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
+				"status":     "Error",
+				"log":        []any{"2016-04-21T01:02:03Z ERROR activate failed"},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
+				"ready-time": "2016-04-21T01:02:03Z",
 			},
 		},
 		"data": map[string]any{

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -1000,6 +1000,8 @@ func (s *generalSuite) TestStateChangesForSnapNameWithApp(c *check.C) {
 	c.Assert(rec.Code, check.Equals, 200)
 }
 
+// This test relies on ctlcmd.StateChangeToChangeInfo(), which was moved from
+// the daemon package to the ctlcmd package.
 func (s *generalSuite) TestStateChange(c *check.C) {
 	restore := state.MockTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -1020,15 +1020,13 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 
 	t2 := st.NewTask("activate", "2...")
 	chg1.AddTask(t2)
-	t2.SetStatus(state.ErrorStatus)
-	t2.Errorf("activate failed")
+	// Setting 'snap-setup' to something that cant be parsed allows us to test that missing data is ignored
+	// and doesn't cause the whole task to be missing from the output
+	t2.Set("snap-setup", "some-snap")
 
 	chg := st.Change(chg1.ID())
 	chg.Set("api-data", map[string]int{"n": 42})
 	st.Unlock()
-
-	// Existing mock function would make task 1 (download) report some-snap as affected snap,
-	// and task 2 (activate) report an error which should be ignored. task 3 (unlink) has no error
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes/"+chg1.ID(), nil)
@@ -1067,11 +1065,9 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 				"id":         t2.ID(),
 				"kind":       "activate",
 				"summary":    "2...",
-				"status":     "Error",
-				"log":        []any{"2016-04-21T01:02:03Z ERROR activate failed"},
-				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
+				"status":     "Do",
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"ready-time": "2016-04-21T01:02:03Z",
 			},
 		},
 		"data": map[string]any{

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -1026,8 +1026,7 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	// and doesn't cause the whole task to be missing from the output
 	t2.Set("snap-setup", "some-snap")
 
-	chg := st.Change(chg1.ID())
-	chg.Set("api-data", map[string]int{"n": 42})
+	chg1.Set("api-data", map[string]int{"n": 42})
 	st.Unlock()
 
 	// Execute

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
@@ -950,9 +951,9 @@ func (s *generalSuite) TestStateChangesForSnapName(c *check.C) {
 
 	// Verify
 	c.Check(rsp.Status, check.Equals, 200)
-	c.Assert(rsp.Result, check.FitsTypeOf, []*daemon.ChangeInfo(nil))
+	c.Assert(rsp.Result, check.FitsTypeOf, []*ctlcmd.ChangeInfo(nil))
 
-	res := rsp.Result.([]*daemon.ChangeInfo)
+	res := rsp.Result.([]*ctlcmd.ChangeInfo)
 	c.Assert(res, check.HasLen, 1)
 	c.Check(res[0].Kind, check.Equals, `install`)
 
@@ -986,9 +987,9 @@ func (s *generalSuite) TestStateChangesForSnapNameWithApp(c *check.C) {
 
 	// Verify
 	c.Check(rsp.Status, check.Equals, 200)
-	c.Assert(rsp.Result, check.FitsTypeOf, []*daemon.ChangeInfo(nil))
+	c.Assert(rsp.Result, check.FitsTypeOf, []*ctlcmd.ChangeInfo(nil))
 
-	res := rsp.Result.([]*daemon.ChangeInfo)
+	res := rsp.Result.([]*ctlcmd.ChangeInfo)
 	c.Assert(res, check.HasLen, 1)
 	c.Check(res[0].Kind, check.Equals, `service-control`)
 

--- a/daemon/export_api_general_test.go
+++ b/daemon/export_api_general_test.go
@@ -55,14 +55,6 @@ func MockWarningsAccessors(okay func(*state.State, time.Time) int, all func(*sta
 	}
 }
 
-func MockSnapstateSnapsAffectedByTask(f func(t *state.Task) ([]string, error)) (restore func()) {
-	old := snapstateSnapsAffectedByTask
-	snapstateSnapsAffectedByTask = f
-	return func() {
-		snapstateSnapsAffectedByTask = old
-	}
-}
-
 func MockSnapdtoolsIsReexecd(f func() (bool, error)) (restore func()) {
 	return testutil.Mock(&snapdtoolIsReexecd, f)
 }

--- a/daemon/export_api_general_test.go
+++ b/daemon/export_api_general_test.go
@@ -55,10 +55,6 @@ func MockWarningsAccessors(okay func(*state.State, time.Time) int, all func(*sta
 	}
 }
 
-type (
-	ChangeInfo = changeInfo
-)
-
 func MockSnapstateSnapsAffectedByTask(f func(t *state.Task) ([]string, error)) (restore func()) {
 	old := snapstateSnapsAffectedByTask
 	snapstateSnapsAffectedByTask = f

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -71,6 +71,11 @@ const snapctlDebounceWindow = 200 * time.Millisecond
 // properly organize the hook tasks in the chain of tasks in the change.
 const finalSeedTask = "mark-seeded"
 
+// To unmarshal the data needed for `snap tasks`, we need access
+// to all struct fields that client.Change has. However, Change.data is an
+// unexported field, so we cannot unmarshal into it directly. There is a
+// changeAndData struct in the client package with all exported fields, but the
+// struct itself is not exported.
 type ChangeInfo struct {
 	ID      string      `json:"id"`
 	Kind    string      `json:"kind"`
@@ -106,7 +111,10 @@ type taskInfoProgress struct {
 	Total int    `json:"total"`
 }
 
-func StateChangeToClientChange(chg *state.Change) *ChangeInfo {
+// To unmarshal the data needed for `snap tasks`, we need access
+// to all struct fields that client.Change has. However, due to unexported
+// fields, we use ChangeInfo instead.
+func StateChangeToChangeInfo(chg *state.Change) *ChangeInfo {
 	status := chg.Status()
 	chgInfo := &ChangeInfo{
 		ID:      chg.ID(),

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -95,20 +96,12 @@ type TaskInfo struct {
 	Summary  string           `json:"summary"`
 	Status   string           `json:"status"`
 	Log      []string         `json:"log,omitempty"`
-	Progress TaskInfoProgress `json:"progress"`
+	Progress client.TaskProgress `json:"progress"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitzero"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
 
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
-}
-
-// TaskInfoProgress represents the progress of a task, including a label and the
-// amount of work done out of the total.
-type TaskInfoProgress struct {
-	Label string `json:"label"`
-	Done  int    `json:"done"`
-	Total int    `json:"total"`
 }
 
 // StateChangeToChangeInfo converts a state.Change to a ChangeInfo struct which has all
@@ -144,7 +137,7 @@ func StateChangeToChangeInfo(chg *state.Change) *ChangeInfo {
 			Summary: t.Summary(),
 			Status:  t.Status().String(),
 			Log:     t.Log(),
-			Progress: TaskInfoProgress{
+			Progress: client.TaskProgress{
 				Label: label,
 				Done:  done,
 				Total: total,

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -72,11 +72,6 @@ const snapctlDebounceWindow = 200 * time.Millisecond
 const finalSeedTask = "mark-seeded"
 
 // ChangeInfo represents the information about a change that is needed for JSON marshaling.
-// To unmarshal the data needed for `snap tasks`, we need access
-// to all struct fields that client.Change has. However, Change.data is an
-// unexported field, so we cannot unmarshal into it directly. There is a
-// changeAndData struct in the client package with all exported fields, but the
-// struct itself is not exported.
 type ChangeInfo struct {
 	ID      string     `json:"id"`
 	Kind    string     `json:"kind"`
@@ -93,9 +88,7 @@ type ChangeInfo struct {
 }
 
 // TaskInfo represents the information about a task that is needed for JSON marshaling
-// for `snap tasks` output. It includes fields such as ID, kind, summary, status, and
-// any additional data associated with the task. The Data field is a map of string keys
-// to raw JSON messages, allowing for flexible inclusion of task-specific data in the output.
+// for `snap tasks` output.
 type TaskInfo struct {
 	ID       string           `json:"id"`
 	Kind     string           `json:"kind"`
@@ -111,8 +104,7 @@ type TaskInfo struct {
 }
 
 // TaskInfoProgress represents the progress of a task, including a label and the
-// amount of work done out of the total. Used in the TaskInfo struct to provide
-// progress information for tasks in the `snap tasks` output.
+// amount of work done out of the total.
 type TaskInfoProgress struct {
 	Label string `json:"label"`
 	Done  int    `json:"done"`

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -71,6 +71,122 @@ const snapctlDebounceWindow = 200 * time.Millisecond
 // properly organize the hook tasks in the chain of tasks in the change.
 const finalSeedTask = "mark-seeded"
 
+type ChangeInfo struct {
+	ID      string      `json:"id"`
+	Kind    string      `json:"kind"`
+	Summary string      `json:"summary"`
+	Status  string      `json:"status"`
+	Tasks   []*taskInfo `json:"tasks,omitempty"`
+	Ready   bool        `json:"ready"`
+	Err     string      `json:"err,omitempty"`
+
+	SpawnTime time.Time  `json:"spawn-time,omitzero"`
+	ReadyTime *time.Time `json:"ready-time,omitempty"`
+
+	Data map[string]*json.RawMessage `json:"data,omitempty"`
+}
+
+type taskInfo struct {
+	ID       string           `json:"id"`
+	Kind     string           `json:"kind"`
+	Summary  string           `json:"summary"`
+	Status   string           `json:"status"`
+	Log      []string         `json:"log,omitempty"`
+	Progress taskInfoProgress `json:"progress"`
+
+	SpawnTime time.Time  `json:"spawn-time,omitzero"`
+	ReadyTime *time.Time `json:"ready-time,omitempty"`
+
+	Data map[string]*json.RawMessage `json:"data,omitempty"`
+}
+
+type taskInfoProgress struct {
+	Label string `json:"label"`
+	Done  int    `json:"done"`
+	Total int    `json:"total"`
+}
+
+func StateChangeToClientChange(chg *state.Change) *ChangeInfo {
+	status := chg.Status()
+	chgInfo := &ChangeInfo{
+		ID:      chg.ID(),
+		Kind:    chg.Kind(),
+		Summary: chg.Summary(),
+		Status:  status.String(),
+		Ready:   status.Ready(),
+
+		SpawnTime: chg.SpawnTime(),
+	}
+	readyTime := chg.ReadyTime()
+	if !readyTime.IsZero() {
+		chgInfo.ReadyTime = &readyTime
+	}
+	if err := chg.Err(); err != nil {
+		chgInfo.Err = err.Error()
+	}
+
+	tasks := chg.Tasks()
+	taskInfos := make([]*taskInfo, len(tasks))
+	for j, t := range tasks {
+		label, done, total := t.Progress()
+
+		taskInfo := &taskInfo{
+			ID:      t.ID(),
+			Kind:    t.Kind(),
+			Summary: t.Summary(),
+			Status:  t.Status().String(),
+			Log:     t.Log(),
+			Progress: taskInfoProgress{
+				Label: label,
+				Done:  done,
+				Total: total,
+			},
+			SpawnTime: t.SpawnTime(),
+		}
+		readyTime := t.ReadyTime()
+		if !readyTime.IsZero() {
+			taskInfo.ReadyTime = &readyTime
+		}
+		if data, err := taskApiData(t); err == nil {
+			taskInfo.Data = data
+		}
+		taskInfos[j] = taskInfo
+	}
+	chgInfo.Tasks = taskInfos
+
+	var data map[string]*json.RawMessage
+	if chg.Get("api-data", &data) == nil {
+		chgInfo.Data = data
+	}
+
+	return chgInfo
+}
+
+// taskApiData returns a map similar to change data which is currently
+// only filled with affected snap names.
+// Example: {"snap-names": ["snap-1", "snap-2"]}
+//
+// Note: This helper could be extended if needed to allow per-task custom
+// data similar to change "api-data".
+func taskApiData(t *state.Task) (map[string]*json.RawMessage, error) {
+	affectedSnaps, err := snapstate.SnapsAffectedByTask(t)
+	if err != nil {
+		return nil, err
+	}
+	if len(affectedSnaps) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(affectedSnaps)
+	if err != nil {
+		return nil, err
+	}
+	var affected json.RawMessage = raw
+	data := map[string]*json.RawMessage{
+		"affected-snaps": &affected,
+	}
+	return data, nil
+}
+
 func currentSnapInfo(st *state.State, snapInstance string) (*snap.Info, error) {
 	var snapst snapstate.SnapState
 	if err := snapstate.Get(st, snapInstance, &snapst); err != nil {

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -81,7 +81,7 @@ type ChangeInfo struct {
 	Kind    string      `json:"kind"`
 	Summary string      `json:"summary"`
 	Status  string      `json:"status"`
-	Tasks   []*taskInfo `json:"tasks,omitempty"`
+	Tasks   []TaskInfo `json:"tasks,omitempty"`
 	Ready   bool        `json:"ready"`
 	Err     string      `json:"err,omitempty"`
 
@@ -91,13 +91,13 @@ type ChangeInfo struct {
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
 
-type taskInfo struct {
+type TaskInfo struct {
 	ID       string           `json:"id"`
 	Kind     string           `json:"kind"`
 	Summary  string           `json:"summary"`
 	Status   string           `json:"status"`
 	Log      []string         `json:"log,omitempty"`
-	Progress taskInfoProgress `json:"progress"`
+	Progress TaskInfoProgress `json:"progress"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitzero"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
@@ -105,7 +105,7 @@ type taskInfo struct {
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
 
-type taskInfoProgress struct {
+type TaskInfoProgress struct {
 	Label string `json:"label"`
 	Done  int    `json:"done"`
 	Total int    `json:"total"`
@@ -134,17 +134,17 @@ func StateChangeToChangeInfo(chg *state.Change) *ChangeInfo {
 	}
 
 	tasks := chg.Tasks()
-	taskInfos := make([]*taskInfo, len(tasks))
+	taskInfos := make([]TaskInfo, len(tasks))
 	for j, t := range tasks {
 		label, done, total := t.Progress()
 
-		taskInfo := &taskInfo{
+		taskInfo := TaskInfo{
 			ID:      t.ID(),
 			Kind:    t.Kind(),
 			Summary: t.Summary(),
 			Status:  t.Status().String(),
 			Log:     t.Log(),
-			Progress: taskInfoProgress{
+			Progress: TaskInfoProgress{
 				Label: label,
 				Done:  done,
 				Total: total,

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -91,11 +91,11 @@ type ChangeInfo struct {
 // TaskInfo represents the information about a task that is needed for JSON marshaling
 // for `snap tasks` output.
 type TaskInfo struct {
-	ID       string           `json:"id"`
-	Kind     string           `json:"kind"`
-	Summary  string           `json:"summary"`
-	Status   string           `json:"status"`
-	Log      []string         `json:"log,omitempty"`
+	ID       string              `json:"id"`
+	Kind     string              `json:"kind"`
+	Summary  string              `json:"summary"`
+	Status   string              `json:"status"`
+	Log      []string            `json:"log,omitempty"`
 	Progress client.TaskProgress `json:"progress"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitzero"`

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -71,19 +71,20 @@ const snapctlDebounceWindow = 200 * time.Millisecond
 // properly organize the hook tasks in the chain of tasks in the change.
 const finalSeedTask = "mark-seeded"
 
+// ChangeInfo represents the information about a change that is needed for JSON marshaling.
 // To unmarshal the data needed for `snap tasks`, we need access
 // to all struct fields that client.Change has. However, Change.data is an
 // unexported field, so we cannot unmarshal into it directly. There is a
 // changeAndData struct in the client package with all exported fields, but the
 // struct itself is not exported.
 type ChangeInfo struct {
-	ID      string      `json:"id"`
-	Kind    string      `json:"kind"`
-	Summary string      `json:"summary"`
-	Status  string      `json:"status"`
+	ID      string     `json:"id"`
+	Kind    string     `json:"kind"`
+	Summary string     `json:"summary"`
+	Status  string     `json:"status"`
 	Tasks   []TaskInfo `json:"tasks,omitempty"`
-	Ready   bool        `json:"ready"`
-	Err     string      `json:"err,omitempty"`
+	Ready   bool       `json:"ready"`
+	Err     string     `json:"err,omitempty"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitzero"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
@@ -91,6 +92,10 @@ type ChangeInfo struct {
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
 
+// TaskInfo represents the information about a task that is needed for JSON marshaling
+// for `snap tasks` output. It includes fields such as ID, kind, summary, status, and
+// any additional data associated with the task. The Data field is a map of string keys
+// to raw JSON messages, allowing for flexible inclusion of task-specific data in the output.
 type TaskInfo struct {
 	ID       string           `json:"id"`
 	Kind     string           `json:"kind"`
@@ -105,15 +110,18 @@ type TaskInfo struct {
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
 
+// TaskInfoProgress represents the progress of a task, including a label and the
+// amount of work done out of the total. Used in the TaskInfo struct to provide
+// progress information for tasks in the `snap tasks` output.
 type TaskInfoProgress struct {
 	Label string `json:"label"`
 	Done  int    `json:"done"`
 	Total int    `json:"total"`
 }
 
-// To unmarshal the data needed for `snap tasks`, we need access
-// to all struct fields that client.Change has. However, due to unexported
-// fields, we use ChangeInfo instead.
+// StateChangeToChangeInfo converts a state.Change to a ChangeInfo struct which has all
+// the exported fields needed for JSON marshaling for `snap tasks` output. It also extracts
+// the "api-data" from the change and includes it in the ChangeInfo.Data field.
 func StateChangeToChangeInfo(chg *state.Change) *ChangeInfo {
 	status := chg.Status()
 	chgInfo := &ChangeInfo{

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -46,7 +46,7 @@ func setupChange() (*state.State, string, *state.Change) {
 	task.SetStatus(state.DoneStatus)
 	task.Logf("Component prepared successfully")
 	task.SetProgress("Preparing component", 1, 1)
-	chg.Set("api-data", map[string]interface{}{
+	chg.Set("api-data", map[string]any{
 		"snap-names": []string{"test-snap"},
 		"kind":       "install-components",
 	})

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -75,7 +75,7 @@ func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
 	c.Check(task1Info.Summary, Equals, "preparing components")
 	c.Check(task1Info.Status, Equals, "Done")
 	c.Assert(task1Info.Log, HasLen, 1)
-	c.Check(strings.Contains(task1Info.Log[0], "Component prepared successfully"), Equals, true)
+	c.Check(task1Info.Log[0], testutil.Contains, "Component prepared successfully")
 	c.Check(task1Info.Progress.Label, Equals, "Preparing component")
 	c.Check(task1Info.Progress.Done, Equals, 1)
 	c.Check(task1Info.Progress.Total, Equals, 1)

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -22,10 +22,10 @@ package ctlcmd_test
 import (
 	"strings"
 
-	. "gopkg.in/check.v1"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
 )
 
 type helperSuite struct {

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -20,103 +20,45 @@
 package ctlcmd_test
 
 import (
-	"encoding/json"
 	"strings"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
-	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type helperSuite struct {
 	testutil.BaseTest
-	mockHandler *hooktest.MockHandler
 }
 
 var _ = Suite(&helperSuite{})
 
-func (s *helperSuite) SetUpTest(c *C) {
-	s.BaseTest.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
-	s.AddCleanup(func() { dirs.SetRootDir("/") })
-	s.mockHandler = hooktest.NewMockHandler()
-}
-
-// setupChangeAndContext creates a state, a change (with an optional initiator),
-// and a non-ephemeral hook context for "test-snap". It also populates the change
-// and task with realistic data for testing StateChangeToChangeInfo conversion.
-func (s *helperSuite) setupChangeAndContext(c *C, taskStatus state.Status, initiatorSnap string) (*state.State, *hookstate.Context, string, *state.Change) {
+func setupChange() (*state.State, string, *state.Change) {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
 
-	// Create a change with a meaningful kind and summary
 	chg := st.NewChange("snapctl-install", "install components for test-snap")
+	task := st.NewTask("prepare-components", "preparing components")
+	chg.AddTask(task)
 
-	// Create multiple tasks to test task conversion
-	task1 := st.NewTask("prepare-components", "preparing components")
-	task2 := st.NewTask("download-component", "downloading component")
-	task3 := st.NewTask("install-component", "installing component")
-
-	chg.AddTask(task1)
-	chg.AddTask(task2)
-	chg.AddTask(task3)
-
-	// Set task dependencies to test task relationships
-	task2.WaitFor(task1)
-	task3.WaitFor(task2)
-
-	// Populate the first task with realistic data
-	task1.SetStatus(state.DoneStatus)
-	task1.Logf("Starting component preparation")
-	task1.Logf("Component prepared successfully")
-	task1.SetProgress("Preparing component", 1, 1)
-
-	// Set the status of task2 based on parameter
-	task2.SetStatus(taskStatus)
-	task2.Logf("Downloading component from store")
-	task2.SetProgress("Downloading", 50, 100)
-
-	// Keep task3 in waiting status
-	task3.SetStatus(state.DoStatus)
-	task3.SetProgress("Waiting to install", 0, 1)
-
-	// Set the requested task status parameter for the second task
-	if taskStatus == state.DoneStatus {
-		task2.SetStatus(state.DoneStatus)
-		task2.Logf("Downloading component from store")
-		task2.Logf("Download complete")
-		task2.SetProgress("Downloading", 100, 100)
-	}
-
-	// Add change-level data (api-data)
+	task.SetStatus(state.DoneStatus)
+	task.Logf("Component prepared successfully")
+	task.SetProgress("Preparing component", 1, 1)
 	chg.Set("api-data", map[string]interface{}{
 		"snap-names": []string{"test-snap"},
 		"kind":       "install-components",
 	})
 
-	if initiatorSnap != "" {
-		chg.Set("initiated-by-snap", initiatorSnap)
-	}
-
-	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "install"}
-	ctx, err := hookstate.NewContext(task1, st, setup, s.mockHandler, "")
-	c.Assert(err, IsNil)
-
-	return st, ctx, chg.ID(), chg
+	return st, chg.ID(), chg
 }
 
 // TestStateChangeToChangeInfo tests the StateChangeToChangeInfo function,
 // verifying that state changes are correctly converted to ChangeInfo structs
 // and that the data can be successfully marshalled and unmarshalled.
 func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
-	st, _, changeID, _ := s.setupChangeAndContext(c, state.DoStatus, "test-snap")
+	st, changeID, _ := setupChange()
 
 	st.Lock()
 	chg := st.Change(changeID)
@@ -130,65 +72,26 @@ func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
 	c.Check(changeInfo.ID, Equals, changeID)
 	c.Check(changeInfo.Kind, Equals, "snapctl-install")
 	c.Check(changeInfo.Summary, Equals, "install components for test-snap")
-	c.Check(changeInfo.Status, Equals, "Do")
-	c.Check(changeInfo.Ready, Equals, false)
+	c.Check(changeInfo.Status, Equals, "Done")
+	c.Check(changeInfo.Ready, Equals, true)
 	c.Check(changeInfo.SpawnTime.IsZero(), Equals, false)
 
-	// Verify tasks were converted
-	c.Assert(changeInfo.Tasks, HasLen, 3)
+	// Verify task was converted
+	c.Assert(changeInfo.Tasks, HasLen, 1)
 
-	// Check first task (should be Done)
+	// Check task (should be Done)
 	task1Info := changeInfo.Tasks[0]
 	c.Check(task1Info.Kind, Equals, "prepare-components")
 	c.Check(task1Info.Summary, Equals, "preparing components")
 	c.Check(task1Info.Status, Equals, "Done")
-	// Log entries include timestamps, so check that they contain the expected messages
-	c.Assert(task1Info.Log, HasLen, 2)
-	c.Check(strings.Contains(task1Info.Log[0], "Starting component preparation"), Equals, true)
-	c.Check(strings.Contains(task1Info.Log[1], "Component prepared successfully"), Equals, true)
+	c.Assert(task1Info.Log, HasLen, 1)
+	c.Check(strings.Contains(task1Info.Log[0], "Component prepared successfully"), Equals, true)
 	c.Check(task1Info.Progress.Label, Equals, "Preparing component")
 	c.Check(task1Info.Progress.Done, Equals, 1)
 	c.Check(task1Info.Progress.Total, Equals, 1)
-
-	// Check second task (should be in Do status)
-	task2Info := changeInfo.Tasks[1]
-	c.Check(task2Info.Kind, Equals, "download-component")
-	c.Check(task2Info.Status, Equals, "Do")
-	c.Check(task2Info.Progress.Label, Equals, "Downloading")
-	c.Check(task2Info.Progress.Done, Equals, 50)
-	c.Check(task2Info.Progress.Total, Equals, 100)
-
-	// Check third task (should be in Do status)
-	task3Info := changeInfo.Tasks[2]
-	c.Check(task3Info.Kind, Equals, "install-component")
-	c.Check(task3Info.Status, Equals, "Do")
 
 	// Verify change-level data (api-data)
 	c.Assert(changeInfo.Data, NotNil)
 	c.Assert(changeInfo.Data["snap-names"], NotNil)
 
-	// Test JSON marshalling
-	jsonData, err := json.Marshal(changeInfo)
-	c.Assert(err, IsNil)
-	c.Assert(jsonData, NotNil)
-	c.Assert(len(jsonData) > 0, Equals, true)
-
-	// Test JSON unmarshalling
-	var unmarshalled ctlcmd.ChangeInfo
-	err = json.Unmarshal(jsonData, &unmarshalled)
-	c.Assert(err, IsNil)
-
-	// Verify unmarshalled data matches original
-	c.Check(unmarshalled.ID, Equals, changeInfo.ID)
-	c.Check(unmarshalled.Kind, Equals, changeInfo.Kind)
-	c.Check(unmarshalled.Summary, Equals, changeInfo.Summary)
-	c.Check(unmarshalled.Status, Equals, changeInfo.Status)
-	c.Check(unmarshalled.Ready, Equals, changeInfo.Ready)
-	c.Assert(unmarshalled.Tasks, HasLen, len(changeInfo.Tasks))
-
-	// Verify task details survived marshalling/unmarshalling
-	c.Check(unmarshalled.Tasks[0].Kind, Equals, task1Info.Kind)
-	c.Check(unmarshalled.Tasks[0].Status, Equals, task1Info.Status)
-	c.Check(unmarshalled.Tasks[1].Progress.Label, Equals, task2Info.Progress.Label)
-	c.Check(unmarshalled.Tasks[1].Progress.Done, Equals, task2Info.Progress.Done)
 }

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -20,8 +20,6 @@
 package ctlcmd_test
 
 import (
-	"strings"
-
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -34,7 +34,10 @@ type helperSuite struct {
 
 var _ = Suite(&helperSuite{})
 
-func setupChange() (*state.State, string, *state.Change) {
+// TestStateChangeToChangeInfo tests the StateChangeToChangeInfo function,
+// verifying that state changes are correctly converted to ChangeInfo structs
+// and that the data can be successfully marshaled and unmarshaled.
+func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
@@ -51,25 +54,12 @@ func setupChange() (*state.State, string, *state.Change) {
 		"kind":       "install-components",
 	})
 
-	return st, chg.ID(), chg
-}
-
-// TestStateChangeToChangeInfo tests the StateChangeToChangeInfo function,
-// verifying that state changes are correctly converted to ChangeInfo structs
-// and that the data can be successfully marshalled and unmarshalled.
-func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
-	st, changeID, _ := setupChange()
-
-	st.Lock()
-	chg := st.Change(changeID)
-	c.Assert(chg, NotNil)
-
 	// Convert the state.Change to ChangeInfo
+	c.Assert(chg, NotNil)
 	changeInfo := ctlcmd.StateChangeToChangeInfo(chg)
-	st.Unlock()
 
 	// Verify basic change information
-	c.Check(changeInfo.ID, Equals, changeID)
+	c.Check(changeInfo.ID, Equals, chg.ID())
 	c.Check(changeInfo.Kind, Equals, "snapctl-install")
 	c.Check(changeInfo.Summary, Equals, "install components for test-snap")
 	c.Check(changeInfo.Status, Equals, "Done")
@@ -93,5 +83,4 @@ func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
 	// Verify change-level data (api-data)
 	c.Assert(changeInfo.Data, NotNil)
 	c.Assert(changeInfo.Data["snap-names"], NotNil)
-
 }

--- a/overlord/hookstate/ctlcmd/helpers_test.go
+++ b/overlord/hookstate/ctlcmd/helpers_test.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"encoding/json"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type helperSuite struct {
+	testutil.BaseTest
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = Suite(&helperSuite{})
+
+func (s *helperSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+	s.mockHandler = hooktest.NewMockHandler()
+}
+
+// setupChangeAndContext creates a state, a change (with an optional initiator),
+// and a non-ephemeral hook context for "test-snap". It also populates the change
+// and task with realistic data for testing StateChangeToChangeInfo conversion.
+func (s *helperSuite) setupChangeAndContext(c *C, taskStatus state.Status, initiatorSnap string) (*state.State, *hookstate.Context, string, *state.Change) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	// Create a change with a meaningful kind and summary
+	chg := st.NewChange("snapctl-install", "install components for test-snap")
+
+	// Create multiple tasks to test task conversion
+	task1 := st.NewTask("prepare-components", "preparing components")
+	task2 := st.NewTask("download-component", "downloading component")
+	task3 := st.NewTask("install-component", "installing component")
+
+	chg.AddTask(task1)
+	chg.AddTask(task2)
+	chg.AddTask(task3)
+
+	// Set task dependencies to test task relationships
+	task2.WaitFor(task1)
+	task3.WaitFor(task2)
+
+	// Populate the first task with realistic data
+	task1.SetStatus(state.DoneStatus)
+	task1.Logf("Starting component preparation")
+	task1.Logf("Component prepared successfully")
+	task1.SetProgress("Preparing component", 1, 1)
+
+	// Set the status of task2 based on parameter
+	task2.SetStatus(taskStatus)
+	task2.Logf("Downloading component from store")
+	task2.SetProgress("Downloading", 50, 100)
+
+	// Keep task3 in waiting status
+	task3.SetStatus(state.DoStatus)
+	task3.SetProgress("Waiting to install", 0, 1)
+
+	// Set the requested task status parameter for the second task
+	if taskStatus == state.DoneStatus {
+		task2.SetStatus(state.DoneStatus)
+		task2.Logf("Downloading component from store")
+		task2.Logf("Download complete")
+		task2.SetProgress("Downloading", 100, 100)
+	}
+
+	// Add change-level data (api-data)
+	chg.Set("api-data", map[string]interface{}{
+		"snap-names": []string{"test-snap"},
+		"kind":       "install-components",
+	})
+
+	if initiatorSnap != "" {
+		chg.Set("initiated-by-snap", initiatorSnap)
+	}
+
+	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "install"}
+	ctx, err := hookstate.NewContext(task1, st, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+
+	return st, ctx, chg.ID(), chg
+}
+
+// TestStateChangeToChangeInfo tests the StateChangeToChangeInfo function,
+// verifying that state changes are correctly converted to ChangeInfo structs
+// and that the data can be successfully marshalled and unmarshalled.
+func (s *helperSuite) TestStateChangeToChangeInfo(c *C) {
+	st, _, changeID, _ := s.setupChangeAndContext(c, state.DoStatus, "test-snap")
+
+	st.Lock()
+	chg := st.Change(changeID)
+	c.Assert(chg, NotNil)
+
+	// Convert the state.Change to ChangeInfo
+	changeInfo := ctlcmd.StateChangeToChangeInfo(chg)
+	st.Unlock()
+
+	// Verify basic change information
+	c.Check(changeInfo.ID, Equals, changeID)
+	c.Check(changeInfo.Kind, Equals, "snapctl-install")
+	c.Check(changeInfo.Summary, Equals, "install components for test-snap")
+	c.Check(changeInfo.Status, Equals, "Do")
+	c.Check(changeInfo.Ready, Equals, false)
+	c.Check(changeInfo.SpawnTime.IsZero(), Equals, false)
+
+	// Verify tasks were converted
+	c.Assert(changeInfo.Tasks, HasLen, 3)
+
+	// Check first task (should be Done)
+	task1Info := changeInfo.Tasks[0]
+	c.Check(task1Info.Kind, Equals, "prepare-components")
+	c.Check(task1Info.Summary, Equals, "preparing components")
+	c.Check(task1Info.Status, Equals, "Done")
+	// Log entries include timestamps, so check that they contain the expected messages
+	c.Assert(task1Info.Log, HasLen, 2)
+	c.Check(strings.Contains(task1Info.Log[0], "Starting component preparation"), Equals, true)
+	c.Check(strings.Contains(task1Info.Log[1], "Component prepared successfully"), Equals, true)
+	c.Check(task1Info.Progress.Label, Equals, "Preparing component")
+	c.Check(task1Info.Progress.Done, Equals, 1)
+	c.Check(task1Info.Progress.Total, Equals, 1)
+
+	// Check second task (should be in Do status)
+	task2Info := changeInfo.Tasks[1]
+	c.Check(task2Info.Kind, Equals, "download-component")
+	c.Check(task2Info.Status, Equals, "Do")
+	c.Check(task2Info.Progress.Label, Equals, "Downloading")
+	c.Check(task2Info.Progress.Done, Equals, 50)
+	c.Check(task2Info.Progress.Total, Equals, 100)
+
+	// Check third task (should be in Do status)
+	task3Info := changeInfo.Tasks[2]
+	c.Check(task3Info.Kind, Equals, "install-component")
+	c.Check(task3Info.Status, Equals, "Do")
+
+	// Verify change-level data (api-data)
+	c.Assert(changeInfo.Data, NotNil)
+	c.Assert(changeInfo.Data["snap-names"], NotNil)
+
+	// Test JSON marshalling
+	jsonData, err := json.Marshal(changeInfo)
+	c.Assert(err, IsNil)
+	c.Assert(jsonData, NotNil)
+	c.Assert(len(jsonData) > 0, Equals, true)
+
+	// Test JSON unmarshalling
+	var unmarshalled ctlcmd.ChangeInfo
+	err = json.Unmarshal(jsonData, &unmarshalled)
+	c.Assert(err, IsNil)
+
+	// Verify unmarshalled data matches original
+	c.Check(unmarshalled.ID, Equals, changeInfo.ID)
+	c.Check(unmarshalled.Kind, Equals, changeInfo.Kind)
+	c.Check(unmarshalled.Summary, Equals, changeInfo.Summary)
+	c.Check(unmarshalled.Status, Equals, changeInfo.Status)
+	c.Check(unmarshalled.Ready, Equals, changeInfo.Ready)
+	c.Assert(unmarshalled.Tasks, HasLen, len(changeInfo.Tasks))
+
+	// Verify task details survived marshalling/unmarshalling
+	c.Check(unmarshalled.Tasks[0].Kind, Equals, task1Info.Kind)
+	c.Check(unmarshalled.Tasks[0].Status, Equals, task1Info.Status)
+	c.Check(unmarshalled.Tasks[1].Progress.Label, Equals, task2Info.Progress.Label)
+	c.Check(unmarshalled.Tasks[1].Progress.Done, Equals, task2Info.Progress.Done)
+}


### PR DESCRIPTION
This move is made to support the `snapctl tasks` PR, which requires these structures to be accessible from the ctlcmd package