### PR TITLE
osutil: use CreateTemp for NewAtomicFile tmp file creation

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -156,7 +156,7 @@ selinux_get_enforce_mode(snappy_t)
 # Allow snapd to manage D-Bus config files for snaps
 optional_policy(`
 	dbus_read_config(snappy_t)
-	allow snappy_t dbusd_etc_t:file { write create rename unlink };
+	allow snappy_t dbusd_etc_t:file { write create rename unlink setattr };
 	allow snappy_t dbusd_etc_t:dir { add_name remove_name };
 	allow snappy_t dbusd_etc_t:lnk_file { read };
 ')
@@ -164,7 +164,7 @@ optional_policy(`
 # Allow snapd to manage kmod-backend (/etc/modules-load.d/) or
 # incorrectly labeled systemd user unit files
 allow snappy_t etc_t:dir { write remove_name add_name };
-allow snappy_t etc_t:file { create write rename unlink };
+allow snappy_t etc_t:file { create write rename unlink setattr };
 
 # Allow snapd to manage udev rules for snaps and trigger events
 optional_policy(`

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -251,3 +251,7 @@ func MockAllDataHomeGlobs(f func() []string) func() {
 		dirsAllDataHomeGlobs = oldAllDataHomeGlobs
 	}
 }
+
+func MockFChmod(f func(file *os.File, mode os.FileMode) error) (restore func()) {
+	return testutil.Mock(&fChmod, f)
+}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -220,8 +220,6 @@ func MockFindGidNoFallback(mock func(name string) (uint64, error)) (restore func
 	return func() { findGidNoGetentFallback = old }
 }
 
-const MaxLinkTries = maxLinkTries
-
 var ParseRawEnvironment = parseRawEnvironment
 
 // ParseRawExpandableEnv returns a new expandable environment parsed from key=value strings.

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -74,6 +75,11 @@ type AtomicFile struct {
 // Cancel also fails. In all these scenarios your filesystem was probably in a
 // rather poor state. Good luck.
 func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (aw *AtomicFile, err error) {
+	basename := filepath.Base(filename)
+	dirname := filepath.Dir(filename)
+	if strings.Contains(basename, "*") {
+		return nil, fmt.Errorf("cannot create tempfile for filename containing '*': %q", basename)
+	}
 	// The tilde is appended so that programs that inspect all files in some
 	// directory are more likely to ignore this file as an editor backup file.
 	//
@@ -81,7 +87,7 @@ func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sy
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	fd, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename)+".*~")
+	fd, err := os.CreateTemp(dirname, basename+".*~")
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +325,12 @@ func AtomicRename(oldName, newName string) (err error) {
 }
 
 func atomicLinkOp(target, linkPath string, op func(target, tmp string) error) error {
-	tmpDir, err := os.MkdirTemp(filepath.Dir(linkPath), filepath.Base(linkPath)+".*~")
+	basename := filepath.Base(linkPath)
+	dirname := filepath.Dir(linkPath)
+	if strings.Contains(basename, "*") {
+		return fmt.Errorf("cannot create tempfile for link path containing '*': %q", basename)
+	}
+	tmpDir, err := os.MkdirTemp(dirname, basename+".*~")
 	if err != nil {
 		return err
 	}

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil/sys"
-	"github.com/snapcore/snapd/randutil"
 )
 
 // AtomicWriteFlags are a bitfield of flags for AtomicWriteFile
@@ -319,23 +318,17 @@ func AtomicRename(oldName, newName string) (err error) {
 	return err2
 }
 
-const maxLinkTries = 10
-
-func atomicLinkOp(target, linkPath string, op func(target, tmp string) error, kind string) error {
-	for tries := 0; tries < maxLinkTries; tries++ {
-		// XXX: would be nice if we could use `os.CreateTemp` here, but there's
-		// no such functionality for creating temporary (sym)links.
-		tmp := linkPath + "." + randutil.RandomString(12) + "~"
-		if err := op(target, tmp); err != nil {
-			if os.IsExist(err) {
-				continue
-			}
-			return err
-		}
-		defer os.Remove(tmp)
-		return AtomicRename(tmp, linkPath)
+func atomicLinkOp(target, linkPath string, op func(target, tmp string) error) error {
+	tmpDir, err := os.MkdirTemp(filepath.Dir(linkPath), filepath.Base(linkPath)+".*~")
+	if err != nil {
+		return err
 	}
-	return fmt.Errorf("cannot create a temporary %s", kind)
+	defer os.RemoveAll(tmpDir)
+	tmp := filepath.Join(tmpDir, "link")
+	if err := op(target, tmp); err != nil {
+		return err
+	}
+	return AtomicRename(tmp, linkPath)
 }
 
 // AtomicSymlink attempts to atomically create a symlink at linkPath, pointing
@@ -343,7 +336,7 @@ func atomicLinkOp(target, linkPath string, op func(target, tmp string) error, ki
 // the target, and then proceeds to rename it atomically, replacing the
 // linkPath.
 func AtomicSymlink(target, linkPath string) error {
-	return atomicLinkOp(target, linkPath, os.Symlink, "symlink")
+	return atomicLinkOp(target, linkPath, os.Symlink)
 }
 
 // AtomicLink attempts to atomically create a hardlink at linkPath, referencing
@@ -351,5 +344,5 @@ func AtomicSymlink(target, linkPath string) error {
 // to the target, and then proceeds to rename it atomically, replacing the
 // linkPath.
 func AtomicLink(target, linkPath string) error {
-	return atomicLinkOp(target, linkPath, os.Link, "link")
+	return atomicLinkOp(target, linkPath, os.Link)
 }

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -64,7 +64,7 @@ type AtomicFile struct {
 //	It _might_ be implemented using O_TMPFILE (see open(2)).
 //
 // Note that it won't follow symlinks and will replace existing symlinks with
-// the real file.
+// the real file. Also, umask is ignored when setting the file's permissions.
 //
 // It is the caller's responsibility to clean up on error, by calling Cancel().
 //
@@ -98,7 +98,7 @@ func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sy
 		}
 	}()
 
-	// XXX: this ignores umask
+	// Chmod ignores umask
 	if err = fChmod(fd, perm); err != nil {
 		return nil, err
 	}

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -82,21 +82,32 @@ func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sy
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	tmp := filename + "." + randutil.RandomString(12) + "~"
-
-	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+	fd, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename)+".*~")
 	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			fd.Close()
+			os.Remove(fd.Name())
+		}
+	}()
+
+	// XXX: this ignores umask
+	if err = fChmod(fd, perm); err != nil {
 		return nil, err
 	}
 
 	return &AtomicFile{
 		File:    fd,
 		target:  filename,
-		tmpname: tmp,
+		tmpname: fd.Name(),
 		uid:     uid,
 		gid:     gid,
 	}, nil
 }
+
+var fChmod = (*os.File).Chmod
 
 // ErrCannotCancel means the Commit operation failed at the last step, and
 // your luck has run out.
@@ -312,6 +323,8 @@ const maxLinkTries = 10
 
 func atomicLinkOp(target, linkPath string, op func(target, tmp string) error, kind string) error {
 	for tries := 0; tries < maxLinkTries; tries++ {
+		// XXX: would be nice if we could use `os.CreateTemp` here, but there's
+		// no such functionality for creating temporary (sym)links.
 		tmp := linkPath + "." + randutil.RandomString(12) + "~"
 		if err := op(target, tmp); err != nil {
 			if os.IsExist(err) {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -93,13 +93,12 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
 	tmpdir := c.MkDir()
 
-	badSubdir := filepath.Join(tmpdir, "foo")
-	err := os.WriteFile(badSubdir, []byte(""), 0644)
+	err := os.Chmod(tmpdir, 0o644) // no directory traversal allowed
 	c.Assert(err, IsNil)
 
-	p := filepath.Join(badSubdir, "bar")
+	p := filepath.Join(tmpdir, "foo")
 	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
-	c.Assert(err, ErrorMatches, "open .*: not a directory")
+	c.Assert(err, ErrorMatches, `open /.*/foo\..*~: permission denied`)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileChmodError(c *C) {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -90,20 +90,40 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) {
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
 	tmpdir := c.MkDir()
-	// ensure we always get the same result
-	rand.Seed(1)
-	expectedRandomness := randutil.RandomString(12) + "~"
-	// ensure we always get the same result
-	rand.Seed(1)
 
-	p := filepath.Join(tmpdir, "foo")
-	err := os.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
+	badSubdir := filepath.Join(tmpdir, "foo")
+	err := os.WriteFile(badSubdir, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
+	p := filepath.Join(badSubdir, "bar")
 	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
-	c.Assert(err, ErrorMatches, "open .*: file exists")
+	c.Assert(err, ErrorMatches, "open .*: not a directory")
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileChmodError(c *C) {
+	tmpdir := c.MkDir()
+
+	// Nothing in the directory to begin
+	entries, err := os.ReadDir(tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 0)
+
+	customError := errors.New("something happened")
+	restore := osutil.MockFChmod(func(file *os.File, mode os.FileMode) error {
+		return customError
+	})
+	defer restore()
+
+	p := filepath.Join(tmpdir, "foo")
+	err = osutil.AtomicWriteFile(p, []byte(""), 0o644, 0)
+	c.Assert(err, Equals, customError)
+
+	// Nothing in the directory after error
+	entries, err = os.ReadDir(tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 0)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -22,7 +22,6 @@ package osutil_test
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
-	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -299,7 +297,7 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 	nested := filepath.Join(d, "nested")
 	nestedBarSymlink := filepath.Join(nested, "bar")
 	err = osutil.AtomicSymlink("target", nestedBarSymlink)
-	c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: no such file or directory`)
+	c.Assert(err, ErrorMatches, `stat /.*/nested: no such file or directory`)
 	checkLeftoverFiles(nestedBarSymlink, nil)
 
 	if os.Geteuid() != 0 {
@@ -309,7 +307,7 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 
 		// no permission to write in dir
 		err = osutil.AtomicSymlink("target", nestedBarSymlink)
-		c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: permission denied`)
+		c.Assert(err, ErrorMatches, `mkdir /.*/nested/bar\..*~: permission denied`)
 		checkLeftoverFiles(nestedBarSymlink, nil)
 
 		err = os.Chmod(nested, 0755)
@@ -332,41 +330,6 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 	c.Assert(err, IsNil)
 	mustReadSymlink(nestedBarSymlink, "/this/is/some/funny/path")
 	checkLeftoverFiles(nestedBarSymlink, []string{nestedBarSymlink})
-}
-
-func createCollisionSequence(c *C, baseName string, many int) {
-	for i := 0; i < many; i++ {
-		expectedRandomness := randutil.RandomString(12) + "~"
-		// ensure we always get the same result
-		err := os.WriteFile(baseName+"."+expectedRandomness, []byte(""), 0644)
-		c.Assert(err, IsNil)
-	}
-}
-
-func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkCollisionError(c *C) {
-	tmpdir := c.MkDir()
-	// ensure we always get the same result
-	rand.Seed(1)
-	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries)
-	// restart random number sequence
-	rand.Seed(1)
-
-	err := osutil.AtomicSymlink("target", p)
-	c.Assert(err, ErrorMatches, "cannot create a temporary symlink")
-}
-
-func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkCollisionHappy(c *C) {
-	tmpdir := c.MkDir()
-	// ensure we always get the same result
-	rand.Seed(1)
-	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries/2)
-	// restart random number sequence
-	rand.Seed(1)
-
-	err := osutil.AtomicSymlink("target", p)
-	c.Assert(err, IsNil)
 }
 
 type AtomicLinkTestSuite struct{}
@@ -404,7 +367,7 @@ func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 	nested := filepath.Join(d, "nested")
 	nestedBarLink := filepath.Join(nested, "bar")
 	err = osutil.AtomicLink(target, nestedBarLink)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`link %s /.*/nested/bar\..*~: no such file or directory`, target))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`stat /.*/nested: no such file or directory`))
 	checkLeftoverFiles(nestedBarLink, nil)
 
 	if os.Geteuid() != 0 {
@@ -414,7 +377,7 @@ func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 
 		// no permission to write in dir
 		err = osutil.AtomicLink(target, nestedBarLink)
-		c.Assert(err, ErrorMatches, fmt.Sprintf(`link %s /.*/nested/bar\..*~: permission denied`, target))
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`mkdir /.*/nested/bar\..*~: permission denied`))
 		checkLeftoverFiles(nestedBarLink, nil)
 
 		err = os.Chmod(nested, 0o755)
@@ -433,36 +396,6 @@ func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 	c.Assert(err, IsNil)
 	mustReadLink(nestedBarLink, newTarget)
 	checkLeftoverFiles(nestedBarLink, []string{nestedBarLink})
-}
-
-func (ts *AtomicLinkTestSuite) TestAtomicLinkCollisionError(c *C) {
-	tmpdir := c.MkDir()
-	// ensure we always get the same result
-	rand.Seed(1)
-	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries)
-	// restart random number sequence
-	rand.Seed(1)
-
-	target := filepath.Join(tmpdir, "target")
-	c.Assert(os.WriteFile(target, []byte(""), 0o644), IsNil)
-	err := osutil.AtomicLink(target, p)
-	c.Assert(err, ErrorMatches, "cannot create a temporary link")
-}
-
-func (ts *AtomicLinkTestSuite) TestAtomicLinkCollisionHappy(c *C) {
-	tmpdir := c.MkDir()
-	// ensure we always get the same result
-	rand.Seed(1)
-	p := filepath.Join(tmpdir, "foo")
-	createCollisionSequence(c, p, osutil.MaxLinkTries/2)
-	// restart random number sequence
-	rand.Seed(1)
-
-	target := filepath.Join(tmpdir, "target")
-	c.Assert(os.WriteFile(target, []byte(""), 0o644), IsNil)
-	err := osutil.AtomicLink(target, p)
-	c.Assert(err, IsNil)
 }
 
 type AtomicRenameTestSuite struct{}

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -88,6 +88,25 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInDirOkay(c *C) {
+	tmpdir := c.MkDir()
+
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	c.Assert(err, IsNil)
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInBasenameError(c *C) {
+	tmpdir := c.MkDir()
+
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for filename containing '\*': "foo\*bar"`)
+}
+
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
 	tmpdir := c.MkDir()
 
