### PR TITLE
o/snapstate: set userID from snapst and from opts as fallback for component installation

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -188,8 +188,11 @@ func componentSetupsForInstall(ctx context.Context, st *state.State, names []str
 		return nil, err
 	}
 
-	// TODO:COMPS: figure out which user to use here
-	user, err := userFromUserID(st, opts.UserID)
+	userID, err := userIDForSnap(st, &snapst, opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+	user, err := userFromUserID(st, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -1085,6 +1085,14 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	}
 	c.Assert(snapsupSetupProfiles.UserID, Equals, expectedUserID)
 
+	s.fakeBackend.ops.MustFindOp(c, "storesvc-snap-action")
+	for _, op := range s.fakeBackend.ops {
+		if op.op == "storesvc-snap-action" || op.op == "storesvc-snap-action:action" {
+			c.Assert(op.userID, Equals, expectedUserID,
+				Commentf("expected userID %d in op %q but got %d", expectedUserID, op.op, op.userID))
+		}
+	}
+
 	prepareKmodComps := setupTs.Tasks()[1]
 	c.Assert(prepareKmodComps.Kind(), Equals, "prepare-kernel-modules-components")
 


### PR DESCRIPTION
Follows https://github.com/canonical/snapd/pull/17020
This resolves [LP2110368](https://bugs.launchpad.net/snapd/+bug/2110368) the issue of installing a component for a private snap from within the snap using snapctl. See [test results](https://warthogs.atlassian.net/browse/SNAPDENG-36844?focusedCommentId=1090584).

[SNAPDENG-36844](https://warthogs.atlassian.net/browse/SNAPDENG-36844)

[SNAPDENG-36844]: https://warthogs.atlassian.net/browse/SNAPDENG-36844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