### PR TITLE
o/snapstate: enable reverts to trigger a seed refresh

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1768,10 +1768,14 @@ func removeRecoverySystemTask(st *state.State, label string) *state.Task {
 // tasks needed to refresh the seed managed by seed-refresh mode, plus the snap
 // names selected for that seed refresh. The selected setup task IDs are written
 // into the recovery-system setup payload so the new seed can consume the
-// refreshed snaps and components. Older seed-refresh systems are removed so
-// that, after finalize records the new system, the two most recently created
-// seed-refresh systems remain tracked.
-func SeedRefreshTasks(st *state.State, dctx snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+// refreshed snaps and components. Older seed-refresh systems are removed
+// according to the selected seed eviction policy.
+func SeedRefreshTasks(
+	st *state.State,
+	dctx snapstate.DeviceContext,
+	candidates []snapstate.SeedRefreshCandidate,
+	eviction snapstate.SeedRefreshEvictionPolicy,
+) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
 	triggers := seedRefreshTriggers(st, dctx)
 
 	var snapsups, compsups []string
@@ -1822,7 +1826,7 @@ func SeedRefreshTasks(st *state.State, dctx snapstate.DeviceContext, candidates 
 		return nil, nil, errors.New("internal error: expected create and finalize recovery system tasks")
 	}
 
-	removeLabels, err := seedRefreshLabelsToRemove(st)
+	removeLabels, err := seedRefreshLabelsToRemove(st, eviction)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2024,7 +2028,11 @@ func appendUnique(slice []string, additions ...string) []string {
 // seedRefreshLabelsToRemove returns the existing seed-refresh systems that
 // should be removed after the next seed-refresh finalize-recovery-system task
 // runs.
-func seedRefreshLabelsToRemove(st *state.State) ([]string, error) {
+func seedRefreshLabelsToRemove(st *state.State, eviction snapstate.SeedRefreshEvictionPolicy) ([]string, error) {
+	if eviction.SeedsToRetain < 1 {
+		return nil, fmt.Errorf("internal error: must retain at least 1 seed, got %d", eviction.SeedsToRetain)
+	}
+
 	var systems []seededSystem
 	if err := st.Get("seeded-systems", &systems); err != nil {
 		if errors.Is(err, state.ErrNoState) {
@@ -2033,22 +2041,27 @@ func seedRefreshLabelsToRemove(st *state.State) ([]string, error) {
 		return nil, err
 	}
 
-	seenSeedRefresh := false
-	removals := make([]string, 0, len(systems))
+	seedRefreshLabels := make([]string, 0, len(systems))
 	for _, system := range systems {
-		if !system.SeedRefresh {
-			continue
+		if system.SeedRefresh {
+			seedRefreshLabels = append(seedRefreshLabels, system.System)
 		}
+	}
 
-		// keep the newest existing seed-refresh entry. finalize-recovery-system
-		// will prepend the new one later, leaving the two most recently created
-		// seed-refresh systems
-		if !seenSeedRefresh {
-			seenSeedRefresh = true
-			continue
-		}
+	removals := make([]string, 0, len(systems))
+	remaining := seedRefreshLabels
 
-		removals = append(removals, system.System)
+	// seeded-systems is stored newest-first. ReplaceLatest is the explicit
+	// exception to keeping newest seed-refresh systems first.
+	if eviction.ReplaceLatest && len(remaining) != 0 {
+		removals = append(removals, remaining[0])
+		remaining = remaining[1:]
+	}
+
+	for len(remaining) > eviction.SeedsToRetain {
+		oldest := remaining[len(remaining)-1]
+		removals = append(removals, oldest)
+		remaining = remaining[:len(remaining)-1]
 	}
 
 	return removals, nil

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2760,7 +2760,7 @@ func (s *deviceMgrSystemsCreateSuite) TestSeedRefreshTasksFinalizeUndoDoesNotRes
 		{
 			InstanceName: s.model.Kernel(),
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(added, DeepEquals, map[string]bool{s.model.Kernel(): true})
 	c.Assert(seedTS, NotNil)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2152,7 +2152,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksSkipsOpeningSeed(c *C) {
 			InstanceName:     "snap-not-in-model",
 			SnapSetupTaskIDs: []string{otherDwnload.ID()},
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(seedTS, NotNil)
 	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
@@ -2189,7 +2189,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasks(c *C) {
 			InstanceName:     "snap-2",
 			SnapSetupTaskIDs: []string{tSnap2.ID()},
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true, "snap-2": true})
 
@@ -2245,7 +2245,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksComponentExclusive(c *C) {
 			InstanceName:          "snap-1",
 			ComponentSetupTaskIDs: []string{compTask1.ID(), compTask2.ID()},
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(seedTS, NotNil)
 	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
@@ -2285,7 +2285,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksUsesNextAvailableLabel(c *C) 
 			InstanceName:     "snap-1",
 			SnapSetupTaskIDs: []string{tSnap.ID()},
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
 
@@ -2305,7 +2305,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksUsesNextAvailableLabel(c *C) 
 	c.Check(systemSetupData["test-system"], Equals, true)
 }
 
-func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
+func (s *deviceMgrSuite) TestCreateSeedRefreshTasksEvictionPolicy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2314,11 +2314,12 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
 	})
 	defer restore()
 
+	// non-seed-refresh entry interleaved to verify it is correctly skipped
 	s.state.Set("seeded-systems", []devicestate.SeededSystem{
-		{System: "current-seed-refresh", SeedRefresh: true},
+		{System: "newest-seed-refresh", SeedRefresh: true},
 		{System: "non-seed-refresh"},
-		{System: "old-seed-refresh-1", SeedRefresh: true},
-		{System: "old-seed-refresh-2", SeedRefresh: true},
+		{System: "middle-seed-refresh", SeedRefresh: true},
+		{System: "oldest-seed-refresh", SeedRefresh: true},
 	})
 	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
 		{"name": "snapd", "type": "snapd"},
@@ -2329,17 +2330,19 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
 	})
 	tSnap := s.state.NewTask("fake-download", "...")
 
-	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, []snapstate.SeedRefreshCandidate{
-		{
-			InstanceName:     "snap-1",
-			SnapSetupTaskIDs: []string{tSnap.ID()},
-		},
-	})
+	candidate := []snapstate.SeedRefreshCandidate{{
+		InstanceName:     "snap-1",
+		SnapSetupTaskIDs: []string{tSnap.ID()},
+	}}
+
+	// SeedsToRetain only: the two oldest seed-refresh entries beyond the
+	// retention limit are removed
+	seedTS, added, err := devicestate.SeedRefreshTasks(s.state, dctx, candidate,
+		snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
 	c.Assert(seedTS.Remove, HasLen, 2)
 	c.Check(seedTS.Remove[0].WaitTasks(), DeepEquals, []*state.Task{seedTS.Finalize})
-	c.Check(seedTS.Remove[1].WaitTasks(), DeepEquals, []*state.Task{seedTS.Finalize})
 
 	var labels []string
 	for _, remove := range seedTS.Remove {
@@ -2347,8 +2350,55 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksAddsPruneTasks(c *C) {
 		c.Assert(remove.Get("remove-recovery-system-setup", &setup), IsNil)
 		labels = append(labels, setup["label"].(string))
 	}
+	c.Check(labels, testutil.DeepUnsortedMatches, []string{"middle-seed-refresh", "oldest-seed-refresh"})
 
-	c.Check(labels, testutil.DeepUnsortedMatches, []string{"old-seed-refresh-1", "old-seed-refresh-2"})
+	// ReplaceLatest replaces the newest seed-refresh with the incoming one,
+	// then SeedsToRetain removes the oldest beyond the retention limit
+	seedTS, added, err = devicestate.SeedRefreshTasks(s.state, dctx, candidate,
+		snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1, ReplaceLatest: true})
+	c.Assert(err, IsNil)
+	c.Assert(added, DeepEquals, map[string]bool{"snap-1": true})
+	c.Assert(seedTS.Remove, HasLen, 2)
+
+	labels = nil
+	for _, remove := range seedTS.Remove {
+		var setup map[string]any
+		c.Assert(remove.Get("remove-recovery-system-setup", &setup), IsNil)
+		labels = append(labels, setup["label"].(string))
+	}
+	c.Check(labels, testutil.DeepUnsortedMatches, []string{"newest-seed-refresh", "oldest-seed-refresh"})
+}
+
+func (s *deviceMgrSuite) TestCreateSeedRefreshTasksInvalidEvictionPolicy(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restore := devicestate.MockTimeNow(func() time.Time {
+		return time.Date(2026, 2, 27, 9, 0, 0, 0, time.UTC)
+	})
+	defer restore()
+
+	s.state.Set("seeded-systems", []devicestate.SeededSystem{
+		{System: "some-seed-refresh", SeedRefresh: true},
+	})
+
+	dctx := s.setupSeedRefreshSeedAndContext(c, []map[string]string{
+		{"name": "snapd", "type": "snapd"},
+		{"name": "core24", "type": "base", "default-channel": "24"},
+		{"name": "pc-kernel", "type": "kernel", "default-channel": "24"},
+		{"name": "pc", "type": "gadget", "default-channel": "24"},
+		{"name": "snap-1"},
+	})
+	candidate := []snapstate.SeedRefreshCandidate{{
+		InstanceName:     "snap-1",
+		SnapSetupTaskIDs: []string{s.state.NewTask("fake-download", "...").ID()},
+	}}
+
+	_, _, err := devicestate.SeedRefreshTasks(
+		s.state, dctx, candidate,
+		snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 0},
+	)
+	c.Assert(err, ErrorMatches, `internal error: must retain at least 1 seed, got 0`)
 }
 
 func (s *deviceMgrSuite) TestUpdateSeedRefreshChange(c *C) {
@@ -2473,7 +2523,7 @@ func (s *deviceMgrSuite) TestCreateSeedRefreshTasksSkipsOptionalSnapNotInCurrent
 			InstanceName:     "snap-1",
 			SnapSetupTaskIDs: []string{s.state.NewTask("fake-download", "...").ID()},
 		},
-	})
+	}, snapstate.SeedRefreshEvictionPolicy{SeedsToRetain: 1})
 	c.Assert(err, IsNil)
 	c.Check(seedTS, IsNil)
 	c.Check(added, IsNil)

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -75,11 +75,12 @@ func UpdateBootRevisions(st *state.State) error {
 		if actual.SnapRevision() != info.SideInfo.Revision {
 			// FIXME: check that there is no task
 			//        for this already in progress
-			ts, err := RevertToRevision(st, actual.SnapName(), actual.SnapRevision(), Flags{}, "")
+			const noRestartBoundaries = false
+			installTS, err := revertToRevisionTaskSet(st, actual.SnapName(), actual.SnapRevision(), Flags{}, "", noRestartBoundaries)
 			if err != nil {
 				return err
 			}
-			tsAll = append(tsAll, ts)
+			tsAll = append(tsAll, installTS.ts)
 		}
 	}
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -165,6 +166,11 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSSimple(c *C) {
 
 	bs.makeInstalledKernelOS(c, st)
 
+	// enable seed refresh to prove that we don't accidentally trigger one
+	tr := config.NewTransaction(st)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
+
 	bs.bootloader.SetBootBase("core_1.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, IsNil)
@@ -178,6 +184,11 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSSimple(c *C) {
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.Kind(), Equals, "update-revisions")
 	c.Assert(chg.IsReady(), Equals, true)
+
+	// make sure that we didn't create the seed-refresh tasks
+	for _, t := range chg.Tasks() {
+		c.Check(t.Kind(), Not(Equals), "create-recovery-system")
+	}
 
 	// core "current" got reverted but canonical-pc-linux did not
 	var snapst snapstate.SnapState

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -235,6 +235,7 @@ func arrangeRebootAndUpdateSeed(
 	st *state.State,
 	stss []snapInstallTaskSet,
 	earlyDownloads map[string]bool,
+	eviction SeedRefreshEvictionPolicy,
 	opts Options,
 ) (seedRefreshTS *state.TaskSet, err error) {
 	for _, sts := range stss {
@@ -251,7 +252,7 @@ func arrangeRebootAndUpdateSeed(
 	// note that seedSnapTaskSets will contain all snaps being refreshed that
 	// will go into the seed, and it might contain a combination of essential
 	// and non-essential snaps.
-	seedTS, seedSnapTaskSets, err := seedRefreshAndSeedSnapTaskSets(st, stss, opts)
+	seedTS, seedSnapTaskSets, err := seedRefreshAndSeedSnapTaskSets(st, stss, eviction, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -398,7 +398,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsUC16NoSplits(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// core, kernel should have individual restart boundaries
@@ -424,7 +432,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssential(c *C) {
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Snapd should have no restart boundaries
@@ -465,7 +481,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -536,7 +560,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadget(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -603,7 +635,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsGadgetKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Expect restart boundaries on both
@@ -671,7 +711,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadgetKernel(c *C) {
 		s.snapInstallTaskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	linkSnapBase := stss[0].TaskSet().MaybeEdge(snapstate.MaybeRebootEdge)
@@ -767,7 +815,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloads(c *C) {
 		"core20":    true,
 		"my-kernel": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		earlyDownloads,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	baseLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -796,7 +852,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdEarlyDownload(c *C) {
 	earlyDownloads := map[string]bool{
 		"snapd": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		earlyDownloads,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	snapdLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -833,7 +897,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssentialEarlyDownlo
 		"snapd":  true,
 		"core20": true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		earlyDownloads,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	snapdEnd, err := stss[0].TaskSet().Edge(snapstate.EndEdge)
@@ -875,7 +947,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloadedAppWaitsAfter
 		"my-kernel": true,
 		"some-app":  true,
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, earlyDownloads, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		earlyDownloads,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	finalEssential, err := stss[1].TaskSet().Edge(snapstate.EndEdge)
@@ -904,7 +984,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsNoEarlyDownloads(c *C) {
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	baseLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
@@ -972,14 +1060,23 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshComponentExclusiv
 		[]*state.Task{postLink},
 	)
 
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, []snapstate.SnapInstallTaskSet{sts}, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		[]snapstate.SnapInstallTaskSet{sts},
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// component-exclusive operations provide only component setup tasks, so snap setup tasks must stay empty.
-	observed.CheckInitialCandidates(c, snapstate.SeedRefreshCandidate{
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
 		InstanceName:          "some-app",
 		ComponentSetupTaskIDs: componentSetupTasks,
-	})
+	}})
 }
 
 func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapd(c *C) {
@@ -992,7 +1089,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapd(c *C) {
 		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Do not expect any restart boundaries to be set on snapd
@@ -1017,7 +1122,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBootBaseAndOtherBases(c *C) 
 		s.snapInstallTaskSetForSnapSetup("core18", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Only the boot-base should have restart boundary.
@@ -1041,7 +1154,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBaseAndWithout(c 
 		s.snapInstallTaskSetForSnapSetup("snap-base-app", "snap-base", snap.TypeApp),
 		s.snapInstallTaskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// No restart boundaries
@@ -1071,7 +1192,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBootBaseAndWithou
 		s.snapInstallTaskSetForSnapSetup("snap-core20-app", "snap-core20", snap.TypeApp),
 		s.snapInstallTaskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// Restart boundaries is set for core20 as the boot-base
@@ -1105,7 +1234,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsAll(c *C) {
 		s.snapInstallTaskSetForSnapSetup("core", "", snap.TypeOS),
 		s.snapInstallTaskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, IsNil)
 
 	// snapd has no restart boundaries set
@@ -1136,6 +1273,14 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsFailsSplit(c *C) {
 	stss := []snapstate.SnapInstallTaskSet{
 		snapstate.NewSnapInstallTaskSetForTest(nil, nil, nil, nil, nil, nil),
 	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(s.state, stss, nil, snapstate.Options{DeviceCtx: s.deviceCtx(c)})
+	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		nil,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
 	c.Assert(err, ErrorMatches, `internal error: snap install task set has empty slices`)
 }

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -36,6 +36,15 @@ type SeedRefreshTaskSet struct {
 	Remove   []*state.Task
 }
 
+// SeedRefreshEvictionPolicy carries the seed-refresh system pruning policy
+// selected by snapstate for the current operation.
+type SeedRefreshEvictionPolicy struct {
+	// SeedsToRetain is the number of existing seed-refresh systems to keep.
+	SeedsToRetain int
+	// ReplaceLatest forces removal of the newest existing seed-refresh system.
+	ReplaceLatest bool
+}
+
 // SeedRefreshCandidate carries information about a snap that might trigger a
 // seed refresh.
 type SeedRefreshCandidate struct {
@@ -52,7 +61,7 @@ type SeedRefreshCandidate struct {
 
 // SeedRefreshTasks is set by devicestate to avoid an import cycle. See
 // devicestate.SeedRefreshTasks.
-var SeedRefreshTasks = func(st *state.State, dctx DeviceContext, candidates []SeedRefreshCandidate) (*SeedRefreshTaskSet, map[string]bool, error) {
+var SeedRefreshTasks = func(st *state.State, dctx DeviceContext, candidates []SeedRefreshCandidate, eviction SeedRefreshEvictionPolicy) (*SeedRefreshTaskSet, map[string]bool, error) {
 	panic("internal error: snapstate.SeedRefreshTasks is unset")
 }
 
@@ -122,7 +131,7 @@ func changeHasPendingSeedRefresh(chg *state.Change) bool {
 
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
-func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
+func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
 	enabled, err := seedRefreshEnabled(st)
 	if err != nil {
 		return nil, nil, err
@@ -152,7 +161,7 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 		candidates = append(candidates, candidate)
 	}
 
-	seedTS, added, err := SeedRefreshTasks(st, deviceCtx, candidates)
+	seedTS, added, err := SeedRefreshTasks(st, deviceCtx, candidates, eviction)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3647,22 +3647,72 @@ func Revert(st *state.State, name string, flags Flags, fromChange string) (*stat
 }
 
 func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Flags, fromChange string) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(st, name, &snapst)
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	seedRefresh, err := seedRefreshEnabled(st)
+	if err != nil {
 		return nil, err
 	}
 
+	// when seed refresh is enabled, the reboot boundaries are set by the
+	// single-reboot and seed-creation code below. thus, we disable their
+	// creation here, in order to not add more than the necessary restart
+	// boundaries.
+	noRestartBoundaries := seedRefresh
+	installTS, err := revertToRevisionTaskSet(st, name, rev, flags, fromChange, noRestartBoundaries)
+	if err != nil {
+		return nil, err
+	}
+
+	if !seedRefresh {
+		return installTS.ts, nil
+	}
+
+	// create a new seed-refresh with the reverted snapd. since the user
+	// probably doesn't want a seed containing a revision they've reverted away
+	// from, we use ReplaceLatest to indicate that the most recent seed should
+	// be replaced with the incoming one. this is only applicable if this snap
+	// triggers a seed refresh.
+	seedTS, err := arrangeRebootAndUpdateSeed(st, []snapInstallTaskSet{installTS}, nil, SeedRefreshEvictionPolicy{
+		SeedsToRetain: 1,
+		ReplaceLatest: true,
+	}, Options{
+		ConflictOptions: ConflictOptions{FromChange: fromChange},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// no seed refresh was triggered, nothing more to do
+	if seedTS == nil {
+		return installTS.ts, nil
+	}
+
+	// note: seed refresh isn't a real task kind, but a specialization of a
+	// normal refresh/revert.
+	if err := checkChangeConflictExclusiveKinds(st, "seed refresh", fromChange); err != nil {
+		return nil, err
+	}
+
+	installTS.ts.AddAll(seedTS)
+	return installTS.ts, nil
+}
+
+func revertToRevisionTaskSet(st *state.State, name string, rev snap.Revision, flags Flags, fromChange string, noRestartBoundaries bool) (snapInstallTaskSet, error) {
+	var snapst SnapState
+	err := Get(st, name, &snapst)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return snapInstallTaskSet{}, err
+	}
+
 	if snapst.Current == rev {
-		return nil, fmt.Errorf("already on requested revision")
+		return snapInstallTaskSet{}, fmt.Errorf("already on requested revision")
 	}
 
 	if !snapst.Active {
-		return nil, fmt.Errorf("cannot revert inactive snaps")
+		return snapInstallTaskSet{}, fmt.Errorf("cannot revert inactive snaps")
 	}
 	i := snapst.LastIndex(rev)
 	if i < 0 {
-		return nil, fmt.Errorf("cannot find revision %s for snap %q", rev, name)
+		return snapInstallTaskSet{}, fmt.Errorf("cannot find revision %s for snap %q", rev, name)
 	}
 
 	flags.Revert = true
@@ -3682,7 +3732,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 
 	info, err := Info(st, name, rev)
 	if err != nil {
-		return nil, err
+		return snapInstallTaskSet{}, err
 	}
 
 	snapsup := SnapSetup{
@@ -3708,12 +3758,13 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 	}
 
 	installTS, err := doInstallOrPreDownload(st, &snapst, &snapsup, compsups, installContext{
-		ConflictOptions: ConflictOptions{FromChange: fromChange},
+		ConflictOptions:     ConflictOptions{FromChange: fromChange},
+		NoRestartBoundaries: noRestartBoundaries,
 	})
 	if err != nil {
-		return nil, err
+		return snapInstallTaskSet{}, err
 	}
-	return installTS.ts, nil
+	return installTS, nil
 }
 
 // TransitionCore transitions from an old core snap name to a new core

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1656,7 +1656,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 		scheduleUpdate(up.Setup.InstanceName(), sts.ts)
 	}
 
-	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, nil, opts)
+	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, nil, SeedRefreshEvictionPolicy{SeedsToRetain: 1}, opts)
 	if err != nil {
 		return nil, false, nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -83,6 +83,7 @@ func TestSnapManager(t *testing.T) { TestingT(t) }
 type observedSeedRefreshCandidates struct {
 	initial       [][]snapstate.SeedRefreshCandidate
 	prerequisites []snapstate.SeedRefreshCandidate
+	evictions     []snapstate.SeedRefreshEvictionPolicy
 }
 
 func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, func()) {
@@ -96,8 +97,9 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 	var observed observedSeedRefreshCandidates
 	var currentSeedTS *snapstate.SeedRefreshTaskSet
 
-	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, eviction snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
 		observed.initial = append(observed.initial, candidates)
+		observed.evictions = append(observed.evictions, eviction)
 
 		added := make(map[string]bool, len(candidates))
 		for _, candidate := range candidates {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -305,17 +305,6 @@ func seedRefreshCandidateFromTaskSet(c *C, ts *state.TaskSet) snapstate.SeedRefr
 	return candidate
 }
 
-func (observed *observedSeedRefreshCandidates) CheckInitialCandidates(c *C, expected ...snapstate.SeedRefreshCandidate) {
-	// we expect just one set of initial candidates, since we should only call
-	// [snapstate.SeedRefreshTasks] just once
-	c.Assert(observed.initial, HasLen, 1)
-	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, expected)
-}
-
-func (observed *observedSeedRefreshCandidates) CheckPrereqCandidates(c *C, expected ...snapstate.SeedRefreshCandidate) {
-	c.Check(observed.prerequisites, testutil.DeepUnsortedMatches, expected)
-}
-
 func mustTaskSetForSnap(c *C, taskSetsBySnap map[string]*state.TaskSet, snapName string) *state.TaskSet {
 	ts := taskSetsBySnap[snapName]
 	c.Assert(ts, NotNil, Commentf("missing task set for %q", snapName))
@@ -20059,11 +20048,13 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefresh(c *C) {
 	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "core18")
 	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
-	observed.CheckInitialCandidates(c,
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
 		seedRefreshCandidateFromTaskSet(c, kernelTS),
 		seedRefreshCandidateFromTaskSet(c, baseTS),
 		seedRefreshCandidateFromTaskSet(c, appTS),
-	)
+	})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(baseTS, kernelTS), Equals, true)
@@ -20138,12 +20129,14 @@ func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c
 	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
 	extraAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
-	observed.CheckInitialCandidates(c,
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
 		seedRefreshCandidateFromTaskSet(c, kernelTS),
 		seedRefreshCandidateFromTaskSet(c, baseTS),
 		seedRefreshCandidateFromTaskSet(c, appTS),
 		seedRefreshCandidateFromTaskSet(c, extraAppTS),
-	)
+	})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(baseTS, kernelTS, appTS), Equals, true)
@@ -20314,10 +20307,10 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 	providerSnapSetup, err := snapstate.TaskSnapSetup(providerSnapSetupTask)
 	c.Assert(err, IsNil)
 	c.Check(providerSnapSetup.InstanceName(), Equals, "content-provider")
-	observed.CheckPrereqCandidates(c, snapstate.SeedRefreshCandidate{
+	c.Check(observed.prerequisites, testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
 		InstanceName:     providerSnapSetup.InstanceName(),
 		SnapSetupTaskIDs: []string{providerSnapSetupTask.ID()},
-	})
+	}})
 
 	// ensure create-recovery-system waits on the LastBeforeLocalModificationsEdge for content-provider
 	c.Check(waitTasksContainKindForSnap(c, seedCreate, "content-provider", "validate-snap"), Equals, true)
@@ -20563,13 +20556,14 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadWithSnapd(c
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
 	extraAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
 
-	observed.CheckInitialCandidates(c,
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
 		seedRefreshCandidateFromTaskSet(c, snapdTS),
 		seedRefreshCandidateFromTaskSet(c, kernelTS),
 		seedRefreshCandidateFromTaskSet(c, baseTS),
 		seedRefreshCandidateFromTaskSet(c, appTS),
 		seedRefreshCandidateFromTaskSet(c, extraAppTS),
-	)
+	})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(snapdTS, baseTS, kernelTS, appTS), Equals, true)
@@ -20777,7 +20771,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRemoveSystemFailureDoesN
 	defer s.state.Unlock()
 
 	oldSeedRefreshTasks := snapstate.SeedRefreshTasks
-	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, _ snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
 		added := make(map[string]bool, len(candidates))
 		for _, candidate := range candidates {
 			if candidate.InstanceName != "kernel" && candidate.InstanceName != "core18" && candidate.InstanceName != "some-app" {
@@ -21048,11 +21042,13 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAddition
 	var appCompSetupTaskIDs []string
 	c.Assert(appSnapSetupTask.Get("component-setup-tasks", &appCompSetupTaskIDs), IsNil)
 	c.Assert(appCompSetupTaskIDs, HasLen, 1)
-	observed.CheckInitialCandidates(c, snapstate.SeedRefreshCandidate{
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
 		InstanceName:          "some-app",
 		SnapSetupTaskIDs:      []string{appSnapSetupTask.ID()},
 		ComponentSetupTaskIDs: appCompSetupTaskIDs,
-	})
+	}})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetLanes(seedTS), testutil.DeepUnsortedMatches, taskSetLanes(appTS))
@@ -21137,7 +21133,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowedOnceParentSeedRef
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshReRefreshCreatesSecondSeed(c *C) {
-	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
 		"base":           "core18",
 		"required-snaps": []any{"some-app"},
@@ -21186,6 +21182,16 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshReRefreshCreatesSecondSe
 	c.Check(restart.Pending(s.state), Equals, restart.RestartSystem)
 	c.Check(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 2)
 	c.Check(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 2)
+	c.Assert(observed.initial, HasLen, 2)
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{
+		{SeedsToRetain: 1},
+		{SeedsToRetain: 1},
+	})
+	c.Assert(observed.initial, HasLen, 2)
+	c.Assert(observed.initial[0], HasLen, 1)
+	c.Check(observed.initial[0][0].InstanceName, Equals, "some-app")
+	c.Assert(observed.initial[1], HasLen, 1)
+	c.Check(observed.initial[1][0].InstanceName, Equals, "some-app")
 
 	// the second reboot completes the re-refresh seed update.
 	s.mockRestartAndSettle(c, chg)
@@ -21305,6 +21311,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshDisabled(c *C) {
 	c.Assert(seedTS, IsNil)
 	c.Check(observed.initial, HasLen, 0)
 	c.Check(observed.prerequisites, HasLen, 0)
+	c.Check(observed.evictions, HasLen, 0)
 
 	lastBeforeLocalBase, err := baseTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20996,6 +20996,247 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentials(c *C) {
 	c.Check(waitsOnTransitively(seedEnd, appEndTask), Equals, true)
 }
 
+func setupSeedRefreshRevertSnapOfType(c *C, st *state.State, spec seedRefreshSnap) (*snap.SideInfo, *snap.SideInfo) {
+	oldSideInfo := &snap.SideInfo{RealName: spec.name, SnapID: spec.snapID, Revision: snap.R(5)}
+	newSideInfo := &snap.SideInfo{RealName: spec.name, SnapID: spec.snapID, Revision: snap.R(7)}
+
+	var oldSnapYaml strings.Builder
+	fmt.Fprintf(&oldSnapYaml, "name: %s\nversion: 1.0\n", spec.name)
+	if spec.snapType != "" {
+		fmt.Fprintf(&oldSnapYaml, "type: %s\n", spec.snapType)
+	}
+	if spec.base != "" {
+		fmt.Fprintf(&oldSnapYaml, "base: %s\n", spec.base)
+	}
+	snaptest.MockSnap(c, oldSnapYaml.String(), oldSideInfo)
+
+	var newSnapYaml strings.Builder
+	fmt.Fprintf(&newSnapYaml, "name: %s\nversion: 2.0\n", spec.name)
+	if spec.snapType != "" {
+		fmt.Fprintf(&newSnapYaml, "type: %s\n", spec.snapType)
+	}
+	if spec.base != "" {
+		fmt.Fprintf(&newSnapYaml, "base: %s\n", spec.base)
+	}
+	snaptest.MockSnap(c, newSnapYaml.String(), newSideInfo)
+
+	snapstate.Set(st, spec.name, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oldSideInfo, newSideInfo}),
+		Current:         newSideInfo.Revision,
+		TrackingChannel: "latest/stable",
+		SnapType:        spec.snapType,
+		Base:            spec.base,
+	})
+
+	return oldSideInfo, newSideInfo
+}
+
+func (s *snapmgrTestSuite) testRevertSeedRefreshRunThrough(c *C, spec seedRefreshSnap, model map[string]any) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, model, []string{spec.name})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restartRequested := mockSeedRefreshRebootHandlers(s, c, nil)
+
+	if spec.snapType == "gadget" {
+		s.o.TaskRunner().AddHandler("update-gadget-cmdline", func(t *state.Task, _ *tomb.Tomb) error {
+			st := t.State()
+			st.Lock()
+			defer st.Unlock()
+			t.SetStatus(state.DoneStatus)
+			return nil
+		}, nil)
+	}
+
+	oldSideInfo, _ := setupSeedRefreshRevertSnapOfType(c, s.state, spec)
+
+	ts, err := snapstate.RevertToRevision(s.state, spec.name, oldSideInfo.Revision, snapstate.Flags{}, "")
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("revert", "revert a snap backwards")
+	chg.AddAll(ts)
+	c.Assert(chg.CheckTaskDependencies(), IsNil)
+
+	setupTask, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	snapsup, err := snapstate.TaskSnapSetup(setupTask)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Revert, Equals, true)
+	c.Check(snapsup.Revision(), Equals, oldSideInfo.Revision)
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
+		InstanceName:     spec.name,
+		SnapSetupTaskIDs: []string{setupTask.ID()},
+	}})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{
+		SeedsToRetain: 1,
+		ReplaceLatest: true,
+	}})
+
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, ts)
+	lastBeforeLocal, err := ts.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
+
+	endTask, err := ts.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	c.Check(waitsOnTransitively(seedFinalize, endTask), Equals, true)
+
+	linkTask, err := ts.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	c.Check(hasDoRestartBoundary(seedCreate), Equals, true)
+	c.Check(hasDoRestartBoundary(linkTask), Equals, false)
+
+	s.settle(c)
+
+	c.Check(restart.Pending(s.state), Equals, restart.RestartSystem)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+	expectedRestarts := []restart.RestartType{restart.RestartSystem}
+	if spec.snapType == "snapd" {
+		expectedRestarts = []restart.RestartType{restart.RestartDaemon, restart.RestartSystem}
+	}
+	c.Check(*restartRequested, DeepEquals, expectedRestarts)
+
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, spec.name, &snapst), IsNil)
+	c.Check(snapst.Current, Equals, oldSideInfo.Revision)
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshSnapdRunThrough(c *C) {
+	s.testRevertSeedRefreshRunThrough(c, seedRefreshSnap{
+		name:     "snapd",
+		snapID:   "snapd-snap-id",
+		snapType: "snapd",
+	}, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	})
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshBaseRunThrough(c *C) {
+	s.testRevertSeedRefreshRunThrough(c, seedRefreshSnap{
+		name:     "core18",
+		snapID:   "core18-snap-id",
+		snapType: "base",
+	}, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	})
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshGadgetRunThrough(c *C) {
+	s.testRevertSeedRefreshRunThrough(c, seedRefreshSnap{
+		name:     "brand-gadget",
+		snapID:   "brand-gadget-id",
+		snapType: "gadget",
+	}, map[string]any{
+		"gadget": "brand-gadget",
+		"kernel": "kernel",
+		"base":   "core18",
+	})
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshKernelRunThrough(c *C) {
+	s.testRevertSeedRefreshRunThrough(c, seedRefreshSnap{
+		name:     "kernel",
+		snapID:   "kernel-id",
+		snapType: "kernel",
+	}, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	})
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshAppRunThrough(c *C) {
+	s.testRevertSeedRefreshRunThrough(c, seedRefreshSnap{
+		name:     "some-app",
+		snapID:   "some-app-id",
+		snapType: "app",
+		base:     "core18",
+	}, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	})
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshBlockedByOtherChanges(c *C) {
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	}, []string{"some-app"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+	)
+	oldSideInfo, _ := setupSeedRefreshRevertSnapOfType(c, s.state, seedRefreshSnap{
+		name:     "some-app",
+		snapID:   "some-app-id",
+		snapType: "app",
+		base:     "core18",
+	})
+
+	chg := s.state.NewChange("unrelated", "...")
+	chg.AddTask(s.state.NewTask("task", "..."))
+
+	_, err := snapstate.RevertToRevision(s.state, "some-app", oldSideInfo.Revision, snapstate.Flags{}, "")
+	c.Assert(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Check(err, ErrorMatches, `other changes in progress \(conflicting change "unrelated"\), change "seed refresh" not allowed until they are done`)
+}
+
+func (s *snapmgrTestSuite) TestRevertSeedRefreshNoopWhenSnapNotSelected(c *C) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	}, nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+	)
+	oldSideInfo, _ := setupSeedRefreshRevertSnapOfType(c, s.state, seedRefreshSnap{
+		name:     "some-app",
+		snapID:   "some-app-id",
+		snapType: "app",
+		base:     "core18",
+	})
+
+	ts, err := snapstate.RevertToRevision(s.state, "some-app", oldSideInfo.Revision, snapstate.Flags{}, "")
+	c.Assert(err, IsNil)
+
+	setupTask, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	snapsup, err := snapstate.TaskSnapSetup(setupTask)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Revert, Equals, true)
+	c.Check(snapsup.Revision(), Equals, oldSideInfo.Revision)
+
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
+		InstanceName:     "some-app",
+		SnapSetupTaskIDs: []string{setupTask.ID()},
+	}})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1, ReplaceLatest: true}})
+	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
+	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAdditionalComponents(c *C) {
 	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",

--- a/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
+++ b/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
@@ -1,11 +1,9 @@
-summary: refresh seed on UC20+
+summary: refresh seed when a model snap moves back to an existing revision
 
 details: |
-  Verify that seed-refresh updates the recovery seed as part of a normal refresh
-  change on Ubuntu Core. The test refreshes the kernel, base, and a
-  non-essential model snap, checks that the refreshed recovery system is
-  recorded, and verifies the refreshed recovery system boots with the refreshed
-  snaps.
+  Verify that moving a model snap back to an existing revision triggers a
+  seed-refresh on Ubuntu Core. Covers snap refresh --revision and revert
+  for kernel, gadget, base, and app snaps.
 
 systems:
   - -ubuntu-1*
@@ -23,6 +21,26 @@ environment:
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
   NESTED_SIGN_SNAPS_FAKESTORE: true
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+
+  BACK_TO_REVISION_METHOD/refresh_kernel: refresh
+  SNAP_UNDER_TEST/refresh_kernel: kernel
+  BACK_TO_REVISION_METHOD/revert_kernel: revert
+  SNAP_UNDER_TEST/revert_kernel: kernel
+
+  BACK_TO_REVISION_METHOD/refresh_gadget: refresh
+  SNAP_UNDER_TEST/refresh_gadget: gadget
+  BACK_TO_REVISION_METHOD/revert_gadget: revert
+  SNAP_UNDER_TEST/revert_gadget: gadget
+
+  BACK_TO_REVISION_METHOD/refresh_base: refresh
+  SNAP_UNDER_TEST/refresh_base: base
+  BACK_TO_REVISION_METHOD/revert_base: revert
+  SNAP_UNDER_TEST/revert_base: base
+
+  BACK_TO_REVISION_METHOD/refresh_app: refresh
+  SNAP_UNDER_TEST/refresh_app: app
+  BACK_TO_REVISION_METHOD/revert_app: revert
+  SNAP_UNDER_TEST/revert_app: app
 
 skip:
   - reason: This test needs test keys to be trusted
@@ -80,6 +98,7 @@ prepare: |
 
   # shellcheck source=tests/lib/core-config.sh
   . "${TESTSLIB}/core-config.sh"
+  wait_for_first_boot_change
 
   remote.exec 'sudo systemctl stop snapd snapd.socket'
   remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data.auth.device."session-macaroon" = "fake-session"' > state.json
@@ -102,10 +121,12 @@ execute: |
   test_snap_name="test-snapd-sh-core${version}"
   model_json="$TESTSLIB/assertions/developer1-${version}-with-app-dangerous.json"
   base_id="$(gojq -r --arg name "${base_snap}" ".snaps[] | select(.name == \$name) | .id" "${model_json}")"
+  gadget_id="$(gojq -r '.snaps[] | select(.name == "pc") | .id' "${model_json}")"
   kernel_id="$(gojq -r '.snaps[] | select(.name == "pc-kernel") | .id' "${model_json}")"
   test_snap_id="$(gojq -r --arg name "${test_snap_name}" ".snaps[] | select(.name == \$name) | .id" "${model_json}")"
   test_snap_path="$("${TESTSTOOLS}/snaps-state" pack-local "${test_snap_name}")"
   test -n "${base_id}"
+  test -n "${gadget_id}"
   test -n "${kernel_id}"
   test -n "${test_snap_id}"
 
@@ -129,21 +150,9 @@ execute: |
       "${snap_id}"
   }
 
