### PR TITLE
interfaces/builtin: make docker implicit on classic

### DIFF
--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -23,7 +23,13 @@ const dockerSummary = `allows access to Docker socket`
 
 const dockerBaseDeclarationSlots = `
   docker:
-    allow-installation: false
+    allow-installation:
+      slot-snap-type:
+        - app
+        - core
+    deny-installation:
+      slot-snap-type:
+        - app
     deny-connection: true
     deny-auto-connection: true
 `
@@ -48,6 +54,7 @@ func init() {
 	registerIface(&commonInterface{
 		name:                  "docker",
 		summary:               dockerSummary,
+		implicitOnClassic:     true,
 		baseDeclarationSlots:  dockerBaseDeclarationSlots,
 		connectedPlugAppArmor: dockerConnectedPlugAppArmor,
 		connectedPlugSecComp:  dockerConnectedPlugSecComp,

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -67,6 +67,11 @@ func (s *DockerInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "docker")
 }
 
+func (s *DockerInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+}
+
 func (s *DockerInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	apparmorSpec := apparmor.NewSpecification(s.plug.AppSet())
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -964,6 +964,26 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	err = ic.Check()
 	c.Assert(err, ErrorMatches, "installation denied by \"docker\" slot rule of interface \"docker\"")
 
+	// The core snap may provide a docker slot (implicit on classic)
+	ic = s.installSlotCand(c, "docker", snap.TypeOS, `name: core
+version: 0
+type: os
+slots:
+  docker:
+`)
+	ic.SnapDeclaration = s.mockSnapDecl(c, "core", "99T7MUlRhtI3U0QFgl5mXXESAiSwt776", "canonical", "")
+	c.Assert(ic.Check(), IsNil)
+
+	// or the snapd snap may provide a docker slot (implicit on classic)
+	ic = s.installSlotCand(c, "docker", snap.TypeOS, `name: snapd
+version: 0
+type: snapd
+slots:
+  docker:
+`)
+	ic.SnapDeclaration = s.mockSnapDecl(c, "snapd", "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4", "canonical", "")
+	c.Assert(ic.Check(), IsNil)
+
 	// test lxd specially
 	ic = s.installSlotCand(c, "lxd", snap.TypeApp, ``)
 	err = ic.Check()

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -889,7 +889,7 @@ var (
 		"docker":                   nil,
 		"egl-driver-libs":          nil,
 		"gbm-driver-libs":          nil,
-		"vulkan-driver-libs":       nil,
+		"gpio-chardev":             nil,
 		"lxd":                      nil,
 		"microceph":                nil,
 		"microceph-support":        nil,
@@ -901,7 +901,7 @@ var (
 		"podman":                   nil,
 		"posix-mq":                 nil,
 		"shared-memory":            nil,
-		"gpio-chardev":             nil,
+		"vulkan-driver-libs":       nil,
 	}
 
 	restrictedPlugInstallation = map[string][]string{
@@ -959,11 +959,10 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	err = icMin.Check()
 	c.Check(err, IsNil)
 
-	// test docker specially
+	// test docker specially - allow-installation for app and core
 	ic = s.installSlotCand(c, "docker", snap.TypeApp, ``)
 	err = ic.Check()
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "installation not allowed by \"docker\" slot rule of interface \"docker\"")
+	c.Assert(err, ErrorMatches, "installation denied by \"docker\" slot rule of interface \"docker\"")
 
 	// test lxd specially
 	ic = s.installSlotCand(c, "lxd", snap.TypeApp, ``)


### PR DESCRIPTION
The docker interface plug allows connecting to the docker socket in the default path /{,var/}run/docker.sock. Since there is no implicit slot, only docker packaged as a snap can satisfy this interface and allow other snaps to connect.

We would like to allow any snap to use docker interface to talk to classically installed docker as well, by making the interface implicit on classic systems.

This presents a small issue when someone DOES install the docker snap. In that case the system will now have two docker slots, the implicit one on the virtual system snap as well as the one on the docker snap itself.

For the moment, this will require people to manually connect the specific snap slot explicitly, although there is no actual difference in permissions as docker snap cannot be used together with the classic package as they both clash on the socket path.

In the future we would like to extend the system policy language to prefer the docker snap if it is installed, and still offer it as the implicit auto-connect candidate.
