### PR TITLE
agents: add skills for snapd build and test workflows

### DIFF
--- a/.agents/skills/build-snapd-snap/SKILL.md
+++ b/.agents/skills/build-snapd-snap/SKILL.md
@@ -23,6 +23,10 @@ Use this skill when you need to:
 - Rebuild after making changes to snapd code
 - Determine which build option to use based on code changes
 
+**When you do NOT need to build**:
+- The `tests/unit/` suite does not require a prebuilt snapd snap. Use `spread` directly for those tests (e.g., `spread garden:ubuntu-24.04-64:tests/unit/go`).
+- Changes only to test infrastructure files (`tests/lib/`, `tests/unit/`, etc.) that don't affect the snap contents — use `spread` directly or `NO_REBUILD=1`.
+
 **Preferred approach**: Use `--clean-snapd-only` to ensure the snapd part is fully rebuilt (clean + rebuild) while preserving other parts.
 
 ## Build Options
@@ -126,14 +130,16 @@ Changes made to:
    -> Reason: Those specific parts need rebuilding
 
 6. Unsure about what changed or dependencies unclear
-   -> Use: full clean (no flags)
-   -> Reason: Safe default that ensures correct build
+   -> Use: --clean-snapd-only (PREFERRED - covers most cases without rebuilding everything)
+   -> Reason: Fast rebuild of the snapd part; only use full clean (no flags) as a last resort
+      when you are certain non-snapd parts (apparmor, dynamic-linker, runtime, etc.) need rebuilding
 
 7. Rapid iteration with no dependency changes (USE WITH CAUTION)
    -> Use: --no-clean
    -> Reason: Fastest option, but verify build correctness
 
 Default choice for most development: --clean-snapd-only
