### PR TITLE
o/snapstate: set UserID for download-component task

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -109,6 +109,11 @@ func InstallComponents(
 		return nil, err
 	}
 
+	snapUserID, err := userIDForSnap(st, &snapst, opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+
 	snapsup := SnapSetup{
 		Base:                        info.Base,
 		SideInfo:                    &info.SideInfo,
@@ -118,6 +123,7 @@ func InstallComponents(
 		Version:                     info.Version,
 		PlugsOnly:                   len(info.Slots) == 0,
 		InstanceKey:                 info.InstanceKey,
+		UserID:                      snapUserID,
 		ComponentExclusiveOperation: true,
 	}
 

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -975,9 +975,30 @@ func (s *snapmgrTestSuite) TestInstallComponentsTransactionPerSnap(c *C) {
 	})
 }
 
+func (s *snapmgrTestSuite) TestInstallComponentsWithSnapStateAndInstallOptsUserIDs(c *C) {
+	s.testInstallComponents(c, testInstallComponentsOpts{
+		userIDSnapState:   s.user.ID,
+		userIDInstallOpts: s.user2.ID,
+	})
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsWithUserIDSnapState(c *C) {
+	s.testInstallComponents(c, testInstallComponentsOpts{
+		userIDSnapState: s.user2.ID,
+	})
+}
+
+func (s *snapmgrTestSuite) TestInstallComponentsWithUserIDInstallOpts(c *C) {
+	s.testInstallComponents(c, testInstallComponentsOpts{
+		userIDInstallOpts: s.user.ID,
+	})
+}
+
 type testInstallComponentsOpts struct {
-	lane        int
-	transaction client.TransactionType
+	lane              int
+	transaction       client.TransactionType
+	userIDInstallOpts int
+	userIDSnapState   int
 }
 
 func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponentsOpts) {
@@ -1007,6 +1028,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 		}),
 		Current:         snapRev,
 		TrackingChannel: "channel-for-components",
+		UserID:          opts.userIDSnapState,
 	})
 
 	components := []string{"standard-component", "kernel-modules-component"}
@@ -1038,6 +1060,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	}
 
 	installOpts := snapstate.Options{
+		UserID: opts.userIDInstallOpts,
 		Flags: snapstate.Flags{
 			Lane:        opts.lane,
 			Transaction: opts.transaction,
@@ -1051,6 +1074,16 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 
 	setupProfiles := setupTs.Tasks()[0]
 	c.Assert(setupProfiles.Kind(), Equals, "setup-profiles")
+
+	snapsupSetupProfiles, err := snapstate.TaskSnapSetup(setupProfiles)
+	c.Assert(err, IsNil)
+	var expectedUserID int
+	if opts.userIDSnapState != 0 {
+		expectedUserID = opts.userIDSnapState
+	} else {
+		expectedUserID = opts.userIDInstallOpts
+	}
+	c.Assert(snapsupSetupProfiles.UserID, Equals, expectedUserID)
 
 	prepareKmodComps := setupTs.Tasks()[1]
 	c.Assert(prepareKmodComps.Kind(), Equals, "prepare-kernel-modules-components")

--- a/overlord/snapstate/handlers_components_download_test.go
+++ b/overlord/snapstate/handlers_components_download_test.go
@@ -65,9 +65,16 @@ func (s *downloadComponentSuite) TestDoDownloadComponentCustomBlobDir(c *C) {
 	})
 }
 
+func (s *downloadComponentSuite) TestDoDownloadComponentWithUserAuth(c *C) {
+	s.testDoDownloadComponent(c, testDoDownloadComponentOpts{
+		withUserAuth: true,
+	})
+}
+
 type testDoDownloadComponentOpts struct {
-	autoRefresh bool
-	blobDir     string
+	autoRefresh  bool
+	blobDir      string
+	withUserAuth bool
 }
 
 func (s *downloadComponentSuite) testDoDownloadComponent(c *C, opts testDoDownloadComponentOpts) {
@@ -78,6 +85,20 @@ func (s *downloadComponentSuite) testDoDownloadComponent(c *C, opts testDoDownlo
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "refresh.rate-limit", "1234B")
 	tr.Commit()
+
+	var userID int
+	var user *auth.UserState
+	if opts.withUserAuth {
+		var err error
+		user, err = auth.NewUser(s.state, auth.NewUserParams{
+			Username:   "username",
+			Email:      "email@test.com",
+			Macaroon:   "user-macaroon",
+			Discharges: []string{"discharge"},
+		})
+		c.Assert(err, IsNil)
+		userID = user.ID
+	}
 
 	si := &snap.SideInfo{
 		RealName: "snap",
@@ -93,6 +114,7 @@ func (s *downloadComponentSuite) testDoDownloadComponent(c *C, opts testDoDownlo
 		InstanceKey:     "key",
 		Flags:           snapstate.Flags{IsAutoRefresh: opts.autoRefresh},
 		DownloadBlobDir: opts.blobDir,
+		UserID:          userID,
 	})
 
 	t.Set("component-setup", &snapstate.ComponentSetup{
@@ -148,11 +170,17 @@ func (s *downloadComponentSuite) testDoDownloadComponent(c *C, opts testDoDownlo
 		}
 	}
 
+	var expectedMacaroon string
+	if opts.withUserAuth {
+		expectedMacaroon = user.StoreMacaroon
+	}
+
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{
 		{
-			name:   "snap+comp",
-			target: expectedPath,
-			opts:   downloadOpts,
+			name:     "snap+comp",
+			target:   expectedPath,
+			opts:     downloadOpts,
+			macaroon: expectedMacaroon,
 		},
 	})
 }


### PR DESCRIPTION
This partly fixes [LP2110368](https://bugs.launchpad.net/snapd/+bug/2110368) where the download of a private snap's component fails. See the [copilot generated overview](https://github.com/canonical/snapd/pull/17020#pullrequestreview-4227322275) for more details.
Based on the [test results](https://warthogs.atlassian.net/browse/SNAPDENG-36844?focusedCommentId=1088401), this fixes the issue of installing components from outside the snap but does not yet resolve the issue of installing components from within the snap using snapctl. That will be then fixed in a follow-up PR.

[SNAPDENG-36844](https://warthogs.atlassian.net/browse/SNAPDENG-36844)

[SNAPDENG-36844]: https://warthogs.atlassian.net/browse/SNAPDENG-36844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