### PR TITLE
tests: fix jq and grep usage in prompting integration test download variants

### DIFF
--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -15,7 +15,7 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the downloads directory"
-if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
+if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep -F "existing.txt" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -49,8 +49,8 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 # Furthermore, rules with identical path patterns are merged, so we don't
 # expect any rules with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
-! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -qE '^[[:space:]]*([2-9]|1[0-9])[0-9]*[[:space:]]'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -49,8 +49,8 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 # Furthermore, rules with identical path patterns are merged, so we don't
 # expect any rules with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | jq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
-! snap debug api /v2/interfaces/requests/rules | jq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -q '^[[:space:]]*[^1[[:space:]]]'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
+! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -qE '^[[:space:]]*([2-9]|1[0-9])[0-9]*[[:space:]]'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -15,7 +15,7 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the downloads directory"
-if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
+if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep -F "existing.txt" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1
 fi
@@ -49,8 +49,7 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 # Furthermore, rules with identical path patterns are merged, so we don't
 # expect any rules with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
-! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -49,7 +49,7 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 # Furthermore, rules with identical path patterns are merged, so we expect a
 # single rule related to this test run.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | MATCH '^1$'
+snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -49,7 +49,7 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 # Furthermore, rules with identical path patterns are merged, so we expect a
 # single rule related to this test run.
-snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
+snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '.result[].constraints."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -47,9 +47,9 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1
 fi
-# Furthermore, rules with identical path patterns are merged, so we don't
-# expect any rules with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+# Furthermore, rules with identical path patterns are merged, so we expect a
+# single rule related to this test run.
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | MATCH '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -15,7 +15,7 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the downloads directory"
-if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
+if ! snap run --shell prompt-requester.home -c "ls ${TEST_DIR}/Downloads" | grep -F "existing.txt" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1
 fi
@@ -48,8 +48,7 @@ fi
 
 # Rules with identical path patterns are merged, so we don't expect any rules
 # with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
-! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -48,7 +48,7 @@ fi
 
 # Rules with identical path patterns are merged, so we expect a single rule
 # related to this test run.
-snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
+snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '.result[].constraints."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -48,8 +48,8 @@ fi
 
 # Rules with identical path patterns are merged, so we don't expect any rules
 # with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | jq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
-! snap debug api /v2/interfaces/requests/rules | jq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -q '^[[:space:]]*[^1[[:space:]]]'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
+! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -qE '^[[:space:]]*([2-9]|1[0-9])[0-9]*[[:space:]]'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -48,7 +48,7 @@ fi
 
 # Rules with identical path patterns are merged, so we expect a single rule
 # related to this test run.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | MATCH '^1$'
+snap debug api '/v2/interfaces/requests/rules?snap=prompt-requester' | jq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | grep '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -48,8 +48,8 @@ fi
 
 # Rules with identical path patterns are merged, so we don't expect any rules
 # with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep '^[[:space:]]*1[[:space:]]'
-! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | uniq -c | grep -qE '^[[:space:]]*([2-9]|1[0-9])[0-9]*[[:space:]]'
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+! snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -46,9 +46,9 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	exit 1
 fi
 
-# Rules with identical path patterns are merged, so we don't expect any rules
-# with duplicate path patterns.
-snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | sort | uniq -d | wc -l | MATCH '^0$'
+# Rules with identical path patterns are merged, so we expect a single rule
+# related to this test run.
+snap debug api /v2/interfaces/requests/rules | gojq '."result".[]."constraints"."path-pattern"' | grep -F "${TEST_DIR}" | wc -l | MATCH '^1$'
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 


### PR DESCRIPTION
Failures spotted by @maykathm here: https://github.com/canonical/snapd/actions/runs/26380848966/job/77649597839#step:25:311
