### PR TITLE
tests: change release/distro-upgrade test to allow for missing interim

### DIFF
--- a/tests/release/distro-upgrade/task.yaml
+++ b/tests/release/distro-upgrade/task.yaml
@@ -53,25 +53,31 @@ restore: |
     sed -i 's/Prompt=normal/Prompt=never/' /etc/update-manager/release-upgrades
 
 execute: |
+    # Grab all supported distros except for the first one, which presumably we're running on
+    mapfile -t upgrades < <(ubuntu-distro-info --supported --release | awk '{print $1}' | sed 1d)
+
+    #####################################################################################
+    # The upgrades array contains the distros that we will be upgrading to.
+    # To manually supply the upgrades, uncomment this next line with desired versions.
+    # upgrades=(24.04 25.10 26.04)
+    #####################################################################################
+
     # Don't fail the test if the distro is missing the latest snapd version. Sometimes one distro
     # doesn't have the latest yet.
     ./check-snapd-version.sh "$(cat initial-snapd-version.txt)" || [ "$SRU_VALIDATION" = "1" ]
     snap version --verbose > snapd-versions/"$(lsb_release -c -s)"
 
-    while not os.query is-ubuntu-devel; do
+    while ! os.query is-ubuntu "${upgrades[${#upgrades[@]}-1]}"; do
         # We can only upgrade the distro if we have all upgrades installed
         apt update
         apt upgrade -y
         if [[ "$SPREAD_REBOOT" = 0 ]]; then
             REBOOT
         fi
-        devel_option=
-        if os.query is-ubuntu-interim; then
-            devel_option="-d"
-        fi
 
         echo "Upgrading $(grep -oP 'CODENAME=\K.*' /etc/os-release | head -1)"
-        sudo do-release-upgrade "$devel_option" -f DistUpgradeViewNonInteractive
+        sudo do-release-upgrade -f DistUpgradeViewNonInteractive || \
+            sudo do-release-upgrade -d -f DistUpgradeViewNonInteractive
 
         if [ "$SRU_VALIDATION" = "1" ] || [ -n "$PPA_VALIDATION_NAME" ]; then
             #shellcheck source=tests/lib/pkgdb.sh
@@ -89,25 +95,13 @@ execute: |
         ./check-snapd-version.sh "$(cat initial-snapd-version.txt)" || [ "$SRU_VALIDATION" = "1" ]
         snap version --verbose > snapd-versions/"$(lsb_release -c -s)"
 
