### PR TITLE
boot/makebootable.go: do not take install observers as parameters

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -264,8 +264,69 @@ type TrustedAssetsInstallObserver interface {
 		volumesAuth *device.VolumesAuthOptions,
 		checkResult *secboot.PreinstallCheckResult,
 	)
-	UpdateBootEntry() error
 	Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
+
+	// BootAssets exposes the trusted assets and the method
+	// to update the boot entry.
+	BootAssets() BootAssets
+	// EncryptionSetup returns the in-progress setup for disk encryption.
+	EncryptionSetup() *EncryptionSetup
+}
+
+// EncryptionSetup contains the in-progress setup for disk encryption.
+// It contains reference to the encrypted containers where
+// to registers keys, and holds the information (other than the
+// boot chains) to calculate PCR profiles.
+type EncryptionSetup struct {
+	dataBootstrappedContainer secboot.BootstrappedContainer
+	saveBootstrappedContainer secboot.BootstrappedContainer
+
+	primaryKey []byte
+
+	volumesAuth *device.VolumesAuthOptions
+
+	// checkResult contains information required during and post install
+	// for optimum PCR configuration and resealing.
+	checkResult *secboot.PreinstallCheckResult
+}
+
+// BootAssets identifies the trusted assets that may be accepted in
+// boot chains and the method to update the boot entry.
+type BootAssets interface {
+	// TrackedAssets returns the boot assets for the run boot chains.
+	TrackedAssets() bootAssetsMap
+	// TrackedRecoveryAssets returns the boot assets for the recovery boot chains.
+	TrackedRecoveryAssets() bootAssetsMap
+	// UpdateBootEntry update the boot entry to boot the current asset chains.
+	UpdateBootEntry() error
+}
+
+type bootAssetsImpl struct {
+	trackedAssets         bootAssetsMap
+	trackedRecoveryAssets bootAssetsMap
+	bootLoader            bootloader.UefiBootloader
+	updatedAssets         []string
+}
+
+func (b *bootAssetsImpl) TrackedAssets() bootAssetsMap {
+	return b.trackedAssets
+}
+
+func (b *bootAssetsImpl) TrackedRecoveryAssets() bootAssetsMap {
+	return b.trackedRecoveryAssets
+}
+
+func (b *bootAssetsImpl) UpdateBootEntry() error {
+	if b.bootLoader == nil && b.updatedAssets == nil {
+		return nil
+	}
+	if b.bootLoader == nil {
+		return fmt.Errorf("internal error: updated assets were provided but not the boot loader")
+	}
+	if b.updatedAssets == nil {
+		return fmt.Errorf("internal error: boot loader was provided but not the updated assets")
+	}
+	return doUpdateBootEntry(b.bootLoader, b.updatedAssets)
 }
 
 type trustedAssetsInstallObserverImpl struct {
@@ -286,19 +347,9 @@ type trustedAssetsInstallObserverImpl struct {
 	trustedRecoveryAssets map[string]string
 	trackedRecoveryAssets bootAssetsMap
 
-	useEncryption             bool
-	dataBootstrappedContainer secboot.BootstrappedContainer
-	saveBootstrappedContainer secboot.BootstrappedContainer
-
 	seedBootloader bootloader.Bootloader
 
-	primaryKey []byte
-
-	volumesAuth *device.VolumesAuthOptions
-
-	// checkResult contains information required during and post install
-	// for optimum PCR configuration and resealing.
-	checkResult *secboot.PreinstallCheckResult
+	encryption *EncryptionSetup
 }
 
 func (o *trustedAssetsInstallObserverImpl) BootLoaderSupportsEfiVariables() bool {
@@ -383,35 +434,61 @@ func (o *trustedAssetsInstallObserverImpl) currentTrustedRecoveryBootAssetsMap()
 	return o.trackedRecoveryAssets
 }
 
+// NewEncryptionSetup create a new EncryptionSetup that references to
+// the encrypted containers where to registers keys, and the local FDE
+// configuration.
+func NewEncryptionSetup(
+	key, saveKey secboot.BootstrappedContainer,
+	primaryKey []byte,
+	volumesAuth *device.VolumesAuthOptions,
+	checkResult *secboot.PreinstallCheckResult,
+) *EncryptionSetup {
+	return &EncryptionSetup{
+		dataBootstrappedContainer: key,
+		saveBootstrappedContainer: saveKey,
+		primaryKey:                primaryKey,
+		volumesAuth:               volumesAuth,
+		checkResult:               checkResult,
+	}
+}
+
 func (o *trustedAssetsInstallObserverImpl) SetEncryptionParams(
 	key, saveKey secboot.BootstrappedContainer,
 	primaryKey []byte,
 	volumesAuth *device.VolumesAuthOptions,
 	checkResult *secboot.PreinstallCheckResult,
 ) {
-	o.useEncryption = true
-	o.dataBootstrappedContainer = key
-	o.saveBootstrappedContainer = saveKey
-	o.primaryKey = primaryKey
-	o.volumesAuth = volumesAuth
-	o.checkResult = checkResult
+	o.encryption = NewEncryptionSetup(key, saveKey, primaryKey, volumesAuth, checkResult)
 }
 
-func (o *trustedAssetsInstallObserverImpl) UpdateBootEntry() error {
+func (o *trustedAssetsInstallObserverImpl) BootAssets() BootAssets {
+	ret := &bootAssetsImpl{
+		trackedAssets:         o.trackedAssets,
+		trackedRecoveryAssets: o.trackedRecoveryAssets,
+	}
+
 	if o.seedBootloader == nil {
-		return nil
+		return ret
 	}
 	efiBl, ok := o.seedBootloader.(bootloader.UefiBootloader)
 	if !ok {
-		return nil
+		return ret
 	}
 
+	// FIXME: we should abstract this into bootloader
 	var updatedAssets []string
 	for name := range o.trackedRecoveryAssets {
 		updatedAssets = append(updatedAssets, name)
 	}
 
-	return doUpdateBootEntry(efiBl, updatedAssets)
+	ret.bootLoader = efiBl
+	ret.updatedAssets = updatedAssets
+
+	return ret
+}
+
+func (o *trustedAssetsInstallObserverImpl) EncryptionSetup() *EncryptionSetup {
+	return o.encryption
 }
 
 // TrustedAssetsUpdateObserverForModel returns a new trusted assets observer for

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -487,10 +487,12 @@ func (s *assetsSuite) TestInstallObserverNonTrustedBootloader(c *C) {
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)
 
-	c.Check(observerImpl.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
-	c.Check(observerImpl.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
-	c.Check(observerImpl.CurrentVolumesAuth(), Equals, volumesAuth)
-	c.Check(observerImpl.CurrentCheckResult(), Equals, checkResult)
+	encryptionParams := observerImpl.EncryptionSetup()
+	c.Assert(encryptionParams, NotNil)
+	c.Check(encryptionParams.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
+	c.Check(encryptionParams.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
+	c.Check(encryptionParams.CurrentVolumesAuth(), Equals, volumesAuth)
+	c.Check(encryptionParams.CurrentCheckResult(), Equals, checkResult)
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
@@ -516,9 +518,11 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)
 
-	c.Check(observerImpl.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
-	c.Check(observerImpl.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
-	c.Check(observerImpl.CurrentCheckResult(), IsNil)
+	encryptionParams := observerImpl.EncryptionSetup()
+	c.Assert(encryptionParams, NotNil)
+	c.Check(encryptionParams.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
+	c.Check(encryptionParams.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
+	c.Check(encryptionParams.CurrentCheckResult(), IsNil)
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
@@ -3145,7 +3149,9 @@ func (s *assetsSuite) TestUpdateBootEntryOnInstall(c *C) {
 
 	obs.ObserveExistingTrustedRecoveryAssets(d)
 
-	err = obs.UpdateBootEntry()
+	bootAssets := obs.BootAssets()
+	c.Assert(bootAssets, NotNil)
+	err = bootAssets.UpdateBootEntry()
 	c.Assert(err, IsNil)
 
 	c.Check(efiVariablesSet, Equals, 1)

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -94,7 +94,7 @@ type TrustedAssetsInstallObserverImpl = trustedAssetsInstallObserverImpl
 
 func TrustedAssetsInstallObserverWithEncryption() TrustedAssetsInstallObserverImpl {
 	return TrustedAssetsInstallObserverImpl{
-		useEncryption: true,
+		encryption: &EncryptionSetup{},
 	}
 }
 
@@ -106,20 +106,20 @@ func (o *trustedAssetsInstallObserverImpl) CurrentTrustedRecoveryBootAssetsMap()
 	return o.currentTrustedRecoveryBootAssetsMap()
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentDataBootstrappedContainer() secboot.BootstrappedContainer {
-	return o.dataBootstrappedContainer
+func (e *EncryptionSetup) CurrentDataBootstrappedContainer() secboot.BootstrappedContainer {
+	return e.dataBootstrappedContainer
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentSaveBootstrappedContainer() secboot.BootstrappedContainer {
-	return o.saveBootstrappedContainer
+func (e *EncryptionSetup) CurrentSaveBootstrappedContainer() secboot.BootstrappedContainer {
+	return e.saveBootstrappedContainer
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentVolumesAuth() *device.VolumesAuthOptions {
-	return o.volumesAuth
+func (e *EncryptionSetup) CurrentVolumesAuth() *device.VolumesAuthOptions {
+	return e.volumesAuth
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentCheckResult() *secboot.PreinstallCheckResult {
-	return o.checkResult
+func (e *EncryptionSetup) CurrentCheckResult() *secboot.PreinstallCheckResult {
+	return e.checkResult
 }
 
 func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash string, recovery bool) {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -467,7 +467,7 @@ func isSealModeenvLocked() bool {
 	return atomic.LoadInt32(&sealModeenvLocked) == 1
 }
 
-func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer TrustedAssetsInstallObserver, makeOpts makeRunnableOptions) error {
+func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup, makeOpts makeRunnableOptions) error {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return fmt.Errorf("internal error: cannot make pre-UC20 system runnable")
 	}
@@ -514,15 +514,9 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 
 	var currentTrustedBootAssets bootAssetsMap
 	var currentTrustedRecoveryBootAssets bootAssetsMap
-	var observerImpl *trustedAssetsInstallObserverImpl
-	if observer != nil {
-		impl, ok := observer.(*trustedAssetsInstallObserverImpl)
-		if !ok {
-			return fmt.Errorf("internal error: expected a trustedAssetsInstallObserverImpl")
-		}
-		observerImpl = impl
-		currentTrustedBootAssets = observerImpl.currentTrustedBootAssetsMap()
-		currentTrustedRecoveryBootAssets = observerImpl.currentTrustedRecoveryBootAssetsMap()
+	if bootAssets != nil {
+		currentTrustedBootAssets = bootAssets.TrackedAssets()
+		currentTrustedRecoveryBootAssets = bootAssets.TrackedRecoveryAssets()
 	}
 	recoverySystemLabel := bootWith.RecoverySystemLabel
 	// write modeenv on the ubuntu-data partition
@@ -658,7 +652,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		return fmt.Errorf("cannot write modeenv: %v", err)
 	}
 
-	if observer != nil && observerImpl.useEncryption {
+	if encryption != nil {
 		protector, err := HookKeyProtectorFactory(bootWith.Kernel)
 		if err != nil && !errors.Is(err, secboot.ErrNoKeyProtector) {
 			return fmt.Errorf("cannot check for fde-setup hook key protector: %v", err)
@@ -685,11 +679,11 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		// modeenv as well as optimum PCR configuration specified in the
 		// check result (when available)
 		if err := sealKeyToModeenv(
-			observerImpl.dataBootstrappedContainer,
-			observerImpl.saveBootstrappedContainer,
-			observerImpl.primaryKey,
-			observerImpl.volumesAuth,
-			observerImpl.checkResult,
+			encryption.dataBootstrappedContainer,
+			encryption.saveBootstrappedContainer,
+			encryption.primaryKey,
+			encryption.volumesAuth,
+			encryption.checkResult,
 			model,
 			modeenv,
 			flags,
@@ -704,8 +698,8 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		return fmt.Errorf("cannot record %q as a recovery capable system: %v", recoverySystemLabel, err)
 	}
 
-	if observer != nil {
-		if err := observer.UpdateBootEntry(); err != nil {
+	if bootAssets != nil {
+		if err := bootAssets.UpdateBootEntry(); err != nil {
 			logger.Debugf("WARNING: %v", err)
 		}
 	}
@@ -764,8 +758,8 @@ func buildOptionalKernelCommandLine(model *asserts.Model, gadgetSnapOrDir string
 // something like boot.EnsureNextBootToRunMode(). This is to enable separately
 // setting up a run system and actually transitioning to it, with hooks, etc.
 // running in between.
-func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer TrustedAssetsInstallObserver) error {
-	return makeRunnableSystem(model, bootWith, observer, makeRunnableOptions{
+func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
+	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
 		SeedDir: dirs.SnapSeedDir,
 	})
 }
@@ -773,10 +767,10 @@ func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 // MakeRunnableStandaloneSystem operates like MakeRunnableSystem but does
 // not assume that the run system being set up is related to the current
 // system. This is appropriate e.g when installing from a classic installer.
-func MakeRunnableStandaloneSystem(model *asserts.Model, bootWith *BootableSet, observer TrustedAssetsInstallObserver, unlocker Unlocker) error {
+func MakeRunnableStandaloneSystem(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup, unlocker Unlocker) error {
 	// TODO consider merging this back into MakeRunnableSystem but need
 	// to consider the properties of the different input used for sealing
-	return makeRunnableSystem(model, bootWith, observer, makeRunnableOptions{
+	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
 		Standalone:    true,
 		SeedDir:       dirs.SnapSeedDir,
 		StateUnlocker: unlocker,
@@ -785,10 +779,10 @@ func MakeRunnableStandaloneSystem(model *asserts.Model, bootWith *BootableSet, o
 
 // MakeRunnableStandaloneSystemFromInitrd is the same as MakeRunnableStandaloneSystem
 // but uses seed dir path expected in initrd.
-func MakeRunnableStandaloneSystemFromInitrd(model *asserts.Model, bootWith *BootableSet, observer TrustedAssetsInstallObserver) error {
+func MakeRunnableStandaloneSystemFromInitrd(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
 	// TODO consider merging this back into MakeRunnableSystem but need
 	// to consider the properties of the different input used for sealing
-	return makeRunnableSystem(model, bootWith, observer, makeRunnableOptions{
+	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
 		Standalone: true,
 		SeedDir:    filepath.Join(InitramfsRunMntDir, "ubuntu-seed"),
 	})
@@ -797,8 +791,8 @@ func MakeRunnableStandaloneSystemFromInitrd(model *asserts.Model, bootWith *Boot
 // MakeRunnableSystemAfterDataReset sets up the system to be able to boot, but it is
 // intended to be called from UC20 factory reset mode right before switching
 // back to the new run system.
-func MakeRunnableSystemAfterDataReset(model *asserts.Model, bootWith *BootableSet, observer TrustedAssetsInstallObserver) error {
-	return makeRunnableSystem(model, bootWith, observer, makeRunnableOptions{
+func MakeRunnableSystemAfterDataReset(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
+	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
 		AfterDataReset: true,
 		SeedDir:        dirs.SnapSeedDir,
 	})

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -517,7 +517,7 @@ func (s *makeBootable20Suite) TestMakeBootableImage20MultipleRecoverySystemsErro
 func (s *makeBootable20Suite) TestMakeSystemRunnable16Fails(c *C) {
 	model := boottest.MakeMockModel()
 
-	err := boot.MakeRunnableSystem(model, nil, nil)
+	err := boot.MakeRunnableSystem(model, nil, nil, nil)
 	c.Assert(err, ErrorMatches, `internal error: cannot make pre-UC20 system runnable`)
 }
 
@@ -560,7 +560,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnableSealWithHookKeyProtector(c *
 	})
 	defer restore()
 
-	err := boot.MakeRunnableSystem(model, bootWith, &observer)
+	err := boot.MakeRunnableSystem(model, bootWith, observer.BootAssets(), observer.EncryptionSetup())
 	c.Assert(err, IsNil)
 
 	c.Assert(gotFlags.HookKeyProtectorFactory, NotNil)
@@ -570,7 +570,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnableSealWithHookKeyProtector(c *
 	})
 	defer restore()
 
-	err = boot.MakeRunnableSystem(model, bootWith, &observer)
+	err = boot.MakeRunnableSystem(model, bootWith, observer.BootAssets(), observer.EncryptionSetup())
 	c.Assert(err, IsNil)
 
 	// now, we don't have the key protector
@@ -861,15 +861,15 @@ version: 5.0
 
 	switch {
 	case opts.standalone && opts.fromInitrd:
-		err = boot.MakeRunnableStandaloneSystemFromInitrd(model, bootWith, obs)
+		err = boot.MakeRunnableStandaloneSystemFromInitrd(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	case opts.standalone && !opts.fromInitrd:
 		u := mockUnlocker{}
-		err = boot.MakeRunnableStandaloneSystem(model, bootWith, obs, u.unlocker)
+		err = boot.MakeRunnableStandaloneSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup(), u.unlocker)
 		c.Check(u.unlocked, Equals, 1)
 	case opts.factoryReset && !opts.fromInitrd:
-		err = boot.MakeRunnableSystemAfterDataReset(model, bootWith, obs)
+		err = boot.MakeRunnableSystemAfterDataReset(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	default:
-		err = boot.MakeRunnableSystem(model, bootWith, obs)
+		err = boot.MakeRunnableSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	}
 	c.Assert(err, IsNil)
 
@@ -1162,7 +1162,7 @@ version: 5.0
 	}
 
 	// no grub marker in gadget directory raises an error
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, ErrorMatches, "internal error: cannot identify run system bootloader: cannot determine bootloader")
 
 	// set up grub.cfg in gadget
@@ -1173,7 +1173,7 @@ version: 5.0
 	// no write access to destination directory
 	restore := assets.MockInternal("grub.cfg", nil)
 	defer restore()
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot install managed bootloader assets: internal error: no boot asset for "grub.cfg"`)
 }
 
@@ -1354,7 +1354,7 @@ version: 5.0
 	})
 	defer restore()
 
-	err = boot.MakeRunnableSystem(model, bootWith, obs)
+	err = boot.MakeRunnableSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	c.Assert(err, ErrorMatches, "seal error")
 	// the TPM was provisioned
 	c.Check(sealKeyForBootChainsCalled, Equals, 1)
@@ -1549,7 +1549,7 @@ version: 5.0
 	})
 	defer restore()
 
-	err = boot.MakeRunnableSystem(model, bootWith, obs)
+	err = boot.MakeRunnableSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	if errMsg != "" {
 		c.Assert(err, ErrorMatches, errMsg)
 		return
@@ -1743,7 +1743,7 @@ version: 5.0
 	})
 	defer restore()
 
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot record "20191216" as a recovery capable system: open .*/run/mnt/ubuntu-seed/EFI/ubuntu/grubenv: no such file or directory`)
 
 }
@@ -2004,7 +2004,7 @@ version: 5.0
 		Recovery:            false,
 		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, IsNil)
 
 	// also do the logical next thing which is to ensure that the system
@@ -2299,7 +2299,7 @@ version: 5.0
 		UnpackedGadgetDir: unpackedGadgetDir,
 	}
 
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, IsNil)
 
 	// ensure that there are no good recovery systems as RecoverySystemLabel was empty
@@ -2386,7 +2386,7 @@ version: 3.0
 		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
-	err = boot.MakeRunnableSystem(model, bootWith, nil)
+	err = boot.MakeRunnableSystem(model, bootWith, nil, nil)
 	c.Assert(err, IsNil)
 
 	installHostWritableDir := filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -525,7 +525,12 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 		KernelMods:          kernelBootInfo.BootableKMods,
 	}
 
-	if err := bootMakeRunnableStandaloneSystem(model, bootWith, trustedInstallObserver); err != nil {
+	// TODO provision TPM
+	if err := bootMakeRunnableStandaloneSystem(
+		model,
+		bootWith,
+		trustedInstallObserver.BootAssets(),
+		trustedInstallObserver.EncryptionSetup()); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_install_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_install_test.go
@@ -326,7 +326,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallModeWithCompsHappy(c *C
 	defer restoreGadgetInstall()
 
 	makeRunnableCalled := false
-	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		makeRunnableCalled = true
 		c.Assert(model.Model(), Equals, "my-model")
 		c.Assert(bootWith.RecoverySystemLabel, Equals, s.sysLabel)
@@ -384,9 +384,6 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallModeWithCompsHappy(c *C
 			return nil
 		},
 		SetEncryptionParamsFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, checkResult *secboot.PreinstallCheckResult) {
-		},
-		UpdateBootEntryFunc: func() error {
-			return nil
 		},
 		ObserveFunc: func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 			return gadget.ChangeApply, nil

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_installrun_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_installrun_test.go
@@ -44,7 +44,6 @@ type MockObserver struct {
 	BootLoaderSupportsEfiVariablesFunc       func() bool
 	ObserveExistingTrustedRecoveryAssetsFunc func(recoveryRootDir string) error
 	SetEncryptionParamsFunc                  func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, checkResult *secboot.PreinstallCheckResult)
-	UpdateBootEntryFunc                      func() error
 	ObserveFunc                              func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
 }
 
@@ -60,12 +59,16 @@ func (m *MockObserver) SetEncryptionParams(key, saveKey secboot.BootstrappedCont
 	m.SetEncryptionParamsFunc(key, saveKey, primaryKey, volumesAuth, checkResult)
 }
 
-func (m *MockObserver) UpdateBootEntry() error {
-	return m.UpdateBootEntryFunc()
-}
-
 func (m *MockObserver) Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 	return m.ObserveFunc(op, partRole, root, relativeTarget, data)
+}
+
+func (m *MockObserver) BootAssets() boot.BootAssets {
+	return nil
+}
+
+func (m *MockObserver) EncryptionSetup() *boot.EncryptionSetup {
+	return nil
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupPresent(c *C) {
@@ -157,7 +160,7 @@ echo '{"features":[]}'
 	defer restoreGadgetInstall()
 
 	makeRunnableCalled := false
-	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		makeRunnableCalled = true
 		c.Assert(model.Model(), Equals, "my-model")
 		c.Assert(bootWith.RecoverySystemLabel, Equals, s.sysLabel)
@@ -205,9 +208,6 @@ echo '{"features":[]}'
 			setBootstrappedContainersCalled++
 			c.Check(key, Equals, dataContainer)
 			c.Check(saveKey, Equals, saveContainer)
-		},
-		UpdateBootEntryFunc: func() error {
-			return nil
 		},
 		ObserveFunc: func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 			return gadget.ChangeApply, nil
@@ -329,7 +329,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupNotPresen
 	defer restoreGadgetInstall()
 
 	makeRunnableCalled := false
-	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restoreMakeRunnableStandaloneSystem := main.MockMakeRunnableStandaloneSystem(func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		makeRunnableCalled = true
 		c.Assert(model.Model(), Equals, "my-model")
 		c.Assert(bootWith.RecoverySystemLabel, Equals, s.sysLabel)
@@ -374,9 +374,6 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupNotPresen
 		},
 		SetEncryptionParamsFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, checkResult *secboot.PreinstallCheckResult) {
 			c.Errorf("unexpected call")
-		},
-		UpdateBootEntryFunc: func() error {
-			return nil
 		},
 		ObserveFunc: func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error) {
 			return gadget.ChangeApply, nil

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -219,7 +219,7 @@ func MockGadgetInstallRun(f func(model gadget.Model, gadgetRoot string, kernelSn
 	}
 }
 
-func MockMakeRunnableStandaloneSystem(f func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error) (restore func()) {
+func MockMakeRunnableStandaloneSystem(f func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error) (restore func()) {
 	old := bootMakeRunnableStandaloneSystem
 	bootMakeRunnableStandaloneSystem = f
 	return func() {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -690,7 +690,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	}
 
 	bootMakeBootableCalled := 0
-	restore = devicestate.MockBootMakeSystemRunnable(func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restore = devicestate.MockBootMakeSystemRunnable(func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		c.Check(model, DeepEquals, mockModel)
 		c.Check(bootWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_1.snap")
 		c.Check(bootWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core20_2.snap")
@@ -698,9 +698,11 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		c.Check(bootWith.RecoverySystemDir, Equals, "")
 		c.Check(bootWith.UnpackedGadgetDir, Equals, filepath.Join(dirs.SnapMountDir, "pc/1"))
 		if tc.encrypt {
-			c.Check(obs, NotNil)
+			c.Check(bootAssets, NotNil)
+			c.Check(encryption, NotNil)
 		} else {
-			c.Check(obs, IsNil)
+			c.Check(bootAssets, IsNil)
+			c.Check(encryption, IsNil)
 		}
 		bootMakeBootableCalled++
 		return nil
@@ -1911,7 +1913,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 	s.state.Unlock()
 	c.Check(mockModel.Grade(), Equals, asserts.ModelGrade(modelGrade))
 
-	restore = devicestate.MockBootMakeSystemRunnable(func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restore = devicestate.MockBootMakeSystemRunnable(func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		return nil
 	})
 	defer restore()
@@ -2399,7 +2401,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	})()
 
 	bootMakeBootableCalled := 0
-	restore = devicestate.MockBootMakeSystemRunnableAfterDataReset(func(makeRunnableModel *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error {
+	restore = devicestate.MockBootMakeSystemRunnableAfterDataReset(func(makeRunnableModel *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error {
 		c.Check(makeRunnableModel, DeepEquals, model)
 		c.Check(bootWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_1.snap")
 		c.Check(bootWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core24_2.snap")
@@ -2419,9 +2421,11 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 			})
 		}
 		if tc.encrypt {
-			c.Check(obs, NotNil)
+			c.Check(bootAssets, NotNil)
+			c.Check(encryption, NotNil)
 		} else {
-			c.Check(obs, IsNil)
+			c.Check(bootAssets, IsNil)
+			c.Check(encryption, IsNil)
 		}
 		bootMakeBootableCalled++
 

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -391,13 +391,13 @@ func MockGadgetIsCompatible(mock func(current, update *gadget.Info) error) (rest
 	}
 }
 
-func MockBootMakeSystemRunnable(f func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error) (restore func()) {
+func MockBootMakeSystemRunnable(f func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error) (restore func()) {
 	restore = testutil.Backup(&bootMakeRunnable)
 	bootMakeRunnable = f
 	return restore
 }
 
-func MockBootMakeSystemRunnableAfterDataReset(f func(model *asserts.Model, bootWith *boot.BootableSet, obs boot.TrustedAssetsInstallObserver) error) (restore func()) {
+func MockBootMakeSystemRunnableAfterDataReset(f func(model *asserts.Model, bootWith *boot.BootableSet, bootAssets boot.BootAssets, encryption *boot.EncryptionSetup) error) (restore func()) {
 	restore = testutil.Backup(&bootMakeRunnableAfterDataReset)
 	bootMakeRunnableAfterDataReset = f
 	return restore

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -343,7 +343,13 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		KernelMods:          kBootInfo.BootableKMods,
 	}
 	timings.Run(perfTimings, "boot-make-runnable", "Make target system runnable", func(timings.Measurer) {
-		err = bootMakeRunnable(deviceCtx.Model(), bootWith, trustedInstallObserver)
+		if trustedInstallObserver != nil {
+			err = bootMakeRunnable(deviceCtx.Model(), bootWith,
+				trustedInstallObserver.BootAssets(),
+				trustedInstallObserver.EncryptionSetup())
+		} else {
+			err = bootMakeRunnable(deviceCtx.Model(), bootWith, nil, nil)
+		}
 	})
 	if err != nil {
 		return fmt.Errorf("cannot make system runnable: %v", err)
@@ -673,7 +679,13 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		KernelMods:          kBootInfo.BootableKMods,
 	}
 	timings.Run(perfTimings, "boot-make-runnable", "Make target system runnable", func(timings.Measurer) {
-		err = bootMakeRunnableAfterDataReset(deviceCtx.Model(), bootWith, trustedInstallObserver)
+		if trustedInstallObserver != nil {
+			err = bootMakeRunnableAfterDataReset(deviceCtx.Model(), bootWith,
+				trustedInstallObserver.BootAssets(),
+				trustedInstallObserver.EncryptionSetup())
+		} else {
+			err = bootMakeRunnableAfterDataReset(deviceCtx.Model(), bootWith, nil, nil)
+		}
 	})
 	if err != nil {
 		return fmt.Errorf("cannot make system runnable: %v", err)
@@ -1247,7 +1259,12 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	logger.Debugf("making the installed system runnable for system label %s", systemLabel)
-	if err := bootMakeRunnableStandalone(systemAndSnaps.Model, bootWith, trustedInstallObserver, st.Unlocker()); err != nil {
+	if err := bootMakeRunnableStandalone(
+		systemAndSnaps.Model,
+		bootWith,
+		trustedInstallObserver.BootAssets(),
+		trustedInstallObserver.EncryptionSetup(),
+		st.Unlocker()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Install observers are not good abstraction for MakeSystemBootable when used for reprovisioning. So instead we make 2 separate abstractions:
    * The boot assets, that can be used to calculate the boot chains and update the boot entry.
    * The encryption parameters
