### PR TITLE
i/builtin: podman interface

### DIFF
--- a/interfaces/builtin/podman.go
+++ b/interfaces/builtin/podman.go
@@ -23,7 +23,9 @@ const podmanSummary = `allows access to Podman socket`
 
 const podmanBaseDeclarationSlots = `
   podman:
-    allow-installation: false
+    allow-installation:
+      slot-snap-type:
+        - core
     deny-connection: true
     deny-auto-connection: true
 `

--- a/interfaces/builtin/podman.go
+++ b/interfaces/builtin/podman.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const podmanSummary = `allows access to Podman socket`
+
+const podmanBaseDeclarationSlots = `
+  podman:
+    allow-installation: false
+    deny-connection: true
+    deny-auto-connection: true
+`
+
+const podmanConnectedPlugAppArmor = `
+# Description: allow access to the Podman service. This gives privileged
+# access to the system via Podman's socket API.
+
+# Allow talking to the Podman service (system socket)
+/{,var/}run/podman/podman.sock rw,
+# Allow talking to the Podman service (rootless/user socket, $XDG_RUNTIME_DIR)
+owner /{,var/}run/user/[0-9]*/podman/podman.sock rw,
+`
+
+const podmanConnectedPlugSecComp = `
+# Description: allow access to the Podman service. This gives privileged
+# access to the system via Podman's socket API.
+
+bind
+socket AF_NETLINK - NETLINK_GENERIC
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "podman",
+		summary:               podmanSummary,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  podmanBaseDeclarationSlots,
+		connectedPlugAppArmor: podmanConnectedPlugAppArmor,
+		connectedPlugSecComp:  podmanConnectedPlugSecComp,
+	})
+}

--- a/interfaces/builtin/podman_test.go
+++ b/interfaces/builtin/podman_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type PodmanInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const podmanMockPlugSnapInfoYaml = `name: podman
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [podman]
+`
+
+const podmanMockSlotSnapInfoYaml = `name: core
+version: 1.0
+type: os
+slots:
+ podman:
+  interface: podman
+`
+
+var _ = Suite(&PodmanInterfaceSuite{
+	iface: builtin.MustInterface("podman"),
+})
+
+func (s *PodmanInterfaceSuite) SetUpTest(c *C) {
+	s.slot, s.slotInfo = MockConnectedSlot(c, podmanMockSlotSnapInfoYaml, nil, "podman")
+	s.plug, s.plugInfo = MockConnectedPlug(c, podmanMockPlugSnapInfoYaml, nil, "podman")
+}
+
+func (s *PodmanInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "podman")
+}
+
+func (s *PodmanInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	apparmorSpec := apparmor.NewSpecification(s.plug.AppSet())
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.podman.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.podman.app"), testutil.Contains, `/{,var/}run/podman/podman.sock`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.podman.app"), testutil.Contains, `/{,var/}run/user/[0-9]*/podman/podman.sock`)
+
+	seccompSpec := seccomp.NewSpecification(s.plug.AppSet())
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.podman.app"})
+	c.Check(seccompSpec.SnippetForTag("snap.podman.app"), testutil.Contains, "bind\n")
+}
+
+func (s *PodmanInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *PodmanInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *PodmanInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2024 Canonical Ltd
+ * Copyright (C) 2016-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -898,6 +898,7 @@ var (
 		"opengl-driver-libs":       nil,
 		"opengles-driver-libs":     nil,
 		"pkcs11":                   nil,
+		"podman":                   nil,
 		"posix-mq":                 nil,
 		"shared-memory":            nil,
 		"gpio-chardev":             nil,
@@ -969,6 +970,12 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	err = ic.Check()
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "installation not allowed by \"lxd\" slot rule of interface \"lxd\"")
+
+	// test podman specially
+	ic = s.installSlotCand(c, "podman", snap.TypeApp, ``)
+	err = ic.Check()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, "installation not allowed by \"podman\" slot rule of interface \"podman\"")
 
 	// test microceph specially
 	ic = s.installSlotCand(c, "microceph", snap.TypeApp, ``)
@@ -1168,6 +1175,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"microovn":                  true,
 		"mir":                       true,
 		"online-accounts-service":   true,
+		"podman":                    true,
 		"posix-mq":                  true,
 		"qualcomm-ipc-router":       true,
 		"raw-volume":                true,

--- a/tests/main/interfaces-podman/podman-consumer/bin/podman-api
+++ b/tests/main/interfaces-podman/podman-consumer/bin/podman-api
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Minimal podman API client over Unix socket for spread testing."""
+import http.client
+import json
+import socket
+import sys
+
+
+class UnixHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path):
+        super().__init__("localhost")
+        self.socket_path = socket_path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+
+
+def api(socket_path, method, path, body=None):
+    conn = UnixHTTPConnection(socket_path)
+    headers = {}
+    if body is not None:
+        body = json.dumps(body)
+        headers["Content-Type"] = "application/json"
+    conn.request(method, path, body=body, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    try:
+        return resp.status, json.loads(data)
+    except (json.JSONDecodeError, ValueError):
+        return resp.status, data.decode("utf-8", errors="replace")
+
+
+def cmd_info(sock):
+    status, data = api(sock, "GET", "/v4.0.0/libpod/info")
+    if status != 200:
+        print("ERROR: info returned {}".format(status), file=sys.stderr)
+        sys.exit(1)
+    print("hostname={}".format(data["host"]["hostname"]))
+    print("os={}".format(data["host"]["os"]))
+
+
+def cmd_run(sock, image, command):
+    # Create container
+    status, ctr = api(sock, "POST", "/v4.0.0/libpod/containers/create", {
+        "image": image,
+        "command": command,
+    })
+    if status != 201:
+        print("ERROR: create returned {}: {}".format(status, ctr), file=sys.stderr)
+        sys.exit(1)
+    ctr_id = ctr["Id"]
+    print("created={}".format(ctr_id[:12]))
+
+    # Start container
+    status, _ = api(sock, "POST", "/v4.0.0/libpod/containers/{}/start".format(ctr_id))
+    if status not in (200, 204):
+        print("ERROR: start returned {}".format(status), file=sys.stderr)
+        sys.exit(1)
+    print("started=true")
+
+    # Wait for container to finish
+    status, wait_data = api(sock, "POST", "/v4.0.0/libpod/containers/{}/wait".format(ctr_id))
+    if status != 200:
+        print("ERROR: wait returned {}".format(status), file=sys.stderr)
+        sys.exit(1)
+    exit_code = wait_data if isinstance(wait_data, int) else wait_data.get("StatusCode", -1)
+    print("exit_code={}".format(exit_code))
+
+    # Remove container
+    status, _ = api(sock, "DELETE", "/v4.0.0/libpod/containers/{}?force=true".format(ctr_id))
+    print("removed={}".format(status in (200, 204)))
+
+    if exit_code != 0:
+        sys.exit(1)
+
+
+def main():
+    sock = sys.argv[1]
+    action = sys.argv[2]
+
+    if action == "info":
+        cmd_info(sock)
+    elif action == "run":
+        image = sys.argv[3]
+        command = sys.argv[4:] if len(sys.argv) > 4 else ["echo", "hello-from-podman"]
+        cmd_run(sock, image, command)
+    else:
+        print("Unknown action: {}".format(action), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/main/interfaces-podman/podman-consumer/bin/root-daemon
+++ b/tests/main/interfaces-podman/podman-consumer/bin/root-daemon
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Run a container via the system podman socket and write the result.
+"$SNAP/bin/podman-api" /run/podman/podman.sock \
+    run docker.io/library/busybox:latest echo hello-from-root-daemon \
+    > "$SNAP_COMMON/root-daemon.out" 2>&1

--- a/tests/main/interfaces-podman/podman-consumer/bin/user-daemon
+++ b/tests/main/interfaces-podman/podman-consumer/bin/user-daemon
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run a container via the rootless podman socket and write the result.
+# XDG_RUNTIME_DIR inside a snap is snap-specific; derive the real path from UID.
+USER_SOCK="/run/user/$(id -u)/podman/podman.sock"
+"$SNAP/bin/podman-api" "$USER_SOCK" \
+    run docker.io/library/busybox:latest echo hello-from-user-daemon \
+    > "$SNAP_USER_COMMON/user-daemon.out" 2>&1

--- a/tests/main/interfaces-podman/podman-consumer/meta/snap.yaml
+++ b/tests/main/interfaces-podman/podman-consumer/meta/snap.yaml
@@ -1,0 +1,21 @@
+name: podman-consumer
+version: 1.0
+summary: Basic podman consumer snap
+description: A test snap declaring a plug on podman
+base: core24
+
+apps:
+  podman-api:
+    command: bin/podman-api
+    plugs: [podman]
+  root-daemon:
+    command: bin/root-daemon
+    daemon: oneshot
+    install-mode: disable
+    plugs: [podman]
+  user-daemon:
+    command: bin/user-daemon
+    daemon: oneshot
+    daemon-scope: user
+    install-mode: disable
+    plugs: [podman]

--- a/tests/main/interfaces-podman/task.yaml
+++ b/tests/main/interfaces-podman/task.yaml
@@ -1,0 +1,134 @@
+summary: Ensure that the podman interface works.
+
+details: |
+  The podman interface grants access to the Podman daemon socket. This test
+  exercises four confinement scenarios:
+
+  1. Root command    — creates containers via the system socket (/run/podman/podman.sock)
+  2. Root daemon     — creates containers via the system socket as a system service
+  3. User command    — creates containers via the rootless socket as a regular user
+  4. User daemon     — creates containers via the rootless socket as a user service
+
+  Each scenario verifies that real container lifecycle operations (create, start,
+  wait, remove) succeed when the plug is connected, and that the command cases
+  are denied when the plug is disconnected.
+
+systems:
+  # No Podman on Ubuntu Core
+  - -ubuntu-core-*
+  # No Podman before 24.04
+  - -ubuntu-1*
+  - -ubuntu-20.04-*
+  - -ubuntu-22.04-*
+
+environment:
+  IMAGE: docker.io/library/busybox:latest
+  ROOT_SOCK: /run/podman/podman.sock
+  ROOT_DAEMON_OUT: /var/snap/podman-consumer/common/root-daemon.out
+  USER_DAEMON_OUT: /home/test/snap/podman-consumer/common/user-daemon.out
+
+prepare: |
+  echo "Install podman"
+  tests.pkgs install podman
+
+  echo "Enable and start the podman system socket"
+  systemctl enable --now podman.socket
+
+  echo "Pull the test image (system)"
+  podman pull "$IMAGE"
+
+  echo "Set up user session for rootless testing"
+  snap set system experimental.user-daemons=true
+  tests.session kill-leaked
+  tests.session -u test prepare
+
+  echo "Enable the rootless podman socket for the test user"
+  tests.session -u test exec systemctl --user enable --now podman.socket
+
+  echo "Pull the test image (rootless)"
+  tests.session -u test exec podman pull "$IMAGE"
+
+  echo "Install the test snap"
+  "$TESTSTOOLS"/snaps-state install-local podman-consumer
+
+restore: |
+  tests.session -u test exec systemctl --user disable --now podman.socket || true
+  tests.session -u test restore
+  snap unset system experimental.user-daemons
+
+  podman system prune -af || true
+  systemctl disable --now podman.socket || true
+
+  rm -f "$ROOT_DAEMON_OUT" "$USER_DAEMON_OUT"
+
+debug: |
+  set +e
+  cat /var/lib/snapd/apparmor/profiles/snap.podman-consumer.podman-api 2>/dev/null
+  systemctl status podman.socket
+  tests.session -u test exec systemctl --user status podman.socket
+  journalctl -u snap.podman-consumer.root-daemon.service
+  tests.session -u test exec journalctl --user -u snap.podman-consumer.user-daemon.service
+  echo "=== root-daemon output ==="
+  cat "$ROOT_DAEMON_OUT" 2>/dev/null
+  echo "=== user-daemon output ==="
+  tests.session -u test exec cat /home/test/snap/podman-consumer/common/user-daemon.out 2>/dev/null || true
+
+execute: |
+  echo "The plug is disconnected by default"
+  snap connections --all | MATCH "podman +podman-consumer:podman +- +-"
+
+  snap connect podman-consumer:podman
+  snap connections | MATCH "podman +podman-consumer:podman +:podman"
+
+  TEST_UID=$(id -u test)
+  USER_SOCK="/run/user/${TEST_UID}/podman/podman.sock"
+
+  echo "=== Case 1: root command — system socket ==="
+  podman-consumer.podman-api "$ROOT_SOCK" run "$IMAGE" echo hello-from-root-command \
+      | MATCH "exit_code=0"
+
+  echo "=== Case 2: root daemon — system socket ==="
+  rm -f "$ROOT_DAEMON_OUT"
+  snap start podman-consumer.root-daemon
+  retry -n 30 --wait 1 test -f "$ROOT_DAEMON_OUT"
+  MATCH "exit_code=0" < "$ROOT_DAEMON_OUT"
+
+  echo "=== Case 3: user command — rootless socket ==="
+  tests.session -u test exec podman-consumer.podman-api "$USER_SOCK" run "$IMAGE" echo hello-from-user-command \
+      | MATCH "exit_code=0"
+
+  echo "=== Case 4: user daemon — rootless socket ==="
+  rm -f "$USER_DAEMON_OUT"
+  tests.session -u test exec systemctl --user start snap.podman-consumer.user-daemon.service
+  retry -n 30 --wait 1 test -f "$USER_DAEMON_OUT"
+  MATCH "exit_code=0" < "$USER_DAEMON_OUT"
+
+  if [ "$(snap debug confinement)" = strict ] ; then
+      echo "Verify AppArmor profile covers both socket paths"
+      MATCH '/{,var/}run/podman/podman.sock rw,' \
+          < /var/lib/snapd/apparmor/profiles/snap.podman-consumer.podman-api
+      MATCH 'owner /{,var/}run/user/\[0-9\]\*/podman/podman.sock rw,' \
+          < /var/lib/snapd/apparmor/profiles/snap.podman-consumer.podman-api
+
+      echo "When the plug is disconnected"
+      snap disconnect podman-consumer:podman
+
+      echo "Root command is denied on the system socket"
+      if podman-consumer.podman-api "$ROOT_SOCK" info 2>root-denied.error; then
+          echo "Expected denial for root command"
+          exit 1
+      fi
+      MATCH "Permission denied" < root-denied.error
+
+      echo "User command is denied on the rootless socket"
+      if tests.session -u test exec podman-consumer.podman-api "$USER_SOCK" info \
+              2>user-denied.error; then
+          echo "Expected denial for user command"
+          exit 1
+      fi
+      MATCH "Permission denied" < user-denied.error
+  fi
+
+  echo "Reconnect and confirm containers still work"
+  snap connect podman-consumer:podman
+  podman-consumer.podman-api "$ROOT_SOCK" run "$IMAGE" echo reconnected | MATCH "exit_code=0"


### PR DESCRIPTION
Gives access to the podman socket.

Targeted at non-snapped podman. Targeting snapped or both snapped and nonsnapped runs into the same socket related issues as docker.

User socket only works if --experimental is set. Reminder to turn that off in the spread test once user services are out of --experimental.

Pending @zyga @pedronis strategy guidance