### PR TITLE
osutil: retry tmp file conflicts during atomic file creation

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -220,7 +220,7 @@ func MockFindGidNoFallback(mock func(name string) (uint64, error)) (restore func
 	return func() { findGidNoGetentFallback = old }
 }
 
-const MaxLinkTries = maxLinkTries
+const MaxTmpPathTries = maxTmpPathTries
 
 var ParseRawEnvironment = parseRawEnvironment
 

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -63,6 +63,8 @@ type AtomicFile struct {
 	renamed bool
 }
 
+const maxTmpPathTries = 10000
+
 // NewAtomicFile builds an AtomicFile backed by an *os.File that will have
 // the given filename, permissions and uid/gid when Committed.
 //
@@ -96,10 +98,20 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	tmp := filename + "." + randutil.RandomString(12) + "~"
-
-	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+	var tmp string
+	var fd *os.File
+	for tries := 0; tries < maxTmpPathTries; tries++ {
+		tmp = filename + "." + randutil.RandomString(12) + "~"
+		fd, err = os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		break
+	}
 	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("cannot create a temporary file")
+		}
 		return nil, err
 	}
 
@@ -322,10 +334,8 @@ func AtomicRename(oldName, newName string) (err error) {
 	return err2
 }
 
-const maxLinkTries = 10
-
 func atomicLinkOp(target, linkPath string, op func(target, tmp string) error, kind string) error {
-	for tries := 0; tries < maxLinkTries; tries++ {
+	for tries := 0; tries < maxTmpPathTries; tries++ {
 		tmp := linkPath + "." + randutil.RandomString(12) + "~"
 		if err := op(target, tmp); err != nil {
 			if os.IsExist(err) {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -153,20 +153,30 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C
 	c.Assert(p, testutil.FileEquals, "hi")
 }
 
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) {
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileCollisionError(c *C) {
 	tmpdir := c.MkDir()
 	// ensure we always get the same result
 	rand.Seed(1)
-	expectedRandomness := randutil.RandomString(12) + "~"
-	// ensure we always get the same result
+	p := filepath.Join(tmpdir, "foo")
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries)
+	// restart random number sequence
 	rand.Seed(1)
 
-	p := filepath.Join(tmpdir, "foo")
-	err := os.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
-	c.Assert(err, IsNil)
+	err := osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
+	c.Assert(err, ErrorMatches, "cannot create a temporary file")
+}
 
-	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
-	c.Assert(err, ErrorMatches, "open .*: file exists")
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileCollisionHappy(c *C) {
+	tmpdir := c.MkDir()
+	// ensure we always get the same result
+	rand.Seed(1)
+	p := filepath.Join(tmpdir, "foo")
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries/2)
+	// restart random number sequence
+	rand.Seed(1)
+
+	err := osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
+	c.Assert(err, IsNil)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
@@ -392,7 +402,7 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkCollisionError(c *C) {
 	// ensure we always get the same result
 	rand.Seed(1)
 	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries)
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries)
 	// restart random number sequence
 	rand.Seed(1)
 
@@ -405,7 +415,7 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkCollisionHappy(c *C) {
 	// ensure we always get the same result
 	rand.Seed(1)
 	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries/2)
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries/2)
 	// restart random number sequence
 	rand.Seed(1)
 
@@ -484,7 +494,7 @@ func (ts *AtomicLinkTestSuite) TestAtomicLinkCollisionError(c *C) {
 	// ensure we always get the same result
 	rand.Seed(1)
 	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries)
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries)
 	// restart random number sequence
 	rand.Seed(1)
 
@@ -499,7 +509,7 @@ func (ts *AtomicLinkTestSuite) TestAtomicLinkCollisionHappy(c *C) {
 	// ensure we always get the same result
 	rand.Seed(1)
 	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries/2)
+	createCollisionSequence(c, p, osutil.MaxTmpPathTries/2)
 	// restart random number sequence
 	rand.Seed(1)
 


### PR DESCRIPTION
Similar to the retry logic which was previously implemented for `AtomicLink` and `AtomicSymlink`, add retry logic for `NewAtomicFile` if there is a conflict when attempting to create a temporary file.

CC @jonathan-conder @benhoyt This is different from the logic implemented in other variants, as those don't have the link retry logic on which this is based.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36937