+Full clean (no flags) is a last resort — only use when certain that non-snapd parts need rebuilding.
 ```
 
 ## Verification

--- a/.agents/skills/build-snapd-snap/SKILL.md
+++ b/.agents/skills/build-snapd-snap/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: build-snapd-snap
+description: Build the snapd snap artifact for testing using ./tests/build-test-snapd-snap
+metadata:
+  project: snapd
+  task-type: build
+---
+
+## Overview
+
+This skill covers how to build the snapd snap artifact required for spread integration testing.
+
+**Command**: `./tests/build-test-snapd-snap`
+
+**Purpose**: Builds the snapd snap package using snapcraft, creating a snap file in the `built-snap/` directory.
+
+**Output**: `built-snap/snapd_*.snap.keep`
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Build the snapd snap before running spread tests
+- Rebuild after making changes to snapd code
+- Determine which build option to use based on code changes
+
+**Preferred approach**: Use `--clean-snapd-only` to ensure the snapd part is fully rebuilt (clean + rebuild) while preserving other parts.
+
+## Build Options
+
+### Option 1: Clean Snapd Only (--clean-snapd-only) - PREFERRED
+
+```bash
+./tests/build-test-snapd-snap --clean-snapd-only
+```
+
+**Use this as the default choice** for most development work.
+
+**What it does**: 
+- Cleans and fully rebuilds only the `snapd` part in `build-aux/snap/snapcraft.yaml`
+- Ensures the snapd part is completely rebuilt from scratch (clean + rebuild)
+- Preserves all other parts (dynamic-linker, runtime, apparmor, etc.)
+
+**Perfect for**:
+- Changes to Go code in cmd/, daemon/, overlord/, interfaces/, etc.
+- Iterating on snapd daemon logic
+- Bug fixes in Go code
+- Most day-to-day development work
+
+**Avoids rebuilding**:
+- `dynamic-linker` (custom glibc dynamic linker)
+- `runtime` (runtime library dependencies)
+- `apparmor` (AppArmor parser and libraries)
+- `patchelf` (ELF manipulation tool)
+- `squashfs-tools` (squashfs filesystem tools)
+- `libcrypto-fips` (FIPS-compliant crypto libraries)
+
+**Build time**: Approximately 1-2 minutes (Go compilation and linking only).
+
+### Option 2: Full Clean (no flags) - Use When Needed
+
+```bash
+./tests/build-test-snapd-snap
+```
+
+**Use when `--clean-snapd-only` is not sufficient**:
+- Non-snapd parts of `build-aux/snap/snapcraft.yaml` were changed
+- AppArmor part configuration in `build-aux/snap/snapcraft.yaml` was modified
+- Changes to `build-aux/snap/local/` scripts
+- Changes to dynamic-linker, runtime, or other non-snapd parts
+- First build of the day after pulling major changes
+- When in doubt about dependencies
+
+**Build time**: Several minutes (builds glibc, apparmor, and all dependencies).
+
+### Option 3: No Clean (--no-clean) - Use With Caution
+
+```bash
+./tests/build-test-snapd-snap --no-clean
+```
+
+**Use when**: Iterating rapidly and confident that no dependencies changed.
+
+**What it does**: Skips `snapcraft clean` (equivalent to `SNAPCRAFT_NO_CLEAN=1`). Note: `built-snap/` directory is still removed and recreated.
+
+**Warning**: May produce incorrect builds if any dependencies have changed. Use with caution.
+
+**Build time**: Fastest option, typically under a minute.
+
+## Snapcraft Parts Reference
+
+The snapd snap consists of multiple parts defined in `build-aux/snap/snapcraft.yaml`:
+
+- **snapd**: Main Go code (daemon, commands, libraries) - the core snapd implementation
+- **apparmor**: AppArmor parser and libraries for security confinement
+- **dynamic-linker**: Custom glibc dynamic linker for the snap
+- **runtime**: Runtime library dependencies (libc, libcap, libseccomp, etc.)
+- **patchelf**: ELF manipulation tool
+- **squashfs-tools**: Tools for creating and managing squashfs filesystems
+- **libcrypto-fips**: FIPS-compliant crypto libraries (conditional)
+
+## Decision Tree
+
+Use this guide to choose the appropriate build option:
+
+```
+Changes made to:
+
+1. Go code in cmd/, daemon/, overlord/, interfaces/, etc.
+   -> Use: --clean-snapd-only (PREFERRED - ensures full rebuild of snapd part)
+   -> Reason: Cleans and fully rebuilds snapd part only
+
+2. AppArmor part in build-aux/snap/snapcraft.yaml
+   -> Use: full clean (no flags)
+   -> Reason: apparmor part must be rebuilt
+
+3. Scripts in build-aux/snap/local/
+   -> Use: full clean (no flags)
+   -> Reason: Build process itself changed
+
+4. Parts configuration in build-aux/snap/snapcraft.yaml (non-snapd parts)
+   -> Use: full clean (no flags)
+   -> Reason: Multiple parts may be affected
+
+5. Changes to dynamic-linker, runtime, or other non-snapd parts
+   -> Use: full clean (no flags)
+   -> Reason: Those specific parts need rebuilding
+
+6. Unsure about what changed or dependencies unclear
+   -> Use: full clean (no flags)
+   -> Reason: Safe default that ensures correct build
+
+7. Rapid iteration with no dependency changes (USE WITH CAUTION)
+   -> Use: --no-clean
+   -> Reason: Fastest option, but verify build correctness
+
+Default choice for most development: --clean-snapd-only
+```
+
+## Verification
+
+After the build completes successfully, verify the snap file was created:
+
+```bash
+ls -lh built-snap/snapd_*.snap.keep
+```
+
+You should see a snap file with a size of approximately 30-40 MB (varies by architecture and build configuration).
+
+## Integration with Spread Tests
+
+The built snap is automatically used by the spread test infrastructure:
+
+- The `run-spread` script looks for the snap in `built-snap/`
+- Use `--no-rebuild` / `-n` flag with `run-spread` to skip rebuilding if the snap already exists
+- See the `run-spread-test` skill for details on running spread tests
+
+## Common Scenarios
+
+**Scenario 1: Fixed a bug in snapd daemon**
+```bash
+# Only Go code changed
+./tests/build-test-snapd-snap --clean-snapd-only
+```
+
+**Scenario 2: Modified AppArmor part configuration**
+```bash
+# Non-snapd part changed
+./tests/build-test-snapd-snap
+```
+
+**Scenario 3: Modified snapcraft.yaml to add new runtime dependency**
+```bash
+# Runtime part affected
+./tests/build-test-snapd-snap
+```
+
+**Scenario 4: Quick iteration on interface implementation**
+```bash
+# First build: use --clean-snapd-only
+./tests/build-test-snapd-snap --clean-snapd-only
+
+# Subsequent iterations: use --no-clean
+./tests/build-test-snapd-snap --no-clean
+```
+
+## Best Practices
+
+**DO**:
+- Use `--clean-snapd-only` as your default for Go code changes (ensures full rebuild)
+- Use full clean when in doubt about dependencies
+- Verify the snap was created after build completes
+- Check build logs for warnings or errors
+
+**DON'T**:
+- Use `--no-clean` unless you're certain dependencies haven't changed
+- Ignore build warnings (they may indicate real issues)
+- Assume a previous build is still valid after pulling changes

--- a/.agents/skills/build-snapd-snap/SKILL.md
+++ b/.agents/skills/build-snapd-snap/SKILL.md
@@ -6,198 +6,35 @@ metadata:
   task-type: build
 ---
 
-## Overview
+## Build the snapd snap
 
-This skill covers how to build the snapd snap artifact required for spread integration testing.
+Command: `./tests/build-test-snapd-snap [OPTIONS]`
+Output: `built-snap/snapd_*.snap.keep` (~30-40 MB)
 
-Command: `./tests/build-test-snapd-snap`
+## When to build
 
-Purpose: Builds the snapd snap package using snapcraft, creating a snap file in the `built-snap/` directory.
+Build when snapd code or snap packaging changed. Skip when only test files (`tests/lib/`, `tests/unit/`) changed — use `./run-spread --download` or `NO_REBUILD=1` instead.
 
-Output: `built-snap/snapd_*.snap.keep`
+## Options
 
-## When to Use This Skill
+| Flag | When to use | Build time |
+|------|-------------|------------|
+| `--clean-snapd-only` | **Default.** Go code changes (cmd/, daemon/, overlord/, interfaces/) | 1-2 min |
+| _(no flags)_ | Non-snapd parts changed: apparmor, dynamic-linker, runtime, `build-aux/snap/` scripts | Several min |
+| `--no-clean` | Rapid iteration, confident no deps changed. May produce incorrect builds. | <1 min |
 
-Use this skill when you need to:
-- Build the snapd snap before running spread tests
-- Rebuild after making changes to snapd code
-- Determine which build option to use based on code changes
+`--clean-snapd-only` rebuilds only the `snapd` part from `build-aux/snap/snapcraft.yaml`, preserving all other parts (apparmor, dynamic-linker, runtime, patchelf, squashfs-tools, libcrypto-fips).
 
-When you do NOT need to build:
-- The `tests/unit/` suite does not require a prebuilt snapd snap. Use `spread` directly for those tests (e.g., `spread garden:ubuntu-24.04-64:tests/unit/go`).
-- Changes only to test infrastructure files (`tests/lib/`, `tests/unit/`, etc.) that don't affect the snap contents — use `./run-spread --download` to fetch the prebuilt snap from master, or set `NO_REBUILD=1` if a snap already exists locally.
-
-Preferred approach: Use `--clean-snapd-only` to ensure the snapd part is fully rebuilt (clean + rebuild) while preserving other parts.
-
-## Build Options
-
-### Option 1: Clean Snapd Only (--clean-snapd-only) - PREFERRED
-
-```bash
-./tests/build-test-snapd-snap --clean-snapd-only
-```
-
-Use this as the default choice for most development work.
-
-What it does:
-- Cleans and fully rebuilds only the `snapd` part in `build-aux/snap/snapcraft.yaml`
-- Ensures the snapd part is completely rebuilt from scratch (clean + rebuild)
-- Preserves all other parts (dynamic-linker, runtime, apparmor, etc.)
-
-Perfect for:
-- Changes to Go code in cmd/, daemon/, overlord/, interfaces/, etc.
-- Iterating on snapd daemon logic
-- Bug fixes in Go code
-- Most day-to-day development work
-
-Avoids rebuilding:
-- `dynamic-linker` (custom glibc dynamic linker)
-- `runtime` (runtime library dependencies)
-- `apparmor` (AppArmor parser and libraries)
-- `patchelf` (ELF manipulation tool)
-- `squashfs-tools` (squashfs filesystem tools)
-- `libcrypto-fips` (FIPS-compliant crypto libraries)
-
-Build time: Approximately 1-2 minutes (Go compilation and linking only).
-
-### Option 2: Full Clean (no flags) - Use When Needed
-
-```bash
-./tests/build-test-snapd-snap
-```
-
-Use when `--clean-snapd-only` is not sufficient:
-- Non-snapd parts of `build-aux/snap/snapcraft.yaml` were changed
-- AppArmor part configuration in `build-aux/snap/snapcraft.yaml` was modified
-- Changes to `build-aux/snap/local/` scripts
-- Changes to dynamic-linker, runtime, or other non-snapd parts
-- First build of the day after pulling major changes
-- When in doubt about dependencies
-
-Build time: Several minutes (builds glibc, apparmor, and all dependencies).
-
-### Option 3: No Clean (--no-clean) - Use With Caution
-
-```bash
-./tests/build-test-snapd-snap --no-clean
-```
-
-Use when: Iterating rapidly and confident that no dependencies changed.
-
-What it does: Skips `snapcraft clean` (equivalent to `SNAPCRAFT_NO_CLEAN=1`). Note: `built-snap/` directory is still removed and recreated.
-
-Warning: May produce incorrect builds if any dependencies have changed. Use with caution.
-
-Build time: Fastest option, typically under a minute.
-
-## Snapcraft Parts Reference
-
-The snapd snap consists of multiple parts defined in `build-aux/snap/snapcraft.yaml`:
-
-- `snapd`: Main Go code (daemon, commands, libraries) - the core snapd implementation
-- `apparmor`: AppArmor parser and libraries for security confinement
-- `dynamic-linker`: Custom glibc dynamic linker for the snap
-- `runtime`: Runtime library dependencies (libc, libcap, libseccomp, etc.)
-- `patchelf`: ELF manipulation tool
-- `squashfs-tools`: Tools for creating and managing squashfs filesystems
-- `libcrypto-fips`: FIPS-compliant crypto libraries (conditional)
-
-## Decision Tree
-
-Use this guide to choose the appropriate build option:
-
-```
-Changes made to:
-
-1. Go code in cmd/, daemon/, overlord/, interfaces/, etc.
-   -> Use: --clean-snapd-only (PREFERRED - ensures full rebuild of snapd part)
-   -> Reason: Cleans and fully rebuilds snapd part only
-
-2. AppArmor part in build-aux/snap/snapcraft.yaml
-   -> Use: full clean (no flags)
-   -> Reason: apparmor part must be rebuilt
-
-3. Scripts in build-aux/snap/local/
-   -> Use: full clean (no flags)
-   -> Reason: Build process itself changed
-
-4. Parts configuration in build-aux/snap/snapcraft.yaml (non-snapd parts)
-   -> Use: full clean (no flags)
-   -> Reason: Multiple parts may be affected
-
-5. Changes to dynamic-linker, runtime, or other non-snapd parts
-   -> Use: full clean (no flags)
-   -> Reason: Those specific parts need rebuilding
-
-6. Unsure about what changed or dependencies unclear
-   -> Use: --clean-snapd-only (PREFERRED - covers most cases without rebuilding everything)
-   -> Reason: Fast rebuild of the snapd part; only use full clean (no flags) as a last resort
-     when you are certain non-snapd parts (apparmor, dynamic-linker, runtime, etc.) need rebuilding
-
-7. Rapid iteration with no dependency changes (USE WITH CAUTION)
-   -> Use: --no-clean
-   -> Reason: Fastest option, but verify build correctness
-
-Default choice for most development: --clean-snapd-only
-Full clean (no flags) is a last resort — only use when certain that non-snapd parts need rebuilding.
-```
+Use full clean (no flags) only when certain that non-snapd parts need rebuilding.
 
 ## Verification
-
-After the build completes successfully, verify the snap file was created:
 
 ```bash
 ls -lh built-snap/snapd_*.snap.keep
 ```
 
-You should see a snap file with a size of approximately 30-40 MB (varies by architecture and build configuration).
+## Integration with spread
 
-## Integration with Spread Tests
-
-The built snap is automatically used by the spread test infrastructure:
-
-- The `run-spread` script looks for the snap in `built-snap/`
-- Set `NO_REBUILD=1` in the environment when calling `run-spread` to skip rebuilding if the snap already exists
-- See the `run-spread-test` skill for details on running spread tests
-
-## Common Scenarios
-
-Scenario 1 — Fixed a bug in snapd daemon:
-```bash
-# Only Go code changed
-./tests/build-test-snapd-snap --clean-snapd-only
-```
-
-Scenario 2 — Modified AppArmor part configuration:
-```bash
-# Non-snapd part changed
-./tests/build-test-snapd-snap
-```
-
-Scenario 3 — Modified snapcraft.yaml to add new runtime dependency:
-```bash
-# Runtime part affected
-./tests/build-test-snapd-snap
-```
-
-Scenario 4 — Quick iteration on interface implementation:
-```bash
-# First build: use --clean-snapd-only
-./tests/build-test-snapd-snap --clean-snapd-only
-
-# Subsequent iterations: use --no-clean
-./tests/build-test-snapd-snap --no-clean
-```
-
-## Best Practices
-
-DO:
-- Use `--clean-snapd-only` as your default for Go code changes (ensures full rebuild)
-- Use full clean when in doubt about dependencies
-- Verify the snap was created after build completes
-- Check build logs for warnings or errors
-
-DON'T:
-- Use `--no-clean` unless you're certain dependencies haven't changed
-- Ignore build warnings (they may indicate real issues)
-- Assume a previous build is still valid after pulling changes
+- `run-spread` looks for the snap in `built-snap/`
+- Set `NO_REBUILD=1` to skip rebuilding when snap already exists
+- See `run-spread-test` skill for running tests

--- a/.agents/skills/build-snapd-snap/SKILL.md
+++ b/.agents/skills/build-snapd-snap/SKILL.md
@@ -151,7 +151,7 @@ You should see a snap file with a size of approximately 30-40 MB (varies by arch
 The built snap is automatically used by the spread test infrastructure:
 
 - The `run-spread` script looks for the snap in `built-snap/`
-- Use `--no-rebuild` / `-n` flag with `run-spread` to skip rebuilding if the snap already exists
+- Set `NO_REBUILD=1` in the environment when calling `run-spread` to skip rebuilding if the snap already exists
 - See the `run-spread-test` skill for details on running spread tests
 
 ## Common Scenarios

--- a/.agents/skills/build-snapd-snap/SKILL.md
+++ b/.agents/skills/build-snapd-snap/SKILL.md
@@ -10,11 +10,11 @@ metadata:
 
 This skill covers how to build the snapd snap artifact required for spread integration testing.
 
-**Command**: `./tests/build-test-snapd-snap`
+Command: `./tests/build-test-snapd-snap`
 
-**Purpose**: Builds the snapd snap package using snapcraft, creating a snap file in the `built-snap/` directory.
+Purpose: Builds the snapd snap package using snapcraft, creating a snap file in the `built-snap/` directory.
 
-**Output**: `built-snap/snapd_*.snap.keep`
+Output: `built-snap/snapd_*.snap.keep`
 
 ## When to Use This Skill
 
@@ -23,11 +23,11 @@ Use this skill when you need to:
 - Rebuild after making changes to snapd code
 - Determine which build option to use based on code changes
 
-**When you do NOT need to build**:
+When you do NOT need to build:
 - The `tests/unit/` suite does not require a prebuilt snapd snap. Use `spread` directly for those tests (e.g., `spread garden:ubuntu-24.04-64:tests/unit/go`).
-- Changes only to test infrastructure files (`tests/lib/`, `tests/unit/`, etc.) that don't affect the snap contents — use `spread` directly or `NO_REBUILD=1`.
+- Changes only to test infrastructure files (`tests/lib/`, `tests/unit/`, etc.) that don't affect the snap contents — use `./run-spread --download` to fetch the prebuilt snap from master, or set `NO_REBUILD=1` if a snap already exists locally.
 
-**Preferred approach**: Use `--clean-snapd-only` to ensure the snapd part is fully rebuilt (clean + rebuild) while preserving other parts.
+Preferred approach: Use `--clean-snapd-only` to ensure the snapd part is fully rebuilt (clean + rebuild) while preserving other parts.
 
 ## Build Options
 
@@ -37,20 +37,20 @@ Use this skill when you need to:
 ./tests/build-test-snapd-snap --clean-snapd-only
 ```
 