-  run_seed_refresh_round() {
-    local change_id boot_id
-
-    boot_id="$(tests.nested boot-id)"
-    change_id="$(remote.exec "sudo snap refresh --no-wait ${base_snap} pc-kernel ${test_snap_name}")"
-    remote.wait-for reboot "${boot_id}"
-    remote.wait-for snap-command
-    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\\s+(Done|Undone|Error)'"
-    remote.exec 'sudo snap changes' | MATCH "^${change_id}\\s+Done"
-  }
-
   assert_live_snap_revisions() {
     local snap_revision snap_name revision
 
-    # accepts name/revision pairs in "snap=revision" format
     for snap_revision in "$@"; do
       snap_name="${snap_revision%%=*}"
       revision="${snap_revision#*=}"
@@ -152,7 +161,6 @@ execute: |
     done
   }
 
-  # verify seeded snap revisions are present in a recovery system
   assert_seed_snap_revisions_present() {
     local system_label="$1"
     local assertions="/run/mnt/ubuntu-seed/systems/${system_label}/assertions/snaps"
@@ -160,13 +168,13 @@ execute: |
 
     shift
 
-    # accepts name/revision pairs in "snap=revision" format
     for snap_revision in "$@"; do
       snap_name="${snap_revision%%=*}"
       revision="${snap_revision#*=}"
 
       case "${snap_name}" in
         "${base_snap}") snap_id="${base_id}" ;;
