### PR TITLE
github: use image-garden from master instead of branch

### DIFF
--- a/.github/actions/setup-image-garden/action.yaml
+++ b/.github/actions/setup-image-garden/action.yaml
@@ -79,7 +79,7 @@ runs:
         - name: Install image garden
           shell: bash
           run: |
-            git clone https://gitlab.com/zygoon/image-garden.git -b 'v0.3.4' /tmp/image-garden --depth 1
+            git clone https://gitlab.com/zygoon/image-garden.git /tmp/image-garden --depth 1
             sudo make install -C /tmp/image-garden
         - name: Install spread
           shell: bash


### PR DESCRIPTION
The tagged version of image garden doesn't support Fedora 44. Use master instead.

Fedora in image garden passed on this run: https://github.com/canonical/snapd/actions/runs/26275543687/job/77341405045