### PR TITLE
cmd/snap: print complex attributes in snap interface output

### DIFF
--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -182,10 +182,21 @@ func (x *cmdInterface) showAttrs(w io.Writer, attrs map[string]any, indent strin
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		value := attrs[name]
-		switch value.(type) {
-		case string, bool, json.Number:
-			fmt.Fprintf(w, "%s  %s:\t%v\n", indent, name, value)
+		x.showAttrValue(w, name, attrs[name], indent)
+	}
+}
+
+func (x *cmdInterface) showAttrValue(w io.Writer, name string, value any, indent string) {
+	switch v := value.(type) {
+	case string, bool, json.Number:
+		fmt.Fprintf(w, "%s  %s:\t%v\n", indent, name, value)
+	case []any:
+		fmt.Fprintf(w, "%s  %s:\n", indent, name)
+		for _, item := range v {
+			fmt.Fprintf(w, "%s    - %v\n", indent, item)
 		}
+	case map[string]any:
+		fmt.Fprintf(w, "%s  %s:\n", indent, name)
+		x.showAttrs(w, v, indent+"  ")
 	}
 }

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -240,6 +240,47 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 	c.Assert(s.Stderr(), Equals, "")
 }
 
+func (s *SnapSuite) TestInterfaceDetailsAndAttrsComplex(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/interfaces")
+		c.Check(r.URL.RawQuery, Equals, "doc=true&names=system-files&plugs=true&select=all&slots=true")
+		body, err := io.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]any{
+			"type": "sync",
+			"result": []*client.Interface{{
+				Name:    "system-files",
+				Summary: "allows access to system files or directories",
+				Plugs: []client.Plug{{
+					Snap: "my-app",
+					Name: "system-files",
+					Attrs: map[string]any{
+						"read":  []any{"/etc/foo", "/etc/bar"},
+						"write": []any{"/var/lib/baz"},
+					},
+				}},
+			}},
+		})
+	})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "--attrs", "system-files"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	expectedStdout := "" +
+		"name:    system-files\n" +
+		"summary: allows access to system files or directories\n" +
+		"plugs:\n" +
+		"  - my-app:\n" +
+		"      read:\n" +
+		"        - /etc/foo\n" +
+		"        - /etc/bar\n" +
+		"      write:\n" +
+		"        - /var/lib/baz\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
 func (s *SnapSuite) TestInterfaceCompletion(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, Equals, "GET")


### PR DESCRIPTION
The output of 'snap interface --attrs' did not properly print attributes using complex data types, such as lists or maps. For this reason, the output for the content or system-files interface lacked details, even though the information is included in the result of snapd API call.

With the patch, the output now contains all necessary information:

```
$ snap interface --attrs system-files
name:          system-files
summary:       allows access to system files or directories
documentation: https://snapcraft.io/docs/system-files-interface
plugs:
  - chromium:etc-chromium-browser-policies:
      read:
        - /etc/chromium-browser/policies
  - cups:etc-cups:
      read:
        - /etc/cups
  - firefox:etc-firefox:
      read:
        - /etc/firefox
  - firefox:host-usr-share-hunspell:
      read:
        - /var/lib/snapd/hostfs/usr/share/hunspell
slots:
  - snapd
```

Fixes: LP#2152908 
Related: SNAPDENG-36922

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
