### PR TITLE
tests: disable temporal cache during prompting smoke tests

### DIFF
--- a/tests/main/apparmor-prompting-smoke/task.yaml
+++ b/tests/main/apparmor-prompting-smoke/task.yaml
@@ -70,7 +70,8 @@ prepare: |
         EXISTING_TEMPORAL_CACHE_TIMEOUT="$(cat "$CACHE_TIMEOUT_PATH")"
         echo "Disabling temporal cache for the duration of this test"
         echo 0 > "$CACHE_TIMEOUT_PATH"
-        tests.cleanup defer echo "$EXISTING_TEMPORAL_CACHE_TIMEOUT" > "$CACHE_TIMEOUT_PATH"
+        # Wrap the command line in quotes so it's not evaluated until the defer runs
+        tests.cleanup defer "echo \"$EXISTING_TEMPORAL_CACHE_TIMEOUT\" > \"$CACHE_TIMEOUT_PATH\""
     fi
 
     tests.session prepare -u test

--- a/tests/main/apparmor-prompting-smoke/task.yaml
+++ b/tests/main/apparmor-prompting-smoke/task.yaml
@@ -63,6 +63,16 @@ skip:
      reason: Ubuntu 22.04 AppArmor parser doesn't support prompting without reexec
 
 prepare: |
+    # Check whether kernel supports temporal cache, and if so, disable it
+    CACHE_TIMEOUT_PATH="/proc/sys/kernel/apparmor_cache_timeout"
+    if [ -e "$CACHE_TIMEOUT_PATH" ] ; then
+        echo "Kernel supports apparmor temporal cache"
+        EXISTING_TEMPORAL_CACHE_TIMEOUT="$(cat "$CACHE_TIMEOUT_PATH")"
+        echo "Disabling temporal cache for the duration of this test"
+        echo 0 > "$CACHE_TIMEOUT_PATH"
+        tests.cleanup defer echo "$EXISTING_TEMPORAL_CACHE_TIMEOUT" > "$CACHE_TIMEOUT_PATH"
+    fi
+
     tests.session prepare -u test
     tests.cleanup defer tests.session restore -u test
 

--- a/tests/main/apparmor-prompting-smoke/task.yaml
+++ b/tests/main/apparmor-prompting-smoke/task.yaml
@@ -65,13 +65,13 @@ skip:
 prepare: |
     # Check whether kernel supports temporal cache, and if so, disable it
     CACHE_TIMEOUT_PATH="/proc/sys/kernel/apparmor_cache_timeout"
+    CACHE_TIMEOUT_SYSCTL="kernel.apparmor_cache_timeout"
     if [ -e "$CACHE_TIMEOUT_PATH" ] ; then
         echo "Kernel supports apparmor temporal cache"
-        EXISTING_TEMPORAL_CACHE_TIMEOUT="$(cat "$CACHE_TIMEOUT_PATH")"
+        EXISTING_TEMPORAL_CACHE_TIMEOUT="$(sysctl -n "$CACHE_TIMEOUT_SYSCTL")"
         echo "Disabling temporal cache for the duration of this test"
-        echo 0 > "$CACHE_TIMEOUT_PATH"
-        # Wrap the command line in quotes so it's not evaluated until the defer runs
-        tests.cleanup defer "echo \"$EXISTING_TEMPORAL_CACHE_TIMEOUT\" > \"$CACHE_TIMEOUT_PATH\""
+        sysctl -w "$CACHE_TIMEOUT_SYSCTL=0"
+        tests.cleanup defer sysctl -w "$CACHE_TIMEOUT_SYSCTL=$EXISTING_TEMPORAL_CACHE_TIMEOUT"
     fi
 
     tests.session prepare -u test


### PR DESCRIPTION
This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36936

unskip:

- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-flag-restart
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-integration-tests
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-prompt-restoration
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-smoke
- openstack:ubuntu-26.04-64:tests/main/apparmor-prompting-snapd-startup
- openstack:ubuntu-26.04-64:tests/main/interfaces-requests-activates-handlers
- openstack:ubuntu-26.04-64:tests/main/snap-interfaces-requests-control