-**Use this as the default choice** for most development work.
+Use this as the default choice for most development work.
 
-**What it does**: 
+What it does:
 - Cleans and fully rebuilds only the `snapd` part in `build-aux/snap/snapcraft.yaml`
 - Ensures the snapd part is completely rebuilt from scratch (clean + rebuild)
 - Preserves all other parts (dynamic-linker, runtime, apparmor, etc.)
 
-**Perfect for**:
+Perfect for:
 - Changes to Go code in cmd/, daemon/, overlord/, interfaces/, etc.
 - Iterating on snapd daemon logic
 - Bug fixes in Go code
 - Most day-to-day development work
 
-**Avoids rebuilding**:
+Avoids rebuilding:
 - `dynamic-linker` (custom glibc dynamic linker)
 - `runtime` (runtime library dependencies)
 - `apparmor` (AppArmor parser and libraries)
@@ -58,7 +58,7 @@ Use this skill when you need to:
 - `squashfs-tools` (squashfs filesystem tools)
 - `libcrypto-fips` (FIPS-compliant crypto libraries)
 
-**Build time**: Approximately 1-2 minutes (Go compilation and linking only).
+Build time: Approximately 1-2 minutes (Go compilation and linking only).
 
 ### Option 2: Full Clean (no flags) - Use When Needed
 
@@ -66,7 +66,7 @@ Use this skill when you need to:
 ./tests/build-test-snapd-snap
 ```
 
-**Use when `--clean-snapd-only` is not sufficient**:
+Use when `--clean-snapd-only` is not sufficient:
 - Non-snapd parts of `build-aux/snap/snapcraft.yaml` were changed
 - AppArmor part configuration in `build-aux/snap/snapcraft.yaml` was modified
 - Changes to `build-aux/snap/local/` scripts
@@ -74,7 +74,7 @@ Use this skill when you need to:
 - First build of the day after pulling major changes
 - When in doubt about dependencies
 
-**Build time**: Several minutes (builds glibc, apparmor, and all dependencies).
+Build time: Several minutes (builds glibc, apparmor, and all dependencies).
 
 ### Option 3: No Clean (--no-clean) - Use With Caution
 
@@ -82,25 +82,25 @@ Use this skill when you need to:
 ./tests/build-test-snapd-snap --no-clean
 ```
 
-**Use when**: Iterating rapidly and confident that no dependencies changed.
+Use when: Iterating rapidly and confident that no dependencies changed.
 
-**What it does**: Skips `snapcraft clean` (equivalent to `SNAPCRAFT_NO_CLEAN=1`). Note: `built-snap/` directory is still removed and recreated.
+What it does: Skips `snapcraft clean` (equivalent to `SNAPCRAFT_NO_CLEAN=1`). Note: `built-snap/` directory is still removed and recreated.
 
-**Warning**: May produce incorrect builds if any dependencies have changed. Use with caution.
+Warning: May produce incorrect builds if any dependencies have changed. Use with caution.
 
-**Build time**: Fastest option, typically under a minute.
+Build time: Fastest option, typically under a minute.
 
 ## Snapcraft Parts Reference
 
 The snapd snap consists of multiple parts defined in `build-aux/snap/snapcraft.yaml`:
 
-- **snapd**: Main Go code (daemon, commands, libraries) - the core snapd implementation
-- **apparmor**: AppArmor parser and libraries for security confinement
-- **dynamic-linker**: Custom glibc dynamic linker for the snap
-- **runtime**: Runtime library dependencies (libc, libcap, libseccomp, etc.)
-- **patchelf**: ELF manipulation tool
-- **squashfs-tools**: Tools for creating and managing squashfs filesystems
-- **libcrypto-fips**: FIPS-compliant crypto libraries (conditional)
+- `snapd`: Main Go code (daemon, commands, libraries) - the core snapd implementation
+- `apparmor`: AppArmor parser and libraries for security confinement
+- `dynamic-linker`: Custom glibc dynamic linker for the snap
+- `runtime`: Runtime library dependencies (libc, libcap, libseccomp, etc.)
+- `patchelf`: ELF manipulation tool
+- `squashfs-tools`: Tools for creating and managing squashfs filesystems
+- `libcrypto-fips`: FIPS-compliant crypto libraries (conditional)
 
 ## Decision Tree
 
@@ -132,7 +132,7 @@ Changes made to:
 6. Unsure about what changed or dependencies unclear
    -> Use: --clean-snapd-only (PREFERRED - covers most cases without rebuilding everything)
    -> Reason: Fast rebuild of the snapd part; only use full clean (no flags) as a last resort
-      when you are certain non-snapd parts (apparmor, dynamic-linker, runtime, etc.) need rebuilding
+     when you are certain non-snapd parts (apparmor, dynamic-linker, runtime, etc.) need rebuilding
 
 7. Rapid iteration with no dependency changes (USE WITH CAUTION)
    -> Use: --no-clean
@@ -162,25 +162,25 @@ The built snap is automatically used by the spread test infrastructure:
 
 ## Common Scenarios
 
-**Scenario 1: Fixed a bug in snapd daemon**
+Scenario 1 — Fixed a bug in snapd daemon:
 ```bash
 # Only Go code changed
 ./tests/build-test-snapd-snap --clean-snapd-only
 ```
 
-**Scenario 2: Modified AppArmor part configuration**
+Scenario 2 — Modified AppArmor part configuration:
 ```bash
 # Non-snapd part changed
 ./tests/build-test-snapd-snap
 ```
 
-**Scenario 3: Modified snapcraft.yaml to add new runtime dependency**
+Scenario 3 — Modified snapcraft.yaml to add new runtime dependency:
 ```bash
 # Runtime part affected
 ./tests/build-test-snapd-snap
 ```
 