+        pc) snap_id="${gadget_id}" ;;
         pc-kernel) snap_id="${kernel_id}" ;;
         "${test_snap_name}") snap_id="${test_snap_id}" ;;
         *)
@@ -181,49 +189,104 @@ execute: |
     done
   }
 
+  assert_snap_revision_in_sequence() {
+    local snap_name="$1"
+    local revision="$2"
+
+    remote.exec "snap list --all ${snap_name}" | awk 'NR != 1 { print $3 }' | MATCH "^${revision}$"
+  }
+
+  run_seed_refresh_change() {
+    local command="$1"
+    local local_revision="${2:-}"
+    local change_id boot_id
+
+    boot_id="$(tests.nested boot-id)"
+    change_id="$(remote.exec "${command}")"
+    remote.wait-for reboot "${boot_id}"
+    remote.wait-for snap-command
+    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\\s+(Done|Undone|Error)'"
+    remote.exec 'sudo snap changes' | MATCH "^${change_id}\\s+Done"
+    remote.exec "sudo snap tasks ${change_id}" | MATCH 'Create recovery system with label'
+    if [ -n "${local_revision}" ]; then
+      remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .*/${snap_name}_${local_revision}.snap"
+      remote.exec "sudo snap tasks ${change_id}" | NOMATCH "Download snap \"${snap_name}\""
+    fi
+  }
+
+  case "${SNAP_UNDER_TEST}" in
+    kernel)
+      snap_name=pc-kernel
+      source_snap="${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap"
+      snap_id="${kernel_id}"
+      ;;
+    gadget)
+      snap_name=pc
+      source_snap="${NESTED_FAKESTORE_BLOB_DIR}/pc.snap"
+      snap_id="${gadget_id}"
+      ;;
+    base)
+      snap_name="${base_snap}"
+      source_snap="${NESTED_FAKESTORE_BLOB_DIR}/${base_snap}.snap"
+      snap_id="${base_id}"
+      ;;
+    app)
+      snap_name="${test_snap_name}"
+      source_snap="${test_snap_path}"
+      snap_id="${test_snap_id}"
+      ;;
+    *)
+      echo "unexpected SNAP_UNDER_TEST: ${SNAP_UNDER_TEST}"
+      exit 1
+      ;;
+  esac
+
   remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems-before.json
