### PR TITLE
many: replace rootPath with dirs.GlobalRootDir

### DIFF
--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -70,8 +70,6 @@ func (s *promptingSuite) SetUpTest(c *C) {
 	))
 	// mock the presence of the notification socket
 	os.MkdirAll(apparmor.NotifySocketPath, 0o755)
-	// mock the presence of permstable32_version with supported version
-	s.AddCleanup(apparmor.MockFsRootPath(dirs.GlobalRootDir))
 	os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "sys/kernel/security/apparmor/features/policy"), 0o755)
 	os.WriteFile(filepath.Join(dirs.GlobalRootDir, "sys/kernel/security/apparmor/features/policy/permstable32_version"), []byte("0x000002"), 0o644)
 

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -555,11 +555,6 @@ var (
 	// system, use a predictable search path for finding the parser.
 	parserSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-	// Filesystem root defined locally to avoid dependency on the
-	// 'dirs' package
-	// TODO: replace rootPath with dirs.GlobalRootDir, since dirs is used elsewhere
-	rootPath = "/"
-
 	// hostAbi30File is the path to the apparmor "3.0" ABI file and is typically
 	// /etc/apparmor.d/abi/3.0. It is not present on all systems. It is notably
 	// absent when using apparmor 2.x. The variable reacts to changes to global
@@ -575,7 +570,7 @@ const featuresSysPath = "sys/kernel/security/apparmor/features"
 // FeaturesSysDir returns the path to the AppArmor features sysfs, which is
 // /sys/kernel/security/apparmor/features, relative to the current root dir.
 func FeaturesSysDir() string {
-	return filepath.Join(rootPath, featuresSysPath)
+	return filepath.Join(dirs.GlobalRootDir, featuresSysPath)
 }
 
 type appArmorProber interface {
@@ -1112,9 +1107,9 @@ func MockParserSearchPath(new string) (restore func()) {
 }
 
 func MockFsRootPath(path string) (restorer func()) {
-	old := rootPath
-	rootPath = path
+	old := dirs.GlobalRootDir
+	dirs.GlobalRootDir = path
 	return func() {
-		rootPath = old
+		dirs.GlobalRootDir = old
 	}
 }

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -1105,11 +1105,3 @@ func MockParserSearchPath(new string) (restore func()) {
 		parserSearchPath = oldAppArmorParserSearchPath
 	}
 }
-
-func MockFsRootPath(path string) (restorer func()) {
-	old := dirs.GlobalRootDir
-	dirs.GlobalRootDir = path
-	return func() {
-		dirs.GlobalRootDir = old
-	}
-}

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -44,6 +44,7 @@ func TestApparmor(t *testing.T) {
 
 type apparmorSuite struct {
 	testutil.BaseTest
+	fakeroot string
 }
 
 var _ = Suite(&apparmorSuite{})
@@ -51,7 +52,8 @@ var _ = Suite(&apparmorSuite{})
 func (s *apparmorSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	dirs.SetRootDir(c.MkDir())
+	s.fakeroot = c.MkDir()
+	dirs.SetRootDir(s.fakeroot)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
 	s.AddCleanup(func() {
@@ -77,9 +79,6 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 }
 
 func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
 	parser := filepath.Join(libSnapdDir, "apparmor_parser")
 	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
@@ -108,9 +107,6 @@ func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
 }
 
 func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi4(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
 	parser := filepath.Join(libSnapdDir, "apparmor_parser")
 	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
@@ -268,43 +264,40 @@ func (*apparmorSuite) TestMockAppArmorFeatures(c *C) {
 const featuresSysPath = "sys/kernel/security/apparmor/features"
 
 func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
-	d := c.MkDir()
-
 	// Pretend that apparmor kernel features directory doesn't exist.
-	dirs.SetRootDir(d)
 	features, err := apparmor.ProbeKernelFeatures()
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(features, DeepEquals, []string{})
 
 	// Pretend that apparmor kernel features directory exists but is empty.
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{})
 
 	// Pretend that apparmor kernel features directory contains some entries.
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo"), 0755), IsNil)
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "bar"), 0755), IsNil)
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "xyz"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "foo"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "bar"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "xyz"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"bar", "foo", "xyz"})
 
 	// Also test sub-features features
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo", "baz"), 0755), IsNil)
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "foo", "qux"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "foo", "baz"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "foo", "qux"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux", "xyz"})
 
 	// But boolean file features are not included
