### PR TITLE
interfaces/network-control: Allow use of the systemd networkctl command

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -152,6 +152,70 @@ dbus (receive)
      member=PropertiesChanged
      peer=(label=unconfined),
 
+# required by networkctl command
+unix (bind) type=stream addr="@*/bus/networkctl*/system",
+/run/systemd/netif/links/ r,
+/run/systemd/netif/links/* r,
+/run/systemd/netif/lldp/[0-9]* r,
+/run/udev/data/n[0-9]* r,
+
+# systemd-networkd, used by networkctl
+#
+# Allow access for networkctl to communicate with systemd-networkd via D-Bus API:
+#
+#  - networkctl(1): https://www.freedesktop.org/software/systemd/man/latest/networkctl.html
+#  - org.freedesktop.network1(5): https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.network1.html
+#  - systemd-networkd.service(8): https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.service.html
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/network1"
+     interface="org.freedesktop.network1.Manager"
+     member="{ListLinks,GetLinkByName,GetLinkByIndex,SetLinkNTP,SetLinkDNS,SetLinkDNSEx,SetLinkDomains,SetLinkDefaultRoute,SetLinkLLMNR,SetLinkMulticastDNS,SetLinkDNSOverTLS,SetLinkDNSSEC,SetLinkDNSSECNegativeTrustAnchors,RevertLinkNTP,RevertLinkDNS,RenewLink,ForceRenewLink,ReconfigureLink,Reload,DescribeLink,Describe}"
+     peer=(name="org.freedesktop.network1", label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/network1"
+     interface="org.freedesktop.DBus.Properties"
+     member=Get{,All}
+     peer=(name="org.freedesktop.network1", label=unconfined),
+
+dbus (receive)
+     bus=system
+     path="/org/freedesktop/network1"
+     interface="org.freedesktop.DBus.Properties"
+     member=PropertiesChanged
+     peer=(label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/network1"
+     interface="org.freedesktop.DBus.Peer"
+     member=Ping
+     peer=(name="org.freedesktop.network1", label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/network1/link/_*"
+     interface="org.freedesktop.network1.Link"
+     member="{SetNTP,SetDNS,SetDNSEx,SetDomains,SetDefaultRoute,SetLLMNR,SetMulticastDNS,SetDNSOverTLS,SetDNSSEC,SetDNSSECNegativeTrustAnchors,RevertNTP,RevertDNS,Renew,ForceRenew,Reconfigure,Describe}"
+     peer=(name="org.freedesktop.network1", label=unconfined),
+
+dbus (send)
+     bus=system
+     path="/org/freedesktop/network1/link/_*"
+     interface="org.freedesktop.DBus.Properties"
+     member=Get{,All}
+     peer=(name="org.freedesktop.network1", label=unconfined),
+
+dbus (receive)
+     bus=system
+     path="/org/freedesktop/network1/link/_*"
+     interface="org.freedesktop.DBus.Properties"
+     member=PropertiesChanged
+     peer=(label=unconfined),
+
 # Allow access to wpa-supplicant for managing WiFi networks
 dbus (receive, send)
     bus=system
@@ -220,6 +284,7 @@ network sna,
 /{,usr/}{,s}bin/iw ixr,
 /{,usr/}{,s}bin/nameif ixr,
 /{,usr/}{,s}bin/netstat ixr,              # -p not supported
+/{,usr/}{,s}bin/networkctl ixr,
 /{,usr/}{,s}bin/nstat ixr,
 /{,usr/}{,s}bin/ping ixr,
 /{,usr/}{,s}bin/ping6 ixr,

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -94,7 +94,19 @@ func (s *NetworkControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/netns/* rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `path="/org/freedesktop/resolve1/link/*"`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface="org.freedesktop.resolve1.Link"`)
+	// Some dbus members policy is wildcard, so splitting this member assert into two
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `member="Set*"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `member="{ListLinks,GetLinkByName,GetLinkByIndex,SetLinkNTP,SetLinkDNS,SetLinkDNSEx,SetLinkDomains,SetLinkDefaultRoute,SetLinkLLMNR,SetLinkMulticastDNS,SetLinkDNSOverTLS,SetLinkDNSSEC,SetLinkDNSSECNegativeTrustAnchors,RevertLinkNTP,RevertLinkDNS,RenewLink,ForceRenewLink,ReconfigureLink,Reload,DescribeLink,Describe}"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `unix (bind) type=stream addr="@*/bus/networkctl*/system",`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/systemd/netif/links/* r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/systemd/netif/lldp/[0-9]* r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/udev/data/n[0-9]* r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}{,s}bin/networkctl ixr,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `path="/org/freedesktop/network1"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface="org.freedesktop.network1.Manager"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `path="/org/freedesktop/network1/link/_*"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface="org.freedesktop.network1.Link"`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label=unconfined),`)
 	// No "xdp" feature is available, so this rule should not be added
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "network xdp,")
 	c.Assert(spec.UpdateNS(), DeepEquals, []string{`


### PR DESCRIPTION
networkctl can be used to query and modify the state of the network links. It's also used internally by various common utilities.

This policy also enables listening for network interface state changes from networkd, and so can be used to run things like networkd-dispatcher too.