-  orig_seed_label="$(gojq -r '.[0].system' seeded-systems-before.json)"
-  latest_seed_label=""
+  previous_seed_label="$(gojq -r '.[0].system' seeded-systems-before.json)"
 
   remote.exec 'sudo snap set core experimental.seed-refresh=true'
 
-  revision=2
-  make_fake_store_revision "${NESTED_FAKESTORE_BLOB_DIR}/${base_snap}.snap" "./${base_snap}-rev${revision}.snap" "${base_id}" "${revision}"
-  make_fake_store_revision "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap" "./pc-kernel-rev${revision}.snap" "${kernel_id}" "${revision}"
-  make_fake_store_revision "${test_snap_path}" "./${test_snap_name}-rev${revision}.snap" "${test_snap_id}" "${revision}"
+  for revision in 2 3; do
+    make_fake_store_revision "${source_snap}" "./${snap_name}-rev${revision}.snap" "${snap_id}" "${revision}"
 
-  run_seed_refresh_round
+    run_seed_refresh_change "sudo snap refresh --no-wait ${snap_name}"
 
-  assert_live_snap_revisions "${base_snap}=${revision}" "pc-kernel=${revision}" "${test_snap_name}=${revision}"
+    assert_live_snap_revisions "${snap_name}=${revision}"
 