-	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "bar", "feat1"), nil, 0o644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "bar", "feat1"), nil, 0o644), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux", "xyz"})
 
 	// Also test that prompt feature is read from permstable32 if it exists
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "policy"), 0755), IsNil)
 	for _, testCase := range []struct {
 		permstableContent string
 		expectedSuffixes  []string
@@ -342,7 +335,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 			[]string{"prompt"},
 		},
 	} {
-		c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32"), []byte(testCase.permstableContent), 0644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32"), []byte(testCase.permstableContent), 0644), IsNil)
 		features, err = apparmor.ProbeKernelFeatures()
 		c.Assert(err, IsNil)
 		expected := []string{"bar", "foo", "foo:baz", "foo:qux", "policy"}
@@ -354,9 +347,9 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	}
 
 	// Set permstable32 to good value
-	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32"), []byte("allow deny prompt"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32"), []byte("allow deny prompt"), 0644), IsNil)
 	// Create notify directory
-	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "policy", "notify"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(s.fakeroot, featuresSysPath, "policy", "notify"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	expected := []string{"bar", "foo", "foo:baz", "foo:qux", "policy", "policy:notify", "policy:permstable32:prompt", "xyz"}
@@ -380,7 +373,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 			[]string{"dbus", "file", "network"},
 		},
 	} {
-		c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "notify", "user"), []byte(testCase.userContent), 0644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "notify", "user"), []byte(testCase.userContent), 0644), IsNil)
 		features, err = apparmor.ProbeKernelFeatures()
 		c.Assert(err, IsNil)
 		expected = []string{"bar", "foo", "foo:baz", "foo:qux", "policy", "policy:notify"}
@@ -393,17 +386,14 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 }
 
 func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C) {
-	d := c.MkDir()
-
 	// Pretend that apparmor kernel features directory doesn't exist.
-	dirs.SetRootDir(d)
 	version, err := apparmor.ProbeKernelFeaturesPermstable32Version()
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(version, Equals, int64(0))
 
 	// Pretend that the permstable32_version file exists but is malformed.
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0o755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), nil, 0o644), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "policy"), 0o755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32_version"), nil, 0o644), IsNil)
 	version, err = apparmor.ProbeKernelFeaturesPermstable32Version()
 	c.Assert(errors.Is(err, strconv.ErrSyntax), Equals, true)
 	c.Check(version, Equals, int64(0))
@@ -430,7 +420,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C)
 			0x1234567890abcdef,
 		},
 	} {
-		c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), []byte(testCase.str), 0o644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32_version"), []byte(testCase.str), 0o644), IsNil)
 		version, err = apparmor.ProbeKernelFeaturesPermstable32Version()
 		c.Check(err, IsNil)
 		c.Check(version, Equals, testCase.ver)
@@ -483,19 +473,19 @@ func probeOneVersionDependentParserFeature(c *C, known *[]string, parserPath, pa
 
 type parserFeatureTestSuite struct {
 	testutil.BaseTest
-	d      string
-	binDir string
+	fakeroot string
+	binDir   string
 }
 
 var _ = Suite(&parserFeatureTestSuite{})
 
 func (s *parserFeatureTestSuite) SetUpTest(c *C) {
-	s.d = c.MkDir()
+	s.fakeroot = c.MkDir()
 	// This is used to find related parser files and isolates us from the host.
-	dirs.SetRootDir(s.d)
+	dirs.SetRootDir(s.fakeroot)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	s.binDir = filepath.Join(s.d, "bin")
+	s.binDir = filepath.Join(s.fakeroot, "bin")
 	err := os.Mkdir(s.binDir, 0o755)
 	c.Assert(err, IsNil)
 
@@ -609,11 +599,8 @@ func (s *parserFeatureTestSuite) TestInternalParser(c *C) {
 
 func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	apparmor.FreshAppArmorAssessment()
-
-	d := c.MkDir()
-	dirs.SetRootDir(d)
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "network"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "policy"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fakeParserScript("4.0.1"))
 	defer mockParserCmd.Restore()
@@ -651,10 +638,8 @@ func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {
 func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	apparmor.FreshAppArmorAssessment()
 
-	d := c.MkDir()
-	dirs.SetRootDir(d)
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "network"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "policy"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fakeParserScript("4.0.1"))
 	defer mockParserCmd.Restore()
@@ -669,7 +654,7 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "io-uring", "mqueue", "mqueue-posix", "prompt", "qipcrtr-socket", "tags", "unconfined", "unsafe", "userns", "xdp"})
 
 	// this makes probing fails but is not done again
