### PR TITLE
tests: skip amazon-linux-2 in the security-logging test

### DIFF
--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -7,6 +7,9 @@ details: |
     when store credentials are available, that a successful login produces
     an "authn_login_success" event in the audit log.
 
+# Amazon Linux 2: systemd-journald-audit.socket is not available
+systems: [ -amazon-linux-2-64 ]
+
 prepare: |
     # Enable the kernel audit subsystem if it isn't already enabled.
     python3 -c "


### PR DESCRIPTION
Amazon-linux-2 does not have working journald audit integration (we see that systemd-journald-audit.socket is absent), so it is not being forwarding audit messages into journalctl

Error in tests
systemctl start systemd-journald-audit.socket -> Failed to start systemd-journald-audit.socket: Unit not found.