-  # verify seed-refresh recorded and promoted the new recovery system
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems.json
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["default-recovery-system"]' > default-recovery-system.json
+    latest_seed_label="$(gojq -r '.[0].system' seeded-systems.json)"
+    test -n "${latest_seed_label}"
+    test "${latest_seed_label}" != "${previous_seed_label}"
+    test "$(gojq -r '.[0]["seed-refresh"]' seeded-systems.json)" = true
+    test "$(gojq -r '.system' default-recovery-system.json)" = "${latest_seed_label}"
+
+    previous_seed_label="${latest_seed_label}"
+  done
+
+  case "${BACK_TO_REVISION_METHOD}" in
+    revert)
+      run_seed_refresh_change "sudo snap revert --revision=2 --no-wait ${snap_name}"
+      ;;
+    refresh)
+      assert_snap_revision_in_sequence "${snap_name}" 2
+      run_seed_refresh_change "sudo snap refresh --revision=2 --no-wait ${snap_name}" 2
+      ;;
+    *)
+      echo "unexpected BACK_TO_REVISION_METHOD: ${BACK_TO_REVISION_METHOD}"
+      exit 1
+      ;;
+  esac
+
+  assert_live_snap_revisions "${snap_name}=2"
+
+  # verify the back-to-revision change created and promoted a new recovery system
   remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems.json
   remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["default-recovery-system"]' > default-recovery-system.json