-        if os.query is-ubuntu-latest-lts; then
-            touch lts-upgrade-done
-        elif os.query is-ubuntu-interim; then
-            touch interim-upgrade-done
-        elif os.query is-ubuntu-devel; then
-            touch devel-upgrade-done
-        fi
+        touch "$(grep -oP 'VERSION_ID="\K.*[^"]+' /etc/os-release)-done"
         SPREAD_REBOOT=0
     done
 
-    if not [ -f lts-upgrade-done ]; then
-        echo "We should have done an LTS upgrade but didn't"
-        exit 1
-    fi
-    if not [ -f interim-upgrade-done ]; then
-        echo "We should have done an interim upgrade but didn't"
-        exit 1
-    fi
-    if not [ -f devel-upgrade-done ]; then
-        echo "We should have done a devel upgrade but didn't"
-        exit 1
-    fi
+    for upgrade in "${upgrades[@]}"; do
+        if [ ! -f "$upgrade-done" ]; then
+            echo "Upgrade to $upgrade failed."
+            exit 1
+        fi
+    done

--- a/tests/release/distro-upgrade/task.yaml
+++ b/tests/release/distro-upgrade/task.yaml
@@ -53,7 +53,12 @@ restore: |
     sed -i 's/Prompt=normal/Prompt=never/' /etc/update-manager/release-upgrades
 
 execute: |
-    # Grab all supported distros except for the first one, which presumably we're running on
+    current=$(ubuntu-distro-info --supported --release | awk '{print $1}' | head -1)
+    if ! os.query is-ubuntu "$current"; then
+        echo "This test should be run on the lowest supported version of ubuntu for a given release, which is currently $current"
+        exit 1
+    fi
+    # Grab all supported distros except for the first one, which we're running on
     mapfile -t upgrades < <(ubuntu-distro-info --supported --release | awk '{print $1}' | sed 1d)
 
     #####################################################################################


### PR DESCRIPTION
Currently, both lts and stable are the same version, which causes the distro-upgrade test to behave not properly.
```
$ ubuntu-distro-info --lts
resolute
$ ubuntu-distro-info --stable
resolute
```
This changes the test to use `ubuntu-distro-info --supported` instead and adds an easy modification point in the test to force the upgrade versions

### Validation: Tested on -proposed

git diff:
```
$ git diff tests/release/distro-upgrade/task.yaml
diff --git a/tests/release/distro-upgrade/task.yaml b/tests/release/distro-upgrade/task.yaml
index 2327e50dba..99adf8938d 100644
--- a/tests/release/distro-upgrade/task.yaml
+++ b/tests/release/distro-upgrade/task.yaml
@@ -59,7 +59,7 @@ execute: |
     #####################################################################################
     # The upgrades array contains the distros that we will be upgrading to.
     # To manually supply the upgrades, uncomment this next line with desired versions.
-    # upgrades=(24.04 25.10 26.04)
+    upgrades=(24.04 25.10 26.04)
     #####################################################################################
 
     # Don't fail the test if the distro is missing the latest snapd version. Sometimes one distro
```
spread run:
```
$ SPREAD_SNAP_REEXEC=0 SPREAD_SRU_VALIDATION=1 spread -no-debug-output -artifacts ./proposed-artifacts garden:ubuntu-22.04-64:tests/release/distro-upgrade
2026-05-19 09:49:58 Project content is packed for delivery (131.36MB).
2026-05-19 09:49:58 If killed, discard servers with: spread -reuse-pid=43323 -discard
2026-05-19 09:49:58 Allocating garden:ubuntu-22.04-64...
2026-05-19 09:49:59 Waiting for garden:ubuntu-22.04-64 to make SSH available at localhost:7069...
2026-05-19 09:49:59 Allocated garden:ubuntu-22.04-64.
2026-05-19 09:49:59 Connecting to garden:ubuntu-22.04-64...
2026-05-19 09:50:20 Connected to garden:ubuntu-22.04-64 at localhost:7069.
2026-05-19 09:50:20 Sending project content to garden:ubuntu-22.04-64...
2026-05-19 09:50:23 Preparing garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64)...
2026-05-19 09:51:37 Preparing garden:ubuntu-22.04-64:tests/release/ (garden:ubuntu-22.04-64)...
2026-05-19 09:53:06 Preparing garden:ubuntu-22.04-64:tests/release/distro-upgrade (garden:ubuntu-22.04-64)...
2026-05-19 09:53:18 Executing garden:ubuntu-22.04-64:tests/release/distro-upgrade (garden:ubuntu-22.04-64) (1/1)...
2026-05-19 09:54:22 Rebooting on garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) as requested...
2026-05-19 09:54:39 Connected after reboot to garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade)
2026-05-19 10:04:39 WARNING: garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) running late. Current output:
-----
(... 3629 lines above ...)
Preparing to unpack .../048-telnet_0.17+2.5-3ubuntu4.1_all.deb ...
Unpacking telnet (0.17+2.5-3ubuntu4.1) over (0.17-44build1) ...
Preparing to unpack .../049-time_1.9-0.2build1_amd64.deb ...
Unpacking time (1.9-0.2build1) over (1.9-0.1build2) ...
Selecting previously unselected package trace-cmd.
Preparing to unpack .../050-trace-cmd_3.2-1ubuntu2_amd64.deb ...
Unpacking trace-cmd (3.2-1ubuntu2) ...
Preparing to unpack .../051-usb.ids_2024.03.18-1_all.deb ...
Unpacking usb.ids (2024.03.18-1) over (2022.04.02-1) ...
Preparing to unpack .../052-usbutils_1%3a017-3build1_amd64.deb ...
-----
.
2026-05-19 10:14:39 WARNING: garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) running late. Current output:
-----
(... 2922 lines above ...)
Removing libtss2-mu0:amd64 (3.2.0-1ubuntu1.1) ...
Removing libtype-tiny-perl (2.004000-1) ...
Removing libtype-tiny-xs-perl:amd64 (0.025-1build3) ...
Removing libunistring2:amd64 (1.0-1) ...
Removing libvpx7:amd64 (1.11.0-2ubuntu2.5) ...
Removing libwacom-bin (2.10.0-2) ...
Removing libwant-perl (0.29-2build4) ...
Removing libweston-9-0 (9.0.0-4ubuntu1) ...
Removing libxcb-dri2-0:amd64 (1.15-1ubuntu2) ...
Removing linux-headers-5.15.0-173-generic (5.15.0-173.183) ...
-----
.
2026-05-19 10:16:07 Rebooting on garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) as requested...
2026-05-19 10:16:25 Connected after reboot to garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade)
2026-05-19 10:26:25 WARNING: garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) running late. Current output:
-----
(... 4478 lines above ...)
Setting up autotools-dev (20240727.1) ...
Setting up libz3-4:amd64 (4.13.3-1) ...
Setting up libpcre2-32-0:amd64 (10.46-1) ...
Setting up libblas3:amd64 (3.12.1-6build1) ...
Setting up libboost-thread1.88.0:amd64 (1.88.0-1.4ubuntu1) ...
Setting up libglib2.0-data (2.86.0-2ubuntu0.3) ...
Setting up libpkgconf3:amd64 (1.8.1-4build1) ...
Setting up libpfm4:amd64 (4.13.0+git99-gc5587f9-1) ...
Setting up rpcsvc-proto (1.4.3-1) ...
Setting up linux-sysctl-defaults (4.14ubuntu2) ...
-----
.
2026-05-19 10:33:37 Rebooting on garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) as requested...
2026-05-19 10:33:55 Connected after reboot to garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade)
2026-05-19 10:43:55 WARNING: garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64:tests/release/distro-upgrade) running late. Current output:
-----
(... 3389 lines above ...)
Unpacking dh-apparmor (5.0.0~beta1-0ubuntu7) over (5.0.0~alpha1-0ubuntu8.3) ...
Preparing to unpack .../790-dh-golang_1.63build1_all.deb ...
Unpacking dh-golang (1.63build1) over (1.63) ...
Preparing to unpack .../791-gdisk_1.0.10-2build1_amd64.deb ...
Unpacking gdisk (1.0.10-2build1) over (1.0.10-2) ...
Preparing to unpack .../792-gnupg2_2.4.8-4ubuntu3_all.deb ...
Unpacking gnupg2 (2.4.8-4ubuntu3) over (2.4.8-2ubuntu2.1) ...
Preparing to unpack .../793-libauthen-sasl-perl_2.2000-1_all.deb ...
Unpacking libauthen-sasl-perl (2.2000-1) over (2.1700-1) ...
Preparing to unpack .../794-liblouisutdml-bin_2.12.0-8build1_amd64.deb ...
-----
.
2026-05-19 10:52:55 Fetching artifacts...
2026-05-19 10:52:55 Restoring garden:ubuntu-22.04-64:tests/release/distro-upgrade (garden:ubuntu-22.04-64)...
2026-05-19 10:53:01 Fetching artifacts...
2026-05-19 10:53:01 Restoring garden:ubuntu-22.04-64 (garden:ubuntu-22.04-64)...
2026-05-19 10:53:01 Discarding garden:ubuntu-22.04-64...
2026-05-19 10:53:01 Successful tasks: 1
2026-05-19 10:53:01 Aborted tasks: 0
```
Check that upgrades executed correctly:
```
$ find proposed-artifacts/ -type f -exec sh -c 'echo "$1"; cat "$1"' _ {} \;
proposed-artifacts/garden:ubuntu-22.04-64:tests/release/distro-upgrade/snapd-versions/noble
snap            2.75.2+ubuntu24.04
snapd           2.75.2+ubuntu24.04
series          16
ubuntu          24.04
kernel          6.8.0-117-generic
architecture    amd64
snapd-bin-from  native-package
snap-bin-from   native-package
proposed-artifacts/garden:ubuntu-22.04-64:tests/release/distro-upgrade/snapd-versions/questing
snap            2.75.2+ubuntu25.10
snapd           2.75.2+ubuntu25.10
series          16
ubuntu          25.10
kernel          6.17.0-29-generic
architecture    amd64
snapd-bin-from  native-package
snap-bin-from   native-package
proposed-artifacts/garden:ubuntu-22.04-64:tests/release/distro-upgrade/snapd-versions/jammy
snap            2.75.2+ubuntu22.04
snapd           2.75.2+ubuntu22.04
series          16
ubuntu          22.04
kernel          5.15.0-179-generic
architecture    amd64
snapd-bin-from  native-package
snap-bin-from   native-package
proposed-artifacts/garden:ubuntu-22.04-64:tests/release/distro-upgrade/snapd-versions/resolute
snap            2.75.2+ubuntu26.04.2
snapd           2.75.2+ubuntu26.04.2
series          16
ubuntu          26.04
kernel          6.17.0-29-generic
architecture    amd64
snapd-bin-from  native-package
snap-bin-from   native-package
```