### PR TITLE
github, spread, tests: remove fedora-42

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -104,7 +104,6 @@ jobs:
       fail-fast: false
       matrix:
         build-config:
-          - { system: fedora-42-64,           pkg-dir: fedora-42,            config: fedora-42-x86_64           }
           - { system: fedora-44-64,           pkg-dir: fedora-44,            config: fedora-44-x86_64           }
           - { system: centos-9-64,            pkg-dir: centos-9,             config: centos-stream-9-x86_64     }
 

--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -31,7 +31,7 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "fedora",
         "backend": "openstack",
-        "systems": "fedora-42-64 fedora-44-64",
+        "systems": "fedora-44-64",
         "alternative-backend": "openstack",
         "tasks": "tests/...",
         "rules": "main"
@@ -191,10 +191,10 @@
       },
       {
         "runs-on": "['ubuntu-latest']",
-        "group": "fedora-42 (garden)",
+        "group": "fedora-44 (garden)",
         "backend": "garden",
         "alternative-backend": "google",
-        "systems": "fedora-42-64",
+        "systems": "fedora-44-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
       }

--- a/spread.yaml
+++ b/spread.yaml
@@ -444,10 +444,6 @@ backends:
                 image: snapd-spread/arch-linux-64
                 workers: 6
 
-            - fedora-42-64:
-                  image: snapd-spread/fedora-42-64
-                  workers: 12
-
             - fedora-44-64:
                   image: snapd-spread/fedora-44-64
                   workers: 12
@@ -808,9 +804,6 @@ backends:
                   username: root
                   password: root
             - opensuse-tumbleweed-selinux-64:
-                  username: root
-                  password: root
-            - fedora-42-64:
                   username: root
                   password: root
             - fedora-44-64:

--- a/tests/lib/external/snapd-testing-tools/spread.yaml
+++ b/tests/lib/external/snapd-testing-tools/spread.yaml
@@ -77,8 +77,8 @@ backends:
             - ubuntu-26.04-64:
                 image: snapd-spread/ubuntu-26.04-64
 
-            - fedora-42-64:
-                image: snapd-spread/fedora-42-64
+            - fedora-44-64:
+                image: snapd-spread/fedora-44-64
             - opensuse-15.6-64:
                 image: snapd-spread/opensuse-15.6-64
             - opensuse-tumbleweed-64:

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -192,9 +192,9 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
-        fedora-42-64)
+        fedora-44-64)
             os.query is-fedora
-            os.query is-fedora 42
+            os.query is-fedora 44
             ! os.query is-fedora rawhide
             os.query is-classic
             ! os.query is-core

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -25,7 +25,6 @@ systems:
     - -arch-linux-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -centos-*
     - -debian-*
-    - -fedora-42-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-44-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -20,7 +20,6 @@ systems:
     - -arch-linux-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -centos-*
     - -debian-*
-    - -fedora-42-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-44-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -13,7 +13,6 @@ systems:
   - -amazon-linux-2-*    # fails to start service daemon-containerd
   - -amazon-linux-2023-* # fails to start service daemon-containerd
   - -centos-9-*          # fails to start service daemon-containerd
-  - -fedora-42-*         # fails to start service daemon-containerd
   - -ubuntu-14.04-*      # doesn't have libseccomp >= 2.4
   - -arch-linux-*        # XXX: no curl to the pod for unknown reasons
   - -opensuse-*          # install hook fails

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -13,6 +13,7 @@ systems:
   - -amazon-linux-2-*    # fails to start service daemon-containerd
   - -amazon-linux-2023-* # fails to start service daemon-containerd
   - -centos-9-*          # fails to start service daemon-containerd
+  - -fedora-44-*          # fails to start service daemon-containerd
   - -ubuntu-14.04-*      # doesn't have libseccomp >= 2.4
   - -arch-linux-*        # XXX: no curl to the pod for unknown reasons
   - -opensuse-*          # install hook fails


### PR DESCRIPTION
Requires https://github.com/canonical/snapd/pull/17036

The only relevant commit is the last one b0213ea743b1c39e593cf9b685140c494afa3715.
Fedora 42 was EOL on May 13, 2026 https://fedorapeople.org/groups/schedule/f-42/f-42-key-tasks.html