### PR TITLE
many: remove experimental persistent per-user mount namespace feature

### DIFF
--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -47,23 +47,23 @@ static void test_feature_enabled__missing_dir(void) {
     char subd[PATH_MAX];
     sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
     sc_mock_feature_flag_dir(subd);
-    g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+    g_assert_false(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }
 
 static void test_feature_enabled__missing_file(void) {
     const char *d = sc_testdir();
     sc_mock_feature_flag_dir(d);
-    g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+    g_assert_false(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }
 
 static void test_feature_enabled__present_file(void) {
     const char *d = sc_testdir();
     sc_mock_feature_flag_dir(d);
     char pname[PATH_MAX];
-    sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
+    sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
     g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-    g_assert_true(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+    g_assert_true(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }
 
 static void test_feature_parallel_instances(void) {

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -33,9 +33,6 @@ static const char *feature_flag_dir = "/var/lib/snapd/features";
 bool sc_feature_enabled(sc_feature_flag flag) {
     const char *file_name;
     switch (flag) {
-        case SC_FEATURE_PER_USER_MOUNT_NAMESPACE:
-            file_name = "per-user-mount-namespace";
-            break;
         case SC_FEATURE_REFRESH_APP_AWARENESS:
             file_name = "refresh-app-awareness";
             break;

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -21,7 +21,6 @@
 #include <stdbool.h>
 
 typedef enum sc_feature_flag {
-    SC_FEATURE_PER_USER_MOUNT_NAMESPACE = 1 << 0,
     SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
     SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
     SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -21,9 +21,9 @@
 #include <stdbool.h>
 
 typedef enum sc_feature_flag {
-    SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
-    SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
-    SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,
+    SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 0,
+    SC_FEATURE_PARALLEL_INSTANCES = 1 << 1,
+    SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 2,
 } sc_feature_flag;
 
 /**

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -909,17 +909,12 @@ static void enter_non_classic_execution_environment(sc_invocation *inv, struct s
                 die("cannot unshare the mount namespace");
             }
             sc_setup_user_mounts(aa, snap_update_ns_fd, inv->snap_instance);
-            /* Preserve the mount per-user namespace. But only if the
-             * experimental feature is enabled. This way if the feature is
-             * disabled user mount namespaces will still exist but will be
+            /* Do not preserve the mount per-user namespace. User mount
+             * namespaces will still exist but will be
              * entirely ephemeral. In addition the call
              * sc_join_preserved_user_ns() will never find a preserved mount
-             * namespace and will always enter this code branch. */
-            if (sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE)) {
-                sc_preserve_populated_per_user_mount_ns(group);
-            } else {
-                debug("NOT preserving per-user mount namespace");
-            }
+             * namespace. */
+            debug("NOT preserving per-user mount namespace");
         }
     }
     // With cgroups v1, associate each snap process with a dedicated

--- a/features/features.go
+++ b/features/features.go
@@ -40,8 +40,6 @@ const (
 	ParallelInstances
 	// Hotplug controls availability of dynamically creating slots based on system hardware.
 	Hotplug
-	// PerUserMountNamespace controls the persistence of per-user mount namespaces.
-	PerUserMountNamespace
 	// RefreshAppAwareness controls refresh being aware of running applications.
 	RefreshAppAwareness
 	// ClassicPreservesXdgRuntimeDir controls $XDG_RUNTIME_DIR in snaps with classic confinement.
@@ -105,11 +103,10 @@ func KnownFeatures() []SnapdFeature {
 // featureNames maps feature constant to stable string representation.
 // The constants here must be synchronized with cmd/libsnap-confine-private/feature.c
 var featureNames = map[SnapdFeature]string{
-	Layouts:               "layouts",
-	ParallelInstances:     "parallel-instances",
-	Hotplug:               "hotplug",
-	PerUserMountNamespace: "per-user-mount-namespace",
-	RefreshAppAwareness:   "refresh-app-awareness",
+	Layouts:             "layouts",
+	ParallelInstances:   "parallel-instances",
+	Hotplug:             "hotplug",
+	RefreshAppAwareness: "refresh-app-awareness",
 
 	ClassicPreservesXdgRuntimeDir: "classic-preserves-xdg-runtime-dir",
 
@@ -153,9 +150,8 @@ var featuresEnabledWhenUnset = map[SnapdFeature]bool{
 
 // featuresExported contains a set of features that are exported outside of snapd.
 var featuresExported = map[SnapdFeature]bool{
-	PerUserMountNamespace: true,
-	RefreshAppAwareness:   true,
-	ParallelInstances:     true,
+	RefreshAppAwareness: true,
+	ParallelInstances:   true,
 
 	ClassicPreservesXdgRuntimeDir: true,
 	HiddenSnapDataHomeDir:         true,

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -48,7 +48,6 @@ func (*featureSuite) TestName(c *C) {
 	check(features.Layouts, "layouts")
 	check(features.ParallelInstances, "parallel-instances")
 	check(features.Hotplug, "hotplug")
-	check(features.PerUserMountNamespace, "per-user-mount-namespace")
 	check(features.RefreshAppAwareness, "refresh-app-awareness")
 	check(features.ClassicPreservesXdgRuntimeDir, "classic-preserves-xdg-runtime-dir")
 	check(features.UserDaemons, "user-daemons")
@@ -93,7 +92,6 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.Layouts, false)
 	check(features.Hotplug, false)
 	check(features.ParallelInstances, true)
-	check(features.PerUserMountNamespace, true)
 	check(features.RefreshAppAwareness, true)
 	check(features.ClassicPreservesXdgRuntimeDir, true)
 	check(features.UserDaemons, false)
@@ -199,7 +197,7 @@ func (*featureSuite) TestIsEnabled(c *C) {
 	defer dirs.SetRootDir("")
 
 	// If the feature file is absent then the feature is disabled.
-	f := features.PerUserMountNamespace
+	f := features.ParallelInstances
 	c.Check(f.IsEnabled(), Equals, false)
 
 	// If the feature file is a regular file then the feature is enabled.
@@ -223,7 +221,6 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.Layouts, true)
 	check(features.ParallelInstances, false)
 	check(features.Hotplug, false)
-	check(features.PerUserMountNamespace, false)
 	check(features.RefreshAppAwareness, true)
 	check(features.ClassicPreservesXdgRuntimeDir, true)
 	check(features.UserDaemons, false)
@@ -249,7 +246,6 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 }
 
 func (*featureSuite) TestControlFile(c *C) {
-	c.Check(features.PerUserMountNamespace.ControlFile(), Equals, "/var/lib/snapd/features/per-user-mount-namespace")
 	c.Check(features.RefreshAppAwareness.ControlFile(), Equals, "/var/lib/snapd/features/refresh-app-awareness")
 	c.Check(features.ParallelInstances.ControlFile(), Equals, "/var/lib/snapd/features/parallel-instances")
 	c.Check(features.HiddenSnapDataHomeDir.ControlFile(), Equals, "/var/lib/snapd/features/hidden-snap-folder")

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -68,16 +68,16 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsHappy(c *C) {
 func (s *experimentalSuite) TestExportedFeatures(c *C) {
 	conf := &mockConf{
 		state: s.state,
-		conf:  map[string]any{featureConf(features.PerUserMountNamespace): true},
+		conf:  map[string]any{featureConf(features.HiddenSnapDataHomeDir): true},
 	}
 	err := configcore.FilesystemOnlyRun(classicDev, conf)
 	c.Assert(err, IsNil)
-	c.Check(features.PerUserMountNamespace.ControlFile(), testutil.FilePresent)
+	c.Check(features.HiddenSnapDataHomeDir.ControlFile(), testutil.FilePresent)
 
-	delete(conf.changes, "experimental.per-user-mount-namespace")
+	delete(conf.changes, "experimental.hidden-snap-folder")
 	err = configcore.FilesystemOnlyRun(classicDev, conf)
 	c.Assert(err, IsNil)
-	c.Check(features.PerUserMountNamespace.ControlFile(), testutil.FilePresent)
+	c.Check(features.HiddenSnapDataHomeDir.ControlFile(), testutil.FilePresent)
 }
 
 func (s *experimentalSuite) TestFilesystemOnlyApply(c *C) {

--- a/tests/main/experimental-features/task.yaml
+++ b/tests/main/experimental-features/task.yaml
@@ -1,27 +1,27 @@
 summary: Experimental features are exported by snapd
 
 details: |
-    Some of the experimental features are exported as flag files that can be
-    easily read by snap-confine and snap-update-ns that otherwise don't have
-    access to the system state.
+  Some of the experimental features are exported as flag files that can be
+  easily read by snap-confine and snap-update-ns that otherwise don't have
+  access to the system state.
 
 execute: |
-    # When a feature that is exported is enabled, a file is created.
-    snap set core experimental.per-user-mount-namespace=true
-    test -f /var/lib/snapd/features/per-user-mount-namespace
+  # When a feature that is exported is enabled, a file is created.
+  snap set core experimental.parallel-instances=true
+  test -f /var/lib/snapd/features/parallel-instances
 
-    # When a feature that is exported is disabled, a file is removed.
-    snap set core experimental.per-user-mount-namespace=false
-    test ! -f /var/lib/snapd/features/per-user-mount-namespace
+  # When a feature that is exported is disabled, a file is removed.
+  snap set core experimental.parallel-instances=false
+  test ! -f /var/lib/snapd/features/parallel-instances
 
-    # When a feature that is not exported is enabled, a file is not created.
-    snap set core experimental.layouts=true
-    test ! -f /var/lib/snapd/features/layouts
+  # When a feature that is not exported is enabled, a file is not created.
+  snap set core experimental.layouts=true
+  test ! -f /var/lib/snapd/features/layouts
 
-    # Features are exported when snapd starts up
-    snap set core experimental.parallel-instances=true
-    test -f /var/lib/snapd/features/parallel-instances
-    systemctl stop snapd
-    rm /var/lib/snapd/features/parallel-instances
-    systemctl start snapd
-    test -f /var/lib/snapd/features/parallel-instances
+  # Features are exported when snapd starts up
+  snap set core experimental.parallel-instances=true
+  test -f /var/lib/snapd/features/parallel-instances
+  systemctl stop snapd
+  rm /var/lib/snapd/features/parallel-instances
+  systemctl start snapd
+  test -f /var/lib/snapd/features/parallel-instances

--- a/tests/main/experimental-features/task.yaml
+++ b/tests/main/experimental-features/task.yaml
@@ -1,27 +1,27 @@
 summary: Experimental features are exported by snapd
 
 details: |
-  Some of the experimental features are exported as flag files that can be
-  easily read by snap-confine and snap-update-ns that otherwise don't have
-  access to the system state.
+    Some of the experimental features are exported as flag files that can be
+    easily read by snap-confine and snap-update-ns that otherwise don't have
+    access to the system state.
 
 execute: |
-  # When a feature that is exported is enabled, a file is created.
-  snap set core experimental.parallel-instances=true
-  test -f /var/lib/snapd/features/parallel-instances
+    # When a feature that is exported is enabled, a file is created.
+    snap set core experimental.parallel-instances=true
+    test -f /var/lib/snapd/features/parallel-instances
 
-  # When a feature that is exported is disabled, a file is removed.
-  snap set core experimental.parallel-instances=false
-  test ! -f /var/lib/snapd/features/parallel-instances
+    # When a feature that is exported is disabled, a file is removed.
+    snap set core experimental.parallel-instances=false
+    test ! -f /var/lib/snapd/features/parallel-instances
 
-  # When a feature that is not exported is enabled, a file is not created.
-  snap set core experimental.layouts=true
-  test ! -f /var/lib/snapd/features/layouts
+    # When a feature that is not exported is enabled, a file is not created.
+    snap set core experimental.layouts=true
+    test ! -f /var/lib/snapd/features/layouts
 
-  # Features are exported when snapd starts up
-  snap set core experimental.parallel-instances=true
-  test -f /var/lib/snapd/features/parallel-instances
-  systemctl stop snapd
-  rm /var/lib/snapd/features/parallel-instances
-  systemctl start snapd
-  test -f /var/lib/snapd/features/parallel-instances
+    # Features are exported when snapd starts up
+    snap set core experimental.parallel-instances=true
+    test -f /var/lib/snapd/features/parallel-instances
+    systemctl stop snapd
+    rm /var/lib/snapd/features/parallel-instances
+    systemctl start snapd
+    test -f /var/lib/snapd/features/parallel-instances


### PR DESCRIPTION
Completely remove persistent per-user mount namespace experimental feature. 

Tracked with [SNAPDENG-36931](https://warthogs.atlassian.net/browse/SNAPDENG-36931?atlOrigin=eyJpIjoiMjA1NTA0YzM3YzcwNDZmMjljZjRiNmVlOTQyYzc4ZjQiLCJwIjoiaiJ9) 

[SNAPDENG-36931]: https://warthogs.atlassian.net/browse/SNAPDENG-36931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