### PR TITLE
spread: set the initial snap mount directory in the cross-build suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1491,6 +1491,7 @@ suites:
         summary: Test building snapd in different architectures
         manual: true
         prepare-each: |
+            tests.invariant set snap-mount-dir "$(os.paths snap-mount-dir)"
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps
         restore-each: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite-each-minimal-no-snaps


### PR DESCRIPTION
The initial snap mount directory wasn't set in the cross-build suite. However, the checks were still being applied.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
