### PR TITLE
o/snapstate, o/s/backend: snap remove removes snapctl mounts

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -119,7 +119,7 @@ type managerBackend interface {
 	RemoveSnapSaveData(info *snap.Info, dev snap.Device) error
 	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error
 	RemoveComponentDir(cpi snap.ContainerPlaceInfo) error
-	RemoveContainerMountUnits(cpi snap.ContainerPlaceInfo, meter progress.Meter) error
+	RemoveContainerMountUnits(cpi snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error
 	DiscardSnapNamespace(snapName string) error
 	DiscardLockedSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string, stateUnlocker runinhibit.Unlocker) error

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -34,6 +34,7 @@ import (
 var (
 	AddMountUnit       = addMountUnit
 	RemoveMountUnit    = removeMountUnit
+	IsUnderAnyDir      = isUnderAnyDir
 	RemoveIfEmpty      = removeIfEmpty
 	SnapDataDirs       = snapDataDirs
 	SnapCommonDataDirs = snapCommonDataDirs

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -20,6 +20,7 @@
 package backend
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
@@ -67,7 +68,7 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 // units whose origin label matches origin are considered (pass "" to match all
 // origins). If baseDirs is non-empty, only units whose mount point lies strictly
 // inside one of those directories are removed; units at or above a base
-// directory are left untouched.  Removal stops and returns an error immediately
+// directory are left untouched. Removal stops and returns an error immediately
 // if any unit cannot be removed.
 func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
@@ -90,10 +91,14 @@ func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter prog
 // provided candidate directories (the path itself being equal to a candidate
 // does not count).
 func isUnderAnyDir(path string, candidates []string) bool {
-	path = strings.TrimRight(path, "/")
 	for _, c := range candidates {
-		c = strings.TrimRight(c, "/")
-		if strings.HasPrefix(path, c+"/") {
+		rel, err := filepath.Rel(c, path)
+		if err != nil {
+			continue
+		}
+		// rel is "." when path == c
+		// rel starts with ".." when path is outside c
+		if rel != "." && !strings.HasPrefix(rel, "..") {
 			return true
 		}
 	}

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -20,6 +20,8 @@
 package backend
 
 import (
+	"strings"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -61,17 +63,39 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 	return sysd.RemoveMountUnitFile(mountDir)
 }
 
-func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error {
+// RemoveContainerMountUnits removes mount units for the given container. Only
+// units whose origin label matches origin are considered (pass "" to match all
+// origins). If baseDirs is non-empty, only units whose mount point lies strictly
+// inside one of those directories are removed; units at or above a base
+// directory are left untouched.  Removal stops and returns an error immediately
+// if any unit cannot be removed.
+func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
-	originFilter := ""
-	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), originFilter)
+	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin)
 	if err != nil {
 		return err
 	}
 	for _, mountPoint := range mountPoints {
+		if len(baseDirs) > 0 && !isUnderAnyDir(mountPoint, baseDirs) {
+			continue
+		}
 		if err := sysd.RemoveMountUnitFile(mountPoint); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// isUnderAnyDir reports whether path is a strict subdirectory of any of the
+// provided candidate directories (the path itself being equal to a candidate
+// does not count).
+func isUnderAnyDir(path string, candidates []string) bool {
+	path = strings.TrimRight(path, "/")
+	for _, c := range candidates {
+		c = strings.TrimRight(c, "/")
+		if strings.HasPrefix(path, c+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -344,4 +344,10 @@ func (s *mountunitSuite) TestIsUnderAnyDir(c *C) {
 	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1/"}), Equals, false)
 	// Unrelated path must not match.
 	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}), Equals, false)
+	// Path with ".." components that escape the candidate after cleaning must not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/../../bar", []string{"/var/snap/foo/1"}), Equals, false)
+	// Path with internal double slash that normalizes to a subdirectory must match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo//1/bar", []string{"/var/snap/foo/1"}), Equals, true)
+	// Relative candidate causes filepath.Rel to error; must not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"var/snap/foo/1"}), Equals, false)
 }

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -212,7 +212,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveContainerMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
@@ -244,7 +244,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveContainerMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
@@ -277,7 +277,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveContainerMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, IsNil)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
@@ -286,4 +286,62 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 3)
 	c.Check(sysd.RemoveMountUnitFileCalls, DeepEquals, returnedMountPoints)
+}
+
+func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
+	info := &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "some-snap",
+			Revision: snap.R(1),
+		},
+	}
+
+	// Only mount points under the specified base dirs should be removed.
+	baseDirs := []string{"/var/snap/some-snap/1", "/var/snap/some-snap/common"}
+	mountPoints := []string{
+		"/var/snap/some-snap/1/target",   // under revision base dir: matched
+		"/var/snap/some-snap/common/dir", // under common base dir: matched
+		"/var/snap/other-snap/1/target",  // unrelated snap: not matched
+	}
+
+	var sysd *FakeSystemd
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &FakeSystemd{}
+		sysd.ListMountUnitsResult = ResultForListMountUnits{mountPoints, nil}
+		return sysd
+	})
+	defer restore()
+
+	b := backend.Backend{}
+	err := b.RemoveContainerMountUnits(info, progress.Null, "mount-control", baseDirs)
+	c.Assert(err, IsNil)
+
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
+		{snapName: "some-snap", origin: "mount-control"},
+	})
+	// Only the two matching mount points should have been removed.
+	c.Assert(sysd.RemoveMountUnitFileCalls, HasLen, 2)
+	c.Assert(sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
+		"/var/snap/some-snap/1/target",
+		"/var/snap/some-snap/common/dir",
+	})
+}
+
+func (s *mountunitSuite) TestIsUnderAnyDir(c *C) {
+	// Subdirectory matches.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1"}), Equals, true)
+	// Trailing slash on path must not affect matching.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1"}), Equals, true)
+	// Trailing slash on candidate must not affect matching.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1/"}), Equals, true)
+	// Trailing slash on both must not affect matching.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1/"}), Equals, true)
+	// Path equal to candidate must not match (strict subdirectory check).
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1"}), Equals, false)
+	// Path equal to candidate with trailing slash on path must not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/", []string{"/var/snap/foo/1"}), Equals, false)
+	// Path equal to candidate with trailing slash on candidate must not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1/"}), Equals, false)
+	// Unrelated path must not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}), Equals, false)
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -95,6 +95,8 @@ type fakeOp struct {
 	requireSnapdTooling bool
 
 	dirOpts  *dirs.SnapDirOptions
+	dirs     []string
+	origin   string
 	undoInfo *backend.UndoInfo
 
 	currentComps []*snap.ComponentSideInfo
@@ -139,6 +141,16 @@ func (ops fakeOps) Count(op string) int {
 		}
 	}
 	return n
+}
+
+func (ops fakeOps) Filter(op string) fakeOps {
+	var filtered fakeOps
+	for i := range ops {
+		if ops[i].op == op {
+			filtered = append(filtered, ops[i])
+		}
+	}
+	return filtered
 }
 
 func (ops fakeOps) First(op string) *fakeOp {
@@ -1714,10 +1726,12 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error {
+func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	f.appendOp(&fakeOp{
-		op:   "remove-snap-mount-units",
-		name: s.ContainerName(),
+		op:     "remove-snap-mount-units",
+		name:   s.ContainerName(),
+		origin: origin,
+		dirs:   baseDirs,
 	})
 	return f.maybeErrForLastOp()
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4043,6 +4043,20 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// Remove mount-control mounts just before removing the data they may be
+	// mounted over. When this is the last revision, remove all mount-control
+	// units for the snap (nil mountBaseDirs = no path filter); otherwise restrict
+	// to the revision-specific data directory only, leaving common data
+	// (shared with remaining revisions) untouched.
+	var mountBaseDirs []string
+	if len(snapst.Sequence.Revisions) > 1 {
+		mountBaseDirs = []string{snap.DataDir(snapsup.InstanceName(), snapsup.Revision())}
+	}
+	const origin = "mount-control"
+	if err := m.backend.RemoveContainerMountUnits(info, nil, origin, mountBaseDirs); err != nil {
+		return err
+	}
+
 	dirOpts := opts.getSnapDirOpts()
 	if err = m.backend.RemoveSnapData(info, dirOpts); err != nil {
 		return err
@@ -4137,7 +4151,9 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if len(snapst.Sequence.Revisions) == 0 {
-		if err = m.backend.RemoveContainerMountUnits(snapsup.containerInfo(), nil); err != nil {
+		origin := ""               // "": remove all mount units regardless of origin
+		var mountBaseDirs []string // nil: no path filter
+		if err = m.backend.RemoveContainerMountUnits(snapsup.containerInfo(), nil, origin, mountBaseDirs); err != nil {
 			return err
 		}
 

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -285,6 +285,11 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
@@ -432,6 +437,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 			op:    "remove-profiles:Doing",
 			name:  "some-snap_instance",
 			revno: snap.R(7),
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap_instance",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -589,6 +599,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			revno: snap.R(7),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap_instance",
+			origin: "mount-control",
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
 		},
@@ -701,6 +716,12 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(3))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/3"),
 		},
@@ -710,6 +731,12 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			stype: "app",
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(5))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/5"),
 		},
