### PR TITLE
tests/main/security-logging: on systems with auditd, disable it during seclog testing

### DIFF
--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -22,6 +22,14 @@ prepare: |
     s.close()
     "
 
+    # auditd holds the netlink audit socket exclusively; if it is running,
+    # journald cannot receive audit messages. Stop it so that
+    # systemd-journald-audit.socket can pick them up.
+    if systemctl is-active auditd.service; then
+        touch auditd-was-active
+        systemctl stop auditd.service
+    fi
+
     if ! systemctl is-active systemd-journald-audit.socket; then
         touch audit-socket-was-inactive
         systemctl stop systemd-journald.service
@@ -35,6 +43,11 @@ restore: |
         systemctl stop systemd-journald-audit.socket
         systemctl restart systemd-journald.service
         rm -f audit-socket-was-inactive
+    fi
+
+    if [ -f auditd-was-active ]; then
+        systemctl start auditd.service
+        rm -f auditd-was-active
     fi
 
     snap logout || true


### PR DESCRIPTION
Fix `openstack:opensuse-16.0-64:tests/main/security-logging` and related failures due to auditd installed.

```
026-05-20T06:12:00.4560321Z 2026-05-20 06:10:43 Restoring openstack:opensuse-tumbleweed-selinux-64:tests/main/ (may200603-954180)...
2026-05-20T06:12:00.4562969Z 2026-05-20 06:10:43 Error executing openstack:opensuse-16.0-64:tests/main/security-logging (may200603-954167) :
2026-05-20T06:12:00.4564618Z -----
2026-05-20T06:12:00.4566478Z + echo 'Checking that the security logger is disabled in snapd stop and enabled on snapd start'
2026-05-20T06:12:00.4568612Z Checking that the security logger is disabled in snapd stop and enabled on snapd start
2026-05-20T06:12:00.4570065Z + journal_pin
2026-05-20T06:12:00.4571213Z + /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state start_new_log
2026-05-20T06:12:00.4572999Z + systemctl restart snapd.service
2026-05-20T06:12:00.4574005Z + snap wait system seed.loaded
2026-05-20T06:12:00.4575169Z + journal_match 'security logger disabled' -u snapd.service
2026-05-20T06:12:00.4576403Z + local 'expression=security logger disabled'
2026-05-20T06:12:00.4577370Z + shift
2026-05-20T06:12:00.4579135Z + /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state match-log 'security logger disabled' -n 3 -u snapd.service
2026-05-20T06:12:00.4584606Z + journal_match 'security logger enabled' -u snapd.service
2026-05-20T06:12:00.4586052Z + local 'expression=security logger enabled'
2026-05-20T06:12:00.4589479Z + shift
2026-05-20T06:12:00.4591396Z + /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state match-log 'security logger enabled' -n 3 -u snapd.service
2026-05-20T06:12:00.4593552Z + echo 'Checking that restart produces disable/enable audit events'
2026-05-20T06:12:00.4595036Z Checking that restart produces disable/enable audit events
2026-05-20T06:12:00.4599009Z + journal_match '"level":"INFO","description":"Security logging enabled","app_id":"canonical.snapd.snapd","type":"security","category":"SYS","event":"sys_logging_enabled"'
2026-05-20T06:12:00.4602124Z + local 'expression="level":"INFO","description":"Security logging enabled","app_id":"canonical.snapd.snapd","type":"security","category":"SYS","event":"sys_logging_enabled"'
2026-05-20T06:12:00.4604492Z + shift
2026-05-20T06:12:00.4608158Z + /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/journal-state match-log '"level":"INFO","description":"Security logging enabled","app_id":"canonical.snapd.snapd","type":"security","category":"SYS","event":"sys_logging_enabled"' -n 3
2026-05-20T06:12:00.4611480Z -----
```
