### PR TITLE
spread.yaml: check if gojq exists before downloading it

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1447,18 +1447,20 @@ prepare: |
     # major differences:
     # - map keys are sorted by default
     # - with --yaml-input, can parse YAML
-    if os.query is-arm64; then
-        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
-            https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_arm64.tar.gz
-    elif os.query is-arm; then
-        # upstream does not provide prebuilt binaries for armhf
-        # built with: GOARCH=arm GOARM=7
-        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
-            https://storage.googleapis.com/snapd-spread-tests/dependencies/gojq_v0.12.16_linux_armhf.tar.gz
-    else
-        # must be amd64
-        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
-            https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_amd64.tar.gz
+    if [ ! -e /tmp/gojq.tar.gz ]; then
+        if os.query is-arm64; then
+            "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+                https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_arm64.tar.gz
+        elif os.query is-arm; then
+            # upstream does not provide prebuilt binaries for armhf
+            # built with: GOARCH=arm GOARM=7
+            "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+                https://storage.googleapis.com/snapd-spread-tests/dependencies/gojq_v0.12.16_linux_armhf.tar.gz
+        else
+            # must be amd64
+            "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+                https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_amd64.tar.gz
+        fi
     fi
 
     (


### PR DESCRIPTION
`spread -reuse` was failing after the first run because it would fail to download gojq if it was already present.