@@ -717,6 +744,11 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/5"),
 			stype: "app",
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -853,8 +885,14 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 2)
+	c.Check(len(s.fakeBackend.ops), Equals, 3)
 	expected := fakeOps{
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(3))},
+		},
 		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/3"),
@@ -967,12 +1005,17 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 10)
+	c.Check(len(s.fakeBackend.ops), Equals, 11)
 	expected := fakeOps{
 		{
 			op:    "auto-disconnect:Doing",
 			name:  "some-snap",
 			revno: snap.R(2),
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -1080,7 +1123,7 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 13)
+	c.Check(len(s.fakeBackend.ops), Equals, 14)
 	expected := fakeOps{
 		{
 			op:    "auto-disconnect:Doing",
@@ -1099,6 +1142,11 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 			op:    "remove-profiles:Doing",
 			name:  "some-snap",
 			revno: snap.R(2),
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -1655,6 +1703,12 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(2))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 		},
@@ -1739,6 +1793,12 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			revno: snap.R(1),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(2))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 		},
@@ -1746,6 +1806,11 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 			stype: "app",
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -2468,6 +2533,12 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "snap1",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("snap1", snap.R(2))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "snap1/2"),
 		},
@@ -2503,6 +2574,11 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "snap1/2"),
 			stype: "app",
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "snap1",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",
@@ -2573,10 +2649,10 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 		},
 	}
 	// start with an easier-to-read error if this fails:
