### PR TITLE
overlord/snapstate: allow openshell to use dameon-scope: user

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -84,6 +84,7 @@ var userDaemonsOverrides = []string{
 	"IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu", // snapd-desktop-integration snap-id
 	"aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj", // prompting-client snap-id
 	"gjf3IPXoRiipCu9K0kVu52f0H56fIksg", // snap-store snap-id
+	"ltw2m6EZ9UVOiglLDFP4blLwLO92hNhu", // openshell snap-id
 }
 
 var ErrNothingToDo = errors.New("nothing to do")


### PR DESCRIPTION
This is a temporary measure as we are working on both snapd and openshell to make integration smooth.
