### PR TITLE
spread, tests, github: drop openSUSE 15.6

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -124,7 +124,6 @@ jobs:
       matrix:
         build-config:
           - { system: "opensuse-tumbleweed-64", dockerfile: "opensuse.dockerfile", image-name: "opensuse/tumbleweed", image-tag: "latest", pkg-dir: "opensuse-tumbleweed" }
-          - { system: "opensuse-15.6-64",       dockerfile: "opensuse.dockerfile", image-name: "opensuse/leap",       image-tag: "15.6",   pkg-dir: "opensuse-15.6"       }
           - { system: "opensuse-16.0-64",       dockerfile: "opensuse.dockerfile", image-name: "opensuse/leap",       image-tag: "16.0",   pkg-dir: "opensuse-16.0"       }
           - { system: "amazon-linux-2-64",      dockerfile: "amazon.dockerfile",   image-name: "amazonlinux",         image-tag: "2",      pkg-dir: "amzn-2"              }
           - { system: "amazon-linux-2023-64",   dockerfile: "amazon.dockerfile",   image-name: "amazonlinux",         image-tag: "2023",   pkg-dir: "amzn-2023"           }

--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -41,7 +41,7 @@
         "group": "opensuse",
         "backend": "openstack",
         "alternative-backend": "google-distro-2",
-        "systems": "opensuse-15.6-64 opensuse-16.0-64 opensuse-tumbleweed-64 opensuse-tumbleweed-selinux-64",
+        "systems": "opensuse-16.0-64 opensuse-tumbleweed-64 opensuse-tumbleweed-selinux-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/spread.yaml
+++ b/spread.yaml
@@ -273,8 +273,6 @@ backends:
                   storage: preserve-size
                   image: centos-9-64
 
-            - opensuse-15.6-64:
-                  workers: 6
             - opensuse-16.0-64:
                   workers: 6
             - opensuse-tumbleweed-64:
@@ -450,9 +448,6 @@ backends:
                   image: snapd-spread/fedora-42-64
                   workers: 12
 
-            - opensuse-15.6-64:
-                image: snapd-spread/opensuse-15.6-64
-                workers: 6
             - opensuse-16.0-64:
                 image: snapd-spread/opensuse-16.0-64
                 workers: 6

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -12,9 +12,6 @@ systems:
     - -fedora-*
     # Too old to support this feature entirely.
     - -ubuntu-14.04-64
-    # Distribution AppArmor parser does not support mqueue mediation.
-    # AppArmor parser does not re-execute despite SNAPD_APPARMOR_REEXEC=1 in /usr/lib/snapd/info.
-    - -opensuse-15.6-64
     # Affected by https://gitlab.com/apparmor/apparmor/-/issues/492
     - -ubuntu-16.04-64
     - -ubuntu-18.04-64

--- a/tests/main/template-memfd/task.yaml
+++ b/tests/main/template-memfd/task.yaml
@@ -20,7 +20,7 @@ skip:
     - reason: "Unsupported by host kernel"
       if: |
           case "$MODE/$SPREAD_SYSTEM" in
-          secret/debian-12-*|secret/ubuntu-22.04-*|secret/centos-9-*|secret/opensuse-15.6-*)
+          secret/debian-12-*|secret/ubuntu-22.04-*|secret/centos-9-*)
               # supports memfd_create, but not memfd_secret, fallthrough
               ;&
           secret/amazon-linux-2023-*)


### PR DESCRIPTION
openSUSE 15.6 has reached EOL, see https://calendar.opensuse.org/teams/product-schedule/events/leap-15-6-eol

Time to drop it from CI.