-**Scenario 4: Quick iteration on interface implementation**
+Scenario 4 — Quick iteration on interface implementation:
 ```bash
 # First build: use --clean-snapd-only
 ./tests/build-test-snapd-snap --clean-snapd-only
@@ -191,13 +191,13 @@ The built snap is automatically used by the spread test infrastructure:
 
 ## Best Practices
 
-**DO**:
+DO:
 - Use `--clean-snapd-only` as your default for Go code changes (ensures full rebuild)
 - Use full clean when in doubt about dependencies
 - Verify the snap was created after build completes
 - Check build logs for warnings or errors
 
-**DON'T**:
+DON'T:
 - Use `--no-clean` unless you're certain dependencies haven't changed
 - Ignore build warnings (they may indicate real issues)
 - Assume a previous build is still valid after pulling changes

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -45,17 +45,14 @@ Build the snapd snap first (load the `build-snapd-snap` skill for details):
 **IMPORTANT**: Do NOT use other backends (`qemu`, `google-*`, `openstack`, etc.) unless the user explicitly instructs you to do so.
 
 **System selection by change type**:
+- **AppArmor changes**: Pick a recent Ubuntu LTS and optionally a Debian system
+- **SELinux changes**: Pick an openSUSE SELinux or Fedora system
+- **Systemd changes**: Pick a recent Ubuntu and a Fedora system
+- **General changes**: Pick the most recent Ubuntu LTS available
 
-| Change Type | Primary Systems | Also Test |
-|------------|-----------------|-----------|
-| AppArmor | ubuntu-24.04-64, ubuntu-22.04-64 | debian-12-64, arch-linux-64 |
-| SELinux | opensuse-tumbleweed-selinux-64, fedora-42-64 | centos-9-64 |
-| Systemd | ubuntu-24.04-64, ubuntu-26.04-64, fedora-42-64 | - |
-| General | ubuntu-24.04-64 | ubuntu-22.04-64 |
+**Available systems**: Discover concrete system names from `spread.yaml` under `backends:garden:systems:`. Do not hardcode system names — they change as releases are added/removed.
 
-**Available systems**: Check `spread.yaml` under `backends:garden:systems:` for the current list of available systems for the garden backend.
-
-**When in doubt**: Follow user's guidance or use ubuntu-24.04-64.
+**When in doubt**: Follow user's guidance or pick the most recent Ubuntu LTS from `spread.yaml`.
 
 ## Test Path Specification
 
@@ -204,7 +201,7 @@ NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
 - When unclear whether a suite needs the prebuilt snap, assume it does — build with `./tests/build-test-snapd-snap --clean-snapd-only` then run with `NO_REBUILD=1`
 - Collect maximum information per run to minimize cycles
 - Prefer `garden` backend for local development
-- Choose systems appropriate to change type (see table above)
+- Choose systems appropriate to change type (see system selection guidelines above)
 - Use `-debug` when logs lack clarity, investigate in shell provided by spread
 - Plan what information you need before executing
 - Follow user's guidance when in doubt

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -21,7 +21,7 @@ Build the snapd snap first (load the `build-snapd-snap` skill for details):
 - First build: `./tests/build-test-snapd-snap`
 - Fast rebuild: `./tests/build-test-snapd-snap --clean-snapd-only`
 
-**Skip rebuild when snap exists**: Use `--no-rebuild` / `-n` flag with `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — drop `--no-rebuild` to trigger a build, or run the build skill first.
+**Skip rebuild when snap exists**: Set `NO_REBUILD=1` in the environment before calling `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — unset `NO_REBUILD` to trigger a build, or run the build skill first.
 
 ## Command Format
 
@@ -32,7 +32,7 @@ Build the snapd snap first (load the `build-snapd-snap` skill for details):
 **IMPORTANT**: A `<backend>:<system>:<test-path>` argument is REQUIRED. Never call `./run-spread` without specifying what to run — spread would attempt to execute all tests on all backends.
 
 **run-spread flags**:
-- `--no-rebuild` / `-n`: Skip rebuilding snapd snap (equivalent to `NO_REBUILD=1`)
+- `--no-rebuild` / `-n`: Skip rebuilding snapd snap. Prefer setting `NO_REBUILD=1` in the environment instead.
 
 **spread flags** (passed through after optional `--`):
 - `-debug`: Create SSH shell on test failure (use when logs lack clarity)
@@ -61,7 +61,7 @@ Build the snapd snap first (load the `build-snapd-snap` skill for details):
 
 ```bash
 tests/main/snap-mgmt              # Single test
-tests/main/interfaces-*            # Pattern matching
+tests/main/interfaces-...            # Pattern matching
 tests/main/...                     # All tests in directory
 ```
 
@@ -71,18 +71,18 @@ Common suites: `tests/main/`, `tests/nested/`, `tests/regression/`
 
 **Standard run (after building snap)**:
 ```bash
-./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/snap-mgmt
+NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
 **With debug shell (when logs unclear)**:
 ```bash
-./run-spread --no-rebuild -- -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+NO_REBUILD=1 ./run-spread -- -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 On failure, provides interactive SSH to inspect logs, re-run commands, examine state.
 
 **Faster iteration (reuse VMs)**:
 ```bash
-./run-spread --no-rebuild -- -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
+NO_REBUILD=1 ./run-spread -- -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
 **First run (builds snap automatically)**:
@@ -94,7 +94,7 @@ On failure, provides interactive SSH to inspect logs, re-run commands, examine s
 
 **Option 1: Single invocation** (spread handles parallelism):
 ```bash
-./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
+NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
 ```
 
 **Option 2: Delegate to subagents** (true parallel execution):
@@ -105,8 +105,8 @@ On failure, provides interactive SSH to inspect logs, re-run commands, examine s
 
 Example:
 ```bash
-# Subagent 1: ./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-1
-# Subagent 2: ./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-2
+# Subagent 1: NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-1
+# Subagent 2: NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-2
 # (up to 4 total)
 ```
 
@@ -151,41 +151,41 @@ Tests can override via `tests/<suite>/<test>/task.yaml` with their own `environm
 **AppArmor changes**:
 ```bash
 # Primary
-./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/security-apparmor
+NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/security-apparmor
 # Verify portability
-./run-spread --no-rebuild garden:debian-12-64:tests/main/security-apparmor
+NO_REBUILD=1 ./run-spread garden:debian-12-64:tests/main/security-apparmor
 ```
 
 **SELinux changes**:
 ```bash
-./run-spread --no-rebuild garden:opensuse-tumbleweed-selinux-64:tests/main/selinux-classic-confinement
-./run-spread --no-rebuild garden:fedora-42-64:tests/main/selinux-clean
+NO_REBUILD=1 ./run-spread garden:opensuse-tumbleweed-selinux-64:tests/main/selinux-classic-confinement
+NO_REBUILD=1 ./run-spread garden:fedora-42-64:tests/main/selinux-clean
 # Other SELinux tests: selinux-data-context, selinux-lxd, selinux-snap-restorecon
 ```
 
 **Investigating unclear failure**:
 ```bash
 # First run
-./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/flaky-test
+NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/flaky-test
 # If logs unclear, add -debug
-./run-spread --no-rebuild -- -debug garden:ubuntu-24.04-64:tests/main/flaky-test
+NO_REBUILD=1 ./run-spread -- -debug garden:ubuntu-24.04-64:tests/main/flaky-test
 ```
 
 **Multiple related tests**:
 ```bash
 # Pattern matching
-./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/interfaces-*
+NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
 # Or delegate to up to 4 subagents for parallel execution
 ```
 
 ## Best Practices
 
 **DO**:
-- Use `--no-rebuild` or `-n` flag when snap already built
+- Prefer `NO_REBUILD=1` in environment when snap already built
 - Collect maximum information per run to minimize cycles
 - Prefer `garden` backend for local development
 - Choose systems appropriate to change type (see table above)
-- Use `-debug` when logs lack clarity
+- Use `-debug` when logs lack clarity, investigate in shell provided by spread
 - Plan what information you need before executing
 - Follow user's guidance when in doubt
 - Limit parallel tests to 4 when using subagents (RAM constraint)
@@ -198,4 +198,4 @@ Tests can override via `tests/<suite>/<test>/task.yaml` with their own `environm
 - Ignore `restore` section failures (indicates cleanup issues)
 - Assume portability between LSMs without testing
 - Use `-debug` by default (only when needed)
-- Forget `--no-rebuild` when snap exists (wastes time)
+- Forget `NO_REBUILD=1` when snap exists (wastes time rebuilding)

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -53,6 +53,41 @@ Available systems: Discover concrete system names from `spread.yaml` under `back
 
 When in doubt: Follow user's guidance or pick the most recent Ubuntu LTS from `spread.yaml`.
 
+## Debugging a failing test
+
+A failing test produces a log like shown below, where the test execution log appears in the place of `<TEST EXECUTION LOG>`, and the test's debug section execution log will appear in place of `<TEST debug: SECTION EXECUTION LOG>`:
+
+
+```bash
++ exec spread -debug garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache
+2026-05-26 14:01:03 Project content is packed for delivery (124.87MB).
+2026-05-26 14:01:03 If killed, discard servers with: spread -reuse-pid=3762927 -discard
+2026-05-26 14:01:03 Allocating garden:ubuntu-24.04-64...
+2026-05-26 14:01:03 Waiting for garden:ubuntu-24.04-64 to make SSH available at localhost:6374...
+2026-05-26 14:01:03 Allocated garden:ubuntu-24.04-64.
+2026-05-26 14:01:03 Connecting to garden:ubuntu-24.04-64...
+2026-05-26 14:01:10 Connected to garden:ubuntu-24.04-64 at localhost:6374.
+2026-05-26 14:01:10 Sending project content to garden:ubuntu-24.04-64...
+2026-05-26 14:01:12 Preparing garden:ubuntu-24.04-64 (garden:ubuntu-24.04-64)...
+2026-05-26 14:01:57 Preparing garden:ubuntu-24.04-64:tests/main/ (garden:ubuntu-24.04-64)...
+2026-05-26 14:02:44 Checking garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64)...
+2026-05-26 14:02:44 Preparing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64)...
+2026-05-26 14:02:51 Executing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) (1/1)...
+2026-05-26 14:02:54 Error executing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) :
+-----
+<TEST EXECUTION LOG>
+-----
+.
+2026-05-26 14:02:54 Debug output for garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) :
+-----
+<TEST debug: SECTION EXECUTION LOG>
+-----
+.
+2026-05-26 14:02:54 Starting shell to debug...
+```
+
+Attempt to capture as much as possible of the error execution log and debug section execution logs, so that you do not need to re-run the same test again.
+
 ## Test Path Specification
 
 ```bash

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -67,6 +67,25 @@ tests/main/...                     # All tests in directory
 
 Common suites: `tests/main/`, `tests/nested/`, `tests/regression/`
 