-	err = os.RemoveAll(d)
+	err = os.RemoveAll(s.fakeroot)
 	c.Assert(err, IsNil)
 
 	_, err = apparmor.KernelFeatures()
@@ -684,9 +669,6 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 }
 
 func (s *apparmorSuite) TestPromptingSupported(c *C) {
-	d := c.MkDir()
-	dirs.SetRootDir(d)
-
 	goodKernelFeatures := []string{"policy:permstable32:prompt"}
 	goodKernelFeaturesWithNotify := []string{"policy:permstable32:prompt", "policy:notify", "policy:notify:user:file"}
 	goodParserFeatures := []string{"prompt"}
@@ -773,15 +755,15 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version could not be read")
 
 	// Create permstable32_version file with a version too early
-	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0o755), IsNil)
-	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), []byte("0x000001"), 0o644), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.fakeroot, featuresSysPath, "policy"), 0o755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32_version"), []byte("0x000001"), 0o644), IsNil)
 
 	supported, reason = apparmor.PromptingSupported()
 	c.Check(supported, Equals, false)
 	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version is 1")
 
 	// Create permstable32_version file with a sufficient version
-	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), []byte("0x000002"), 0o644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.fakeroot, featuresSysPath, "policy", "permstable32_version"), []byte("0x000002"), 0o644), IsNil)
 
 	for _, kernelFeatures := range [][]string{goodKernelFeatures, goodKernelFeaturesWithNotify} {
 		restore := apparmor.MockFeatures(kernelFeatures, nil, goodParserFeatures, nil)
@@ -955,9 +937,6 @@ func (s *apparmorSuite) TestUpdateHomedirsTunableWriteFail(c *C) {
 }
 
 func (s *apparmorSuite) TestUpdateHomedirsTunableHappy(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	err := apparmor.UpdateHomedirsTunable([]string{"/home/a", "/dir2"})
 	c.Assert(err, IsNil)
 	configFile := filepath.Join(dirs.GlobalRootDir, "/etc/apparmor.d/tunables/home.d/snapd")
@@ -975,9 +954,6 @@ func (s *apparmorSuite) TestUpdateHomedirsTunableHappyNoDirs(c *C) {
 }
 
 func (s *apparmorSuite) TestSnapdAppArmorSupportsReexecImpl(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	// with no info file should indicate it does not support reexec
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
 
@@ -1000,9 +976,6 @@ func (s *apparmorSuite) TestSetupConfCacheDirs(c *C) {
 }
 
 func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	libSnapdDir := filepath.Join(dirs.SnapMountDir, "/snapd/42/usr/lib/snapd")
 	parser := filepath.Join(libSnapdDir, "apparmor_parser")
 	c.Assert(os.MkdirAll(libSnapdDir, 0755), IsNil)
@@ -1031,9 +1004,7 @@ func (s *apparmorSuite) TestSetupNotifySocketPath(c *C) {
 }
 
 func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-	fakeApparmorFunctionsPath := filepath.Join(fakeroot, "/lib/apparmor/functions")
+	fakeApparmorFunctionsPath := filepath.Join(s.fakeroot, "/lib/apparmor/functions")
 	err := os.MkdirAll(filepath.Dir(fakeApparmorFunctionsPath), 0750)
 	c.Assert(err, IsNil)
 
@@ -1059,14 +1030,11 @@ func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {
 }
 
 func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicy(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
-
 	// systemAppArmorLoadsSnapPolicy() will look at this path so it
 	// needs to be the real path, not a faked one
-	dirs.SnapAppArmorDir = dirs.SnapAppArmorDir[len(fakeroot):]
+	dirs.SnapAppArmorDir = dirs.SnapAppArmorDir[len(s.fakeroot):]
 
-	fakeApparmorFunctionsPath := filepath.Join(fakeroot, "/lib/apparmor/functions")
+	fakeApparmorFunctionsPath := filepath.Join(s.fakeroot, "/lib/apparmor/functions")
 	err := os.MkdirAll(filepath.Dir(fakeApparmorFunctionsPath), 0755)
 	c.Assert(err, IsNil)
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -271,8 +271,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	d := c.MkDir()
 
 	// Pretend that apparmor kernel features directory doesn't exist.
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 	features, err := apparmor.ProbeKernelFeatures()
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(features, DeepEquals, []string{})
@@ -397,8 +396,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C)
 	d := c.MkDir()
 
 	// Pretend that apparmor kernel features directory doesn't exist.
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 	version, err := apparmor.ProbeKernelFeaturesPermstable32Version()
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(version, Equals, int64(0))
@@ -613,14 +611,13 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	apparmor.FreshAppArmorAssessment()
 
 	d := c.MkDir()
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fakeParserScript("4.0.1"))
 	defer mockParserCmd.Restore()
-	restore = apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 	defer restore()
 
 	apparmor.ProbedLevel()
@@ -655,14 +652,13 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	apparmor.FreshAppArmorAssessment()
 
 	d := c.MkDir()
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fakeParserScript("4.0.1"))
 	defer mockParserCmd.Restore()
-	restore = apparmor.MockParserSearchPath(mockParserCmd.BinDir())
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 	defer restore()
 
 	features, err := apparmor.KernelFeatures()
@@ -689,8 +685,7 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 
 func (s *apparmorSuite) TestPromptingSupported(c *C) {
 	d := c.MkDir()
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 
 	goodKernelFeatures := []string{"policy:permstable32:prompt"}
 	goodKernelFeaturesWithNotify := []string{"policy:permstable32:prompt", "policy:notify", "policy:notify:user:file"}
@@ -770,7 +765,7 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 	// Create a file at the notify path, doesn't matter what kind of file.
 	// The actual file is a socket, but a directory will do here for convenience.
 	c.Assert(os.MkdirAll(apparmor.NotifySocketPath, 0o755), IsNil)
-	restore = apparmor.MockFeatures(goodKernelFeatures, nil, goodParserFeatures, nil)
+	restore := apparmor.MockFeatures(goodKernelFeatures, nil, goodParserFeatures, nil)
 	defer restore()
 
 	supported, reason := apparmor.PromptingSupported()

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -25,7 +25,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -125,8 +125,7 @@ func (s *versionSuite) TestVersionsLikelySupportedChecks(c *C) {
 		c.Assert(testCase.expectedSupport, HasLen, len(notify.Versions))
 
 		tmpdir := c.MkDir()
-		restore := apparmor.MockFsRootPath(tmpdir)
-		defer restore()
+		dirs.SetRootDir(tmpdir)
 
 		versionsDir := filepath.Join(tmpdir, "sys/kernel/security/apparmor/features/policy/notify_versions")
 
@@ -140,7 +139,7 @@ func (s *versionSuite) TestVersionsLikelySupportedChecks(c *C) {
 			c.Assert(f.Close(), IsNil)
 		}
 
-		restore = notify.MockApparmorMetadataTagsSupportedByKernel(func() bool {
+		restore := notify.MockApparmorMetadataTagsSupportedByKernel(func() bool {
 			return testCase.metadataTagsSupported
 		})
 		defer restore()
@@ -151,6 +150,7 @@ func (s *versionSuite) TestVersionsLikelySupportedChecks(c *C) {
 			c.Check(supported, Equals, testCase.expectedSupport[i], Commentf("version: %d\ntestCase: %+v", version, testCase))
 		}
 	}
+	dirs.SetRootDir("")
 }
 
 var fakeVersions = []notify.VersionAndCheck{

--- a/sandbox/apparmor/process.go
+++ b/sandbox/apparmor/process.go
@@ -25,16 +25,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
 
 func labelFromPid(pid int) (string, error) {
 	// first check new kernel path, /proc/<pid>/attr/apparmor/current, falling
 	// back to the old path if that doesn't exist
-	procFile := filepath.Join(rootPath, fmt.Sprintf("proc/%v/attr/apparmor/current", pid))
+	procFile := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/attr/apparmor/current", pid))
 	if !osutil.FileExists(procFile) {
 		// fallback
-		procFile = filepath.Join(rootPath, fmt.Sprintf("proc/%v/attr/current", pid))
+		procFile = filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/attr/current", pid))
 	}
 	contents, err := os.ReadFile(procFile)
 	if os.IsNotExist(err) {

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 )
@@ -58,15 +57,12 @@ func (s *apparmorSuite) TestDecodeLabelUnrecognisedSnapLabel(c *C) {
 }
 
 func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
-	d := c.MkDir()
-	dirs.SetRootDir(d)
-
 	// when the new file exists we use that one
-	newProcFile := filepath.Join(d, "proc/42/attr/apparmor/current")
+	newProcFile := filepath.Join(s.fakeroot, "proc/42/attr/apparmor/current")
 	c.Assert(os.MkdirAll(filepath.Dir(newProcFile), 0755), IsNil)
 	c.Assert(os.WriteFile(newProcFile, []byte("snap.foo.app"), 0644), IsNil)
 
-	oldProcFile := filepath.Join(d, "proc/42/attr/current")
+	oldProcFile := filepath.Join(s.fakeroot, "proc/42/attr/current")
 	c.Assert(os.MkdirAll(filepath.Dir(oldProcFile), 0755), IsNil)
 	c.Assert(os.WriteFile(oldProcFile, []byte("random-other-unread-data"), 0644), IsNil)
 
@@ -78,14 +74,11 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 }
 
 func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
-	d := c.MkDir()
-	dirs.SetRootDir(d)
-
 	// When no /proc/$pid/attr/current exists, assume unconfined
 	_, _, _, err := apparmor.SnapAppFromPid(42)
 	c.Check(err, ErrorMatches, `security label "unconfined" does not belong to a snap`)
 
-	procFile := filepath.Join(d, "proc/42/attr/current")
+	procFile := filepath.Join(s.fakeroot, "proc/42/attr/current")
 	c.Assert(os.MkdirAll(filepath.Dir(procFile), 0755), IsNil)
 
 	c.Assert(os.WriteFile(procFile, []byte("not-read"), 0000), IsNil)

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 )
@@ -58,8 +59,7 @@ func (s *apparmorSuite) TestDecodeLabelUnrecognisedSnapLabel(c *C) {
 
 func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 	d := c.MkDir()
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 
 	// when the new file exists we use that one
 	newProcFile := filepath.Join(d, "proc/42/attr/apparmor/current")
@@ -79,8 +79,7 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 
 func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
 	d := c.MkDir()
-	restore := apparmor.MockFsRootPath(d)
-	defer restore()
+	dirs.SetRootDir(d)
 
 	// When no /proc/$pid/attr/current exists, assume unconfined
 	_, _, _, err := apparmor.SnapAppFromPid(42)

--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -43,12 +43,6 @@ const (
 	cgroupMountPoint = "/sys/fs/cgroup"
 )
 
-var (
-	// Filesystem root defined locally to avoid dependency on the 'dirs'
-	// package
-	rootPath = "/"
-)
-
 const (
 	// Separate block, because iota is fun
 	Unknown = iota
@@ -62,9 +56,6 @@ var (
 )
 
 func init() {
-	dirs.AddRootDirCallback(func(root string) {
-		rootPath = root
-	})
 	probeVersion, probeErr = probeCgroupVersion()
 	// handles error case gracefully
 	pickVersionSpecificImpl()
@@ -98,11 +89,11 @@ func fsTypeForPathImpl(path string) (int64, error) {
 // ProcPidPath returns the path to the cgroup file under /proc for the given
 // process id.
 func ProcPidPath(pid int) string {
-	return filepath.Join(rootPath, fmt.Sprintf("proc/%v/cgroup", pid))
+	return filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/cgroup", pid))
 }
 
 func probeCgroupVersion() (version int, err error) {
-	cgroupMount := filepath.Join(rootPath, cgroupMountPoint)
+	cgroupMount := filepath.Join(dirs.GlobalRootDir, cgroupMountPoint)
 	typ, err := fsTypeForPath(cgroupMount)
 	if err != nil {
 		return Unknown, fmt.Errorf("cannot determine cgroup version: %v", err)

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -143,11 +143,11 @@ func applyToSnap(snapName string, action func(groupName string) error, skipError
 		return fmt.Errorf("internal error: skip error is nil")
 	}
 	canary := fmt.Sprintf("snap.%s.", snapName)
-	cgroupRoot := filepath.Join(rootPath, cgroupMountPoint)
+	cgroupRoot := filepath.Join(dirs.GlobalRootDir, cgroupMountPoint)
 	if _, dir, _ := osutil.DirExists(cgroupRoot); !dir {
 		return nil
 	}
-	return filepath.Walk(filepath.Join(rootPath, cgroupMountPoint), func(name string, info os.FileInfo, err error) error {
+	return filepath.Walk(filepath.Join(dirs.GlobalRootDir, cgroupMountPoint), func(name string, info os.FileInfo, err error) error {
 		if err != nil {
 			if skipError(err) {
 				// we don't know whether it's a file or
@@ -248,7 +248,7 @@ func freezeSnapProcessesImplV2(ctx context.Context, snapName string) error {
 	if err != nil {
 		return err
 	}
-	ownGroupDir := filepath.Join(rootPath, cgroupMountPoint, ownGroup)
+	ownGroupDir := filepath.Join(dirs.GlobalRootDir, cgroupMountPoint, ownGroup)
 	freezeOne := func(dir string) error {
 		if dir == ownGroupDir {
 			// let's not freeze ourselves

--- a/sandbox/cgroup/memory.go
+++ b/sandbox/cgroup/memory.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/snapcore/snapd/dirs"
 )
 
 var (
@@ -72,7 +74,7 @@ func CheckMemoryCgroup() error {
 }
 
 func checkV1CgroupMemoryController() (bool, error) {
-	cgroupsFile, err := os.Open(filepath.Join(rootPath, cgroupV1ControllersPath))
+	cgroupsFile, err := os.Open(filepath.Join(dirs.GlobalRootDir, cgroupV1ControllersPath))
 	if err != nil {
 		return false, fmt.Errorf("cannot open cgroups file: %w", err)
 	}
@@ -101,7 +103,7 @@ func checkV1CgroupMemoryController() (bool, error) {
 
 func checkV2CgroupMemoryController() (bool, error) {
 	// check at the root controller
-	f, err := os.Open(filepath.Join(rootPath, cgroupV2ControllersPath))
+	f, err := os.Open(filepath.Join(dirs.GlobalRootDir, cgroupV2ControllersPath))
 	if err != nil {
 		return false, err
 	}

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -119,12 +120,12 @@ func InstancePathsOfSnap(snapInstanceName string, options InstancePathsOptions) 
 		// In v2 mode scan all of /sys/fs/cgroup as there is no specialization
 		// anymore (each directory represents a hierarchy with equal
 		// capabilities and old split into controllers is gone).
-		cgroupPathToScan = filepath.Join(rootPath, cgroupMountPoint)
+		cgroupPathToScan = filepath.Join(dirs.GlobalRootDir, cgroupMountPoint)
 	} else {
 		// In v1 mode scan just /sys/fs/cgroup/systemd as that is sufficient
 		// for finding snap-specific cgroup names. Systemd uses this for
 		// tracking and scopes and services are represented there.
-		cgroupPathToScan = filepath.Join(rootPath, cgroupMountPoint, "systemd")
+		cgroupPathToScan = filepath.Join(dirs.GlobalRootDir, cgroupMountPoint, "systemd")
 	}
 
 	// Walk the cgroup tree and look for "cgroup.procs" files. Having found one


### PR DESCRIPTION
Replaces `rootPath` variable with `dirs.GlobalRootDir` in sandbox/apparmor. Pointed out in https://github.com/canonical/snapd/pull/15624#discussion_r2168930082.

Tracked by: [SNAPDENG-35226](https://warthogs.atlassian.net/browse/SNAPDENG-35226?atlOrigin=eyJpIjoiOTdmYWEyMzFiNGY3NDE3N2FkYTBmMzllNDg2MzJiZTgiLCJwIjoiaiJ9)


[SNAPDENG-35226]: https://warthogs.atlassian.net/browse/SNAPDENG-35226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