### PR TITLE
o/ifacestate: properly handle undo scenarios where auto-connections are dropped

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -369,8 +369,11 @@ func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *in
 		task.Logf("%s", snap.BadInterfacesSummary(snapInfo))
 	}
 
-	affectedConnections, err := m.reloadConnections(snapName)
+	affectedConnections, changedConns, err := m.reloadConnections(snapName)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := saveChangedConnectionsForSetupProfilesRestore(task, snapName, changedConns); err != nil {
 		return nil, nil, err
 	}
 	return disconnectedSnaps, affectedConnections, nil
@@ -694,6 +697,9 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 		FinishRestartDefault: snapsup.Type == snap.TypeSnapd,
 	}
 	if err := snapstateFinishRestart(task, snapsup, finishOpts); err != nil {
+		return err
+	}
+	if err := restoreConnectionsForSetupProfiles(task); err != nil {
 		return err
 	}
 
@@ -2003,7 +2009,7 @@ func (m *InterfaceManager) transitionConnectionsCoreMigration(st *state.State, o
 	// on disk are rewritten. This is ok because core/ubuntu-core have
 	// exactly the same profiles and nothing in the generated policies
 	// has the core snap-name encoded.
-	if _, err := m.reloadConnections(newName); err != nil {
+	if _, _, err := m.reloadConnections(newName); err != nil {
 		return err
 	}
 

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -395,7 +395,7 @@ func (m *InterfaceManager) setupProfilesForAppSet(
 	st := task.State()
 
 	snapName := appSet.InstanceName()
-	disconnectedSnaps, affectedConnections, err := m.refreshAppSetConnections(task, appSet)
+	disconnectedSnaps, reloadedConns, err := m.refreshAppSetConnections(task, appSet)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (m *InterfaceManager) setupProfilesForAppSet(
 	snapsWithConnectedSlots := make(map[string]bool)
 	newConnectedSnaps := make(map[string]bool)
 	// Identify affected snaps on either side of the connection.
-	for _, connID := range affectedConnections {
+	for _, connID := range reloadedConns {
 		connRef, err := interfaces.ParseConnRef(connID)
 		if err != nil {
 			return nil, fmt.Errorf("internal error: cannot parse existing connection: %w", err)

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -337,6 +337,9 @@ func (d delayedEffectsForSnaps) EnqueueFor(snapName affectedSnap, backend interf
 	d[snapName][backend] = append(d[snapName][backend], item)
 }
 
+// refreshAppSetConnections refreshes repository connections for appSet and, on
+// the setup-profiles do path, records undo data for persisted connection state
+// that reloadConnections changed or dropped.
 func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *interfaces.SnapAppSet) ([]string, []string, error) {
 	snapInfo := appSet.Info()
 	snapName := appSet.InstanceName()
@@ -369,16 +372,16 @@ func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *in
 		task.Logf("%s", snap.BadInterfacesSummary(snapInfo))
 	}
 
-	reloadedConns, changedConns, err := m.reloadConnections(snapName)
+	reloadedConns, changedOrDroppedConns, err := m.reloadConnections(snapName)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// if this task modified any connection states, we take a snapshot of the
-	// original connections so that we can restore them on the undo path, if
+	// if this task modified any connection states, take a snapshot of the
+	// original connections so that setup-profiles' undo can restore them, if
 	// needed
 	if task.Status() != state.UndoingStatus {
-		if err := snapshotChangedConnectionsForUndo(task, snapName, changedConns); err != nil {
+		if err := snapshotChangedConnectionsForUndo(task, snapName, changedOrDroppedConns); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -706,6 +709,10 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	if err := snapstateFinishRestart(task, snapsup, finishOpts); err != nil {
 		return err
 	}
+
+	// restore any connection state snapshot saved by refreshAppSetConnections on
+	// the original setup-profiles do path before rebuilding profiles for the old
+	// revision
 	if err := restoreConnectionsForSetupProfiles(task); err != nil {
 		return err
 	}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -373,9 +373,14 @@ func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *in
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := saveChangedConnectionsForSetupProfilesRestore(task, snapName, changedConns); err != nil {
+
+	// if this task modified any connection states, we take a snapshot of the
+	// original connections so that we can restore them on the undo path, if
+	// needed
+	if err := snapshotChangedConnectionsForUndo(task, snapName, changedConns); err != nil {
 		return nil, nil, err
 	}
+
 	return disconnectedSnaps, affectedConnections, nil
 }
 

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -369,7 +369,7 @@ func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *in
 		task.Logf("%s", snap.BadInterfacesSummary(snapInfo))
 	}
 
-	affectedConnections, changedConns, err := m.reloadConnections(snapName)
+	reloadedConns, changedConns, err := m.reloadConnections(snapName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -377,11 +377,13 @@ func (m *InterfaceManager) refreshAppSetConnections(task *state.Task, appSet *in
 	// if this task modified any connection states, we take a snapshot of the
 	// original connections so that we can restore them on the undo path, if
 	// needed
-	if err := snapshotChangedConnectionsForUndo(task, snapName, changedConns); err != nil {
-		return nil, nil, err
+	if task.Status() != state.UndoingStatus {
+		if err := snapshotChangedConnectionsForUndo(task, snapName, changedConns); err != nil {
+			return nil, nil, err
+		}
 	}
 
-	return disconnectedSnaps, affectedConnections, nil
+	return disconnectedSnaps, reloadedConns, nil
 }
 
 func (m *InterfaceManager) setupProfilesForAppSet(

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -426,15 +426,103 @@ func isBroken(st *state.State, snapName string) (bool, error) {
 	return false, nil
 }
 
+func cloneConnState(connState *schema.ConnState) *schema.ConnState {
+	clone := *connState
+
+	cloneAttrs := func(attrs map[string]any) map[string]any {
+		if attrs == nil {
+			return nil
+		}
+		return utils.CopyAttributes(attrs)
+	}
+
+	clone.StaticPlugAttrs = cloneAttrs(connState.StaticPlugAttrs)
+	clone.DynamicPlugAttrs = cloneAttrs(connState.DynamicPlugAttrs)
+	clone.StaticSlotAttrs = cloneAttrs(connState.StaticSlotAttrs)
+	clone.DynamicSlotAttrs = cloneAttrs(connState.DynamicSlotAttrs)
+
+	return &clone
+}
+
+// saveChangedConnectionsForSetupProfilesRestore records original connection
+// states for setup-profiles do tasks whose undo can restore them.
+func saveChangedConnectionsForSetupProfilesRestore(task *state.Task, instanceName string, changedConns map[string]*schema.ConnState) error {
+	if len(changedConns) == 0 {
+		return nil
+	}
+
+	// undo setup-profiles also calls this code while rebuilding old profiles,
+	// but restoration data should only come from the original do path
+	if task.Status() == state.UndoingStatus {
+		return nil
+	}
+
+	// if this isn't the setup-profiles task that is going to handle the undo,
+	// then we don't need to keep track of these on the task
+	if !shouldUndoSetupProfiles(task, instanceName) {
+		return nil
+	}
+
+	var originalConns map[string]*schema.ConnState
+	err := task.Get("original-connection-states", &originalConns)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if originalConns == nil {
+		originalConns = make(map[string]*schema.ConnState)
+	}
+
+	for connID, connState := range changedConns {
+		if originalConns[connID] != nil {
+			// a setup-profiles task can be retried after saving original states
+			// and unlocking for backend setup. keep the original snapshot.
+			continue
+		}
+		originalConns[connID] = connState
+	}
+
+	task.Set("original-connection-states", originalConns)
+
+	return nil
+}
+
+// restoreConnectionsForSetupProfiles restores connection states saved on a
+// setup-profiles task.
+func restoreConnectionsForSetupProfiles(task *state.Task) error {
+	var original map[string]*schema.ConnState
+	err := task.Get("original-connection-states", &original)
+	if errors.Is(err, state.ErrNoState) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	st := task.State()
+
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+
+	for connID, connState := range original {
+		conns[connID] = connState
+	}
+	setConns(st, conns)
+
+	return nil
+}
+
 // reloadConnections reloads connections stored in the state in the repository.
 // Using non-empty snapName the operation can be scoped to connections
 // affecting a given snap.
 //
-// The return value is the list of affected snap names and their connection IDs.
-func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectionIDs []string, err error) {
+// The return value is the list of affected snap names and their connection IDs,
+// plus the original connection states that were changed.
+func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectionIDs []string, changedConns map[string]*schema.ConnState, err error) {
 	conns, err := getConns(m.state)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var policyChecker interfaces.PolicyFunc
@@ -445,21 +533,22 @@ func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectio
 	if errors.Is(err, state.ErrNoState) {
 		// everything else is a noop, as no model means no connections
 		// to reload
-		return nil, nil
+		return nil, nil, nil
 	} else if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	autoChecker, err = newAutoConnectChecker(m.state, m.repo, deviceCtx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	connChecker, err = newConnectChecker(m.state, deviceCtx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	connStateChanged := false
+	changedConns = make(map[string]*schema.ConnState)
 
 	var reloadedConnections []string
 ConnsLoop:
@@ -473,7 +562,7 @@ ConnsLoop:
 		}
 		connRef, err := interfaces.ParseConnRef(connId)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// Apply filtering, this allows us to reload only a subset of
 		// connections (and similarly, refresh the static attributes of only a
@@ -497,13 +586,14 @@ ConnsLoop:
 				for _, snapName := range []string{connRef.PlugRef.Snap, connRef.SlotRef.Snap} {
 					broken, err := isBroken(m.state, snapName)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					if broken {
 						logger.Noticef("Snap %q is broken, ignored by reloadConnections", snapName)
 						continue ConnsLoop
 					}
 				}
+				changedConns[connId] = cloneConnState(connState)
 				delete(conns, connId)
 				connStateChanged = true
 			}
@@ -540,11 +630,11 @@ ConnsLoop:
 
 		plugAppSet, err := interfaces.NewSnapAppSet(plugInfo.Snap, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		slotAppSet, err := interfaces.NewSnapAppSet(slotInfo.Snap, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		cplug := interfaces.NewConnectedPlug(plugInfo, plugAppSet, newStaticPlugAttrs, connState.DynamicPlugAttrs)
@@ -568,6 +658,7 @@ ConnsLoop:
 			reloadedConnections = append(reloadedConnections, connId)
 
 			if updateStaticAttrs {
+				changedConns[connId] = cloneConnState(connState)
 				connState.StaticPlugAttrs = staticPlugAttrs
 				connState.StaticSlotAttrs = staticSlotAttrs
 				connStateChanged = true
@@ -578,7 +669,7 @@ ConnsLoop:
 		setConns(m.state, conns)
 	}
 
-	return reloadedConnections, nil
+	return reloadedConnections, changedConns, nil
 }
 
 // removeConnections disconnects all connections of the snap in the repo. It should only be used if the snap

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -444,17 +444,10 @@ func cloneConnState(connState *schema.ConnState) *schema.ConnState {
 	return &clone
 }
 
-// snapshotModifiedConnectionsForUndo records a snapshot of the connection
-// states, prior to modification. This enables the undo of setup-profiles to
-// restore them, if needed.
+// snapshotChangedConnectionsForUndo records original states for connections
+// changed by setup-profiles so undo can restore them, if needed.
 func snapshotChangedConnectionsForUndo(task *state.Task, instanceName string, changedConns map[string]*schema.ConnState) error {
 	if len(changedConns) == 0 {
-		return nil
-	}
-
-	// undo setup-profiles also calls this code while rebuilding old profiles,
-	// but restoration data should only come from the original do path
-	if task.Status() == state.UndoingStatus {
 		return nil
 	}
 
@@ -518,8 +511,8 @@ func restoreConnectionsForSetupProfiles(task *state.Task) error {
 // Using non-empty snapName the operation can be scoped to connections
 // affecting a given snap.
 //
-// The return value is the list of affected snap names and their connection IDs,
-// plus the original connection states that were changed.
+// The return value is the list of reloaded connection IDs, plus the original
+// connection states whose persisted state was changed.
 func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectionIDs []string, changedConns map[string]*schema.ConnState, err error) {
 	conns, err := getConns(m.state)
 	if err != nil {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -444,8 +444,9 @@ func cloneConnState(connState *schema.ConnState) *schema.ConnState {
 	return &clone
 }
 
-// snapshotChangedConnectionsForUndo records original states for connections
-// changed by setup-profiles so undo can restore them, if needed.
+// snapshotChangedConnectionsForUndo records original states for persisted
+// connections that setup-profiles changed or dropped so undo can restore them,
+// if needed.
 func snapshotChangedConnectionsForUndo(task *state.Task, instanceName string, changedConns map[string]*schema.ConnState) error {
 	if len(changedConns) == 0 {
 		return nil
@@ -458,7 +459,7 @@ func snapshotChangedConnectionsForUndo(task *state.Task, instanceName string, ch
 	}
 
 	var connectionSnapshot map[string]*schema.ConnState
-	err := task.Get("changed-connection-snapshot", &connectionSnapshot)
+	err := task.Get("changed-or-dropped-connection-snapshot", &connectionSnapshot)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
@@ -475,16 +476,16 @@ func snapshotChangedConnectionsForUndo(task *state.Task, instanceName string, ch
 		connectionSnapshot[connID] = connState
 	}
 
-	task.Set("changed-connection-snapshot", connectionSnapshot)
+	task.Set("changed-or-dropped-connection-snapshot", connectionSnapshot)
 
 	return nil
 }
 
-// restoreConnectionsForSetupProfiles restores connection states saved on a
-// setup-profiles task.
+// restoreConnectionsForSetupProfiles restores connection states saved by
+// snapshotChangedConnectionsForUndo on a setup-profiles task.
 func restoreConnectionsForSetupProfiles(task *state.Task) error {
 	var connectionSnapshot map[string]*schema.ConnState
-	err := task.Get("changed-connection-snapshot", &connectionSnapshot)
+	err := task.Get("changed-or-dropped-connection-snapshot", &connectionSnapshot)
 	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
@@ -512,8 +513,12 @@ func restoreConnectionsForSetupProfiles(task *state.Task) error {
 // affecting a given snap.
 //
 // The return value is the list of reloaded connection IDs, plus the original
-// connection states whose persisted state was changed.
-func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectionIDs []string, changedConns map[string]*schema.ConnState, err error) {
+// connection states whose persisted state was changed or dropped.
+func (m *InterfaceManager) reloadConnections(snapName string) (
+	reloadedConnectionIDs []string,
+	changedOrDroppedConns map[string]*schema.ConnState,
+	err error,
+) {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return nil, nil, err
@@ -542,7 +547,7 @@ func (m *InterfaceManager) reloadConnections(snapName string) (reloadedConnectio
 	}
 
 	connStateChanged := false
-	changedConns = make(map[string]*schema.ConnState)
+	changedOrDroppedConns = make(map[string]*schema.ConnState)
 
 	var reloadedConnections []string
 ConnsLoop:
@@ -587,7 +592,7 @@ ConnsLoop:
 						continue ConnsLoop
 					}
 				}
-				changedConns[connId] = cloneConnState(connState)
+				changedOrDroppedConns[connId] = cloneConnState(connState)
 				delete(conns, connId)
 				connStateChanged = true
 			}
@@ -652,7 +657,7 @@ ConnsLoop:
 			reloadedConnections = append(reloadedConnections, connId)
 
 			if updateStaticAttrs {
-				changedConns[connId] = cloneConnState(connState)
+				changedOrDroppedConns[connId] = cloneConnState(connState)
 				connState.StaticPlugAttrs = staticPlugAttrs
 				connState.StaticSlotAttrs = staticSlotAttrs
 				connStateChanged = true
@@ -663,7 +668,7 @@ ConnsLoop:
 		setConns(m.state, conns)
 	}
 
-	return reloadedConnections, changedConns, nil
+	return reloadedConnections, changedOrDroppedConns, nil
 }
 
 // removeConnections disconnects all connections of the snap in the repo. It should only be used if the snap

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -444,9 +444,10 @@ func cloneConnState(connState *schema.ConnState) *schema.ConnState {
 	return &clone
 }
 
-// saveChangedConnectionsForSetupProfilesRestore records original connection
-// states for setup-profiles do tasks whose undo can restore them.
-func saveChangedConnectionsForSetupProfilesRestore(task *state.Task, instanceName string, changedConns map[string]*schema.ConnState) error {
+// snapshotModifiedConnectionsForUndo records a snapshot of the connection
+// states, prior to modification. This enables the undo of setup-profiles to
+// restore them, if needed.
+func snapshotChangedConnectionsForUndo(task *state.Task, instanceName string, changedConns map[string]*schema.ConnState) error {
 	if len(changedConns) == 0 {
 		return nil
 	}
@@ -463,25 +464,25 @@ func saveChangedConnectionsForSetupProfilesRestore(task *state.Task, instanceNam
 		return nil
 	}
 
-	var originalConns map[string]*schema.ConnState
-	err := task.Get("original-connection-states", &originalConns)
+	var connectionSnapshot map[string]*schema.ConnState
+	err := task.Get("changed-connection-snapshot", &connectionSnapshot)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
-	if originalConns == nil {
-		originalConns = make(map[string]*schema.ConnState)
+	if connectionSnapshot == nil {
+		connectionSnapshot = make(map[string]*schema.ConnState)
 	}
 
 	for connID, connState := range changedConns {
-		if originalConns[connID] != nil {
-			// a setup-profiles task can be retried after saving original states
-			// and unlocking for backend setup. keep the original snapshot.
+		if connectionSnapshot[connID] != nil {
+			// a setup-profiles task can be retried after saving the connection
+			// states and unlocking for backend setup. keep the first snapshot.
 			continue
 		}
-		originalConns[connID] = connState
+		connectionSnapshot[connID] = connState
 	}
 
-	task.Set("original-connection-states", originalConns)
+	task.Set("changed-connection-snapshot", connectionSnapshot)
 
 	return nil
 }
@@ -489,8 +490,8 @@ func saveChangedConnectionsForSetupProfilesRestore(task *state.Task, instanceNam
 // restoreConnectionsForSetupProfiles restores connection states saved on a
 // setup-profiles task.
 func restoreConnectionsForSetupProfiles(task *state.Task) error {
-	var original map[string]*schema.ConnState
-	err := task.Get("original-connection-states", &original)
+	var connectionSnapshot map[string]*schema.ConnState
+	err := task.Get("changed-connection-snapshot", &connectionSnapshot)
 	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
@@ -505,7 +506,7 @@ func restoreConnectionsForSetupProfiles(task *state.Task) error {
 		return err
 	}
 
-	for connID, connState := range original {
+	for connID, connState := range connectionSnapshot {
 		conns[connID] = connState
 	}
 	setConns(st, conns)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -206,7 +206,7 @@ func (m *InterfaceManager) StartUp() error {
 	if err := removeStaleConnections(m.state); err != nil {
 		return err
 	}
-	if _, err := m.reloadConnections(""); err != nil {
+	if _, _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -6869,6 +6869,172 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Check(snapst.PendingSecurity.SideInfo.Revision, Equals, snapInfo.Revision)
 }
 
+func (s *interfaceManagerSuite) TestFailedRefreshRestoresAutoConnectionPrunedFromIncomingRevision(c *C) {
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
+
+	producerInfo := s.mockSnap(c, `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: test
+`)
+	oldConsumerInfo := s.mockSnap(c, `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: test
+`)
+
+	connID := "consumer:plug producer:slot"
+	expectedConns := map[string]any{
+		connID: map[string]any{
+			"interface": "test",
+			"auto":      true,
+		},
+	}
+	s.state.Lock()
+	s.state.Set("conns", expectedConns)
+	s.state.Unlock()
+
+	mgr := s.manager(c)
+	repo := mgr.Repository()
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: oldConsumerInfo.InstanceName(), Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: producerInfo.InstanceName(), Name: "slot"},
+	}
+	_, err := repo.Connection(connRef)
+	c.Assert(err, IsNil)
+
+	newConsumerInfo := s.mockUpdatedSnap(c, `
+name: consumer
+version: 2
+apps:
+ app:
+  command: foo
+`, 2)
+
+	s.secBackend.SetupCallback = func(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository) error {
+		if appSet.InstanceName() == newConsumerInfo.InstanceName() && appSet.Info().Revision == newConsumerInfo.Revision {
+			return fmt.Errorf("fail setup consumer rev 2")
+		}
+		return nil
+	}
+
+	change := s.addSetupSnapSecurityChangeWithOptions(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: newConsumerInfo.SnapName(),
+			Revision: newConsumerInfo.Revision,
+		},
+	}, setupSnapSecurityChangeOptions{active: false})
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Status(), Equals, state.ErrorStatus)
+	c.Assert(change.Err(), ErrorMatches, "(?s).*fail setup consumer rev 2.*")
+
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), IsNil)
+	c.Check(conns, DeepEquals, expectedConns)
+
+	_, err = repo.Connection(connRef)
+	c.Check(err, IsNil)
+}
+
+func (s *interfaceManagerSuite) TestFailedRefreshRestoresStaticAttributesUpdatedFromIncomingRevision(c *C) {
+	s.MockSnapDecl(c, "producer", "same-publisher", nil)
+	producerInfo := s.mockSnap(c, `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: content
+  content: foo
+  attr: old-slot
+`)
+	s.MockSnapDecl(c, "consumer", "same-publisher", nil)
+	oldConsumerInfo := s.mockSnap(c, `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: content
+  content: bar
+  attr: old-plug
+`)
+
+	connID := "consumer:plug producer:slot"
+	expectedConns := map[string]any{
+		connID: map[string]any{
+			"interface":   "content",
+			"plug-static": map[string]any{"content": "foo", "attr": "old-plug"},
+			"slot-static": map[string]any{"content": "foo", "attr": "old-slot"},
+		},
+	}
+	s.state.Lock()
+	s.state.Set("conns", expectedConns)
+	s.state.Unlock()
+
+	mgr := s.manager(c)
+	repo := mgr.Repository()
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: oldConsumerInfo.InstanceName(), Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: producerInfo.InstanceName(), Name: "slot"},
+	}
+	conn, err := repo.Connection(connRef)
+	c.Assert(err, IsNil)
+	c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "old-plug"})
+	c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "old-slot"})
+
+	newConsumerInfo := s.mockUpdatedSnap(c, `
+name: consumer
+version: 2
+plugs:
+ plug:
+  interface: content
+  content: foo
+  attr: new-plug
+apps:
+ app:
+  command: foo
+`, 2)
+
+	s.secBackend.SetupCallback = func(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository) error {
+		if appSet.InstanceName() == newConsumerInfo.InstanceName() && appSet.Info().Revision == newConsumerInfo.Revision {
+			return fmt.Errorf("fail setup consumer rev 2")
+		}
+		return nil
+	}
+
+	change := s.addSetupSnapSecurityChangeWithOptions(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: newConsumerInfo.SnapName(),
+			Revision: newConsumerInfo.Revision,
+		},
+	}, setupSnapSecurityChangeOptions{active: false})
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Status(), Equals, state.ErrorStatus)
+	c.Assert(change.Err(), ErrorMatches, "(?s).*fail setup consumer rev 2.*")
+
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), IsNil)
+	c.Check(conns, DeepEquals, expectedConns)
+
+	conn, err = repo.Connection(connRef)
+	c.Assert(err, IsNil)
+	c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "old-plug"})
+	c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "old-slot"})
+}
+
 // Test that when a snap refresh changes confinement from classic to strict and
 // setup-profiles fails, undo restores the old security profiles using the
 // old classic confinement flag.

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -6963,7 +6963,7 @@ version: 1
 plugs:
  plug:
   interface: content
