### PR TITLE
interfaces/seccomp/template: allow rseq_slice_yield

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -375,6 +375,7 @@ rmdir
 
 # glibc 2.35 unconditionally calls rseq for all threads
 rseq
+rseq_slice_yield
 
 rt_sigaction
 rt_sigpending


### PR DESCRIPTION
Relevant docs:
https://lwn.net/Articles/1038235/
https://lkml.org/lkml/2025/11/16/418
https://docs.kernel.org/userspace-api/rseq.html