-
   latest_seed_label="$(gojq -r '.[0].system' seeded-systems.json)"
   test -n "${latest_seed_label}"
-  test "${latest_seed_label}" != "${orig_seed_label}"
+  test "${latest_seed_label}" != "${previous_seed_label}"
   test "$(gojq -r '.[0]["seed-refresh"]' seeded-systems.json)" = true
-  test "$(gojq -r '.[1].system' seeded-systems.json)" = "${orig_seed_label}"
   test "$(gojq -r '.system' default-recovery-system.json)" = "${latest_seed_label}"
-  test "$(gojq '[.[] | select(."seed-refresh" == true)] | length' seeded-systems.json)" = 1
-
-  # verify the refreshed snaps are present in the seed
   remote.exec "test -d /run/mnt/ubuntu-seed/systems/${latest_seed_label}"
-  assert_seed_snap_revisions_present "${latest_seed_label}" "${base_snap}=${revision}" "pc-kernel=${revision}" "${test_snap_name}=${revision}"
-  assert_seed_snap_revisions_present "${orig_seed_label}" "${base_snap}=1" pc-kernel=1 "${test_snap_name}=1"
-
-  # boot into the newest recovery system and verify the refreshed snaps are
-  # present there too
-  boot_id="$(tests.nested boot-id)"
-  remote.exec 'sudo snap reboot --recover' || true
-  remote.wait-for reboot "${boot_id}"
-  remote.wait-for snap-command
-  remote.exec 'sudo snap wait system seed.loaded'
-
-  remote.exec 'cat /proc/cmdline' | MATCH 'snapd_recovery_mode=recover'
-  remote.exec 'sudo cat /var/lib/snapd/modeenv' > modeenv.recover
-  MATCH 'mode=recover' < modeenv.recover
-  MATCH "recovery_system=${latest_seed_label}" < modeenv.recover
-
-  assert_live_snap_revisions "${base_snap}=2" pc-kernel=2 "${test_snap_name}=2"
+  assert_seed_snap_revisions_present "${latest_seed_label}" "${snap_name}=2"