-	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
-	c.Check(s.fakeBackend.ops[0:5], DeepEquals, expected[0:5])
-	c.Check(s.fakeBackend.ops[11:16], DeepEquals, expected[11:16])
-	c.Check(s.fakeBackend.ops[22:], DeepEquals, expected[22:])
+	c.Assert(len(s.fakeBackend.ops), Equals, len(expected))
+	c.Check(s.fakeBackend.ops[0:6], DeepEquals, expected[0:6])
+	c.Check(s.fakeBackend.ops[12:18], DeepEquals, expected[12:18])
+	c.Check(s.fakeBackend.ops[24:], DeepEquals, expected[24:])
 	// Check component tasks, that can run in parallel so the order is not
 	// deterministic, but still needs to follow an order per component.
 	checkComps := func(ops, exp1, exp2 fakeOps) {
@@ -2592,8 +2668,8 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			}
 		}
 	}
-	checkComps(s.fakeBackend.ops[5:11], expected[5:8], expected[8:11])
-	checkComps(s.fakeBackend.ops[16:22], expected[16:19], expected[19:22])
+	checkComps(s.fakeBackend.ops[6:12], expected[6:9], expected[9:12])
+	checkComps(s.fakeBackend.ops[18:24], expected[18:21], expected[21:24])
 }
 
 func (s *snapmgrTestSuite) TestRemoveWithTerminate(c *C) {
@@ -2724,4 +2800,109 @@ func (s *snapmgrTestSuite) TestRemoveWithNFSSnapDirMustPurge(c *C) {
 	warns, _ := s.state.PendingWarnings()
 	c.Assert(warns, HasLen, 1)
 	c.Assert(warns[0].String(), Equals, "May not be able to remove user data under NFS mounted snap directory")
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataRemovesMountControlMountsLastRevision(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Last revision; removing it removes all mount-control mounts for the snap.
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)},
+		}),
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	chg := s.state.NewChange("remove", "remove snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), &snapstate.RemoveFlags{Purge: true})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	// doClearSnapData and doDiscardSnap both call RemoveContainerMountUnits when
+	// removing the last revision.
+	mountOps := s.fakeBackend.ops.Filter("remove-snap-mount-units")
+	c.Assert(mountOps, HasLen, 2)
+	// doClearSnapData: last revision → no path filter (nil dirs), origin="mount-control".
+	c.Check(mountOps[0], DeepEquals, fakeOp{
+		op:     "remove-snap-mount-units",
+		name:   "some-snap",
+		origin: "mount-control",
+	})
+	// doDiscardSnap: snap fully removed → no origin filter, no path filter.
+	c.Check(mountOps[1], DeepEquals, fakeOp{
+		op:   "remove-snap-mount-units",
+		name: "some-snap",
+	})
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataRemovesMountControlMountsSingleRevision(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Two revisions present; removing only rev3 removes its revision-specific mounts.
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)},
+		}),
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	chg := s.state.NewChange("remove", "remove snap revision")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(3), nil)
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	// doClearSnapData calls RemoveContainerMountUnits once for the removed revision;
+	// doDiscardSnap skips it because other revisions remain.
+	mountOps := s.fakeBackend.ops.Filter("remove-snap-mount-units")
+	c.Assert(mountOps, HasLen, 1)
+	// doClearSnapData: non-last revision → path filter to revision-specific data dir only.
+	c.Check(mountOps[0], DeepEquals, fakeOp{
+		op:     "remove-snap-mount-units",
+		name:   "some-snap",
+		origin: "mount-control",
+		dirs:   []string{snap.DataDir("some-snap", snap.R(3))},
+	})
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenRemoveMountUnitsErrors(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)},
+		}),
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "remove-snap-mount-units" {
+			return errors.New("mock remove-snap-mount-units error")
+		}
+		return nil
+	}
+
+	chg := s.state.NewChange("remove", "remove snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), &snapstate.RemoveFlags{Purge: true})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	// The change must have failed because clear-snap propagated the error.
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, "(?s).*mock remove-snap-mount-units error.*")
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6112,6 +6112,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "ubuntu-core",
+			origin: "mount-control",
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "ubuntu-core/1"),
 		},
