### PR TITLE
o/configstate: validate map keys in JSON config values

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -48,6 +48,31 @@ func ParseKey(key string) (subkeys []string, err error) {
 	return subkeys, nil
 }
 
+// validateMapKeys takes an unmarshalled JSON object and checks that any map
+// keys nested within match the format expected by path keys.
+func validateMapKeys(value any) error {
+	switch v := value.(type) {
+	case map[string]any:
+		for k, sub := range v {
+			if !validKey.MatchString(k) {
+				return fmt.Errorf("invalid option name: %q", k)
+			}
+
+			if err := validateMapKeys(sub); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, elem := range v {
+			if err := validateMapKeys(elem); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func purgeNulls(config any) any {
 	switch config := config.(type) {
 	// map of json raw messages is the starting point for purgeNulls, this is the configuration we receive

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -48,14 +48,22 @@ func ParseKey(key string) (subkeys []string, err error) {
 	return subkeys, nil
 }
 
+type invalidKeyError struct {
+	field string
+}
+
+func (e *invalidKeyError) Error() string {
+	return fmt.Sprintf("invalid option name: %q", e.field)
+}
+
 // validateMapKeys takes an unmarshalled JSON object and checks that any map
 // keys nested within match the format expected by path keys.
-func validateMapKeys(value any) error {
+func validateMapKeys(value any) *invalidKeyError {
 	switch v := value.(type) {
 	case map[string]any:
 		for k, sub := range v {
 			if !validKey.MatchString(k) {
-				return fmt.Errorf("invalid option name: %q", k)
+				return &invalidKeyError{field: k}
 			}
 
 			if err := validateMapKeys(sub); err != nil {
@@ -321,6 +329,7 @@ type ConfSetter interface {
 // patch keys can be dotted as the key argument to Set.
 // The patch is applied according to the order of its keys sorted by depth,
 // with top keys sorted first.
+// State must be locked by caller.
 func Patch(cfg ConfSetter, snapName string, patch map[string]any) error {
 	patchKeys := sortPatchKeysByDepth(patch)
 	for _, key := range patchKeys {

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -39,6 +39,16 @@ var _ = Suite(&configHelpersSuite{})
 
 func (s *configHelpersSuite) SetUpTest(c *C) {
 	s.state = state.New(nil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapJSON := json.RawMessage(`{}`)
+	s.state.Set("snaps", map[string]*json.RawMessage{
+		"snap1":     &snapJSON,
+		"snap2":     &snapJSON,
+		"snap3":     &snapJSON,
+		"some-snap": &snapJSON,
+	})
 }
 
 func (s *configHelpersSuite) TestConfigSnapshot(c *C) {

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -150,6 +150,10 @@ func (t *Transaction) Set(instanceName, key string, value any) error {
 		return errors.New("internal error: key cannot be an empty string")
 	}
 
+	if err := validateMapKeys(value); err != nil {
+		return err
+	}
+
 	config := t.changes[instanceName]
 	if config == nil {
 		config = make(map[string]any)

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 // Transaction holds a copy of the configuration originally present in the
@@ -134,6 +135,33 @@ func shadowsExternalConfig(instanceName string, key string, value any) error {
 	return nil
 }
 
+// snapBase returns the base for the given instance name. State must be locked
+// by caller.
+func snapBase(st *state.State, instanceName string) (string, error) {
+	type partialSnap struct {
+		Base string `json:"base"`
+	}
+
+	var snaps map[string]*json.RawMessage
+	err := st.Get("snaps", &snaps)
+	if err != nil {
+		return "", err
+	}
+
+	raw, ok := snaps[instanceName]
+	if !ok {
+		return "", state.ErrNoState
+	}
+
+	var snap partialSnap
+	err = json.Unmarshal(*raw, &snap)
+	if err != nil {
+		return "", fmt.Errorf("cannot unmarshal snap state: %v", err)
+	}
+
+	return snap.Base, nil
+}
+
 // Set sets the provided snap's configuration key to the given value.
 // The provided key may be formed as a dotted key path through nested maps.
 // For example, the "a.b.c" key describes the {a: {b: {c: value}}} map.
@@ -142,6 +170,7 @@ func shadowsExternalConfig(instanceName string, key string, value any) error {
 //
 // The provided value must marshal properly by encoding/json.
 // Changes are not persisted until Commit is called.
+// State must be locked by caller.
 func (t *Transaction) Set(instanceName, key string, value any) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -150,8 +179,22 @@ func (t *Transaction) Set(instanceName, key string, value any) error {
 		return errors.New("internal error: key cannot be an empty string")
 	}
 
-	if err := validateMapKeys(value); err != nil {
-		return err
+	if keyErr := validateMapKeys(value); keyErr != nil {
+		if instanceName == "system" || instanceName == "core" {
+			return keyErr
+		}
+
+		base, err := snapBase(t.state, instanceName)
+		if err != nil {
+			return fmt.Errorf("cannot set option for %q: %w", instanceName, err)
+		}
+
+		coreVer, err := naming.CoreVersion(base)
+		if err == nil && coreVer >= 26 {
+			return keyErr
+		}
+
+		t.state.Warnf("Option value has invalid field name %q. For core26+ snaps, fields must be dash separated lowercase alphanumerics.", keyErr.field)
 	}
 
 	config := t.changes[instanceName]

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -356,6 +356,13 @@ var setGetTests = [][]setGetOp{{
 	`set one.bad--bad.two=1 => invalid option name: "bad--bad"`,
 	`set one.-bad.two=1 => invalid option name: "-bad"`,
 	`set one.bad-.two=1 => invalid option name: "bad-"`,
+	// Invalid keys nested in JSON objects.
+	`set one={"Bad":1} => invalid option name: "Bad"`,
+	`set one={"bad_key":1} => invalid option name: "bad_key"`,
+	`set one={"good":{"Bad":1}} => invalid option name: "Bad"`,
+	`set one=[{"Bad":1}] => invalid option name: "Bad"`,
+	`set one=[{"good":{"Bad":1}}] => invalid option name: "Bad"`,
+	`set one=[1,[{"Bad":1}]] => invalid option name: "Bad"`,
 }}
 
 func (s *transactionSuite) TestSetGet(c *C) {

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -49,6 +49,12 @@ func (s *transactionSuite) SetUpTest(c *C) {
 	s.transaction = config.NewTransaction(s.state)
 
 	config.ClearExternalConfigMap()
+
+	snapJSON := json.RawMessage(`{}`)
+	s.state.Set("snaps", map[string]*json.RawMessage{
+		"some-snap":  &snapJSON,
+		"other-snap": &snapJSON,
+	})
 }
 
 type setGetOp string
@@ -502,33 +508,33 @@ func (s *transactionSuite) TestCommitOverNilSnapConfig(c *C) {
 	defer s.state.Unlock()
 
 	// simulate invalid nil map created due to LP #1917870 by snap restore
-	s.state.Set("config", map[string]any{"test-snap": nil})
+	s.state.Set("config", map[string]any{"some-snap": nil})
 	t := config.NewTransaction(s.state)
 
-	c.Assert(t.Set("test-snap", "foo", "bar"), IsNil)
+	c.Assert(t.Set("some-snap", "foo", "bar"), IsNil)
 	t.Commit()
 	var v string
-	t.Get("test-snap", "foo", &v)
+	t.Get("some-snap", "foo", &v)
 	c.Assert(v, Equals, "bar")
 }
 
 func (s *transactionSuite) TestGetUnmarshalError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(s.transaction.Set("test-snap", "foo", "good"), IsNil)
+	c.Check(s.transaction.Set("some-snap", "foo", "good"), IsNil)
 	s.transaction.Commit()
 
 	tr := config.NewTransaction(s.state)
-	c.Check(tr.Set("test-snap", "foo", "break"), IsNil)
+	c.Check(tr.Set("some-snap", "foo", "break"), IsNil)
 
 	// Pristine state is good, value in the transaction breaks.
 	broken := brokenType{`"break"`}
-	err := tr.Get("test-snap", "foo", &broken)
+	err := tr.Get("some-snap", "foo", &broken)
 	c.Assert(err, ErrorMatches, ".*BAM!.*")
 
 	// Pristine state breaks, nothing in the transaction.
 	tr.Commit()
-	err = tr.Get("test-snap", "foo", &broken)
+	err = tr.Get("some-snap", "foo", &broken)
 	c.Assert(err, ErrorMatches, ".*BAM!.*")
 }
 
@@ -557,19 +563,19 @@ func (s *transactionSuite) TestPristineIsNotTainted(c *C) {
 	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
-	c.Check(tr.Set("test-snap", "foo.a.a", "a"), IsNil)
+	c.Check(tr.Set("some-snap", "foo.a.a", "a"), IsNil)
 	tr.Commit()
 
 	var data any
 	var result any
 	tr = config.NewTransaction(s.state)
-	c.Check(tr.Set("test-snap", "foo.b", "b"), IsNil)
-	c.Check(tr.Set("test-snap", "foo.a.a", "b"), IsNil)
-	c.Assert(tr.Get("test-snap", "foo", &result), IsNil)
+	c.Check(tr.Set("some-snap", "foo.b", "b"), IsNil)
+	c.Check(tr.Set("some-snap", "foo.a.a", "b"), IsNil)
+	c.Assert(tr.Get("some-snap", "foo", &result), IsNil)
 	c.Check(result, DeepEquals, map[string]any{"a": map[string]any{"a": "b"}, "b": "b"})
 
 	pristine := tr.PristineConfig()
-	c.Assert(json.Unmarshal([]byte(*pristine["test-snap"]["foo"]), &data), IsNil)
+	c.Assert(json.Unmarshal([]byte(*pristine["some-snap"]["foo"]), &data), IsNil)
 	c.Assert(data, DeepEquals, map[string]any{"a": map[string]any{"a": "a"}})
 }
 
@@ -910,4 +916,54 @@ func (s *transactionSuite) TestEmptyKeyValue(c *C) {
 
 	err = tr.Set("some-snap", "", nil)
 	c.Assert(err, ErrorMatches, "internal error: key cannot be an empty string")
+}
+
+func (s *transactionSuite) TestBadFieldErrorCore26AndSystemSnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapState := json.RawMessage(`{"base": "core26"}`)
+	s.state.Set("snaps", map[string]*json.RawMessage{
+		"my-snap": &snapState,
+	})
+
+	tests := []struct {
+		snap string
+		key  string
+		val  any
+		err  string
+	}{
+		{snap: "system", key: "opts", val: map[string]any{"Bad": 1}, err: `invalid option name: "Bad"`},
+		{snap: "system", key: "opts", val: map[string]any{"good": 1}},
+		{snap: "my-snap", key: "opts", val: map[string]any{"Bad": 1}, err: `invalid option name: "Bad"`},
+		{snap: "my-snap", key: "opts", val: map[string]any{"good": 1}},
+	}
+
+	for _, t := range tests {
+		tr := config.NewTransaction(s.state)
+		err := tr.Set(t.snap, t.key, t.val)
+		if t.err != "" {
+			c.Check(err, ErrorMatches, t.err, Commentf("snap=%q key=%q val=%v", t.snap, t.key, t.val))
+		} else {
+			c.Check(err, IsNil, Commentf("snap=%q key=%q val=%v", t.snap, t.key, t.val))
+		}
+	}
+}
+
+func (s *transactionSuite) TestWarnBadFieldForNonCore26Snaps(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapState := json.RawMessage(`{"base": "core22"}`)
+	s.state.Set("snaps", map[string]*json.RawMessage{
+		"my-snap": &snapState,
+	})
+
+	tr := config.NewTransaction(s.state)
+	err := tr.Set("my-snap", "opts", map[string]any{"Bad": 1})
+	c.Assert(err, IsNil)
+
+	ws := s.state.AllWarnings()
+	c.Assert(ws, HasLen, 1)
+	c.Check(ws[0].String(), Matches, `Option value has invalid field name "Bad". For core26\+ snaps, fields must be dash separated lowercase alphanumerics.`)
 }

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -20,6 +20,7 @@
 package ctlcmd_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -141,6 +142,9 @@ func (s *getSuite) TestGetTests(c *C) {
 		state := state.New(nil)
 		state.Lock()
 
+		snapJSON := json.RawMessage(`{}`)
+		state.Set("snaps", map[string]*json.RawMessage{"test-snap": &snapJSON})
+
 		task := state.NewTask("test-task", "my test task")
 		setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "test-hook"}
 
@@ -202,6 +206,9 @@ func (s *getSuite) TestGetPartialNestedStruct(c *C) {
 		state := state.New(nil)
 		state.Lock()
 
+		snapJSON := json.RawMessage(`{}`)
+		state.Set("snaps", map[string]*json.RawMessage{"test-snap": &snapJSON})
+
 		task := state.NewTask("test-task", "my test task")
 		setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "test-hook"}
 
@@ -242,6 +249,9 @@ func (s *getSuite) TestGetPartialNestedStruct(c *C) {
 func (s *getSuite) TestGetRegularUser(c *C) {
 	state := state.New(nil)
 	state.Lock()
+
+	snapJSON := json.RawMessage(`{}`)
+	state.Set("snaps", map[string]*json.RawMessage{"test-snap": &snapJSON})
 
 	task := state.NewTask("test-task", "my test task")
 	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "test-hook"}

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -164,7 +164,9 @@ func (s *setCommand) setConfigSetting(context *hookstate.Context) error {
 	}
 
 	for _, key := range confKeys {
-		tr.Set(s.context().InstanceName(), key, confValues[key])
+		if err := tr.Set(s.context().InstanceName(), key, confValues[key]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -154,8 +154,8 @@ func (s *setCommand) Execute(args []string) error {
 
 func (s *setCommand) setConfigSetting(context *hookstate.Context) error {
 	context.Lock()
+	defer context.Unlock()
 	tr := configstate.ContextTransaction(context)
-	context.Unlock()
 
 	opts := &clientutil.ParseConfigOptions{String: s.String, Typed: s.Typed}
 	confValues, confKeys, err := clientutil.ParseConfigValues(s.Positional.ConfValues, opts)

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -75,6 +75,11 @@ func (s *setSuite) TestInvalidArguments(c *C) {
 	c.Check(err, ErrorMatches, ".*interface attributes can only be set during the execution of prepare hooks.*")
 }
 
+func (s *setSuite) TestSetInvalidValueKey(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set", `foo={"bad_key":1}`}, 0, nil)
+	c.Assert(err, ErrorMatches, `invalid option name: "bad_key"`)
+}
+
 func (s *setSuite) TestCommand(c *C) {
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "foo=bar", "baz=qux"}, 0, nil)
 	c.Check(err, IsNil)

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -58,6 +58,11 @@ func (s *setSuite) SetUpTest(c *C) {
 	state.Lock()
 	defer state.Unlock()
 
+	snapJSON := json.RawMessage(`{"base": "core26"}`)
+	state.Set("snaps", map[string]*json.RawMessage{
+		"test-snap": &snapJSON,
+	})
+
 	task := state.NewTask("test-task", "my test task")
 	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "test-hook"}
 

--- a/overlord/hookstate/ctlcmd/unset.go
+++ b/overlord/hookstate/ctlcmd/unset.go
@@ -81,8 +81,8 @@ func (s *unsetCommand) Execute(args []string) error {
 
 	if !s.View {
 		context.Lock()
+		defer context.Unlock()
 		tr := configstate.ContextTransaction(context)
-		context.Unlock()
 
 		// unsetting options
 		for _, confKey := range s.Positional.ConfKeys {

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -20,6 +20,7 @@
 package ctlcmd_test
 
 import (
+	"encoding/json"
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -47,6 +48,11 @@ func (s *unsetSuite) SetUpTest(c *C) {
 	state := state.New(nil)
 	state.Lock()
 	defer state.Unlock()
+
+	snapJSON := json.RawMessage(`{}`)
+	state.Set("snaps", map[string]*json.RawMessage{
+		"test-snap": &snapJSON,
+	})
 
 	task := state.NewTask("test-task", "my test task")
 	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "hook"}

--- a/snap/naming/core_version.go
+++ b/snap/naming/core_version.go
@@ -29,10 +29,9 @@ var (
 	coreNameFormat = regexp.MustCompile("^core(?P<version>[0-9]*)(?:-.*)?$")
 )
 
-// CoreVersion extract the version component of the core snap name
+// CoreVersion extract the version component of the core snap name.
 // Most core snap names are of the form coreXX where XX is a number.
-// CoreVersion returns that number. In case of "core", it returns
-// 16.
+// CoreVersion returns that number. In case of "core", it returns 16.
 func CoreVersion(base string) (int, error) {
 	foundCore := coreNameFormat.FindStringSubmatch(base)
 

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -126,9 +126,9 @@ case $command in
 	"test-nonexisting")
 		test_nonexisting
 		;;
-  "test-snapctl-set-bar-doc")
-    test_snapctl_set_bar_doc
-    ;;
+	"test-snapctl-set-bar-doc")
+		test_snapctl_set_bar_doc
+		;;
 	"test-snapctl-set-foo")
 		test_snapctl_set_foo
 		;;
@@ -136,27 +136,27 @@ case $command in
 		test_snapctl_get_foo
 		;;
 	"test-snapctl-foo-null")
-    test_snapctl_foo_null
-    ;;
+		test_snapctl_foo_null
+		;;
 	"test-exit-one")
 		test_exit_one
 		;;
-  "test-get-int")
-    test_get_int_number
-    ;;
-  "test-get-nested")
-    test_get_nested
-    ;;
-  "test-unset-with-unset")
-    test_snapctl_unset_with_unset
+	"test-get-int")
+		test_get_int_number
 		;;
-  "noop")
+	"test-get-nested")
+		test_get_nested
 		;;
-  "test-unset")
-    test_snapctl_unset
+	"test-unset-with-unset")
+		test_snapctl_unset_with_unset
 		;;
-  "test-snapctl-set-invalid-field")
-    test_snapctl_set_invalid_field
+	"noop")
+		;;
+	"test-unset")
+		test_snapctl_unset
+		;;
+	"test-snapctl-set-invalid-field")
+		test_snapctl_set_invalid_field
 		;;
 	*)
 		echo "Invalid command: '$command'"

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -24,6 +24,14 @@ test_snapctl_set_bar_doc() {
   fi
 }
 
+test_snapctl_set_invalid_field() {
+  echo "Setting bar to object with invalid field"
+  if ! snapctl set -t bar="{\"Foo\":3}"; then
+    echo "snapctl set unexpectedly failed"
+    exit 1
+  fi
+}
+
 test_snapctl_get_foo() {
 	echo "Getting foo"
 	if ! output="$(snapctl get foo)"; then
@@ -141,12 +149,15 @@ case $command in
     ;;
   "test-unset-with-unset")
     test_snapctl_unset_with_unset
-	;;
+		;;
   "noop")
-	;;
+		;;
   "test-unset")
     test_snapctl_unset
-	;;
+		;;
+  "test-snapctl-set-invalid-field")
+    test_snapctl_set_invalid_field
+		;;
 	*)
 		echo "Invalid command: '$command'"
 		exit 1

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -87,11 +87,11 @@ execute: |
     fi
     [[ "$obtained" == *"invalid option name"* ]]
 
-    if obtained=$(snap set -t snapctl-hooks 'command=[{"Foo":123}]' 2>&1); then
-        echo "Expected usage of an invalid key to result in an error"
-        exit 1
-    fi
-    [[ "$obtained" == *"invalid option name"* ]]
+    # although the "Foo" field is invalid, we only error on this for core26+ snaps.
+    # For other snaps we log a warning
+    snap set snapctl-hooks command=test-snapctl-set-invalid-field
+    snap warnings | tail -n2 | tr -d '\n' | tr -s '  ' ' ' | grep -F 'Option value has invalid field name "Foo". For core26+ snaps, fields must be dash separated lowercase alphanumerics.'
+    snap okay
 
     echo "Install should fail altogether as it has a broken hook"
     if obtained=$(snap install --dangerous failing-config-hooks_1.0_all.snap 2>&1); then

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -87,6 +87,12 @@ execute: |
     fi
     [[ "$obtained" == *"invalid option name"* ]]
 
+    if obtained=$(snap set -t snapctl-hooks 'command=[{"Foo":123}]' 2>&1); then
+        echo "Expected usage of an invalid key to result in an error"
+        exit 1
+    fi
+    [[ "$obtained" == *"invalid option name"* ]]
+
     echo "Install should fail altogether as it has a broken hook"
     if obtained=$(snap install --dangerous failing-config-hooks_1.0_all.snap 2>&1); then
         echo "Expected install of snap with broken configure hook to fail"

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -90,7 +90,7 @@ execute: |
     # although the "Foo" field is invalid, we only error on this for core26+ snaps.
     # For other snaps we log a warning
     snap set snapctl-hooks command=test-snapctl-set-invalid-field
-    snap warnings | tail -n2 | tr -d '\n' | tr -s '  ' ' ' | grep -F 'Option value has invalid field name "Foo". For core26+ snaps, fields must be dash separated lowercase alphanumerics.'
+    snap warnings | tail -n2 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'Option value has invalid field name "Foo". For core26\+ snaps, fields must be dash separated lowercase alphanumerics.'
     snap okay
 
     echo "Install should fail altogether as it has a broken hook"

--- a/tests/main/snapctl-from-snap/snapctl-from-snap-core26/bin/snapctl-get
+++ b/tests/main/snapctl-from-snap/snapctl-from-snap-core26/bin/snapctl-get
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl get "$@"

--- a/tests/main/snapctl-from-snap/snapctl-from-snap-core26/bin/snapctl-set
+++ b/tests/main/snapctl-from-snap/snapctl-from-snap-core26/bin/snapctl-set
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl set "$@"

--- a/tests/main/snapctl-from-snap/snapctl-from-snap-core26/meta/hooks/configure
+++ b/tests/main/snapctl-from-snap/snapctl-from-snap-core26/meta/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl set foo=bar

--- a/tests/main/snapctl-from-snap/snapctl-from-snap-core26/meta/snap.yaml
+++ b/tests/main/snapctl-from-snap/snapctl-from-snap-core26/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: snapctl-from-snap-core26
+version: 1.0
+base: core26
+apps:
+    snapctl-get:
+        command: bin/snapctl-get
+    snapctl-set:
+        command: bin/snapctl-set

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -10,6 +10,7 @@ details: |
 environment:
     SNAP/nobase: snapctl-from-snap
     SNAP/wcore18: snapctl-from-snap-core18
+    SNAP/core26: snapctl-from-snap-core26
 
 prepare: |
     echo "Build basic test package"
@@ -71,14 +72,23 @@ execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-get foo | MATCH bar
 
+    echo "Verify invalid option names are rejected"
+    if [ "$SNAP" == "snapctl-from-snap-core26" ]; then
+      "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set Foo=123 2>&1 | MATCH "error: snapctl: invalid option name: \"Foo\""
+      "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo=[{"Bar":1}]' 2>&1 | MATCH "invalid option name: \"Bar\""
+      "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo={"bar_baz":1}' 2>&1 | MATCH "invalid option name: \"bar_baz\""
+      # we don't need to re-run the rest of the test
+      exit 0
+    else
+      "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set Foo=123 2>&1 | MATCH "error: snapctl: invalid option name: \"Foo\""
+      "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo=[{"Bar":1}]'
+      snap warnings | tail -n2 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'Option value has invalid field name "Bar". For core26\+ snaps, fields must be dash separated lowercase alphanumerics.'
+      snap okay
+    fi
+
     echo "Verify that snapctl set can modify configuration values"
     "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set foo=123
     "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-get foo | MATCH 123
-
-    echo "Verify invalid option names are rejected"
-    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set Foo=123 2>&1 | MATCH "error: snapctl: invalid option name: \"Foo\""
-    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo=[{"Bar":1}]' 2>&1 | MATCH "invalid option name: \"Bar\""
-    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo={"bar_baz":1}' 2>&1 | MATCH "invalid option name: \"bar_baz\""
 
     echo "Verify configuration value with snap get"
     snap get "$SNAP" foo | MATCH 123

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -75,6 +75,11 @@ execute: |
     "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set foo=123
     "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-get foo | MATCH 123
 
+    echo "Verify invalid option names are rejected"
+    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set Foo=123 2>&1 | MATCH "error: snapctl: invalid option name: \"Foo\""
+    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo=[{"Bar":1}]' 2>&1 | MATCH "invalid option name: \"Bar\""
+    "$SNAP_MOUNT_DIR/bin/$SNAP".snapctl-set -t 'foo={"bar_baz":1}' 2>&1 | MATCH "invalid option name: \"bar_baz\""
+
     echo "Verify configuration value with snap get"
     snap get "$SNAP" foo | MATCH 123
 


### PR DESCRIPTION
Although we were validating sub-keys in option paths, we weren't doing the analogous check in the JSON objects passed as values. So `snap set foo bar.Bad_name=1` would correctly error but `snap set -t foo bar='{"Bad_name":1}'` wouldn't.

Fixes https://bugs.launchpad.net/snapd/+bug/2072331
https://warthogs.atlassian.net/browse/SNAPDENG-36367

Also related https://github.com/canonical/snapd/pull/14162
