### PR TITLE
s/apparmor: use os.WriteFile in apparmor_test.go

### DIFF
--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -115,9 +115,7 @@ func (s *SystemObserveInterfaceSuite) TestMountPermanentPlug(c *C) {
 	// mount for it
 	fakeBootDir := filepath.Join(tmpdir, "/boot")
 	c.Assert(os.MkdirAll(fakeBootDir, 0777), IsNil)
-	file, err := os.OpenFile(filepath.Join(fakeBootDir, "config-5.10"), os.O_CREATE, 0644)
-	c.Assert(err, IsNil)
-	c.Assert(file.Close(), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(fakeBootDir, "config-5.10"), nil, 0o644), IsNil)
 
 	mountSpec := &mount.Specification{}
 	c.Assert(mountSpec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -299,9 +299,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux", "xyz"})
 
 	// But boolean file features are not included
-	file, err := os.OpenFile(filepath.Join(d, featuresSysPath, "bar", "feat1"), os.O_CREATE, 0o644)
-	c.Assert(err, IsNil)
-	c.Assert(file.Close(), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "bar", "feat1"), nil, 0o644), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"bar", "foo", "foo:baz", "foo:qux", "xyz"})
@@ -407,9 +405,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C)
 
 	// Pretend that the permstable32_version file exists but is malformed.
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0o755), IsNil)
-	f, err := os.OpenFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), os.O_CREATE, 0o644)
-	c.Assert(err, IsNil)
-	f.Close()
+	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), nil, 0o644), IsNil)
 	version, err = apparmor.ProbeKernelFeaturesPermstable32Version()
 	c.Assert(errors.Is(err, strconv.ErrSyntax), Equals, true)
 	c.Check(version, Equals, int64(0))

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -53,10 +53,7 @@ func (s *binariesTestSuite) SetUpTest(c *C) {
 	s.tempdir = c.MkDir()
 	dirs.SetRootDir(s.tempdir)
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.BashCompletionScript), 0755), IsNil)
-	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	c.Assert(err, IsNil)
-	f.Write([]byte("#\nBASH_COMPLETION_VERSINFO=(2 6)\n"))
-	f.Close()
+	c.Assert(os.WriteFile(dirs.BashCompletionScript, []byte("#\nBASH_COMPLETION_VERSINFO=(2 6)\n"), 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TearDownTest(c *C) {
@@ -125,11 +122,7 @@ func (s *binariesTestSuite) prepareReadOnlyLegacyDir(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
-
-	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	c.Assert(err, IsNil)
-	f.Write([]byte("#\n#   RELEASE: 2.1\n"))
-	f.Close()
+	c.Assert(os.WriteFile(dirs.BashCompletionScript, []byte("#\n#   RELEASE: 2.1\n"), 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
@@ -151,10 +144,7 @@ func (s *binariesTestSuite) prepareUseLegacy(c *C) {
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
-	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	c.Assert(err, IsNil)
-	f.Write([]byte("#\n#   RELEASE: 2.1\n"))
-	f.Close()
+	c.Assert(os.WriteFile(dirs.BashCompletionScript, []byte("#\n#   RELEASE: 2.1\n"), 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
@@ -175,10 +165,7 @@ func (s *binariesTestSuite) prepareOldButNotThatOld(c *C) {
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
-	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	c.Assert(err, IsNil)
-	f.Write([]byte("#\n#   RELEASE: 2.2\n"))
-	f.Close()
+	c.Assert(os.WriteFile(dirs.BashCompletionScript, []byte("#\n#   RELEASE: 2.2\n"), 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
@@ -198,10 +185,7 @@ func (s *binariesTestSuite) prepareUnknownVersion(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
-
-	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	c.Assert(err, IsNil)
-	f.Close()
+	c.Assert(os.WriteFile(dirs.BashCompletionScript, nil, 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {


### PR DESCRIPTION
Replace several separate `os.OpenFile`, `c.Check(err, IsNil)`, `c.Check(file.Close(), IsNil)` calls with a single `os.WriteFile` call.

Pointed out in https://github.com/canonical/snapd/pull/15624#discussion_r2165853492

Tracked with: [SNAPDENG-35228](https://warthogs.atlassian.net/browse/SNAPDENG-35228?atlOrigin=eyJpIjoiMzEzNTU1YzQ5MzYwNGEzOThlMzYxY2VhOTJhNjkyMDIiLCJwIjoiaiJ9)

[SNAPDENG-35228]: https://warthogs.atlassian.net/browse/SNAPDENG-35228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