--- a/tests/nested/manual/seed-refresh-eviction/task.yaml
+++ b/tests/nested/manual/seed-refresh-eviction/task.yaml
@@ -1,11 +1,10 @@
-summary: refresh seed on UC20+
+summary: evict old seed-refresh systems after app refreshes
 
 details: |
-  Verify that seed-refresh updates the recovery seed as part of a normal refresh
-  change on Ubuntu Core. The test refreshes the kernel, base, and a
-  non-essential model snap, checks that the refreshed recovery system is
-  recorded, and verifies the refreshed recovery system boots with the refreshed
-  snaps.
+  Verify the seed-refresh eviction policy on Ubuntu Core. Refreshes a single
+  non-essential model app repeatedly and checks that the oldest seed-refresh
+  system and its seed snap are removed while newer systems are retained. Also
+  checks that reverting replaces the latest seed-refresh system.
 
 systems:
   - -ubuntu-1*
@@ -98,15 +97,10 @@ execute: |
   . "${TESTSLIB}/core-config.sh"
 
   version="$(tests.nested show version)"
-  base_snap="core${version}"
   test_snap_name="test-snapd-sh-core${version}"
   model_json="$TESTSLIB/assertions/developer1-${version}-with-app-dangerous.json"
-  base_id="$(gojq -r --arg name "${base_snap}" ".snaps[] | select(.name == \$name) | .id" "${model_json}")"
-  kernel_id="$(gojq -r '.snaps[] | select(.name == "pc-kernel") | .id' "${model_json}")"
   test_snap_id="$(gojq -r --arg name "${test_snap_name}" ".snaps[] | select(.name == \$name) | .id" "${model_json}")"
   test_snap_path="$("${TESTSTOOLS}/snaps-state" pack-local "${test_snap_name}")"
-  test -n "${base_id}"
-  test -n "${kernel_id}"
   test -n "${test_snap_id}"
 
   make_fake_store_revision() {
@@ -129,11 +123,11 @@ execute: |
       "${snap_id}"
   }
 
-  run_seed_refresh_round() {
+  run_seed_refresh_change() {
     local change_id boot_id
 
     boot_id="$(tests.nested boot-id)"
-    change_id="$(remote.exec "sudo snap refresh --no-wait ${base_snap} pc-kernel ${test_snap_name}")"
+    change_id="$(remote.exec "sudo snap refresh --no-wait ${test_snap_name}")"
     remote.wait-for reboot "${boot_id}"
     remote.wait-for snap-command
     retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\\s+(Done|Undone|Error)'"
@@ -143,7 +137,6 @@ execute: |
   assert_live_snap_revisions() {
     local snap_revision snap_name revision
 
-    # accepts name/revision pairs in "snap=revision" format
     for snap_revision in "$@"; do
       snap_name="${snap_revision%%=*}"
       revision="${snap_revision#*=}"
@@ -152,78 +145,78 @@ execute: |
     done
   }
 
-  # verify seeded snap revisions are present in a recovery system
-  assert_seed_snap_revisions_present() {
-    local system_label="$1"
-    local assertions="/run/mnt/ubuntu-seed/systems/${system_label}/assertions/snaps"
-    local snap_revision snap_name revision snap_id
-
-    shift
-
-    # accepts name/revision pairs in "snap=revision" format
-    for snap_revision in "$@"; do
-      snap_name="${snap_revision%%=*}"
-      revision="${snap_revision#*=}"
-
-      case "${snap_name}" in
-        "${base_snap}") snap_id="${base_id}" ;;
-        pc-kernel) snap_id="${kernel_id}" ;;
-        "${test_snap_name}") snap_id="${test_snap_id}" ;;
-        *)
-          echo "unexpected snap: ${snap_name}"
-          exit 1
-          ;;
-      esac
-
-      remote.exec "test -f /var/lib/snapd/seed/snaps/${snap_name}_${revision}.snap"
-      remote.exec "sudo grep -Fxq 'snap-id: ${snap_id}' ${assertions}"
-      remote.exec "sudo grep -Fxq 'snap-revision: ${revision}' ${assertions}"
-    done
-  }
-
   remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems-before.json
   orig_seed_label="$(gojq -r '.[0].system' seeded-systems-before.json)"
-  latest_seed_label=""
+  previous_seed_label="${orig_seed_label}"
 
   remote.exec 'sudo snap set core experimental.seed-refresh=true'
 