@@ -6215,6 +6220,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 			op:    "remove-profiles:Doing",
 			name:  "ubuntu-core",
 			revno: snap.R(1),
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "ubuntu-core",
+			origin: "mount-control",
 		},
 		{
 			op:   "remove-snap-data",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -445,6 +445,12 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			op: "update-aliases",
 		},
 		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(1))},
+		},
+		{
 			op:   "remove-snap-data",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
 		},
@@ -452,6 +458,12 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/1"),
 			stype: "app",
+		},
+		{
+			op:     "remove-snap-mount-units",
+			name:   "some-snap",
+			origin: "mount-control",
+			dirs:   []string{snap.DataDir("some-snap", snap.R(2))},
 		},
 		{
 			op:   "remove-snap-data",

--- a/tests/main/remove-impacted-by-mounts/task.yaml
+++ b/tests/main/remove-impacted-by-mounts/task.yaml
@@ -8,8 +8,11 @@ details: |
     The test checks that
     - snap remove succeeds if the mounts under snap's global data directories
       are visible only in the snap's namespace (and not in the host's namespace)
+    - snap remove succeeds if the mounts under snap's global data directories were
+      created via the mount-control interface (snapctl mount)
     - _currently_ snap remove fails if the mounts under snap's global/user data
-      directories are visible in the host's namespace. This behavior needs to be fixed.
+      directories were created directly by the user (not via mount-control).
+      This behavior needs to be fixed.
 
 environment:
     SNAP_NAME: test-snapd-mount-control
@@ -27,7 +30,7 @@ environment:
     MOUNT_DEST_USER_DATA: $SNAP_USER_DATA/target1
     # each test variant will execute: test_$CASE $MOUNT_DEST
     CASE/v1,v2: remove_succeeds_when_slave_mount_in_snap_ns_under
-    CASE/v3,v4: remove_currently_fails_when_snapctl_mount_in_host_ns_under
+    CASE/v3,v4: remove_succeeds_when_snapctl_mount_in_host_ns_under
     CASE/v5,v6: remove_currently_fails_when_user_mount_in_host_ns_under
     MOUNT_DEST/v1,v3: $MOUNT_DEST_GLOBAL_COMMON
     MOUNT_DEST/v2,v4: $MOUNT_DEST_GLOBAL_DATA
@@ -94,39 +97,26 @@ execute: |
         test -e "$mount_dest/file1"
     }
 
