### PR TITLE
core-initrd: add nfnetlink to the initramfs

### DIFF
--- a/core-initrd/26.04/modules/main/extra-modules.conf
+++ b/core-initrd/26.04/modules/main/extra-modules.conf
@@ -4,6 +4,8 @@ squashfs
 ahci
 usb-storage
 nls_iso8859-1
+# To speed-up boot until LP#2150773 is SRUed
+nfnetlink
 # For fsck.vfat
 kmod-nls-cp437
 sdhci-pci


### PR DESCRIPTION
This speeds-up opening of nf netlink sockets, fixing the speed regression described in LP#2150773.