-  revision=2
-  make_fake_store_revision "${NESTED_FAKESTORE_BLOB_DIR}/${base_snap}.snap" "./${base_snap}-rev${revision}.snap" "${base_id}" "${revision}"
-  make_fake_store_revision "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap" "./pc-kernel-rev${revision}.snap" "${kernel_id}" "${revision}"
-  make_fake_store_revision "${test_snap_path}" "./${test_snap_name}-rev${revision}.snap" "${test_snap_id}" "${revision}"
+  for revision in 2 3 4; do
+    make_fake_store_revision "${test_snap_path}" "./${test_snap_name}-rev${revision}.snap" "${test_snap_id}" "${revision}"
 
-  run_seed_refresh_round
+    run_seed_refresh_change
+    assert_live_snap_revisions "${test_snap_name}=${revision}"
 
-  assert_live_snap_revisions "${base_snap}=${revision}" "pc-kernel=${revision}" "${test_snap_name}=${revision}"
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems.json
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["default-recovery-system"]' > default-recovery-system.json
+    latest_seed_label="$(gojq -r '.[0].system' seeded-systems.json)"
+    test -n "${latest_seed_label}"
+    test "${latest_seed_label}" != "${previous_seed_label}"
+    test "$(gojq -r '.[0]["seed-refresh"]' seeded-systems.json)" = true
+    test "$(gojq -r '.system' default-recovery-system.json)" = "${latest_seed_label}"
+    remote.exec "test -d /run/mnt/ubuntu-seed/systems/${latest_seed_label}"
 
-  # verify seed-refresh recorded and promoted the new recovery system
-  remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems.json
-  remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["default-recovery-system"]' > default-recovery-system.json
+    case "${revision}" in
+      2)
+        first_seed_refresh_label="${latest_seed_label}"
+        ;;
+      3)
+        second_seed_refresh_label="${latest_seed_label}"
+        ;;
+      4)
+        third_seed_refresh_label="${latest_seed_label}"
+        # verify the oldest seed-refresh system was evicted
+        test "$(gojq '[.[] | select(."seed-refresh" == true)] | length' seeded-systems.json)" = 2
+        test "$(gojq -r '.[1].system' seeded-systems.json)" = "${second_seed_refresh_label}"
+        test "$(gojq -r '.[2].system' seeded-systems.json)" = "${orig_seed_label}"
+        test "$(gojq "[.[] | select(.system == \"${first_seed_refresh_label}\")] | length" seeded-systems.json)" = 0
+        test "$(gojq "[.[] | select(.system == \"${second_seed_refresh_label}\")] | length" seeded-systems.json)" = 1
+        remote.exec "test ! -d /run/mnt/ubuntu-seed/systems/${first_seed_refresh_label}"
+        remote.exec "test -d /run/mnt/ubuntu-seed/systems/${second_seed_refresh_label}"
+        remote.exec "test ! -f /var/lib/snapd/seed/snaps/${test_snap_name}_2.snap"
+        remote.exec "test -f /var/lib/snapd/seed/snaps/${test_snap_name}_3.snap"
+        remote.exec "test -f /var/lib/snapd/seed/snaps/${test_snap_name}_4.snap"
+        ;;
+    esac
 
-  latest_seed_label="$(gojq -r '.[0].system' seeded-systems.json)"
-  test -n "${latest_seed_label}"
-  test "${latest_seed_label}" != "${orig_seed_label}"
-  test "$(gojq -r '.[0]["seed-refresh"]' seeded-systems.json)" = true
-  test "$(gojq -r '.[1].system' seeded-systems.json)" = "${orig_seed_label}"
-  test "$(gojq -r '.system' default-recovery-system.json)" = "${latest_seed_label}"
-  test "$(gojq '[.[] | select(."seed-refresh" == true)] | length' seeded-systems.json)" = 1
+    previous_seed_label="${latest_seed_label}"
+  done
 
-  # verify the refreshed snaps are present in the seed
-  remote.exec "test -d /run/mnt/ubuntu-seed/systems/${latest_seed_label}"
-  assert_seed_snap_revisions_present "${latest_seed_label}" "${base_snap}=${revision}" "pc-kernel=${revision}" "${test_snap_name}=${revision}"
-  assert_seed_snap_revisions_present "${orig_seed_label}" "${base_snap}=1" pc-kernel=1 "${test_snap_name}=1"
-
-  # boot into the newest recovery system and verify the refreshed snaps are
-  # present there too
   boot_id="$(tests.nested boot-id)"
-  remote.exec 'sudo snap reboot --recover' || true
+  change_id="$(remote.exec "sudo snap revert --revision=3 --no-wait ${test_snap_name}")"
   remote.wait-for reboot "${boot_id}"
   remote.wait-for snap-command
-  remote.exec 'sudo snap wait system seed.loaded'
+  retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\\s+(Done|Undone|Error)'"
+  remote.exec 'sudo snap changes' | MATCH "^${change_id}\\s+Done"
 
-  remote.exec 'cat /proc/cmdline' | MATCH 'snapd_recovery_mode=recover'
-  remote.exec 'sudo cat /var/lib/snapd/modeenv' > modeenv.recover
-  MATCH 'mode=recover' < modeenv.recover
-  MATCH "recovery_system=${latest_seed_label}" < modeenv.recover
+  assert_live_snap_revisions "${test_snap_name}=3"
 
-  assert_live_snap_revisions "${base_snap}=2" pc-kernel=2 "${test_snap_name}=2"
+  remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["seeded-systems"]' > seeded-systems.json
+  remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data["default-recovery-system"]' > default-recovery-system.json
+  latest_seed_label="$(gojq -r '.[0].system' seeded-systems.json)"
+  test -n "${latest_seed_label}"
+  test "${latest_seed_label}" != "${previous_seed_label}"
+  test "$(gojq -r '.[0]["seed-refresh"]' seeded-systems.json)" = true
+  test "$(gojq -r '.[1].system' seeded-systems.json)" = "${second_seed_refresh_label}"
+  test "$(gojq -r '.[2].system' seeded-systems.json)" = "${orig_seed_label}"
+  test "$(gojq -r '.system' default-recovery-system.json)" = "${latest_seed_label}"
+
+  # verify revert replaced the latest seed-refresh system with the incoming one
+  test "$(gojq '[.[] | select(."seed-refresh" == true)] | length' seeded-systems.json)" = 2
+  test "$(gojq "[.[] | select(.system == \"${second_seed_refresh_label}\")] | length" seeded-systems.json)" = 1
+  test "$(gojq "[.[] | select(.system == \"${third_seed_refresh_label}\")] | length" seeded-systems.json)" = 0
+  remote.exec "test -d /run/mnt/ubuntu-seed/systems/${latest_seed_label}"
+  remote.exec "test -d /run/mnt/ubuntu-seed/systems/${second_seed_refresh_label}"
+  remote.exec "test ! -d /run/mnt/ubuntu-seed/systems/${third_seed_refresh_label}"
+  remote.exec "test -f /var/lib/snapd/seed/snaps/${test_snap_name}_3.snap"
+  remote.exec "test ! -f /var/lib/snapd/seed/snaps/${test_snap_name}_4.snap"


### PR DESCRIPTION
This PR adds support for seed-refresh to snap reverts. Note that the retention policy we use for seeds differs when doing a refresh compared to a revert.

Sorry this is large, but most changes are tests. Let me know if anyone would like this to be broken down. I could reasonably land the first commit without the final two if we want.