### PR TITLE
store/tooling,seed/seedwriter: validate snap-id from model assertion against store

### DIFF
--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1316,8 +1316,14 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap, fetchAsserts AssertsFetchFunc
 			}
 		}
 
-		// TODO: optionally check that model snap name and
-		// info snap name match
+		if !sn.local {
+			if modelID := sn.SnapRef.ID(); modelID != "" && info.ID() != "" {
+				if modelID != info.ID() {
+					return fmt.Errorf("snap %q snap-id mismatch: model assertion declares snap-id %q but store returned snap-id %q",
+						sn.SnapName(), modelID, info.ID())
+				}
+			}
+		}
 
 		needsClassic := info.NeedsClassic()
 		if needsClassic {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -808,6 +808,126 @@ func (s *writerSuite) TestDownloadedPublisherMismatchGadget(c *C) {
 	c.Check(err, ErrorMatches, `cannot use gadget "pc" published by "developerid" for model by "my-brand"`)
 }
 
+func (s *writerSuite) TestDownloadedSnapIDMismatch(c *C) {
+	wrongID := strings.Repeat("x", 32)
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []any{
+			map[string]any{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]any{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]any{
+				"name": "required20",
+				// Intentionally wrong snap-id: does not match what the
+				// store will return for "required20".
+				"id": wrongID,
+			},
+		},
+	})
+
+	s.opts.Label = "20191030"
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+
+	s.expectedSysSnap = "snapd"
+
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap, s.fetchAsserts(c))
+	c.Check(err, ErrorMatches, `snap "required20" snap-id mismatch: model assertion declares snap-id "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" but store returned snap-id ".*"`)
+}
+
+func (s *writerSuite) TestDownloadedSnapIDMatchPasses(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []any{
+			map[string]any{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]any{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]any{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			},
+		},
+	})
+
+	s.opts.Label = "20191030"
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+
+	s.expectedSysSnap = "snapd"
+
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap, s.fetchAsserts(c))
+	c.Check(err, IsNil)
+}
+
+func (s *writerSuite) TestDownloadedSnapIDMissingInModelSkipsCheck(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []any{
+			map[string]any{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]any{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]any{
+				// No "id" field: valid for dangerous grade.
+				"name": "required20",
+			},
+		},
+	})
+
+	s.opts.Label = "20191030"
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+
+	s.expectedSysSnap = "snapd"
+
+	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap, s.fetchAsserts(c))
+	c.Check(err, IsNil)
+}
+
 func (s *writerSuite) TestDownloadedMissingDefaultProvider(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -404,7 +404,8 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 	for _, sn := range toDownload {
 		actions = append(actions, &store.SnapAction{
 			Action:         "download",
-			InstanceName:   sn.Snap.SnapName(), // XXX consider using snap-id first
+			InstanceName:   sn.Snap.SnapName(),
+			SnapID:         sn.Snap.ID(),
 			Channel:        sn.Channel,
 			Revision:       sn.Revision,
 			CohortKey:      sn.CohortKey,

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -567,6 +567,45 @@ func (s *toolingSuite) TestDownloadManySnapWithComps(c *C) {
 	c.Check(numReq, Equals, 1)
 }
 
+func (s *toolingSuite) TestDownloadManyForwardsSnapIDToStoreAction(c *C) {
+	s.setupSnaps(c, map[string]string{"core": "canonical"}, "")
+
+	coreID := s.AssertedSnapID("core")
+	snapsToDownld := []tooling.SnapToDownload{
+		{Snap: naming.NewSnapRef("core", coreID)},
+	}
+	dlDir := c.MkDir()
+	bdf := func(si *snap.Info, _ map[string]*snap.ComponentInfo) (string, map[string]string, error) {
+		return filepath.Join(dlDir, si.SnapName()), nil, nil
+	}
+	topts := tooling.DownloadManyOptions{BeforeDownloadFunc: bdf}
+	_, err := s.tsto.DownloadMany(snapsToDownld, nil, topts)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.storeActions, HasLen, 1)
+	c.Check(s.storeActions[0].InstanceName, Equals, "core")
+	c.Check(s.storeActions[0].SnapID, Equals, coreID)
+}
+
+func (s *toolingSuite) TestDownloadManyNoSnapIDWhenEmpty(c *C) {
+	s.setupSnaps(c, map[string]string{"core": "canonical"}, "")
+
+	snapsToDownld := []tooling.SnapToDownload{
+		{Snap: naming.Snap("core")},
+	}
+	dlDir := c.MkDir()
+	bdf := func(si *snap.Info, _ map[string]*snap.ComponentInfo) (string, map[string]string, error) {
+		return filepath.Join(dlDir, si.SnapName()), nil, nil
+	}
+	topts := tooling.DownloadManyOptions{BeforeDownloadFunc: bdf}
+	_, err := s.tsto.DownloadMany(snapsToDownld, nil, topts)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.storeActions, HasLen, 1)
+	c.Check(s.storeActions[0].InstanceName, Equals, "core")
+	c.Check(s.storeActions[0].SnapID, Equals, "")
+}
+
 func (s *toolingSuite) TestSetAssertionMaxFormats(c *C) {
 	c.Check(s.tsto.AssertionMaxFormats(), IsNil)
 


### PR DESCRIPTION
When building a snap image, the `snap-id` declared in a model assertion for each snap was never validated against the `snap-id` returned by the store. The store was queried by snap name only, meaning a model assertion with a wrong `snap-id` (for example copy-pasted from a different snap) would silently produce a valid image without any error.

I came across this situation when I accidentally kept the ID for `core24` while building an image with `core22` as base after copy-pasting an example.

This change fixes the issue in two complementary ways:

- _store/tooling_: the `snap-id` from the model assertion is now forwarded as `SnapID` in the store `SnapAction` request. The store will reject the request if the name and `snap-id` are inconsistent. An empty `snap-id` (valid for `dangerous` models without an `id` field) is serialized with `omitempty` and so is safely ignored by the store.
- _seed/seedwriter_: after a snap is downloaded and its store-returned `snap.Info` is available, the model-declared `snap-id` is compared against the store-returned `snap-id`. A mismatch produces a hard error. The check is skipped when either `id` is empty (dangerous snaps without an `id` field, or local snaps).