### PR TITLE
usersession/userd/settings: "check" before prompting user asking confirmation for "set"

### DIFF
--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -6,7 +6,8 @@ details: |
     back to snapd user session daemon, to present a question to the user.
 
     The test exercises the xdg-settings' program ability to set the default web
-    browser and default URL scheme handler.
+    browser and default URL scheme handler, and verifies that redundant set
+    calls are silently skipped when the value is already correct (LP #1966067).
 
 # Not supposed to work on Ubuntu Core systems as we don't have
 # a user session environment there
@@ -30,82 +31,79 @@ prepare: |
             /                                                 \
             org.freedesktop.DBus.Peer.Ping
 
-    # Create a small helper which will tell us if snap passes
-    # the settings to the right handler
-    cat << 'EOF' > /tmp/xdg-settings
-    #!/bin/sh
-    echo "$@" > /tmp/xdg-settings-output
-    EOF
-
-    chmod +x /tmp/xdg-settings
-    touch /usr/bin/xdg-settings
-    mount --bind /tmp/xdg-settings /usr/bin/xdg-settings
+    # backup mimeapps.list so real xdg-settings changes can be restored
+    if [ -d /home/test/.config ]; then
+        tests.backup prepare /home/test/.config
+        touch has-test-config-backup
+    else
+        tests.cleanup defer rm -rfv /home/test/.config
+    fi
 
 restore: |
     tests.session -u test restore
-    umount -f /usr/bin/xdg-settings || true
-    umount -f /usr/bin/zenity || true
+    if [ -f has-test-config-backup ]; then
+         tests.backup restore /home/test/.config
+    fi
+    umount -f /usr/bin/zenity 2>/dev/null || true
+    umount -f /usr/bin/kdialog 2>/dev/null || true
 
 execute: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
-    ensure_xdg_settings_output() {
-        rm -f /tmp/xdg-settings-output
-
-        # run xdg-settings from inside the snap
-        tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper "$@"
-
-        if [ $# -eq 3 ]; then
-            # the dbus interface rewrites the final param to be <snap name>_<desktop file>
-            test_output="$1 $2 test-snapd-xdg-settings_$3"
-        elif [ $# -eq 4 ]; then
-            # the dbus interface rewrites the final param to be <snap name>_<desktop file>
-            test_output="$1 $2 $3 test-snapd-xdg-settings_$4"
-        else
-            return
-        fi
-
-        # verify that the command was transmitted corrected via dbus
-        test -e /tmp/xdg-settings-output
-        test "$(cat /tmp/xdg-settings-output)" = "$test_output"
-    }
-
-    ensure_error_no_xdg_settings_output() {
-        rm -f /tmp/xdg-settings-output
-
-        # run xdg-settings from inside the snap
-        not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper "$@"
-
-        # verify that the output file doesn't exist
-        test ! -e /tmp/xdg-settings-output
-    }
-
-    # ensure zenity answers "yes"
+    # ensure zenity answers "yes" for the dialog prompt
     touch /usr/bin/zenity
     mount --bind /bin/true /usr/bin/zenity
 
-    # Test valid actions
-    ensure_xdg_settings_output "set" "default-web-browser" "browser.desktop"
-    ensure_xdg_settings_output "set" "default-url-scheme-handler" "irc" "browser.desktop"
+    # Test: set default-web-browser succeeds when user accepts
+    tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-web-browser browser.desktop
 
-    # Test unknown action
-    ensure_error_no_xdg_settings_output "unknown" 2> stderr.log
-    MATCH 'unknown action unknown' < stderr.log
+    # Verify it was actually set
+    OUTPUT=$(tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        check default-web-browser browser.desktop)
+    test "$OUTPUT" = "yes"
 
-    # Ensure settings whitelist works
-    ensure_error_no_xdg_settings_output "set" "random-settting" "something" 2> stderr.log
-    MATCH 'invalid setting "random-settting"' < stderr.log
+    OUTPUT=$(tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        get default-web-browser)
+    test "$OUTPUT" = "browser.desktop"
 
-    # Ensure settings value validation works
-    ensure_error_no_xdg_settings_output "set" "default-web-browser" "inälid" 2> stderr.log
-    MATCH 'cannot set "default-web-browser" setting to invalid value "inälid"' < stderr.log
+    # Test: set default-url-scheme-handler succeeds when user accepts
+    tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-url-scheme-handler x-test browser.desktop
 
-    ensure_error_no_xdg_settings_output "set" "default-url-scheme-handler" "irc" "inälid" 2> stderr.log
-    MATCH 'cannot set "default-url-scheme-handler" subproperty "irc" setting to invalid value "inälid"' < stderr.log
+    OUTPUT=$(tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        check default-url-scheme-handler x-test browser.desktop)
+    test "$OUTPUT" = "yes"
 
-    # ensure zenity answers "no"
+    # Test: set skips dialog when value is already set (LP #1966067)
+    # Replace zenity with /bin/false — if set still succeeds, no dialog was shown
     umount /usr/bin/zenity
     mount --bind /bin/false /usr/bin/zenity
 
-    ensure_error_no_xdg_settings_output "set" "default-web-browser" "browser.desktop"
+    tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-web-browser browser.desktop
+
+    tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-url-scheme-handler x-test browser.desktop
+
+    # Test: set fails when user declines and value is NOT already set
+    not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-url-scheme-handler x-other browser.desktop
+
+    # Test: validation errors
+    not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        unknown 2> stderr.log
+    MATCH 'unknown action unknown' < stderr.log
+
+    not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set random-settting something 2> stderr.log
+    MATCH 'invalid setting "random-settting"' < stderr.log
+
+    not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-web-browser "inälid" 2> stderr.log
+    MATCH 'cannot set "default-web-browser" setting to invalid value "inälid"' < stderr.log
+
+    not tests.session -u test exec test-snapd-xdg-settings.xdg-settings-wrapper \
+        set default-url-scheme-handler irc "inälid" 2> stderr.log
+    MATCH 'cannot set "default-url-scheme-handler" subproperty "irc" setting to invalid value "inälid"' < stderr.log

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -36,6 +36,8 @@ prepare: |
         tests.backup prepare /home/test/.config
         touch has-test-config-backup
     else
+        mkdir -p /home/test/.config
+        chown test:test /home/test/.config
         tests.cleanup defer rm -rfv /home/test/.config
     fi
 

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -14,6 +14,7 @@ details: |
 systems:
     - -amazon-linux-2-*  # does not support systemd --user
     - -ubuntu-14.04-*  # not supported as desktop OS, systemd too old for tests.session
+    - -ubuntu-16.04-*  # xdg-settings cannot find snap desktop files (XDG_DATA_DIRS issue)
     - -ubuntu-core-*  # test exercises regular xdg-settings, not the custom one in ubuntu-core
 
 prepare: |

--- a/tests/main/xdg-settings/test-snapd-xdg-settings/meta/gui/browser.desktop
+++ b/tests/main/xdg-settings/test-snapd-xdg-settings/meta/gui/browser.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Browser
-Exec=test-snapd-tools-xdg-settings.browser
+Exec=test-snapd-xdg-settings.browser
 Type=Application
 Categories=Utilities;Useless;
 

--- a/usersession/userd/settings.go
+++ b/usersession/userd/settings.go
@@ -229,6 +229,24 @@ func checkOutput(cmd *exec.Cmd, command string, setspec *settingSpec) (string, *
 	return string(output), nil
 }
 
+// runXdgSettings runs "xdg-settings <command> <setting> [subproperty] [value]"
+// and returns the trimmed output.
+func runXdgSettings(command string, setspec *settingSpec, value string) (string, *dbus.Error) {
+	args := []string{command, setspec.setting}
+	if setspec.subproperty != "" {
+		args = append(args, setspec.subproperty)
+	}
+	if value != "" {
+		args = append(args, value)
+	}
+	cmd := exec.Command("xdg-settings", args...)
+	output, err := checkOutput(cmd, command, setspec)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
 // Check implements the 'Check' method of the 'io.snapcraft.Settings'
 // DBus interface.
 //
@@ -244,13 +262,7 @@ func (s *Settings) Check(setting string, check string, sender dbus.Sender) (stri
 		return "", err
 	}
 
-	cmd := exec.Command("xdg-settings", "check", setting, desktopFile)
-	output, err := checkOutput(cmd, "check", settingMain)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(output), nil
+	return runXdgSettings("check", settingMain, desktopFile)
 }
 
 // CheckSub implements the 'CheckSub' method of the 'io.snapcraft.Settings'
@@ -268,13 +280,7 @@ func (s *Settings) CheckSub(setting string, subproperty string, check string, se
 		return "", err
 	}
 
-	cmd := exec.Command("xdg-settings", "check", setting, subproperty, desktopFile)
-	output, err := checkOutput(cmd, "check", settingSub)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(output), nil
+	return runXdgSettings("check", settingSub, desktopFile)
 }
 
 // Get implements the 'Get' method of the 'io.snapcraft.Settings'
@@ -291,8 +297,7 @@ func (s *Settings) Get(setting string, sender dbus.Sender) (string, *dbus.Error)
 		return "", err
 	}
 
-	cmd := exec.Command("xdg-settings", "get", setting)
-	output, err := checkOutput(cmd, "get", settingMain)
+	output, err := runXdgSettings("get", settingMain, "")
 	if err != nil {
 		return "", err
 	}
@@ -314,8 +319,7 @@ func (s *Settings) GetSub(setting string, subproperty string, sender dbus.Sender
 		return "", err
 	}
 
-	cmd := exec.Command("xdg-settings", "get", setting, subproperty)
-	output, err := checkOutput(cmd, "get", settingSub)
+	output, err := runXdgSettings("get", settingSub, "")
 	if err != nil {
 		return "", err
 	}
@@ -338,12 +342,18 @@ func (s *Settings) Set(setting string, new string, sender dbus.Sender) *dbus.Err
 		return err
 	}
 
