### PR TITLE
tests: add openstack-validation backend to the nested tests execution

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1724,6 +1724,7 @@ suites:
             - openstack-ext
             - openstack-arm-ext
             - openstack-ext-dev
+            - openstack-validation
         environment:
             NESTED_TYPE: "classic"
             # Enable kvm in the qemu command line


### PR DESCRIPTION
The openstack-validation backend is used to run edge validation for core snaps. Since we updated spread logic to determine the tasks to be executed the validation for amd64 is not being executed.
