### PR TITLE
o/fdestate: remove all tmp keyslots on error

### DIFF
--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -684,6 +684,7 @@ func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslotRefs []Key
 	addTemporaryRecoveryKeys := st.NewTask("fde-add-recovery-keys", "Add temporary recovery key slots")
 	addTemporaryRecoveryKeys.Set("recovery-key-id", recoveryKeyID)
 	addTemporaryRecoveryKeys.Set("keyslots", tmpKeyslotRefs)
+	addTemporaryRecoveryKeys.Set("remove-all-on-error", true)
 	ts.AddTask(addTemporaryRecoveryKeys)
 
 	removeOldRecoveryKeys := st.NewTask("fde-remove-keys", "Remove old recovery key slots")

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -920,6 +920,7 @@ func ReplacePlatformKey(st *state.State, volumesAuth *device.VolumesAuthOptions,
 	addTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
 	addTemporaryKeys.Set("auth-mode", authMode)
 	addTemporaryKeys.Set("roles", tmpKeyslotRoles)
+	addTemporaryKeys.Set("remove-all-on-error", true)
 	ts.AddTask(addTemporaryKeys)
 
 	removeOldKeys := st.NewTask("fde-remove-keys", fmt.Sprintf("Remove old %s key slots", keyType))

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -684,10 +684,10 @@ func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslotRefs []Key
 	addTemporaryRecoveryKeys := st.NewTask("fde-add-recovery-keys", "Add temporary recovery key slots")
 	addTemporaryRecoveryKeys.Set("recovery-key-id", recoveryKeyID)
 	addTemporaryRecoveryKeys.Set("keyslots", tmpKeyslotRefs)
-	// Remove all tmp keyslots during cleanup in case of erroring after
-	// a re-run (e.g. after system or snapd restart) where the context
-	// of the added keyslots might have been lost due to a restart and
-	// the keyslots will not be cleaned up automatically.
+	// Force remove all tmp keyslots during cleanup in case of erroring
+	// after a re-run (e.g. after system or snapd restart) where we might
+	// have lost the credentials (e.g. passphrase) stored in-memory after
+	// system reboot.
 	//
 	// Note that it is fine to remove all added keys because the original
 	// keyslots being replaced are only removed after the tmp keys have
@@ -928,10 +928,10 @@ func ReplacePlatformKey(st *state.State, volumesAuth *device.VolumesAuthOptions,
 	addTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
 	addTemporaryKeys.Set("auth-mode", authMode)
 	addTemporaryKeys.Set("roles", tmpKeyslotRoles)
-	// Remove all tmp keyslots during cleanup in case of erroring after
-	// a re-run (e.g. after system or snapd restart) where the context
-	// of the added keyslots might have been lost due to a restart and
-	// the keyslots will not be cleaned up automatically.
+	// Force remove all tmp keyslots during cleanup in case of erroring
+	// after a re-run (e.g. after system or snapd restart) where we might
+	// have lost the credentials (e.g. passphrase) stored in-memory after
+	// system reboot.
 	//
 	// Note that it is fine to remove all added keys because the original
 	// keyslots being replaced are only removed after the tmp keys have

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -684,6 +684,14 @@ func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslotRefs []Key
 	addTemporaryRecoveryKeys := st.NewTask("fde-add-recovery-keys", "Add temporary recovery key slots")
 	addTemporaryRecoveryKeys.Set("recovery-key-id", recoveryKeyID)
 	addTemporaryRecoveryKeys.Set("keyslots", tmpKeyslotRefs)
+	// Remove all tmp keyslots during cleanup in case of erroring after
+	// a re-run (e.g. after system or snapd restart) where the context
+	// of the added keyslots might have been lost due to a restart and
+	// the keyslots will not be cleaned up automatically.
+	//
+	// Note that it is fine to remove all added keys because the original
+	// keyslots being replaced are only removed after the tmp keys have
+	// been successfully added.
 	addTemporaryRecoveryKeys.Set("remove-all-on-error", true)
 	ts.AddTask(addTemporaryRecoveryKeys)
 
@@ -920,6 +928,14 @@ func ReplacePlatformKey(st *state.State, volumesAuth *device.VolumesAuthOptions,
 	addTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
 	addTemporaryKeys.Set("auth-mode", authMode)
 	addTemporaryKeys.Set("roles", tmpKeyslotRoles)
+	// Remove all tmp keyslots during cleanup in case of erroring after
+	// a re-run (e.g. after system or snapd restart) where the context
+	// of the added keyslots might have been lost due to a restart and
+	// the keyslots will not be cleaned up automatically.
+	//
+	// Note that it is fine to remove all added keys because the original
+	// keyslots being replaced are only removed after the tmp keys have
+	// been successfully added.
 	addTemporaryKeys.Set("remove-all-on-error", true)
 	ts.AddTask(addTemporaryKeys)
 

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -335,6 +335,10 @@ func (s *fdeMgrSuite) testReplaceRecoveryKey(c *C, defaultKeyslots bool) {
 	var tskKeyslots []fdestate.KeyslotRef
 	c.Assert(tsks[0].Get("keyslots", &tskKeyslots), IsNil)
 	c.Check(tskKeyslots, DeepEquals, tmpKeyslots)
+	// check all tmp keys will be removed on error
+	var tskRemoveAll bool
+	c.Assert(tsks[0].Get("remove-all-on-error", &tskRemoveAll), IsNil)
+	c.Check(tskRemoveAll, Equals, true)
 
 	c.Check(tsks[1].Summary(), Matches, "Remove old recovery key slots")
 	c.Check(tsks[1].Kind(), Equals, "fde-remove-keys")

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -764,6 +764,10 @@ func (s *fdeMgrSuite) testReplacePlatformKey(c *C, authMode device.AuthMode, def
 	var tskKeyslots []fdestate.KeyslotRef
 	c.Assert(tsks[0].Get("keyslots", &tskKeyslots), IsNil)
 	c.Check(tskKeyslots, DeepEquals, tmpKeyslots)
+	// check all tmp keys will be removed on error
+	var tskRemoveAll bool
+	c.Assert(tsks[0].Get("remove-all-on-error", &tskRemoveAll), IsNil)
+	c.Check(tskRemoveAll, Equals, true)
 	var tskAuthMode device.AuthMode
 	c.Assert(tsks[0].Get("auth-mode", &tskAuthMode), IsNil)
 	c.Check(tskAuthMode, Equals, authMode)

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -57,6 +57,11 @@ func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) (err erro
 		return err
 	}
 
+	var removeAllOnError bool
+	if err := t.Get("remove-all-on-error", &removeAllOnError); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
 	// XXX: unlock state and let conflict detection handle the rest?
 
 	containers, err := m.GetEncryptedContainers()
@@ -76,10 +81,11 @@ func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) (err erro
 		if err == nil {
 			return
 		}
-		// TODO:FDEM: a dedicated clean up for stray tmp key slots (recovery or not)
-		// is needed to account for left-over tmp key slot from a failed re-run for
-		// example.
-		for _, keyslotRef := range addedKeyslots {
+		target := addedKeyslots
+		if removeAllOnError {
+			target = keyslotRefs
+		}
+		for _, keyslotRef := range target {
 			devicePath := containerDevicePath[keyslotRef.ContainerRole]
 			if err := secbootDeleteContainerKey(devicePath, keyslotRef.Name); err != nil {
 				// best effort deletion, log errors only

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -297,6 +297,11 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 		return fmt.Errorf("internal error: unexpected authentication mode %q", authMode)
 	}
 
+	var removeAllOnError bool
+	if err := t.Get("remove-all-on-error", &removeAllOnError); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
 	var keyslotRoles map[string][]string
 	if err := t.Get("roles", &keyslotRoles); err != nil {
 		return err
@@ -336,7 +341,11 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 		if err == nil {
 			return
 		}
-		for _, keyslotRef := range addedKeyslots {
+		target := addedKeyslots
+		if removeAllOnError {
+			target = keyslotRefs
+		}
+		for _, keyslotRef := range target {
 			devicePath := containerDevicePath[keyslotRef.ContainerRole]
 			if err := secbootDeleteContainerKey(devicePath, keyslotRef.Name); err != nil {
 				// best effort deletion, log errors only

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -129,6 +129,7 @@ func (s *fdeMgrSuite) TestDoAddRecoveryKeys(c *C) {
 		expectedAdds, expectedDeletes []string
 		badRecoveryKeyID              bool
 		expiredRecoveryKeyID          bool
+		removeAllOnError              bool
 		errOn                         []string
 		expectedErr                   string
 	}
@@ -200,6 +201,66 @@ func (s *fdeMgrSuite) TestDoAddRecoveryKeys(c *C) {
 			},
 			expectedErr: `insufficient capacity on container system-data`,
 		},
+		// test "remove-all-on-error"
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-2"},
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-3"},
+			},
+			removeAllOnError: true,
+			errOn: []string{
+				"add:/dev/disk/by-uuid/data:tmp-default-recovery-3",
+			},
+			expectedAdds: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery-1",
+				"/dev/disk/by-uuid/data:tmp-default-recovery-2",
+			},
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery-1",
+				"/dev/disk/by-uuid/data:tmp-default-recovery-2",
+				"/dev/disk/by-uuid/data:tmp-default-recovery-3",
+			},
+			expectedErr: `cannot add recovery key slot \(container-role: "system-data", name: "tmp-default-recovery-3"\): add error on /dev/disk/by-uuid/data:tmp-default-recovery-3`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "some-key-1"}, // already exists
+				{ContainerRole: "system-data", Name: "tmp-default-recovery"},
+				{ContainerRole: "system-save", Name: "tmp-default-recovery"},
+			},
+			removeAllOnError: true,
+			errOn:            []string{"add:/dev/disk/by-uuid/save:tmp-default-recovery"},
+			expectedAdds:     []string{"/dev/disk/by-uuid/data:tmp-default-recovery"},
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:some-key-1",
+				"/dev/disk/by-uuid/data:tmp-default-recovery",
+				"/dev/disk/by-uuid/save:tmp-default-recovery",
+			},
+			expectedErr: `cannot add recovery key slot \(container-role: "system-save", name: "tmp-default-recovery"\): add error on /dev/disk/by-uuid/save:tmp-default-recovery`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-2"},
+				{ContainerRole: "system-data", Name: "tmp-default-recovery-3"},
+			},
+			removeAllOnError: true,
+			errOn: []string{
+				"add:/dev/disk/by-uuid/data:tmp-default-recovery-3",    // to trigger clean up
+				"delete:/dev/disk/by-uuid/data:tmp-default-recovery-2", // to test best effort deletion
+			},
+			expectedAdds: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery-1",
+				"/dev/disk/by-uuid/data:tmp-default-recovery-2",
+			},
+			// best effort deletion still applies
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery-1",
+				"/dev/disk/by-uuid/data:tmp-default-recovery-3",
+			},
+			expectedErr: `cannot add recovery key slot \(container-role: "system-data", name: "tmp-default-recovery-3"\): add error on /dev/disk/by-uuid/data:tmp-default-recovery-3`,
+		},
 	}
 
 	for i, tc := range tcs {
@@ -229,6 +290,9 @@ func (s *fdeMgrSuite) TestDoAddRecoveryKeys(c *C) {
 
 		task := s.st.NewTask("fde-add-recovery-keys", "test")
 		task.Set("keyslots", tc.keyslots)
+		if tc.removeAllOnError {
+			task.Set("remove-all-on-error", true)
+		}
 
 		var rkeyID string
 		var err error

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -976,6 +976,7 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 		badAuthValue                  bool
 		recoveryMode                  bool
 		noop                          bool
+		removeAllOnError              bool
 		roles                         [][]string
 		expectedAdds, expectedDeletes []string
 		errOn                         []string
@@ -1048,6 +1049,73 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 			keyslots: []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}},
 			authMode: device.AuthModePassphrase,
 			noop:     true,
