### PR TITLE
interfaces/network-observe: Allow listening for systemd networkd link property changes via D-Bus

### DIFF
--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -62,6 +62,45 @@ dbus send
      member="Resolve{Address,Hostname,Record,Service}"
      peer=(name="org.freedesktop.resolve1"),
 
+# systemd-networkd
+#
+# Allow access to listen for link property changes from systemd-networkd via the D-Bus API:
+#
+#   https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.network1.html
+#
+# This can be used to run things like networkd-dispatcher, or similar, inside a snap
+#
+#include <abstractions/dbus-strict>
+dbus receive
+     bus=system
+     path=/org/freedesktop/network1
+     interface=org.freedesktop.DBus.Properties
+     member=PropertiesChanged
+     peer=(label=unconfined),
+
+dbus receive
+     bus=system
+     path=/org/freedesktop/network1/link/_*
+     interface=org.freedesktop.DBus.Properties
+     member=PropertiesChanged
+     peer=(label=unconfined),
+
+# Allow reading systemd-networkd link properties explicitly if an app needs to query state on-demand
+dbus send
+     bus=system
+     path=/org/freedesktop/network1/link/_*
+     interface=org.freedesktop.DBus.Properties
+     member=Get{,All}
+     peer=(name=org.freedesktop.network1, label=unconfined),
+
+# Allow access to read only systemd-networkd Manager objects
+dbus send
+     bus=system
+     path=/org/freedesktop/network1
+     interface=org.freedesktop.network1.Manager
+     member={ListLinks,GetLinkByName,DescribeLink,Describe}
+     peer=(name=org.freedesktop.network1, label=unconfined),
+
 #include <abstractions/ssl_certs>
 
 # see loaded kernel modules

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -91,6 +91,23 @@ func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capset\n")
 }
 
+func (s *NetworkObserveInterfaceSuite) TestAppArmorSpecSystemdNetworkd(c *C) {
+	apparmorSpec := apparmor.NewSpecification(s.plug.AppSet())
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+
+	snippet := apparmorSpec.SnippetForTag("snap.other.app2")
+	c.Assert(snippet, testutil.Contains, "path=/org/freedesktop/network1")
+	c.Assert(snippet, testutil.Contains, "path=/org/freedesktop/network1/link/_*")
+	c.Assert(snippet, testutil.Contains, "interface=org.freedesktop.DBus.Properties")
+	c.Assert(snippet, testutil.Contains, "member=PropertiesChanged")
+	c.Assert(snippet, testutil.Contains, "member=Get{,All}")
+	c.Assert(snippet, testutil.Contains, "interface=org.freedesktop.network1.Manager")
+	c.Assert(snippet, testutil.Contains, "member={ListLinks,GetLinkByName,DescribeLink,Describe}")
+	c.Assert(snippet, testutil.Contains, "peer=(name=org.freedesktop.network1, label=unconfined)")
+}
+
 func (s *NetworkObserveInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }


### PR DESCRIPTION
Allow listening for network interface state changes when using systemd-networkd, by allowing access to listen for Link Object properties changed messages, and querying link properties.

This allows automations to be created that don't have to rely on direct interface polling.