+## Tests That Don't Need the Snapd Snap
+
+The following suites do not install or use the prebuilt snapd snap during execution. For these, invoke `spread` directly without `run-spread`:
+
+```bash
+spread garden:ubuntu-24.04-64:tests/unit/go
+spread garden:ubuntu-24.04-64:tests/cross/go-build
+```
+
+This avoids the snap build/check entirely and is significantly faster. The suite's prepare phase installs snapd from distro packages when `USE_PREBUILT_SNAPD_SNAP` is not set to `true`.
+
+**When to use `spread` directly** (without `run-spread`):
+- `tests/unit/` suite — runs Go unit tests and static checks, no snap needed
+- `tests/cross/` suite — cross-compiles Go commands, no snap needed
+- Any test where only test infrastructure files (e.g., `tests/lib/`) were changed and you don't need the snapd snap to be rebuilt/installed
+
+**When you must use `run-spread`**:
+- `tests/main/`, `tests/nested/`, `tests/regression/` — these suites install and exercise the snapd snap
+
 ## Common Workflows
 
 **Standard run (after building snap)**:
@@ -182,6 +201,7 @@ NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
 
 **DO**:
 - Prefer `NO_REBUILD=1` in environment when snap already built
+- When unclear whether a suite needs the prebuilt snap, assume it does — build with `./tests/build-test-snapd-snap --clean-snapd-only` then run with `NO_REBUILD=1`
 - Collect maximum information per run to minimize cycles
 - Prefer `garden` backend for local development
 - Choose systems appropriate to change type (see table above)
@@ -189,6 +209,9 @@ NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
 - Plan what information you need before executing
 - Follow user's guidance when in doubt
 - Limit parallel tests to 4 when using subagents (RAM constraint)
+- Verify whether the test snapd snap has been built, i.e. there is a file
+  `built-snap/snapd_*.snap.keep`, if not, suggest building it, or use the
+  build-snapd-snap skill to do so, respecting guidelines listed in the skill.
 
 **DON'T**:
 - Call `./run-spread` without a `backend:system:test` argument (would run everything)
@@ -199,3 +222,6 @@ NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
 - Assume portability between LSMs without testing
 - Use `-debug` by default (only when needed)
 - Forget `NO_REBUILD=1` when snap exists (wastes time rebuilding)
+- Call `./run-spread` without `NO_REBUILD=1` when a snap already exists in `built-snap/` — without it, `run-spread` triggers a full rebuild which takes several minutes
+- Use `run-spread` for `tests/unit/` or `tests/cross/` suites — use `spread` directly instead (no snap needed)
+- Assume a suite does NOT need the snap without checking — when unclear, assume it does and build with `build-snapd-snap --clean-snapd-only` before running with `NO_REBUILD=1`

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -7,234 +7,113 @@ metadata:
   execution-time: slow
 ---
 
-## Overview
+## Run spread tests
 
-Run spread integration tests in VMs to verify snapd functionality across different Linux distributions.
+Command: `./run-spread [spread-flags] <backend>:<system>:<test-path>`
 
-Command: `./run-spread <backend>:<system>:<test-path>`
-
-Critical: Tests take 5-15 minutes each. Collect as much information as possible in each run to avoid wasting cycles.
+Tests take 5-15 minutes each. Maximize information per run.
 
 ## Prerequisites
 
-Build the snapd snap first (load the `build-snapd-snap` skill for details):
-- First build: `./tests/build-test-snapd-snap`
-- Fast rebuild: `./tests/build-test-snapd-snap --clean-snapd-only`
+Build the snap first (see `build-snapd-snap` skill), then use `NO_REBUILD=1`.
+If no local snap exists: either build one, or use `./run-spread --download` to fetch from master.
 
-Skip rebuild when snap exists: Set `NO_REBUILD=1` in the environment before calling `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — unset `NO_REBUILD` to trigger a build, or run the build skill first.
-
-Download prebuilt snap from 'master' branch: Use `./run-spread --download <backend>:<system>:<test>`. This is useful when only test infrastructure files changed and you don't need a locally built snap.
-
-## Command Format
+## Quick reference
 
 ```bash
-./run-spread [spread-flags] <backend>:<system>:<test-path>
-```
-
-A `<backend>:<system>:<test-path>` argument is REQUIRED. Never call `./run-spread` without specifying what to run — spread would attempt to execute all tests on all backends.
-
-Spread flags (passed through):
-- `-debug`: Create SSH shell on test failure. Use this by default — it avoids needing a re-run when logs are unclear.
-- `-reuse`: Keep VMs running between tests (faster iteration)
-
-## Backend and System Selection
-
-Always use `garden` backend for local development (no credentials, fast, full control).
-
-Do NOT use other backends (`qemu`, `google-*`, `openstack`, etc.) unless the user explicitly instructs you to do so.
-
-System selection by change type:
-- AppArmor changes: Pick a recent Ubuntu LTS and optionally a Debian system
-- SELinux changes: Pick an openSUSE SELinux or Fedora system
-- Systemd changes: Pick a recent Ubuntu and a Fedora system
-- General changes: Pick the most recent Ubuntu LTS available
-
-Available systems: Discover concrete system names from `spread.yaml` under `backends:garden:systems:`. Do not hardcode system names — they change as releases are added/removed.
-
-When in doubt: Follow user's guidance or pick the most recent Ubuntu LTS from `spread.yaml`.
-
-## Debugging a failing test
-
-A failing test produces a log like shown below, where the test execution log appears in the place of `<TEST EXECUTION LOG>`, and the test's debug section execution log will appear in place of `<TEST debug: SECTION EXECUTION LOG>`:
-
-
-```bash
-+ exec spread -debug garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache
-2026-05-26 14:01:03 Project content is packed for delivery (124.87MB).
-2026-05-26 14:01:03 If killed, discard servers with: spread -reuse-pid=3762927 -discard
-2026-05-26 14:01:03 Allocating garden:ubuntu-24.04-64...
-2026-05-26 14:01:03 Waiting for garden:ubuntu-24.04-64 to make SSH available at localhost:6374...
-2026-05-26 14:01:03 Allocated garden:ubuntu-24.04-64.
-2026-05-26 14:01:03 Connecting to garden:ubuntu-24.04-64...
-2026-05-26 14:01:10 Connected to garden:ubuntu-24.04-64 at localhost:6374.
-2026-05-26 14:01:10 Sending project content to garden:ubuntu-24.04-64...
-2026-05-26 14:01:12 Preparing garden:ubuntu-24.04-64 (garden:ubuntu-24.04-64)...
-2026-05-26 14:01:57 Preparing garden:ubuntu-24.04-64:tests/main/ (garden:ubuntu-24.04-64)...
-2026-05-26 14:02:44 Checking garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64)...
-2026-05-26 14:02:44 Preparing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64)...
-2026-05-26 14:02:51 Executing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) (1/1)...
-2026-05-26 14:02:54 Error executing garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) :
------
-<TEST EXECUTION LOG>
------
-.
-2026-05-26 14:02:54 Debug output for garden:ubuntu-24.04-64:tests/main/snap-download-corrupted-cleanup:valid_cache (garden:ubuntu-24.04-64) :
------
-<TEST debug: SECTION EXECUTION LOG>
------
-.
-2026-05-26 14:02:54 Starting shell to debug...
-```
-
-Attempt to capture as much as possible of the error execution log and debug section execution logs, so that you do not need to re-run the same test again.
-
-## Test Path Specification
-
-```bash
-tests/main/snap-mgmt              # Single test
-tests/main/interfaces-...         # Pattern matching
-tests/main/...                    # All tests in directory
-```
-
-## Tests That Don't Need the Snapd Snap
-
-The following suites do not install or use the prebuilt snapd snap during execution. For these, invoke `spread` directly without `run-spread`:
-
-```bash
-spread garden:ubuntu-24.04-64:tests/unit/go
-spread garden:ubuntu-24.04-64:tests/cross/go-build
-```
-
-This avoids the snap build/check entirely and is significantly faster. The suite's prepare phase installs snapd from distro packages when `USE_PREBUILT_SNAPD_SNAP` is not set to `true`.
-
-When to use `spread` directly (without `run-spread`):
-- `tests/unit/` suite — runs Go unit tests and static checks, no snap needed
-- `tests/cross/` suite — cross-compiles Go commands, no snap needed
-- Any test where only test infrastructure files (e.g., `tests/lib/`) were changed and you don't need the snapd snap to be rebuilt/installed
-
-When you must use `run-spread`:
-- `tests/main/`, `tests/nested/`, `tests/regression/` — these suites install and exercise the snapd snap
-
-## Common Workflows
-
-Standard run (after building snap):
-```bash
+# Standard (snap already built)
 NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
