### PR TITLE
cmd/snap-update-ns: ensure that a /tmp/.X11-unix created inside the mount ns has expected permissions

### DIFF
--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -91,6 +91,13 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// permission only matters if the plug-side app constructs its mount
 	// namespace before the slot-side app is launched.
 	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap-private-tmp/snap.*/tmp/.X11-unix", 0777|os.ModeSticky)
+	// This is to ensure the mount target directory /tmp/.X11-unix inside the
+	// mount namespace is created with the same permissions as a typical host
+	// /tmp/.X11-unix. When x11 interface is connected, the target path is
+	// shadowed by a bind mount from the host, so the actual mode is only
+	// visible when said interface is disconnected after being connected earlier
+	// with the mount namespace being preserved.
+	as.AddModeHint("/tmp/.X11-unix", 0777|os.ModeSticky)
 	// This is to ensure private shared-memory directories have
 	// the right permissions.
 	as.AddModeHint("/dev/shm/snap.*", 0777|os.ModeSticky)

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -82,6 +82,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap-private-tmp/snap.x11-server/tmp"), Equals, os.FileMode(0777)|os.ModeSticky)
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap-private-tmp/snap.x11-server/foo"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap-private-tmp/snap.x11-server/tmp/.X11-unix"), Equals, os.FileMode(0777)|os.ModeSticky)
+	c.Check(as.ModeForPath("/tmp/.X11-unix"), Equals, os.FileMode(0777)|os.ModeSticky)
 	c.Check(as.ModeForPath("/dev/shm/snap.some-snap"), Equals, os.FileMode(0777)|os.ModeSticky)
 
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME


### PR DESCRIPTION
The /tmp/.X11-unix target path created inside the snap's mount ns is hidden when the mount added by the x11 interface is executed. However, to keep things consistent we should ensure that it is created with a reasonable mode, which matches what a typical /tmp/.X11-unix directory would have.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
