### PR TITLE
tests: automatically add 'auto rerun spread' label to prs

### DIFF
--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -48,7 +48,7 @@ jobs:
         fi
 
         labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
-        if grep -q '^Skip spread$' <<<$labels; then
+        if grep -q '^Skip spread$' <<<$labels || grep -q '^Run only one system$' <<<$labels'; then
           exit 0
         fi
 

--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -1,9 +1,12 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  pull_request_target:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   triage:
+    if: github.event_name == 'pull_request_target'
     permissions:
       contents: read
       pull-requests: write
@@ -26,12 +29,27 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'Skip spread')
       run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Run only one system'
 
-    - name: Apply auto rerun label using gh CLI
-      env:
-        GH_TOKEN: ${{ github.token }}
-      if: >-
-        (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
-        github.event.pull_request.draft != true &&
-        !contains(github.event.pull_request.labels.*.name, 'Skip spread') &&
-        !contains(github.event.pull_request.labels.*.name, 'Auto rerun spread')
-      run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Auto rerun spread'
+  auto-rerun-label-on-approval:
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+    - name: Add Auto rerun spread label after second approval
+      run: |
+        if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+          exit 0
+        fi
+
+        labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+        if grep -q '^Skip spread$' <<<$labels; then
+          exit 0
+        fi
+
+        approvals=$(gh pr view "$PR_NUMBER" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .author.login' | sort -u | wc -l)
+        if [ "$approvals" -ge 2 ] && ! grep -q '^Auto rerun spread$' <<<$labels; then
+          gh pr edit "$PR_NUMBER" --add-label 'Auto rerun spread'
+        fi

--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -20,5 +20,18 @@ jobs:
     - name: Apply draft label using gh CLI
       env:
         GH_TOKEN: ${{ github.token }}
-      if: github.event.action == 'opened' && github.event.pull_request.draft == true && !contains(github.event.pull_request.labels.*.name, 'Skip spread')
+      if: >-
+        github.event.action == 'opened' &&
+        github.event.pull_request.draft == true &&
+        !contains(github.event.pull_request.labels.*.name, 'Skip spread')
       run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Run only one system'
+
+    - name: Apply auto rerun label using gh CLI
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: >-
+        (github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
+        github.event.pull_request.draft != true &&
+        !contains(github.event.pull_request.labels.*.name, 'Skip spread') &&
+        !contains(github.event.pull_request.labels.*.name, 'Auto rerun spread')
+      run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Auto rerun spread'

--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -38,6 +38,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
     - name: Add Auto rerun spread label after second approval
       run: |
         if [ "${{ github.event.pull_request.draft }}" = "true" ]; then

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -88,8 +88,8 @@ jobs:
             exit 0
           fi
           num_approvals=$(gh pr view "$pr" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .state' | wc -l)
-          if [ $num_approvals = "0" ]; then
-            echo "setting auto rerun to false because it has no approvals"
+          if [ "$num_approvals" -lt 2 ]; then
+            echo "setting auto rerun to false because it has fewer than 2 approvals"
             echo "AUTO_RERUN=false" >> $GITHUB_ENV
           fi
       
@@ -112,8 +112,8 @@ jobs:
             # analyzer will echo out that same line, so grab the first occurrence.
             num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1)
             
-            if [ -n "$num_failed" ] && [ $num_failed -ge 20 ]; then 
-              echo "Setting rerun to false because there were 20 or more failures on a fundamental system"
+            if [ -n "$num_failed" ] && [ $num_failed -ge 30 ]; then
+              echo "Setting rerun to false because there were 30 or more failures on a fundamental system"
               echo "AUTO_RERUN=false" >> $GITHUB_ENV
             fi
           done

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -71,15 +71,7 @@ jobs:
       - name: Unzip PR number
         run: unzip pr_number.zip
 
-      - name: Check for rerun label
-        run: |
-          labels=$(gh pr view $(cat pr_number) --json labels | jq -r '.labels[].name')
-          if grep -q '^Auto rerun spread$' <<<$labels; then
-            echo "AUTO_RERUN=true" >> $GITHUB_ENV
-          fi
-
-      - name: Check for draft and approvals
-        if: env.AUTO_RERUN == 'true'
+      - name: Check for rerun eligibility
         run: |
           pr=$(cat pr_number)
           if [ "$(gh pr view "$pr" --json isDraft --jq '.isDraft')" = "true" ]; then
@@ -87,9 +79,18 @@ jobs:
             echo "AUTO_RERUN=false" >> $GITHUB_ENV
             exit 0
           fi
-          num_approvals=$(gh pr view "$pr" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .state' | wc -l)
-          if [ "$num_approvals" -lt 2 ]; then
-            echo "setting auto rerun to false because it has fewer than 2 approvals"
+
+          labels=$(gh pr view "$pr" --json labels --jq '.labels[].name')
+          has_label=false
+          if grep -q '^Auto rerun spread$' <<<$labels; then
+            has_label=true
+          fi
+
+          num_approvals=$(gh pr view "$pr" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .author.login' | sort -u | wc -l)
+          if [ "$has_label" = "true" ] && [ "$num_approvals" -ge 1 ]; then
+            echo "AUTO_RERUN=true" >> $GITHUB_ENV
+          else
+            echo "setting auto rerun to false because it is missing the label or has insufficient approvals"
             echo "AUTO_RERUN=false" >> $GITHUB_ENV
           fi
       


### PR DESCRIPTION
This change adds the "auto rerun spread" label in the prs, and triggers reruns when the pr has 2 or more approvals. Otherwise the pr is not re-triggered.

Also the max number of failed tests is increased to 30. Otherwise the pr is not re-triggered