-```
 
-Faster iteration (reuse VMs):
-```bash
+# First run (auto-builds snap)
+./run-spread -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+
+# Download prebuilt from master (test-only changes)
+./run-spread --download -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+
+# Reuse VMs for faster iteration
 NO_REBUILD=1 ./run-spread -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
-First run (builds snap automatically):
+Always specify `<backend>:<system>:<test-path>` — bare `./run-spread` runs everything.
+
+## Flags
+
+- `-debug`: Get SSH shell on failure. Use by default.
+- `-reuse`: Keep VMs alive between runs (faster iteration).
+
+## Backend and system
+
+Always use `garden`. Do not use `qemu`, `google-*`, `openstack` etc. unless user explicitly says so.
+
+System selection:
+- AppArmor changes → recent Ubuntu LTS, optionally Debian
+- SELinux changes → openSUSE SELinux or Fedora
+- Systemd changes → recent Ubuntu + Fedora
+- General → most recent Ubuntu LTS
+
+Discover system names from `spread.yaml` under `backends:garden:systems:`. Don't hardcode — they change.
+
+## Suites that don't need the snap
+
+Use `spread` directly (not `run-spread`) for:
+- `tests/unit/` — Go unit tests
+- `tests/cross/` — cross-compilation
+
 ```bash
-./run-spread -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+spread garden:ubuntu-24.04-64:tests/unit/go
 ```
 
-Download prebuilt snap from master (test-only changes):
+All other suites (`tests/main/`, `tests/nested/`, `tests/regression/`) require the snap — use `run-spread`.
+
+## Parallel execution
+
+Single invocation is serial on garden (1 worker). For true parallelism, delegate to subagents — max 4 concurrent (each VM uses 3-4 GB RAM).
+
+## Test path patterns
+
 ```bash
-./run-spread --download -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+tests/main/snap-mgmt            # Single test
+tests/main/interfaces-...       # Glob
+tests/main/...                  # All in directory
 ```
 
-## Running Multiple Tests in Parallel
+## Failure output structure
 
-Option 1 — Single invocation (serial execution on garden backend since it uses 1 worker):
-```bash
-NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
+```
+Error executing garden:<system>:<test> :
+-----
+<execute section output — shows the failing commands>
+-----
+Debug output for garden:<system>:<test> :
+-----
+<debug section output — extra diagnostic info>
+-----
+Starting shell to debug...
 ```
 
-Option 2 — Delegate to subagents (true parallel execution):
-- Each subagent runs one test
-- Limit: 4 parallel tests maximum (each VM uses 3-4 GB RAM)
-- Requires 16GB+ system RAM for 4 parallel tests
-- Use when tests are independent and time savings justify complexity
+Capture as much of the error and debug output as possible to avoid re-runs.
 
-Example:
+## Interpreting failures
+
+Phases: prepare → execute → restore → debug (on failure)
+
+- Execute failure: look for MATCH/NOMATCH assertions (`grep -qE` wrappers from `tests/lib/`)
+- Prepare failure: missing deps or system incompatibility
+- Restore failure: incomplete cleanup (fix to avoid pollution)
+
+Debug shell useful commands:
 ```bash
-# Subagent 1: NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-1
-# Subagent 2: NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-2
-# (up to 4 total)
+journalctl -u snapd
+snap changes
+snap tasks <change-id>
 ```
 
-## Interpreting Test Failures
+## Rules
 
-Test phases:
-1. `prepare`: Setup (install dependencies, configure system)
-2. `execute`: Main test logic and assertions
-3. `restore`: Cleanup (should be idempotent)
-4. `debug`: Debug output (shown on failure)
-
-Common failure patterns:
-- Execute failure: Check assertion failures (MATCH, NOMATCH — these are `grep -qE` wrappers from `tests/lib/`), compare actual vs expected output
-- Prepare failure: Missing dependencies or system incompatibility
-- Restore failure: Incomplete cleanup logic (fix to avoid test pollution)
-
-Debug shell commands:
-```bash
-journalctl -u snapd              # View snapd logs
-snap changes                     # See all operations
-snap tasks <change-id>           # Detailed task info
-ls -la /var/snap/                # Check test files
-```
-
-## spread.yaml Configuration
-
-The `spread.yaml` file defines test infrastructure:
-- `environment:`: Global env vars for all tests
-- `backends:`: Backend configurations (garden, google, qemu)
-- `backends:<backend>:systems:`: Available systems per backend
-- `suites:`: Test suite configs (tests/main/, tests/nested/)
-
-Tests can override via `tests/<suite>/<test>/task.yaml` with their own `environment`, `systems`, `backends`, etc.
-
-## Examples by Scenario
-
-AppArmor changes:
-```bash
-# Primary
-NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/security-apparmor
-# Verify portability
-NO_REBUILD=1 ./run-spread -debug garden:debian-12-64:tests/main/security-apparmor
-```
-
-Investigating unclear failure:
-```bash
-NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/flaky-test
-# -debug gives you a shell on failure to inspect the system
-```
-
-Multiple related tests:
-```bash
-# Pattern matching
-NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/interfaces-...
-# Or delegate to up to 4 subagents for parallel execution
-```
-
-## Best Practices
-
-DO:
-- Use `-debug` by default to get a shell on failure without re-running
-- Prefer `NO_REBUILD=1` in environment when snap already built
-- When unclear whether a suite needs the prebuilt snap, assume it does — build with `./tests/build-test-snapd-snap --clean-snapd-only` then run with `NO_REBUILD=1`
-- Collect maximum information per run to minimize cycles
-- Prefer `garden` backend for local development
-- Choose systems appropriate to change type (see system selection guidelines above)
-- Plan what information you need before executing
-- Follow user's guidance when in doubt
-- Limit parallel tests to 4 when using subagents (RAM constraint)
-- Verify whether the test snapd snap has been built, i.e. there is a file
-  `built-snap/snapd_*.snap.keep`, if not, suggest building it, or use the
-  build-snapd-snap skill to do so, respecting guidelines listed in the skill.
-
-DON'T:
-- Call `./run-spread` without a `backend:system:test` argument (would run everything)
-- Use backends other than `garden` unless explicitly instructed
-- Waste test cycles running without clear purpose
-- Exceed 4 parallel tests with subagents (RAM exhaustion)
-- Ignore `restore` section failures (indicates cleanup issues)
-- Assume portability between LSMs without testing
-- Forget `NO_REBUILD=1` when snap exists (wastes time rebuilding)
-- Call `./run-spread` without `NO_REBUILD=1` when a snap already exists in `built-snap/` — without it, `run-spread` triggers a full rebuild which takes several minutes
-- Use `run-spread` for `tests/unit/` or `tests/cross/` suites — use `spread` directly instead (no snap needed)
-- Assume a suite does NOT need the snap without checking — when unclear, assume it does and build with `build-snapd-snap --clean-snapd-only` before running with `NO_REBUILD=1`
+- Always use `-debug` to avoid re-runs on failure
+- Always set `NO_REBUILD=1` when snap exists
+- Never run `./run-spread` without a test path
+- Never use non-garden backends unless instructed
+- Max 4 parallel subagent tests (RAM)
+- When unsure if suite needs snap, assume yes — build first
+- Verify `built-snap/snapd_*.snap.keep` exists before running with `NO_REBUILD=1`

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -108,6 +108,10 @@ snap changes
 snap tasks <change-id>
 ```
 
+## spread.yaml structure
+
+Key sections: `environment:` (global vars), `backends:` (garden/google/qemu configs), `backends:<backend>:systems:` (available systems), `suites:` (test suite configs). Individual tests can override settings in their `task.yaml`.
+
 ## Rules
 
 - Always use `-debug` to avoid re-runs on failure

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -11,9 +11,9 @@ metadata:
 
 Run spread integration tests in VMs to verify snapd functionality across different Linux distributions.
 
-**Command**: `./run-spread <backend>:<system>:<test-path>`
+Command: `./run-spread <backend>:<system>:<test-path>`
 
-**Critical**: Tests take 5-15 minutes each. Collect as much information as possible in each run to avoid wasting cycles.
+Critical: Tests take 5-15 minutes each. Collect as much information as possible in each run to avoid wasting cycles.
 
 ## Prerequisites
 
@@ -21,48 +21,45 @@ Build the snapd snap first (load the `build-snapd-snap` skill for details):
 - First build: `./tests/build-test-snapd-snap`
 - Fast rebuild: `./tests/build-test-snapd-snap --clean-snapd-only`
 
-**Skip rebuild when snap exists**: Set `NO_REBUILD=1` in the environment before calling `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — unset `NO_REBUILD` to trigger a build, or run the build skill first.
+Skip rebuild when snap exists: Set `NO_REBUILD=1` in the environment before calling `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — unset `NO_REBUILD` to trigger a build, or run the build skill first.
+
+Download prebuilt snap from 'master' branch: Use `./run-spread --download <backend>:<system>:<test>`. This is useful when only test infrastructure files changed and you don't need a locally built snap.
 
 ## Command Format
 
 ```bash
-./run-spread [--no-rebuild|-n] [--] [spread-flags] <backend>:<system>:<test-path>
+./run-spread [spread-flags] <backend>:<system>:<test-path>
 ```
 