+		},
+		// test "remove-all-on-error"
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-2"},
+				{ContainerRole: "system-data", Name: "tmp-default-3"},
+			},
+			removeAllOnError: true,
+			authMode:         device.AuthModePassphrase,
+			roles:            [][]string{{"run"}, {"run"}, {"run"}},
+			errOn: []string{
+				"add:/dev/disk/by-uuid/data:tmp-default-3",
+			},
+			expectedAdds: []string{
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-2",
+			},
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-2",
+				"/dev/disk/by-uuid/data:tmp-default-3",
+			},
+			expectedErr: `cannot add platform key slot \(container-role: "system-data", name: "tmp-default-3"\): add error on /dev/disk/by-uuid/data:tmp-default-3`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "default"}, // already exists
+				{ContainerRole: "system-data", Name: "tmp-default-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-2"},
+			},
+			removeAllOnError: true,
+			authMode:         device.AuthModePIN,
+			roles:            [][]string{{"run"}, {"run"}, {"run"}},
+			errOn:            []string{"add:/dev/disk/by-uuid/data:tmp-default-2"},
+			expectedAdds:     []string{"/dev/disk/by-uuid/data:tmp-default-1"},
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:default",
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-2",
+			},
+			expectedErr: `cannot add platform key slot \(container-role: "system-data", name: "tmp-default-2"\): add error on /dev/disk/by-uuid/data:tmp-default-2`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-2"},
+				{ContainerRole: "system-data", Name: "tmp-default-3"},
+			},
+			removeAllOnError: true,
+			authMode:         device.AuthModeNone,
+			noVolumesAuth:    true,
+			roles:            [][]string{{"run"}, {"run"}, {"run"}},
+			errOn: []string{
+				"add:/dev/disk/by-uuid/data:tmp-default-3",    // to trigger clean up
+				"delete:/dev/disk/by-uuid/data:tmp-default-2", // to test best effort deletion
+			},
+			expectedAdds: []string{
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-2",
+			},
+			// best effort deletion still applies
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-3",
+			},
+			expectedErr: `cannot add platform key slot \(container-role: "system-data", name: "tmp-default-3"\): add error on /dev/disk/by-uuid/data:tmp-default-3`,
 		},
 	}
 
@@ -1170,6 +1238,9 @@ func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 		task.Set("keyslots", tc.keyslots)
 		task.Set("auth-mode", tc.authMode)
 		task.Set("roles", roles)
+		if tc.removeAllOnError {
+			task.Set("remove-all-on-error", true)
+		}
 
 		chg := s.st.NewChange("sample", "...")
 		chg.AddTask(task)


### PR DESCRIPTION
This change improves robustness of `fde-add-{recovery,platform}-keys` task handlers by removing leftover (already added) keyslots in case of erroring after a re-run for example after a system (or snapd) restart.

JIRA: [SNAPDENG-35608](https://warthogs.atlassian.net/browse/SNAPDENG-35608)

[SNAPDENG-35608]: https://warthogs.atlassian.net/browse/SNAPDENG-35608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