+	// Work around misbehaving snap clients that call Set on every launch
+	// without first checking the current value, causing a redundant
+	// confirmation prompt. Skip the prompt if already set. (LP #1966067)
+	if output, err := runXdgSettings("check", settingMain, desktopFile); err == nil && output == "yes" {
+		return nil
+	}
+
 	if err := setDialog(s, settingMain, desktopFile, sender); err != nil {
 		return err
 	}
 
-	cmd := exec.Command("xdg-settings", "set", setting, desktopFile)
-	if _, err := checkOutput(cmd, "set", settingMain); err != nil {
+	if _, err := runXdgSettings("set", settingMain, desktopFile); err != nil {
 		return err
 	}
 
@@ -365,12 +375,18 @@ func (s *Settings) SetSub(setting string, subproperty string, new string, sender
 		return err
 	}
 
+	// Work around misbehaving snap clients that call SetSub on every launch
+	// without first checking the current value, causing a redundant
+	// confirmation prompt. Skip the prompt if already set. (LP #1966067)
+	if output, err := runXdgSettings("check", settingSub, desktopFile); err == nil && output == "yes" {
+		return nil
+	}
+
 	if err := setDialog(s, settingSub, desktopFile, sender); err != nil {
 		return err
 	}
 
-	cmd := exec.Command("xdg-settings", "set", setting, subproperty, desktopFile)
-	if _, err := checkOutput(cmd, "set", settingSub); err != nil {
+	if _, err := runXdgSettings("set", settingSub, desktopFile); err != nil {
 		return err
 	}
 

--- a/usersession/userd/settings_test.go
+++ b/usersession/userd/settings_test.go
@@ -100,6 +100,9 @@ case "$1" in
             default-url-scheme-handler)
                 if [ "$3" = "irc" ] && [ "$4" = "some-snap_ircclient.desktop" ]; then
                     echo "yes"
+                elif [ "$3" = "irc2" ]; then
+                    echo "fail"
+                    exit 1
                 else
                     echo "no"
                 fi
@@ -256,7 +259,9 @@ func (s *settingsSuite) testSetUserDeclined(c *C) {
 
 	err = s.settings.Set("default-web-browser", "bar.desktop", ":some-dbus-sender")
 	c.Assert(err, ErrorMatches, `cannot change configuration: user declined change`)
-	c.Check(s.mockXdgSettings.Calls(), IsNil)
+	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
+		{"xdg-settings", "check", "default-web-browser", "some-snap_bar.desktop"},
+	})
 	// FIXME: this needs PR#4342
 	/*
 		c.Check(mockZenity.Calls(), DeepEquals, [][]string{
@@ -290,16 +295,17 @@ func (s *settingsSuite) TestSetUserDeclinedZenity(c *C) {
 }
 
 func (s *settingsSuite) testSetUserAccepts(c *C) {
-	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_foo.desktop")
+	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_baz.desktop")
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
 	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = s.settings.Set("default-web-browser", "foo.desktop", ":some-dbus-sender")
+	err = s.settings.Set("default-web-browser", "baz.desktop", ":some-dbus-sender")
 	c.Assert(err, IsNil)
 	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
-		{"xdg-settings", "set", "default-web-browser", "some-snap_foo.desktop"},
+		{"xdg-settings", "check", "default-web-browser", "some-snap_baz.desktop"},
+		{"xdg-settings", "set", "default-web-browser", "some-snap_baz.desktop"},
 	})
 	// FIXME: this needs PR#4342
 	/*
@@ -316,10 +322,11 @@ func (s *settingsSuite) testSetUserAcceptsURLScheme(c *C) {
 	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = s.settings.SetSub("default-url-scheme-handler", "irc", "ircclient.desktop", ":some-dbus-sender")
+	err = s.settings.SetSub("default-url-scheme-handler", "xmpp", "ircclient.desktop", ":some-dbus-sender")
 	c.Assert(err, IsNil)
 	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
-		{"xdg-settings", "set", "default-url-scheme-handler", "irc", "some-snap_ircclient.desktop"},
+		{"xdg-settings", "check", "default-url-scheme-handler", "xmpp", "some-snap_ircclient.desktop"},
+		{"xdg-settings", "set", "default-url-scheme-handler", "xmpp", "some-snap_ircclient.desktop"},
 	})
 }
 
@@ -389,6 +396,62 @@ func (s *settingsSuite) TestSetUserAcceptsZenityUrlSchemeXdgSettingsError(c *C) 
 	err = s.settings.SetSub("default-url-scheme-handler", "irc2", "ircclient.desktop", ":some-dbus-sender")
 	c.Assert(err, ErrorMatches, `cannot set "default-url-scheme-handler" subproperty "irc2" setting: fail`)
 	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
+		{"xdg-settings", "check", "default-url-scheme-handler", "irc2", "some-snap_ircclient.desktop"},
+		{"xdg-settings", "set", "default-url-scheme-handler", "irc2", "some-snap_ircclient.desktop"},
+	})
+}
+
+func (s *settingsSuite) TestSetSkipsWhenAlreadySet(c *C) {
+	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_foo.desktop")
+	err := os.MkdirAll(filepath.Dir(df), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(df, nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = s.settings.Set("default-web-browser", "foo.desktop", ":some-dbus-sender")
+	c.Assert(err, IsNil)
+	// Only check is called, no dialog, no set
+	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
+		{"xdg-settings", "check", "default-web-browser", "some-snap_foo.desktop"},
+	})
+}
+
+func (s *settingsSuite) TestSetSubSkipsWhenAlreadySet(c *C) {
+	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_ircclient.desktop")
+	err := os.MkdirAll(filepath.Dir(df), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(df, nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = s.settings.SetSub("default-url-scheme-handler", "irc", "ircclient.desktop", ":some-dbus-sender")
+	c.Assert(err, IsNil)
+	// Only check is called, no dialog, no set
+	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
+		{"xdg-settings", "check", "default-url-scheme-handler", "irc", "some-snap_ircclient.desktop"},
+	})
+}
+
+func (s *settingsSuite) TestSetSubProceedsWhenCheckFails(c *C) {
+	// force kdialog exec missing
+	restoreKDialog := ui.MockHasKDialogExecutable(func() bool { return false })
+	restoreCmds := mockUIcommands(c, "true")
+	defer func() {
+		restoreKDialog()
+		restoreCmds()
+	}()
+
+	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_ircclient.desktop")
+	err := os.MkdirAll(filepath.Dir(df), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(df, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// irc2 causes check to fail, so we fall through to dialog + set
+	// set also fails for irc2, verifying the full path was taken
+	err = s.settings.SetSub("default-url-scheme-handler", "irc2", "ircclient.desktop", ":some-dbus-sender")
+	c.Assert(err, ErrorMatches, `cannot set "default-url-scheme-handler" subproperty "irc2" setting: fail`)
+	c.Check(s.mockXdgSettings.Calls(), DeepEquals, [][]string{
+		{"xdg-settings", "check", "default-url-scheme-handler", "irc2", "some-snap_ircclient.desktop"},
 		{"xdg-settings", "set", "default-url-scheme-handler", "irc2", "some-snap_ircclient.desktop"},
 	})
 }


### PR DESCRIPTION
Apparently some snaps never check the url-handler setting before calling
requesting it to be set. Since we naively ask the user each time, even
if the setting's is already correct, the user would still get a prompt
asking for confirmation. It's highly unlikely we can force snaps to
behave, so let's add a workaround at least.

Related: LP#1966067 SNAPDENG-36876