-**IMPORTANT**: A `<backend>:<system>:<test-path>` argument is REQUIRED. Never call `./run-spread` without specifying what to run — spread would attempt to execute all tests on all backends.
+A `<backend>:<system>:<test-path>` argument is REQUIRED. Never call `./run-spread` without specifying what to run — spread would attempt to execute all tests on all backends.
 
-**run-spread flags**:
-- `--no-rebuild` / `-n`: Skip rebuilding snapd snap. Prefer setting `NO_REBUILD=1` in the environment instead.
-
-**spread flags** (passed through after optional `--`):
-- `-debug`: Create SSH shell on test failure (use when logs lack clarity)
+Spread flags (passed through):
+- `-debug`: Create SSH shell on test failure. Use this by default — it avoids needing a re-run when logs are unclear.
 - `-reuse`: Keep VMs running between tests (faster iteration)
 
 ## Backend and System Selection
 
-**Always use `garden` backend** for local development (no credentials, fast, full control).
+Always use `garden` backend for local development (no credentials, fast, full control).
 
-**IMPORTANT**: Do NOT use other backends (`qemu`, `google-*`, `openstack`, etc.) unless the user explicitly instructs you to do so.
+Do NOT use other backends (`qemu`, `google-*`, `openstack`, etc.) unless the user explicitly instructs you to do so.
 
-**System selection by change type**:
-- **AppArmor changes**: Pick a recent Ubuntu LTS and optionally a Debian system
-- **SELinux changes**: Pick an openSUSE SELinux or Fedora system
-- **Systemd changes**: Pick a recent Ubuntu and a Fedora system
-- **General changes**: Pick the most recent Ubuntu LTS available
+System selection by change type:
+- AppArmor changes: Pick a recent Ubuntu LTS and optionally a Debian system
+- SELinux changes: Pick an openSUSE SELinux or Fedora system
+- Systemd changes: Pick a recent Ubuntu and a Fedora system
+- General changes: Pick the most recent Ubuntu LTS available
 
-**Available systems**: Discover concrete system names from `spread.yaml` under `backends:garden:systems:`. Do not hardcode system names — they change as releases are added/removed.
+Available systems: Discover concrete system names from `spread.yaml` under `backends:garden:systems:`. Do not hardcode system names — they change as releases are added/removed.
 
-**When in doubt**: Follow user's guidance or pick the most recent Ubuntu LTS from `spread.yaml`.
+When in doubt: Follow user's guidance or pick the most recent Ubuntu LTS from `spread.yaml`.
 
 ## Test Path Specification
 
 ```bash
 tests/main/snap-mgmt              # Single test
-tests/main/interfaces-...            # Pattern matching
-tests/main/...                     # All tests in directory
+tests/main/interfaces-...         # Pattern matching
+tests/main/...                    # All tests in directory
 ```
-
-Common suites: `tests/main/`, `tests/nested/`, `tests/regression/`
 
 ## Tests That Don't Need the Snapd Snap
 
@@ -75,76 +72,70 @@ spread garden:ubuntu-24.04-64:tests/cross/go-build
 
 This avoids the snap build/check entirely and is significantly faster. The suite's prepare phase installs snapd from distro packages when `USE_PREBUILT_SNAPD_SNAP` is not set to `true`.
 
-**When to use `spread` directly** (without `run-spread`):
+When to use `spread` directly (without `run-spread`):
 - `tests/unit/` suite — runs Go unit tests and static checks, no snap needed
 - `tests/cross/` suite — cross-compiles Go commands, no snap needed
 - Any test where only test infrastructure files (e.g., `tests/lib/`) were changed and you don't need the snapd snap to be rebuilt/installed
 
-**When you must use `run-spread`**:
+When you must use `run-spread`:
 - `tests/main/`, `tests/nested/`, `tests/regression/` — these suites install and exercise the snapd snap
 
 ## Common Workflows
 
-**Standard run (after building snap)**:
+Standard run (after building snap):
 ```bash
-NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/snap-mgmt
+NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
-**With debug shell (when logs unclear)**:
+Faster iteration (reuse VMs):
 ```bash
-NO_REBUILD=1 ./run-spread -- -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
-```
-On failure, provides interactive SSH to inspect logs, re-run commands, examine state.
-
-**Faster iteration (reuse VMs)**:
-```bash
-NO_REBUILD=1 ./run-spread -- -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
+NO_REBUILD=1 ./run-spread -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
-**First run (builds snap automatically)**:
+First run (builds snap automatically):
 ```bash
-./run-spread garden:ubuntu-24.04-64:tests/main/snap-mgmt
+./run-spread -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+```
+
+Download prebuilt snap from master (test-only changes):
+```bash
+./run-spread --download -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
 ```
 
 ## Running Multiple Tests in Parallel
 
-**Option 1: Single invocation** (spread handles parallelism):
+Option 1 — Single invocation (serial execution on garden backend since it uses 1 worker):
 ```bash
-NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
+NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
 ```
 
-**Option 2: Delegate to subagents** (true parallel execution):
+Option 2 — Delegate to subagents (true parallel execution):
 - Each subagent runs one test
-- **Limit: 4 parallel tests maximum** (each VM uses 3-4 GB RAM)
+- Limit: 4 parallel tests maximum (each VM uses 3-4 GB RAM)
 - Requires 16GB+ system RAM for 4 parallel tests
 - Use when tests are independent and time savings justify complexity
 
 Example:
 ```bash
-# Subagent 1: NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-1
-# Subagent 2: NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/test-2
+# Subagent 1: NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-1
+# Subagent 2: NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/test-2
 # (up to 4 total)
 ```
 
 ## Interpreting Test Failures
 
-**Test phases**:
+Test phases:
 1. `prepare`: Setup (install dependencies, configure system)
 2. `execute`: Main test logic and assertions
 3. `restore`: Cleanup (should be idempotent)
 4. `debug`: Debug output (shown on failure)
 
-**Common failure patterns**:
-- **Execute failure**: Check assertion failures (MATCH, NOMATCH), compare actual vs expected output
-- **Prepare failure**: Missing dependencies or system incompatibility
-- **Restore failure**: Incomplete cleanup logic (fix to avoid test pollution)
+Common failure patterns:
+- Execute failure: Check assertion failures (MATCH, NOMATCH — these are `grep -qE` wrappers from `tests/lib/`), compare actual vs expected output
+- Prepare failure: Missing dependencies or system incompatibility
+- Restore failure: Incomplete cleanup logic (fix to avoid test pollution)
 
-**When to use `-debug`**:
-- Test fails but logs don't show clear reason
-- Need to inspect files, run commands manually, check service status
-- Don't use by default (adds overhead, requires interaction)
-
-**Debug shell commands**:
+Debug shell commands:
 ```bash
 journalctl -u snapd              # View snapd logs
 snap changes                     # See all operations
@@ -164,45 +155,36 @@ Tests can override via `tests/<suite>/<test>/task.yaml` with their own `environm
 
 ## Examples by Scenario
 
-**AppArmor changes**:
+AppArmor changes:
 ```bash
 # Primary
-NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/security-apparmor
+NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/security-apparmor
 # Verify portability
-NO_REBUILD=1 ./run-spread garden:debian-12-64:tests/main/security-apparmor
+NO_REBUILD=1 ./run-spread -debug garden:debian-12-64:tests/main/security-apparmor
 ```
 
-**SELinux changes**:
+Investigating unclear failure:
 ```bash
-NO_REBUILD=1 ./run-spread garden:opensuse-tumbleweed-selinux-64:tests/main/selinux-classic-confinement
-NO_REBUILD=1 ./run-spread garden:fedora-42-64:tests/main/selinux-clean
-# Other SELinux tests: selinux-data-context, selinux-lxd, selinux-snap-restorecon
+NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/flaky-test
+# -debug gives you a shell on failure to inspect the system
 ```
 
-**Investigating unclear failure**:
-```bash
-# First run
-NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/flaky-test
-# If logs unclear, add -debug
-NO_REBUILD=1 ./run-spread -- -debug garden:ubuntu-24.04-64:tests/main/flaky-test
-```
-
-**Multiple related tests**:
+Multiple related tests:
 ```bash
 # Pattern matching
-NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
+NO_REBUILD=1 ./run-spread -debug garden:ubuntu-24.04-64:tests/main/interfaces-...
 # Or delegate to up to 4 subagents for parallel execution
 ```
 
 ## Best Practices
 
-**DO**:
+DO:
+- Use `-debug` by default to get a shell on failure without re-running
 - Prefer `NO_REBUILD=1` in environment when snap already built
 - When unclear whether a suite needs the prebuilt snap, assume it does — build with `./tests/build-test-snapd-snap --clean-snapd-only` then run with `NO_REBUILD=1`
 - Collect maximum information per run to minimize cycles
 - Prefer `garden` backend for local development
 - Choose systems appropriate to change type (see system selection guidelines above)
-- Use `-debug` when logs lack clarity, investigate in shell provided by spread
 - Plan what information you need before executing
 - Follow user's guidance when in doubt
 - Limit parallel tests to 4 when using subagents (RAM constraint)