-  content: bar
+  content: foo
   attr: old-plug
 `)
 

--- a/overlord/ifacestate/schema/schema.go
+++ b/overlord/ifacestate/schema/schema.go
@@ -23,6 +23,10 @@ package schema
 import "github.com/snapcore/snapd/snap"
 
 // ConnState holds properties of an interface connection.
+//
+// Note: ifacestate.cloneConnState makes a deep copy of this type. If we add any
+// more reference-like types (slices, maps) to this struct, that function needs
+// an update.
 type ConnState struct {
 	Auto      bool   `json:"auto,omitempty" yaml:"auto"`
 	ByGadget  bool   `json:"by-gadget,omitempty" yaml:"by-gadget"`

--- a/tests/main/connections-after-failed-refresh/task.yaml
+++ b/tests/main/connections-after-failed-refresh/task.yaml
@@ -26,6 +26,7 @@ execute: |
 
   echo "Verify that interfaces of the snap are connected"
   snap connections test-snap | MATCH "^home +test-snap:home +:home"
+  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
   snap connections test-snap | MATCH "^hardware-observe +test-snap:hardware-observe +:hardware-observe"
   snap connections test-snap | MATCH "^system-observe +test-snap:system-observe +:system-observe"
 
@@ -38,6 +39,7 @@ execute: |
 
   echo "Interfaces are still connected"
   snap connections test-snap | MATCH "^home +test-snap:home +:home"
+  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
   snap connections test-snap | MATCH "^system-observe +test-snap:system-observe +:system-observe"
   snap connections test-snap | MATCH "^hardware-observe +test-snap:hardware-observe +:hardware-observe"
 
@@ -49,6 +51,7 @@ execute: |
 
   echo "Interfaces are still connected"
   snap connections test-snap | MATCH "^home +test-snap:home +:home"
+  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
   snap connections test-snap | MATCH "^system-observe +test-snap:system-observe +:system-observe"
   snap connections test-snap | MATCH "^hardware-observe +test-snap:hardware-observe +:hardware-observe"
 

--- a/tests/main/connections-after-failed-refresh/task.yaml
+++ b/tests/main/connections-after-failed-refresh/task.yaml
@@ -26,9 +26,10 @@ execute: |
 
   echo "Verify that interfaces of the snap are connected"
   snap connections test-snap | MATCH "^home +test-snap:home +:home"
-  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
   snap connections test-snap | MATCH "^hardware-observe +test-snap:hardware-observe +:hardware-observe"
   snap connections test-snap | MATCH "^system-observe +test-snap:system-observe +:system-observe"
+  # network-bind exists only in v1, covering restoration of a pruned auto-connection
+  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
 
   echo "The snap fails to refresh"
   if "$TESTSTOOLS"/snaps-state install-local test-snap-v2 > install.log 2>&1 ; then
@@ -39,9 +40,10 @@ execute: |
 
   echo "Interfaces are still connected"
   snap connections test-snap | MATCH "^home +test-snap:home +:home"
-  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
   snap connections test-snap | MATCH "^system-observe +test-snap:system-observe +:system-observe"
   snap connections test-snap | MATCH "^hardware-observe +test-snap:hardware-observe +:hardware-observe"
+  # network-bind exists only in v1, covering restoration of a pruned auto-connection
+  snap connections test-snap | MATCH "^network-bind +test-snap:network-bind +:network-bind"
 
   if snap try test-snap-v2 > try.log 2>&1 ; then
     echo "Expected test-snap-v2 try to fail"

--- a/tests/main/connections-after-failed-refresh/test-snap-v1/meta/snap.yaml
+++ b/tests/main/connections-after-failed-refresh/test-snap-v1/meta/snap.yaml
@@ -3,5 +3,6 @@ version: 1.0
 
 plugs:
   home:
+  network-bind:
   hardware-observe:
   system-observe:


### PR DESCRIPTION
When a refresh moves to a revision that drops an auto-connected plug, `reloadConnections` removes that auto-connection from the connection state. If the refresh fails, the deleted auto-connection is not restored. This leaves the interface disconnected after the undo has completed.

This only impacts auto-connections because manual connections whose plug or slot is missing in the new revision are kept in the connection state, but auto-connections are pruned.

A similar idea applies to static plug and slot attributes from the new revision. If the refresh fails, rollback restores the old snap revision, but the new revision's static attributes are kept in the connection state.

To solve this problem, this PR updates `setup-profiles` so that it keeps track of connection state changes and restores them in the undo handler.