@@ -332,6 +351,31 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 	checkLeftoverFiles(nestedBarSymlink, []string{nestedBarSymlink})
 }
 
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkAsteriskInDirOkay(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicSymlink(target, p)
+	c.Assert(err, IsNil)
+}
+
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkAsteriskInBasenameError(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicSymlink(target, p)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for link path containing '\*': "foo\*bar"`)
+}
+
 type AtomicLinkTestSuite struct{}
 
 var _ = Suite(&AtomicLinkTestSuite{})
@@ -396,6 +440,31 @@ func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 	c.Assert(err, IsNil)
 	mustReadLink(nestedBarLink, newTarget)
 	checkLeftoverFiles(nestedBarLink, []string{nestedBarLink})
+}
+
+func (ts *AtomicLinkTestSuite) TestAtomicLinkAsteriskInDirOkay(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicLink(target, p)
+	c.Assert(err, IsNil)
+}
+
+func (ts *AtomicLinkTestSuite) TestAtomicLinkAsteriskInBasenameError(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicLink(target, p)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for link path containing '\*': "foo\*bar"`)
 }
 
 type AtomicRenameTestSuite struct{}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -759,7 +759,7 @@ func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C)
 	defer os.Chmod(d, 0755)
 
 	err := s.be.LinkSnap(s.info, mockDev, mockLinkContextWithStateUnlocker(), s.perfTimings)
-	c.Assert(err, ErrorMatches, `(?i).*symlink.*permission denied.*`)
+	c.Assert(err, ErrorMatches, `(?i).*mkdir /.*/hello/current.*: permission denied.*`)
 
 	c.Check(s.info.DataDir(), testutil.FileAbsent)
 	c.Check(filepath.Join(s.info.DataDir(), "..", "current"), testutil.FileAbsent)
@@ -799,7 +799,7 @@ func (s *linkCleanupSuite) testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c *C
 		StateUnlocker: func() (relock func()) { return func() {} },
 	}
 	err = s.be.LinkSnap(info, mockDev, linkCtx, s.perfTimings)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("symlink %s /.*/snapd/current.*: permission denied", info.Revision))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("mkdir /.*/snapd/current.*: permission denied"))
 
 	isUndo := false
 	reboot, err := s.be.MaybeSetNextBoot(info, mockDev, isUndo)


### PR DESCRIPTION
This is an alternative to #17091, using `os.CreateTemp` from the standard library instead of rolling a custom retry mechanism.

CC @hpidcock @benhoyt @jonathan-conder

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36937