@@ -210,14 +192,13 @@ NO_REBUILD=1 ./run-spread garden:ubuntu-24.04-64:tests/main/interfaces-...
   `built-snap/snapd_*.snap.keep`, if not, suggest building it, or use the
   build-snapd-snap skill to do so, respecting guidelines listed in the skill.
 
-**DON'T**:
+DON'T:
 - Call `./run-spread` without a `backend:system:test` argument (would run everything)
 - Use backends other than `garden` unless explicitly instructed
 - Waste test cycles running without clear purpose
 - Exceed 4 parallel tests with subagents (RAM exhaustion)
 - Ignore `restore` section failures (indicates cleanup issues)
 - Assume portability between LSMs without testing
-- Use `-debug` by default (only when needed)
 - Forget `NO_REBUILD=1` when snap exists (wastes time rebuilding)
 - Call `./run-spread` without `NO_REBUILD=1` when a snap already exists in `built-snap/` — without it, `run-spread` triggers a full rebuild which takes several minutes
 - Use `run-spread` for `tests/unit/` or `tests/cross/` suites — use `spread` directly instead (no snap needed)

--- a/.agents/skills/run-spread-test/SKILL.md
+++ b/.agents/skills/run-spread-test/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: run-spread-test
+description: Run spread integration tests for snapd. Tests are slow - collect as much information as possible in each run to avoid wasting cycles.
+metadata:
+  project: snapd
+  task-type: test
+  execution-time: slow
+---
+
+## Overview
+
+Run spread integration tests in VMs to verify snapd functionality across different Linux distributions.
+
+**Command**: `./run-spread <backend>:<system>:<test-path>`
+
+**Critical**: Tests take 5-15 minutes each. Collect as much information as possible in each run to avoid wasting cycles.
+
+## Prerequisites
+
+Build the snapd snap first (load the `build-snapd-snap` skill for details):
+- First build: `./tests/build-test-snapd-snap`
+- Fast rebuild: `./tests/build-test-snapd-snap --clean-snapd-only`
+
+**Skip rebuild when snap exists**: Use `--no-rebuild` / `-n` flag with `./run-spread`. If no prebuilt snap exists in `built-snap/`, the script exits with an error — drop `--no-rebuild` to trigger a build, or run the build skill first.
+
+## Command Format
+
+```bash
+./run-spread [--no-rebuild|-n] [--] [spread-flags] <backend>:<system>:<test-path>
+```
+
+**IMPORTANT**: A `<backend>:<system>:<test-path>` argument is REQUIRED. Never call `./run-spread` without specifying what to run — spread would attempt to execute all tests on all backends.
+
+**run-spread flags**:
+- `--no-rebuild` / `-n`: Skip rebuilding snapd snap (equivalent to `NO_REBUILD=1`)
+
+**spread flags** (passed through after optional `--`):
+- `-debug`: Create SSH shell on test failure (use when logs lack clarity)
+- `-reuse`: Keep VMs running between tests (faster iteration)
+
+## Backend and System Selection
+
+**Always use `garden` backend** for local development (no credentials, fast, full control).
+
+**IMPORTANT**: Do NOT use other backends (`qemu`, `google-*`, `openstack`, etc.) unless the user explicitly instructs you to do so.
+
+**System selection by change type**:
+
+| Change Type | Primary Systems | Also Test |
+|------------|-----------------|-----------|
+| AppArmor | ubuntu-24.04-64, ubuntu-22.04-64 | debian-12-64, arch-linux-64 |
+| SELinux | opensuse-tumbleweed-selinux-64, fedora-42-64 | centos-9-64 |
+| Systemd | ubuntu-24.04-64, ubuntu-26.04-64, fedora-42-64 | - |
+| General | ubuntu-24.04-64 | ubuntu-22.04-64 |
+
+**Available systems**: Check `spread.yaml` under `backends:garden:systems:` for the current list of available systems for the garden backend.
+
+**When in doubt**: Follow user's guidance or use ubuntu-24.04-64.
+
+## Test Path Specification
+
+```bash
+tests/main/snap-mgmt              # Single test
+tests/main/interfaces-*            # Pattern matching
+tests/main/...                     # All tests in directory
+```
+
+Common suites: `tests/main/`, `tests/nested/`, `tests/regression/`
+
+## Common Workflows
+
+**Standard run (after building snap)**:
+```bash
+./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/snap-mgmt
+```
+
+**With debug shell (when logs unclear)**:
+```bash
+./run-spread --no-rebuild -- -debug garden:ubuntu-24.04-64:tests/main/snap-mgmt
+```
+On failure, provides interactive SSH to inspect logs, re-run commands, examine state.
+
+**Faster iteration (reuse VMs)**:
+```bash
+./run-spread --no-rebuild -- -reuse garden:ubuntu-24.04-64:tests/main/snap-mgmt
+```
+
+**First run (builds snap automatically)**:
+```bash
+./run-spread garden:ubuntu-24.04-64:tests/main/snap-mgmt
+```
+
+## Running Multiple Tests in Parallel
+
+**Option 1: Single invocation** (spread handles parallelism):
+```bash
+./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-a garden:ubuntu-24.04-64:tests/main/test-b
+```
+
+**Option 2: Delegate to subagents** (true parallel execution):
+- Each subagent runs one test
+- **Limit: 4 parallel tests maximum** (each VM uses 3-4 GB RAM)
+- Requires 16GB+ system RAM for 4 parallel tests
+- Use when tests are independent and time savings justify complexity
+
+Example:
+```bash
+# Subagent 1: ./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-1
+# Subagent 2: ./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/test-2
+# (up to 4 total)
+```
+
+## Interpreting Test Failures
+
+**Test phases**:
+1. `prepare`: Setup (install dependencies, configure system)
+2. `execute`: Main test logic and assertions
+3. `restore`: Cleanup (should be idempotent)
+4. `debug`: Debug output (shown on failure)
+
+**Common failure patterns**:
+- **Execute failure**: Check assertion failures (MATCH, NOMATCH), compare actual vs expected output
+- **Prepare failure**: Missing dependencies or system incompatibility
+- **Restore failure**: Incomplete cleanup logic (fix to avoid test pollution)
+
+**When to use `-debug`**:
+- Test fails but logs don't show clear reason
+- Need to inspect files, run commands manually, check service status
+- Don't use by default (adds overhead, requires interaction)
+
+**Debug shell commands**:
+```bash
+journalctl -u snapd              # View snapd logs
+snap changes                     # See all operations
+snap tasks <change-id>           # Detailed task info
+ls -la /var/snap/                # Check test files
+```
+
+## spread.yaml Configuration
+
+The `spread.yaml` file defines test infrastructure:
+- `environment:`: Global env vars for all tests
+- `backends:`: Backend configurations (garden, google, qemu)
+- `backends:<backend>:systems:`: Available systems per backend
+- `suites:`: Test suite configs (tests/main/, tests/nested/)
+
+Tests can override via `tests/<suite>/<test>/task.yaml` with their own `environment`, `systems`, `backends`, etc.
+
+## Examples by Scenario
+
+**AppArmor changes**:
+```bash
+# Primary
+./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/security-apparmor
+# Verify portability
+./run-spread --no-rebuild garden:debian-12-64:tests/main/security-apparmor
+```
+
+**SELinux changes**:
+```bash
+./run-spread --no-rebuild garden:opensuse-tumbleweed-selinux-64:tests/main/selinux-classic-confinement
+./run-spread --no-rebuild garden:fedora-42-64:tests/main/selinux-clean
+# Other SELinux tests: selinux-data-context, selinux-lxd, selinux-snap-restorecon
+```
+
+**Investigating unclear failure**:
+```bash
+# First run
+./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/flaky-test
+# If logs unclear, add -debug
+./run-spread --no-rebuild -- -debug garden:ubuntu-24.04-64:tests/main/flaky-test
+```
+
+**Multiple related tests**:
+```bash
+# Pattern matching
+./run-spread --no-rebuild garden:ubuntu-24.04-64:tests/main/interfaces-*
+# Or delegate to up to 4 subagents for parallel execution
+```
+
+## Best Practices
+
+**DO**:
+- Use `--no-rebuild` or `-n` flag when snap already built
+- Collect maximum information per run to minimize cycles
+- Prefer `garden` backend for local development
+- Choose systems appropriate to change type (see table above)
+- Use `-debug` when logs lack clarity
+- Plan what information you need before executing
+- Follow user's guidance when in doubt
+- Limit parallel tests to 4 when using subagents (RAM constraint)
+
+**DON'T**:
+- Call `./run-spread` without a `backend:system:test` argument (would run everything)
+- Use backends other than `garden` unless explicitly instructed
+- Waste test cycles running without clear purpose
+- Exceed 4 parallel tests with subagents (RAM exhaustion)
+- Ignore `restore` section failures (indicates cleanup issues)
+- Assume portability between LSMs without testing
+- Use `-debug` by default (only when needed)
+- Forget `--no-rebuild` when snap exists (wastes time)


### PR DESCRIPTION
Add two skills to guide AI agents:
  - build-snapd-snap: Building the snapd snap artifact with appropriate clean options
  - run-spread-test: Running spread tests efficiently with system selection guidance and parallel execution limits

