### PR TITLE
many: inline constant to fix govet error

### DIFF
--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -97,7 +97,7 @@ func (e AttributeNotCompatibleError) Is(target error) bool {
 // the val parameter, which therefore must be a pointer.
 func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal any, val any) error {
 	rt := reflect.TypeOf(val)
-	if rt.Kind() != reflect.Ptr || val == nil {
+	if rt.Kind() != reflect.Pointer || val == nil {
 		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", attrName, ifaceName)
 	}
 

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -490,9 +490,9 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 
 // arg must be a pointer to a struct
 func fillStruct(a any, c *C) {
-	if t := reflect.TypeOf(a); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+	if t := reflect.TypeOf(a); t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Struct {
 		k := t.Kind()
-		if k == reflect.Ptr {
+		if k == reflect.Pointer {
 			k = t.Elem().Kind()
 		}
 		c.Fatalf("first argument must be expected a pointer to a struct, not %s", k)

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -91,7 +91,7 @@ func backupMockables(mockablesByPtr []any) (backup []*reflect.Value) {
 	for i, ptr := range mockablesByPtr {
 		mockedPtr := reflect.ValueOf(ptr)
 
-		if mockedPtr.Type().Kind() != reflect.Ptr {
+		if mockedPtr.Type().Kind() != reflect.Pointer {
 			panic("Backup: each mockable must be passed by pointer!")
 		}
 


### PR DESCRIPTION
Fix some issues reported by `govet`
```
metautil/type_conversions.go:100:18: inline: Constant reflect.Ptr should be inlined (govet)
store/details_v2_test.go:493:41: inline: Constant reflect.Ptr should be inlined (govet)
store/details_v2_test.go:495:11: inline: Constant reflect.Ptr should be inlined (govet)
testutil/base.go:94:33: inline: Constant reflect.Ptr should be inlined (govet)

4 issues:
* govet: 4
```