### PR TITLE
tests: fix nss-modules:winbind test

### DIFF
--- a/tests/main/interfaces-mount-control-cifs/task.yaml
+++ b/tests/main/interfaces-mount-control-cifs/task.yaml
@@ -26,9 +26,7 @@ prepare: |
     fi
 
     tests.pkgs install samba smbclient
-    # back up the origianl configuration
-    tests.backup prepare /etc/samba
-    tests.cleanup defer tests.backup restore /etc/samba
+    tests.cleanup defer tests.pkgs remove --purge samba smbclient
 
     # set up the share
     cat <<-__SMB__ >>'/etc/samba/smb.conf'

--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -86,12 +86,10 @@ prepare: |
         tests.cleanup defer rm -f /etc/exports.d/test.exports
         ;;
       cifs)
-        # Install samba.
         tests.pkgs install samba
+        tests.cleanup defer tests.pkgs remove --purge samba
 
         # Create the var-home share.
-        tests.backup prepare /etc/samba
-        tests.cleanup defer tests.backup restore /etc/samba
         # NOTE: due to <<- and the fact that this is shell-in-yaml, the spaces
         # are followed by tabs.
         cat <<-__SMB__ >>'/etc/samba/smb.conf'


### PR DESCRIPTION
Fix a recurring failure in `nss-modules:winbind` due to files in /etc/samba being leftover from other tests.
```
mv: cannot stat '/etc/samba/smb.conf.bak': No such file or directory
tests.cleanup: deferred command "mv /etc/samba/smb.conf.bak /etc/samba/smb.conf" failed with exit code 1
```

https://warthogs.atlassian.net/browse/SNAPDENG-36927