-    then_remove_currently_fails_mount_remains_src_data_lost () {
+    then_remove_succeeds_mount_removed_src_data_intact() {
         local mount_dest=$1
-        echo "Currently snap remove will fail due to the mount being present in the snap's data directory"
-        echo "THIS NEEDS TO BE FIXED!"
-        not snap remove "${SNAP_NAME}"
-        echo "and the mount is still active"
-        echo "THIS NEEDS TO BE FIXED!"
-        MATCH "$mount_dest" < /proc/self/mountinfo
-        echo "and currently the mount's source data is unfortunately removed"
-        echo "THIS NEEDS TO BE FIXED!"
-        test ! -e "$MOUNT_SRC/file1"
-    }
-
-    cleaning_up_snapctl_mount_should_make_remove_successful() {
-        local mount_dest=$1
-        echo "Below steps can be removed once the above snap remove issues are fixed"
-        echo "Enable the snap (if required) after a failed remove to allow cleanup"
-        snap enable "${SNAP_NAME}" || true
-        echo "Unmount via snapctl"
-        "${SNAP_NAME}".cmd snapctl umount "$mount_dest"
-        echo "and unmount should have succeeded"
-        NOMATCH "$mount_dest" < /proc/self/mountinfo
-        echo "Now snap remove should succeed"
+        echo "Verify that snap remove succeeds"
         snap remove "${SNAP_NAME}"
+        echo "and the mount is no longer active in the host's namespace"
+        NOMATCH "$mount_dest" < /proc/self/mountinfo
+        echo "and the mount unit file is removed from disk"
+        UNIT_NAME="$(systemd-escape -p "$mount_dest").mount"
+        test ! -e "/etc/systemd/system/$UNIT_NAME"
+        test ! -e "/run/systemd/system/$UNIT_NAME"
+        echo "but the mount's source data is still there"
+        test -e "$MOUNT_SRC/file1"
     }
 
-    test_remove_currently_fails_when_snapctl_mount_in_host_ns_under() {
+    test_remove_succeeds_when_snapctl_mount_in_host_ns_under() {
         local mount_dest=$1
         setup_src_data
         setup_test_snap
         when_snapctl_mount_in_host_ns "$mount_dest"
-        then_remove_currently_fails_mount_remains_src_data_lost "$mount_dest"
-        cleaning_up_snapctl_mount_should_make_remove_successful "$mount_dest"
+        then_remove_succeeds_mount_removed_src_data_intact "$mount_dest"
         echo
     }
 
@@ -152,6 +142,19 @@ execute: |
         NOMATCH "$mount_dest" < /proc/self/mountinfo
         echo "Now snap remove should succeed"
         snap remove "${SNAP_NAME}"
+    }
+
+    then_remove_currently_fails_mount_remains_src_data_lost () {
+        local mount_dest=$1
+        echo "Currently snap remove will fail due to the mount being present in the snap's data directory"
+        echo "THIS NEEDS TO BE FIXED!"
+        not snap remove "${SNAP_NAME}"
+        echo "and the mount is still active"
+        echo "THIS NEEDS TO BE FIXED!"
+        MATCH "$mount_dest" < /proc/self/mountinfo
+        echo "and currently the mount's source data is unfortunately removed"
+        echo "THIS NEEDS TO BE FIXED!"
+        test ! -e "$MOUNT_SRC/file1"
     }
 
     test_remove_currently_fails_when_user_mount_in_host_ns_under() {


### PR DESCRIPTION
This resolves the issue of failing `snap remove` when there are mounts under snap (global) data dirs, created by a snap (for ex. with mount-control interface) using `snapctl mount`.
* `RemoveContainerMountUnits` is now used also in "clear-snap" task to remove the mount units with "mount-control" origin. This is needed before removing snap data.
* `RemoveContainerMountUnits` now also allows filtering mounts based on baseDirs, to enable revision-specific `snap remove`
* While removing the last snap revision, all snapctl created mounts - including the ones outside snap data dirs - will be removed

Combines [SNAPDENG-36725](https://warthogs.atlassian.net/browse/SNAPDENG-36725) and [SNAPDENG-36726](https://warthogs.atlassian.net/browse/SNAPDENG-36726)

**Notes**
* This does not remove mounts created by a user within snap (global / user) data dirs
* This does not remove mounts created by a snap (for ex. with mount-control interface) using `mount` under shared mount propagation paths such as `/media`. There seems no way of identifying which snap (or if a user) created a mount there.

**Future Work**
* Handle `snap remove` if a user created mount exists within snap (global / user) data dirs
* Exclude snapctl created mount points while saving snapshots (automatic or manual)

[SNAPDENG-36725]: https://warthogs.atlassian.net/browse/SNAPDENG-36725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNAPDENG-36726]: https://warthogs.atlassian.net/browse/SNAPDENG-36726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