### PR TITLE
cmd/snap-confine: allow linking to libm

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -34,6 +34,7 @@
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libm.so* mr,
     # normal libs in order
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,


### PR DESCRIPTION
This is coming from Debian, where a bug was reported that snapd regressed in sid (the rolling next release) where snap-confine fails to start due to libm denial.

The denial was

May 24 21:09:56 tempestus kernel: audit: type=1400 audit(1779649796.463:218): apparmor="DENIED" operation="file_mmap" class="file" profile="/usr/lib/snapd/snap-confine" name="/usr/lib/x86_64-linux-gnu/libm.so.6" pid=153497 comm="snap-confine" requested_mask="m" denied_mask="m" fsuid=1000 ouid=0

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1137435