### PR TITLE
i/builtin: fix custom-device for-device validation

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -193,8 +193,10 @@ func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]any,
 			// override of implicit device match
 			var ok bool
 			deviceOverrideVal, ok = value.(string)
-			if !ok || !strutil.ListContains(devices, deviceOverrideVal) {
-				err = fmt.Errorf(`cannot find matching device "%v"`, value)
+			if !ok {
+				err = fmt.Errorf(`"for-device" must be a string, but got %T: %v`, value, value)
+			} else if !strutil.ListContains(devices, deviceOverrideVal) {
+				err = fmt.Errorf(`cannot find matching device %q`, deviceOverrideVal)
 			}
 		default:
 			err = errors.New(`unknown tag`)

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -191,9 +191,10 @@ func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]any,
 			err = iface.validateUDevValueMap(value)
 		case "for-device":
 			// override of implicit device match
-			deviceOverrideVal = value.(string)
-			if !strutil.ListContains(devices, deviceOverrideVal) {
-				err = fmt.Errorf("cannot find matching device %q", deviceOverrideVal)
+			var ok bool
+			deviceOverrideVal, ok = value.(string)
+			if !ok || !strutil.ListContains(devices, deviceOverrideVal) {
+				err = fmt.Errorf(`cannot find matching device "%v"`, value)
 			}
 		default:
 			err = errors.New(`unknown tag`)

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -342,6 +342,10 @@ apps:
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: foo\n      for-device: /dev/bar",
 			`custom-device "udev-tagging" invalid "for-device" tag: cannot find matching device "/dev/bar"`,
 		},
+		{
+			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: foo\n      for-device: 1234",
+			`custom-device "udev-tagging" invalid "for-device" tag: cannot find matching device "1234"`,
+		},
 	}
 
 	for _, testData := range data {

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -344,7 +344,7 @@ apps:
 		},
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: foo\n      for-device: 1234",
-			`custom-device "udev-tagging" invalid "for-device" tag: cannot find matching device "1234"`,
+			`custom-device "udev-tagging" invalid "for-device" tag: "for-device" must be a string, but got int64: 1234`,
 		},
 	}
 


### PR DESCRIPTION
There was an un-checked type assertion which could cause a panic if a non-string value was given.

Spotted by @artiepoole in #16994
