### PR TITLE
cmd/snap-confine: allow inheriting unix sockets from snaps

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -613,4 +613,9 @@
     deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
     deny /etc/nsswitch.conf r,
     deny /etc/passwd r,
+
+    # Allow snap-confine to inherit sockets from other snaps. This prevents classic snaps
+    # from having broken stdin redirected to unix sockets that are established by said snap,
+    # e.g. opencode.
+    unix (send, receive) addr=none peer=(addr=none, label="snap.*"),
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -58,7 +58,7 @@ package apparmor
 // 'base: other').
 //
 // The preamble and default accesses common to all bases go in templateCommon.
-// These rules include the aformentioned host file rules as well as non-file
+// These rules include the aforementioned host file rules as well as non-file
 // rules (eg signal, dbus, unix, etc).
 var templateCommon = `
 # vim:syntax=apparmor
@@ -504,6 +504,11 @@ var templateCommon = `
   # Work around for https://gitlab.com/apparmor/apparmor/-/issues/571
   # which prevents access to mmap MAP_HUGETLB.
   allow file / rwm,
+
+  # Allow snaps to inherit sockets from other snaps. This prevents snaps
+  # invoked by classic snaps with output redirected to a socket pair from losing
+  # their stdio files.
+  unix (send, receive) addr=none peer=(addr=none, label="snap.*"),
   
   ###DEVMODE_SNAP_CONFINE###
 `

--- a/tests/main/classic-snap-confine-unix-inheritance/task.yaml
+++ b/tests/main/classic-snap-confine-unix-inheritance/task.yaml
@@ -1,0 +1,32 @@
+summary: Classic snaps can launch other snaps and use unix socket pairs for I/O
+
+details: |
+    Classic snaps are not constrained by apparmor but when they invoke snap-confine,
+    indirectly, to launch another snap, with I/O redirected to a unix socket pair,
+    they may observe that I/O is lost because kernel re-validation of inherited file
+    descriptors when executing snap-confine, causes them to be closed and replaced with
+    /dev/null, unless snap-confine itself had rights to access them.
+
+    Snap-confine now has a rule that allows it to use unix sockets labelled by another
+    snap which should allow a classic launcher (e.g. opencode) to run a strictly confined
+    snap while retaining I/O redirection.
+
+systems: [-ubuntu-core-*]
+
+prepare: |
+    if [ ! -e /snap ]; then
+      ln -s /var/lib/snapd/snap /snap
+      tests.cleanup defer rm -f /snap
+    fi
+    snap pack test-snapd-classic-launcher
+    snap install --classic --dangerous test-snapd-classic-launcher_1.0_all.snap
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-classic-confinement --classic
+
+execute: |
+    # Running non-snap application works:
+    test-snapd-classic-launcher echo hello | MATCH hello
+    # Running strict snap application works:
+    test-snapd-classic-launcher snap run test-snapd-sh.sh -c "echo hello" | MATCH hello
+    # Running classic snap application works.
+    test-snapd-classic-launcher snap run test-snapd-classic-confinement.sh -c "echo hello" | MATCH hello

--- a/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/bin/run
+++ b/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/bin/run
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import socket, os, sys, subprocess, threading
+
+
+def main() -> None:
+    # Create socketpair
+    s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    # Use subprocess to run the command with stdout/stderr connected to the socket.
+    # The socket fd s2 is inherited as stdout/stderr by the child process.
+    proc = subprocess.Popen(sys.argv[1:], stdout=s2.fileno(), stderr=s2.fileno())
+
+    # Parent: close s2 (parent's copy), start drain thread (reads from s1), wait
+    s2.close()
+
+    # Drain socket into stdout.
+    def drain() -> None:
+        try:
+            while True:
+                data = s1.recv(65536)
+                if not data:
+                    break
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+        except Exception as exc:
+            println("exception: {}".format(exc), file=os.stderr)
+            pass
+        finally:
+            s1.close()
+
+    t = threading.Thread(target=drain, daemon=True)
+    t.start()
+
+    # Wait for child (draining socket during wait)
+    proc.wait()
+
+    # Close s1 to signal EOF to drain thread
+    s1.close()
+    t.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/meta/snap.yaml
+++ b/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-classic-launcher
+version: 1.0
+confinement: classic
+
+apps:
+    test-snapd-classic-launcher:
+        command: bin/run


### PR DESCRIPTION
This fixes calling snaps from classic snaps, e.g. opencode can now correctly call snapcraft or go and actually see the output without redirecting it to a file.
