### PR TITLE
store: verify cached downloads in the do path, detect obvious corruption

### DIFF
--- a/store/store_download.go
+++ b/store/store_download.go
@@ -131,14 +131,33 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		return err
 	}
 
-	// TODO: the cache entry may have been corrupted (e.g. due to a power loss
-	// on a filesystem with metadata-only journaling), in which case Get() may
-	// link an invalid file as the download target. Ideally, Get() should verify
-	// the cached entry (e.g. check size against downloadInfo.Size) and treat a
-	// corrupted entry as a cache miss, triggering a re-download from the store.
+	// TODO: we trust the cache to contain valid/uncorrupted data, but we could
+	// Get() to a target path with the .partial suffix and run through the
+	// resumed download verification code path which would automatically
+	// redownload the file if it's found to be corrupted; however this comes
+	// with the cost of hashing the whole file again
 	if s.cacher.Get(downloadInfo.Sha3_384, targetPath) {
-		logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
-		return nil
+		// double check that the cached entry has the expected size to detect
+		// most frequent symptoms of corruption (e.g. 0-byte files which may
+		// appear on power loss); silent bit rot are expected to be caught by
+		// the caller at some point, for which they can call
+		// CleanupDownloadArtifacts() to have the invalid snap blobs removed.
+		if fi, err := os.Lstat(targetPath); err == nil {
+			// check the size if one was provided by the store, otherwise accept
+			// any non-0 size as correct
+			if fi.Size() > 0 && (fi.Size() == downloadInfo.Size || downloadInfo.Size == 0) {
+				logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
+				return nil
+			}
+		}
+		// size mismatch — treat as cache miss and re-download.
+		logger.Debugf("Cache entry for SHA3_384 …%.5s has unexpected size, re-downloading.", downloadInfo.Sha3_384)
+		// remove the target path and the cache entry which is likely corrupted
+		// as well, ignore errors
+		_ = os.Remove(targetPath)
+		// we do not know whether the cache entry is also bad, so let's drop it as a
+		// precaution
+		_ = s.cacher.Drop(downloadInfo.Sha3_384)
 	}
 
 	if len(s.supportedDeltaFormats()) > 0 {

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -115,6 +115,20 @@ type DownloadOptions struct {
 	LeavePartialOnError bool
 }
 
+// Detect most frequent symptoms of corruption (e.g. 0-byte files which may
+// appear on power loss). Does not check for silent bit rot, which may cause
+// bit/byte flips.
+func isDownloadLikelyNotCorrupted(targetPath string, downloadInfo *snap.DownloadInfo) bool {
+	if fi, err := os.Lstat(targetPath); err == nil {
+		// check the size if one was provided by the store, otherwise accept
+		// any non-0 size as correct
+		if fi.Size() > 0 && (fi.Size() == downloadInfo.Size || downloadInfo.Size == 0) {
+			return true
+		}
+	}
+	return false
+}
+
 // Download downloads the snap addressed by download info and returns its
 // filename.
 // The file is saved in temporary storage, and should be removed
@@ -137,27 +151,27 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 	// redownload the file if it's found to be corrupted; however this comes
 	// with the cost of hashing the whole file again
 	if s.cacher.Get(downloadInfo.Sha3_384, targetPath) {
-		// double check that the cached entry has the expected size to detect
-		// most frequent symptoms of corruption (e.g. 0-byte files which may
-		// appear on power loss); silent bit rot are expected to be caught by
-		// the caller at some point, for which they can call
+		// we either got the file entry from the cache, or it already existed at
+		// the target path. More sophisticated corruption cases are expected to
+		// be caught by the caller at some point, for which they can call
 		// CleanupDownloadArtifacts() to have the invalid snap blobs removed.
-		if fi, err := os.Lstat(targetPath); err == nil {
-			// check the size if one was provided by the store, otherwise accept
-			// any non-0 size as correct
-			if fi.Size() > 0 && (fi.Size() == downloadInfo.Size || downloadInfo.Size == 0) {
-				logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
-				return nil
-			}
+		if isDownloadLikelyNotCorrupted(targetPath, downloadInfo) {
+			logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
+			return nil
 		}
-		// size mismatch — treat as cache miss and re-download.
-		logger.Debugf("Cache entry for SHA3_384 …%.5s has unexpected size, re-downloading.", downloadInfo.Sha3_384)
-		// remove the target path and the cache entry which is likely corrupted
-		// as well, ignore errors
+		// remove the target path and try to recover from the cache again,
+		// maybe only the preexisting target path is corrupted
 		_ = os.Remove(targetPath)
-		// we do not know whether the cache entry is also bad, so let's drop it as a
-		// precaution
+
+		if s.cacher.Get(downloadInfo.Sha3_384, targetPath) && isDownloadLikelyNotCorrupted(targetPath, downloadInfo) {
+			logger.Debugf("Recovered snap file from cache for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
+			return nil
+		}
+		// best effort attempt failed, the cache entry is likely bad as well, remove both
+		_ = os.Remove(targetPath)
 		_ = s.cacher.Drop(downloadInfo.Sha3_384)
+		// ... and re-download.
+		logger.Debugf("Cache entry for SHA3_384 …%.5s has unexpected size, re-downloading.", downloadInfo.Sha3_384)
 	}
 
 	if len(s.supportedDeltaFormats()) > 0 {

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -124,7 +124,7 @@ func (s *storeDownloadSuite) TestDownloadOK(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
 
-func (s *storeDownloadSuite) TestDownloadRangeRequest(c *C) {
+func (s *storeDownloadSuite) TestDownloadRangeRequestNon0Partial(c *C) {
 	partialContentStr := "partial content "
 	missingContentStr := "was downloaded"
 	expectedContentStr := partialContentStr + missingContentStr
@@ -145,6 +145,34 @@ func (s *storeDownloadSuite) TestDownloadRangeRequest(c *C) {
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := os.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
+	c.Assert(err, IsNil)
+
+	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(targetFn, testutil.FileEquals, expectedContentStr)
+}
+
+func (s *storeDownloadSuite) TestDownloadRangeRequest0Partial(c *C) {
+	expectedContentStr := "partial content was downloaded"
+
+	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		c.Check(resume, Equals, int64(0)) // full download
+		c.Check(url, Equals, "URL")
+		w.Write([]byte(expectedContentStr))
+		return nil
+	})
+	defer restore()
+
+	snap := &snap.Info{}
+	snap.RealName = "foo"
+	snap.DownloadURL = "URL"
+	snap.Sha3_384 = "abcdabcd"
+	snap.Size = int64(len(expectedContentStr))
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	// 0-sized partial download
+	err := os.WriteFile(targetFn+".partial", nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
@@ -780,12 +808,24 @@ type cacheObserver struct {
 
 	dropErr map[string]error
 
+	data map[string][]byte
+
 	cleanupCalls int
 }
 
 func (co *cacheObserver) Get(cacheKey, targetPath string) bool {
 	co.gets = append(co.gets, fmt.Sprintf("%s:%s", cacheKey, targetPath))
-	return co.inCache[cacheKey]
+	if co.inCache[cacheKey] {
+		// Simulate the real cache behavior of creating a hard link
+		os.MkdirAll(filepath.Dir(targetPath), 0755)
+		var data []byte
+		if co.data != nil {
+			data = co.data[cacheKey]
+		}
+		os.WriteFile(targetPath, data, 0600)
+		return true
+	}
+	return false
 }
 
 func (co *cacheObserver) GetPath(cacheKey string) string {
@@ -840,8 +880,13 @@ func (co *cacheObserver) Cleanup() error {
 	return nil
 }
 
-func (s *storeDownloadSuite) TestDownloadCacheHit(c *C) {
-	obs := &cacheObserver{inCache: map[string]bool{"the-snaps-sha3_384": true}}
+func (s *storeDownloadSuite) TestDownloadCacheHitHappy(c *C) {
+	obs := &cacheObserver{
+		inCache: map[string]bool{"the-snaps-sha3_384": true},
+		data: map[string][]byte{
+			"the-snaps-sha3_384": []byte("happy-content"),
+		},
+	}
 	restore := s.store.MockCacher(obs)
 	defer restore()
 
@@ -851,17 +896,116 @@ func (s *storeDownloadSuite) TestDownloadCacheHit(c *C) {
 	})
 	defer restore()
 
-	snap := &snap.Info{}
-	snap.Sha3_384 = "the-snaps-sha3_384"
+	si := &snap.Info{}
+	si.Sha3_384 = "the-snaps-sha3_384"
+	// expected size is non-zero, so that we hit the non-download code path
+	si.DownloadInfo.Size = int64(len([]byte("happy-content")))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := s.store.Download(s.ctx, "foo", path, &snap.DownloadInfo, nil, nil, nil)
+	err := s.store.Download(s.ctx, "foo", path, &si.DownloadInfo, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", snap.Sha3_384, path)})
+	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
 	c.Check(obs.puts, IsNil)
 	c.Check(obs.drops, IsNil)
 	c.Check(obs.cleanupCalls, Equals, 0)
+}
+
+func (s *storeDownloadSuite) TestDownloadCacheHitNoSizeKnown(c *C) {
+	obs := &cacheObserver{
+		inCache: map[string]bool{"the-snaps-sha3_384": true},
+		data: map[string][]byte{
+			"the-snaps-sha3_384": []byte("happy-content"),
+		},
+	}
+	restore := s.store.MockCacher(obs)
+	defer restore()
+
+	restore = store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		c.Fatalf("download should not be called when results come from the cache")
+		return nil
+	})
+	defer restore()
+
+	si := &snap.Info{}
+	si.Sha3_384 = "the-snaps-sha3_384"
+	// download info has no size, so that we hit the size-mismatch path
+	si.DownloadInfo.Size = 0
+
+	path := filepath.Join(c.MkDir(), "downloaded-file")
+	err := s.store.Download(s.ctx, "foo", path, &si.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
+	c.Check(obs.puts, IsNil)
+	c.Check(obs.drops, IsNil)
+	c.Check(obs.cleanupCalls, Equals, 0)
+}
+
+func (s *storeDownloadSuite) TestDownloadCacheHitCorruptRedownloads(c *C) {
+	// Cache reports a hit but the file has size smaller than expected by store provided information.
+	obs := &cacheObserver{
+		inCache: map[string]bool{"the-snaps-sha3_384": true},
+		data:    map[string][]byte{"the-snaps-sha3_384": []byte("too-short")},
+	}
+	restore := s.store.MockCacher(obs)
+	defer restore()
+
+	downloadWasCalled := false
+	restore = store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		downloadWasCalled = true
+		return nil
+	})
+	defer restore()
+
+	si := &snap.Info{}
+	si.Sha3_384 = "the-snaps-sha3_384"
+	si.DownloadInfo.Size = 1024 // expected size is non-zero
+
+	path := filepath.Join(c.MkDir(), "downloaded-file")
+	err := s.store.Download(s.ctx, "foo", path, &si.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(downloadWasCalled, Equals, true)
+
+	// The mock Get() writes mocked data, if any, to the target path. The file is
+	// shorter than the size reported by the store, so it's treated as corrupt and
+	// removed before re-downloading.
+	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
+	// The file is dropped.
+	c.Check(obs.drops, DeepEquals, []string{si.Sha3_384})
+}
+
+func (s *storeDownloadSuite) TestDownloadCacheHitCorruptRedownloads0Size(c *C) {
+	// Cache reports a hit but file has 0 size, and also the download info has
+	// no expected size information.
+	obs := &cacheObserver{
+		inCache: map[string]bool{"the-snaps-sha3_384": true},
+		data:    map[string][]byte{"the-snaps-sha3_384": nil},
+	}
+	restore := s.store.MockCacher(obs)
+	defer restore()
+
+	downloadWasCalled := false
+	restore = store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		downloadWasCalled = true
+		return nil
+	})
+	defer restore()
+
+	si := &snap.Info{}
+	si.Sha3_384 = "the-snaps-sha3_384"
+	si.DownloadInfo.Size = 0 // expected size is zero
+
+	path := filepath.Join(c.MkDir(), "downloaded-file")
+	err := s.store.Download(s.ctx, "foo", path, &si.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(downloadWasCalled, Equals, true)
+
+	// The mock Get() creates a 0-byte file which lacking any additional hint on
+	// the expected size is clearly invalid.
+	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
+	// The file is dropped.
+	c.Check(obs.drops, DeepEquals, []string{si.Sha3_384})
 }
 
 func (s *storeDownloadSuite) TestDownloadCacheMiss(c *C) {

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -816,7 +816,13 @@ type cacheObserver struct {
 func (co *cacheObserver) Get(cacheKey, targetPath string) bool {
 	co.gets = append(co.gets, fmt.Sprintf("%s:%s", cacheKey, targetPath))
 	if co.inCache[cacheKey] {
-		// Simulate the real cache behavior of creating a hard link
+		// Simulate the real cache behavior of creating a hard link.
+		// If the target already exists, os.Link() would return EEXIST
+		// which the real cache silently ignores, returning true without
+		// overwriting.
+		if _, err := os.Lstat(targetPath); err == nil {
+			return true
+		}
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 			panic(fmt.Sprintf("cannot create directory: %v", err))
 		}
@@ -982,8 +988,11 @@ func (s *storeDownloadSuite) TestDownloadCacheHitCorruptRedownloads(c *C) {
 
 	// The mock Get() writes mocked data, if any, to the target path. The file is
 	// shorter than the size reported by the store, so it's treated as corrupt and
-	// removed before re-downloading.
-	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
+	// removed before re-downloading. Get() is called twice (initial + retry).
+	c.Check(obs.gets, DeepEquals, []string{
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+	})
 	// The file is dropped.
 	c.Check(obs.drops, DeepEquals, []string{si.Sha3_384})
 }
@@ -1015,10 +1024,57 @@ func (s *storeDownloadSuite) TestDownloadCacheHitCorruptRedownloads0Size(c *C) {
 	c.Check(downloadWasCalled, Equals, true)
 
 	// The mock Get() creates a 0-byte file which lacking any additional hint on
-	// the expected size is clearly invalid.
-	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("%s:%s", si.Sha3_384, path)})
+	// the expected size is clearly invalid. Get() is called twice (initial + retry).
+	c.Check(obs.gets, DeepEquals, []string{
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+	})
 	// The file is dropped.
 	c.Check(obs.drops, DeepEquals, []string{si.Sha3_384})
+}
+
+func (s *storeDownloadSuite) TestDownloadCacheHitRecoveryFromPreexistingCorruptTarget(c *C) {
+	// A pre-existing corrupt (0-byte) file at targetPath causes the first
+	// Get() to return true without overwriting (simulating os.Link EEXIST).
+	// Download() detects the size mismatch, removes the target, retries
+	// Get() which now successfully writes the cached data, and recovery
+	// succeeds without re-downloading.
+	validData := []byte("valid-snap-data-1234567890")
+	obs := &cacheObserver{
+		inCache: map[string]bool{"the-snaps-sha3_384": true},
+		data:    map[string][]byte{"the-snaps-sha3_384": validData},
+	}
+	restore := s.store.MockCacher(obs)
+	defer restore()
+
+	restore = store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		// download not called, we recover from the cache
+		c.Fatalf("download should not be called when results come from the cache")
+		return nil
+	})
+	defer restore()
+
+	si := &snap.Info{}
+	si.Sha3_384 = "the-snaps-sha3_384"
+	si.DownloadInfo.Size = int64(len(validData))
+
+	path := filepath.Join(c.MkDir(), "downloaded-file")
+	// Create a pre-existing 0-byte file at targetPath to simulate a stale
+	// corrupt blob from a previous interrupted operation.
+	err := os.WriteFile(path, nil, 0600)
+	c.Assert(err, IsNil)
+
+	err = s.store.Download(s.ctx, "foo", path, &si.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	// Get() was called twice: first hit returns true but target is corrupt,
+	// second hit after removal writes valid data.
+	c.Check(obs.gets, DeepEquals, []string{
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+		fmt.Sprintf("%s:%s", si.Sha3_384, path),
+	})
+	// No drops — the cache entry is valid.
+	c.Check(obs.drops, IsNil)
 }
 
 func (s *storeDownloadSuite) TestDownloadCacheMiss(c *C) {

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -817,12 +817,16 @@ func (co *cacheObserver) Get(cacheKey, targetPath string) bool {
 	co.gets = append(co.gets, fmt.Sprintf("%s:%s", cacheKey, targetPath))
 	if co.inCache[cacheKey] {
 		// Simulate the real cache behavior of creating a hard link
-		os.MkdirAll(filepath.Dir(targetPath), 0755)
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			panic(fmt.Sprintf("cannot create directory: %v", err))
+		}
 		var data []byte
 		if co.data != nil {
 			data = co.data[cacheKey]
 		}
-		os.WriteFile(targetPath, data, 0600)
+		if err := os.WriteFile(targetPath, data, 0600); err != nil {
+			panic(fmt.Sprintf("cannot write file: %v", err))
+		}
 		return true
 	}
 	return false
@@ -846,6 +850,15 @@ func (co *cacheObserver) Put(cacheKey, sourcePath string) error {
 		}
 	}
 	co.inCache[cacheKey] = true
+	// Simulate real cache: store content for future Get() calls
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		panic(fmt.Sprintf("cacheObserver Put(): cannot read source %q: %v", sourcePath, err))
+	}
+	if co.data == nil {
+		co.data = make(map[string][]byte)
+	}
+	co.data[cacheKey] = data
 	return nil
 }
 
@@ -1090,6 +1103,8 @@ func (s *storeDownloadSuite) TestDownloadDeltaCacheMiss(c *C) {
 	restore = store.MockApplyDelta(func(_ context.Context, s *store.Store, name string, deltaPath string, deltaInfo *snap.DeltaInfo, targetPath string, targetSha3_384 string) error {
 		applyDeltaCalls++
 		c.Check(deltaPath, Equals, pathDeltaPartial)
+		// Simulate successful delta application by creating the target file
+		c.Assert(os.WriteFile(targetPath, []byte("rebuilt-snap"), 0600), IsNil)
 		return nil
 	})
 	defer restore()

--- a/tests/main/snap-download-corrupted-cleanup/task.yaml
+++ b/tests/main/snap-download-corrupted-cleanup/task.yaml
@@ -1,17 +1,25 @@
-summary: Verify corrupted snap files are cleaned up when download task is undone
+summary: Verify corrupted snap cache entries are detected and re-downloaded
 
 details: |
-    Verify that undo of snap-download cleans up corrupted snap blob files.
-    Two scenarios are tested:
-    - valid_cache: blob is zeroed but cache entry is valid; blob is removed
-      and cache is preserved for reuse on the next download attempt.
-    - corrupt_cache: both blob and cache entry are zeroed; both are removed
-      and the subsequent refresh re-downloads from the store.
+    Verify that Download() detects a corrupted (size-mismatched) cache entry
+    and self-heals by re-downloading from the store.
+    Three scenarios are tested:
+    - valid-cache: blob is zeroed but cache entry is valid; download detects
+      the 0-byte target, recovers from the valid cache entry without
+      re-downloading from the store.
+    - corrupt-cache: both blob and cache entry are zeroed; download detects
+      the size mismatch in both, drops the cache entry and re-downloads from
+      the store.
+    - bitflip-cache: cache entry has correct size but corrupted content (a
+      flipped byte); download treats it as a cache hit (size matches), but
+      validate-snap fails (hash mismatch). The undo handler cleans up the
+      corrupt cache entry, and a subsequent refresh re-downloads successfully.
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
     CACHEMODE/corrupt_cache: corrupt
     CACHEMODE/valid_cache: valid
+    CACHEMODE/bitflip_cache: bitflip
 
 skip:
     - reason: This test needs test keys to be trusted
@@ -61,39 +69,53 @@ execute: |
 
     snap remove --revision "$rev_new" test-snapd-sh-core24
 
-    echo "Create corrupted (empty) snap file to short-circuit download task"
+    echo "Create corrupted snap file"
+    # for valid_cache: target file is 0-byte; for corrupt_cache: target file is too short
+    # for bitflip_cache: no target file created (only cache entry is modified)
     rm -fv "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
-    touch "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
 
     if [ "$CACHEMODE" = "corrupt" ]; then
-        echo "Also corrupt the cache entry"
+        touch "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
+        echo "Also corrupt the cache entry (truncate to 0)"
         truncate -s 0 "$cache_file_rev_new"
-    fi
-
-    echo "Attempt refresh"
-    if snap refresh test-snapd-sh-core24 2>install.err; then
-        echo "Refresh should have failed but succeeded"
-        exit 1
-    fi
-
-    echo "Verify installation failed"
-    MATCH "snap file is unexpected empty and possibly corrupted" < install.err
-
-    echo "Verify installation change shows error"
-    snap change --last refresh > change.out
-    MATCH "ERROR cannot verify snap" < change.out
-    MATCH "Undone.*Download snap.*test-snapd-sh-core24" < change.out
-
-    echo "Verify undo cleaned up the corrupted blob"
-    not test -f "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
-
-    if [ "$CACHEMODE" = "corrupt" ]; then
-        echo "Corrupt cache entry was dropped"
-        not test -f "$cache_file_rev_new"
+    elif [ "$CACHEMODE" = "bitflip" ]; then
+        echo "Flip a byte in the cache entry (keeps same size, wrong hash)"
+        printf '\xff' | dd of="$cache_file_rev_new" bs=1 count=1 conv=notrunc
     else
-        echo "Valid cache entry is preserved"
-        test -f "$cache_file_rev_new"
+        echo "Create a 0-sized target file"
+        touch "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
     fi
 
-    echo "Subsequent refresh succeeds"
-    snap refresh test-snapd-sh-core24
+    if [ "$CACHEMODE" = "bitflip" ]; then
+        # Corrupted, non-0 sized file fails validation, but is ultimately
+        # cleaned up in undo.
+        echo "Attempt refresh - bitflip passes size check but fails validation"
+        if snap refresh test-snapd-sh-core24 2> install.err; then
+            echo "Refresh should have failed but succeeded"
+            exit 1
+        fi
+
+        echo "Verify installation failed with signature error"
+        MATCH "no matching signatures found" < install.err
+
+        echo "Verify undo cleaned up the corrupt cache entry"
+        not test -f "$cache_file_rev_new"
+
+        echo "Verify undo cleaned up the corrupted blob"
+        not test -f "/var/lib/snapd/snaps/test-snapd-sh-core24_${rev_new}.snap"
+
+        echo "Subsequent refresh re-downloads and succeeds"
+        snap refresh test-snapd-sh-core24
+    else
+        # These two cases (recovery from cache vs re-download) are
+        # indistinguishable here; hard links share inode metadata so mtime
+        # changes in both paths. See unit tests for behavioral verification.
+        # TODO: extend the fakestore with download/request statistics such that
+        # we can assert whether a download occurred more reliably than looking
+        # at the logs.
+        echo "Attempt refresh - self-heals"
+        snap refresh test-snapd-sh-core24
+    fi
+
+    echo "Verify the snap was refreshed successfully"
+    test "$(readlink "$SNAP_MOUNT_DIR"/test-snapd-sh-core24/current)" = "$rev_new"


### PR DESCRIPTION
This is a followup for #16691, where the undo path attempts to clean up downloaded snap blobs. Given that a power loss may happen at any point, even before we proceed to the validate-snap task, extend the Download() to add self-recovery capability which tries to detect the most obvious, but also most frequent, signs of corruption.

Related: [SNAPDENG-36946](https://warthogs.atlassian.net/browse/SNAPDENG-36946)


[SNAPDENG-36946]: https://warthogs.atlassian.net/browse/SNAPDENG-36946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