### PR TITLE
tests/lib/tools/tests.invariant: fix invocation of tests.invariant in tests/cross/ suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1609,6 +1609,8 @@ suites:
     tests/cross/:
         summary: Cross-compile tests
         systems: [ubuntu-24.04-64]
+        prepare: |
+            tests.invariant set snap-mount-dir "$(os.paths snap-mount-dir)"
 
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -140,7 +140,7 @@ check_leftover_defer_sh() {
 }
 
 check_broken_snaps() {
-	if ! command -v /usr/bin/snap >/dev/null 2>&1; then
+	if ! command -v snap >/dev/null 2>&1; then
 		return 0
 	fi
 

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -140,6 +140,10 @@ check_leftover_defer_sh() {
 }
 
 check_broken_snaps() {
+	if ! command -v /usr/bin/snap >/dev/null 2>&1; then
+		return 0
+	fi
+
 	n="$1" # invariant name
 	(
 		SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"


### PR DESCRIPTION
The tests/cross/ suite does not install the snapd package, thus the snap command may not be available.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
