### PR TITLE
asserts: add shared external key manager implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,9 @@ linters:
         path: arch/arch_test.go
       - linters:
           - testpackage
+        path: asserts/extkeypairmgrimpl_test.go
+      - linters:
+          - testpackage
         path: asserts/findwildcard_test.go
       - linters:
           - testpackage

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -203,6 +203,9 @@ type PublicKey interface {
 	// verify verifies signature is valid for content using the key.
 	verify(content []byte, sig *packet.Signature) error
 
+	// cryptoPublicKey exposes the underlying crypto public key to internal package code.
+	cryptoPublicKey() crypto.PublicKey
+
 	keyEncoder
 }
 
@@ -219,6 +222,10 @@ func (opgPubKey *openpgpPubKey) verify(content []byte, sig *packet.Signature) er
 	h := sig.Hash.New()
 	h.Write(content)
 	return opgPubKey.pubKey.VerifySignature(h, sig)
+}
+
+func (opgPubKey *openpgpPubKey) cryptoPublicKey() crypto.PublicKey {
+	return opgPubKey.pubKey.PublicKey
 }
 
 func (opgPubKey openpgpPubKey) keyEncode(w io.Writer) error {
@@ -265,6 +272,15 @@ func DecodePublicKey(pubKey []byte) (PublicKey, error) {
 // EncodePublicKey serializes a public key, typically for embedding in an assertion.
 func EncodePublicKey(pubKey PublicKey) ([]byte, error) {
 	return encodeKey(pubKey, "public key")
+}
+
+func cryptoRSAPublicKey(pubKey PublicKey) (*rsa.PublicKey, error) {
+	cryptoPubKey := pubKey.cryptoPublicKey()
+	rsaPubKey, ok := cryptoPubKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected RSA public key, got instead: %T", cryptoPubKey)
+	}
+	return rsaPubKey, nil
 }
 
 // PrivateKey is a cryptographic private/public key pair.
@@ -353,7 +369,7 @@ type extPGPPrivateKey struct {
 	doSign     func(content []byte) (*packet.Signature, error)
 }
 
-func newExtPGPPrivateKey(exportedPubKeyStream io.Reader, from string, sign func(content []byte) (*packet.Signature, error)) (*extPGPPrivateKey, error) {
+func readOpenPGPRSAPublicKey(exportedPubKeyStream io.Reader) (PublicKey, string, error) {
 	var pubKey *packet.PublicKey
 
 	rd := packet.NewReader(exportedPubKeyStream)
@@ -363,34 +379,47 @@ func newExtPGPPrivateKey(exportedPubKeyStream io.Reader, from string, sign func(
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("cannot read exported public key: %v", err)
+			return nil, "", fmt.Errorf("cannot read exported public key: %v", err)
 		}
 		cand, ok := pkt.(*packet.PublicKey)
-		if ok {
-			if cand.IsSubkey {
-				continue
-			}
-			if pubKey != nil {
-				return nil, fmt.Errorf("cannot select exported public key, found many")
-			}
-			pubKey = cand
+		if !ok {
+			continue
 		}
+		if cand.IsSubkey {
+			continue
+		}
+		if pubKey != nil {
+			return nil, "", fmt.Errorf("cannot select exported public key, found many")
+		}
+		pubKey = cand
 	}
 
 	if pubKey == nil {
-		return nil, fmt.Errorf("cannot read exported public key, found none (broken export)")
-
+		return nil, "", fmt.Errorf("cannot read exported public key, found none (broken export)")
 	}
 
 	rsaPubKey, ok := pubKey.PublicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("not a RSA key")
+		return nil, "", fmt.Errorf("not a RSA key")
+	}
+
+	return RSAPublicKey(rsaPubKey), fmt.Sprintf("%X", pubKey.Fingerprint), nil
+}
+
+func newExtPGPPrivateKey(exportedPubKeyStream io.Reader, from string, sign func(content []byte) (*packet.Signature, error)) (*extPGPPrivateKey, error) {
+	pubKey, fingerprint, err := readOpenPGPRSAPublicKey(exportedPubKeyStream)
+	if err != nil {
+		return nil, err
+	}
+	rsaPubKey, err := cryptoRSAPublicKey(pubKey)
+	if err != nil {
+		return nil, err
 	}
 
 	return &extPGPPrivateKey{
-		pubKey:     RSAPublicKey(rsaPubKey),
+		pubKey:     pubKey,
 		from:       from,
-		externalID: fmt.Sprintf("%X", pubKey.Fingerprint),
+		externalID: fingerprint,
 		bitLen:     rsaPubKey.N.BitLen(),
 		doSign:     sign,
 	}, nil

--- a/asserts/crypto_test.go
+++ b/asserts/crypto_test.go
@@ -20,6 +20,13 @@
 package asserts_test
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/openpgp/packet"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -93,4 +100,24 @@ func (s *cryptoSuite) TestVerifyWithKeyWrongSignature(c *C) {
 	err = asserts.RawVerifyWithKey(dataOne, signatureTwo, pub)
 	c.Check(err, NotNil)
 	c.Check(err, ErrorMatches, ".*hash tag doesn't match")
+}
+
+func (s *cryptoSuite) TestReadOpenPGPRSAPublicKey(c *C) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	c.Assert(err, IsNil)
+
+	primary := packet.NewRSAPublicKey(time.Now(), &privKey.PublicKey)
+	subkey := packet.NewRSAPublicKey(time.Now(), &privKey.PublicKey)
+	subkey.IsSubkey = true
+
+	buf := new(bytes.Buffer)
+	err = primary.Serialize(buf)
+	c.Assert(err, IsNil)
+	err = subkey.Serialize(buf)
+	c.Assert(err, IsNil)
+
+	pubKey, fingerprint, err := asserts.ReadOpenPGPRSAPublicKeyInTest(bytes.NewReader(buf.Bytes()))
+	c.Assert(err, IsNil)
+	c.Check(pubKey.ID(), Equals, asserts.RSAPublicKey(&privKey.PublicKey).ID())
+	c.Check(fingerprint, Equals, fmt.Sprintf("%X", primary.Fingerprint))
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -44,6 +44,9 @@ var AssembleAndSignInTest = assembleAndSign
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
 
+// readOpenPGPRSAPublicKey exposed for tests
+var ReadOpenPGPRSAPublicKeyInTest = readOpenPGPRSAPublicKey
+
 // NewDecoderStressed makes a Decoder with a stressed setup with the given buffer and maximum sizes.
 func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSigSize int) *Decoder {
 	return (&Decoder{

--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -257,11 +257,6 @@ func (em *ExternalKeypairManager) List() ([]ExternalKeyInfo, error) {
 	return res, nil
 }
 
-// see https://datatracker.ietf.org/doc/html/rfc2313 and more recently
-// and more precisely about SHA-512:
-// https://datatracker.ietf.org/doc/html/rfc3447#section-9.2 Notes 1.
-var digestInfoSHA512Prefix = []byte{0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40}
-
 func (em *ExternalKeypairManager) signWith(keyName string, digest []byte) (signature []byte, err error) {
 	// wrap the digest into the needed DigestInfo, the RSA-PKCS
 	// mechanism or equivalent is expected not to do this on its

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -1,0 +1,347 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"bytes"
+	"crypto"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/openpgp/packet"
+)
+
+type extKeypairMgrSigning string
+
+const (
+	extKeypairMgrSigningRSAPKCS extKeypairMgrSigning = "RSA-PKCS"
+	extKeypairMgrSigningOpenPGP extKeypairMgrSigning = "OpenPGP"
+)
+
+// extKeypairMgrBackend defines the backend contract for the shared external
+// keypair manager implementation. keyHandle is the preferred backend-native
+// identifier and Visit is the discovery path used for enumeration and fallback
+// lookup by name when by-name lookup is not available.
+type extKeypairMgrBackend interface {
+	// CheckFeatures validates backend support and returns the supported signing method.
+	CheckFeatures() (extKeypairMgrSigning, error)
+	// Visit discovers keys and may be used for both enumeration and fallback search.
+	Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error
+	// RSAPKCSSign signs the caller-prepared RSA-PKCS input using keyHandle.
+	RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error)
+	// Sign signs content directly and returns a detached OpenPGP signature packet.
+	Sign(keyHandle string, content []byte) ([]byte, error)
+}
+
+type extKeypairMgrByNameLookupBackend interface {
+	// LoadByName resolves a user-visible name directly when the backend supports by-name lookup.
+	LoadByName(name string) (*extKeypairMgrLoadedKey, error)
+}
+
+type extKeypairMgrLoadedKey struct {
+	name      string
+	keyHandle string
+	pubKey    PublicKey
+}
+
+type extKeypairMgrCachedKey struct {
+	name      string
+	keyHandle string
+	pubKey    PublicKey
+	privKey   PrivateKey
+}
+
+// extKeypairMgrConfig carries configuration for the shared external
+// keypair manager implementation.
+type extKeypairMgrConfig struct {
+	// signingWith identifies the signing backend for diagnostics and error messages.
+	signingWith string
+	// keyStore names the backing key store for diagnostics, in particular key not found errors.
+	keyStore string
+}
+
+type extKeypairMgrImpl struct {
+	backend       extKeypairMgrBackend
+	signingMethod extKeypairMgrSigning
+	signingWith   string
+	keyStore      string
+	nameToID      map[string]string
+	// cache is keyed by public key ID and contains the loaded key information, including the private key when it has been requested.
+	cache map[string]*extKeypairMgrCachedKey
+}
+
+func newExtKeypairMgrImpl(backend extKeypairMgrBackend, config extKeypairMgrConfig) (*extKeypairMgrImpl, error) {
+	signingMethod, err := backend.CheckFeatures()
+	if err != nil {
+		return nil, err
+	}
+	return &extKeypairMgrImpl{
+		backend:       backend,
+		signingMethod: signingMethod,
+		signingWith:   config.signingWith,
+		keyStore:      config.keyStore,
+		nameToID:      make(map[string]string),
+		cache:         make(map[string]*extKeypairMgrCachedKey),
+	}, nil
+}
+
+func (m *extKeypairMgrImpl) keyNotFoundError() error {
+	return &keyNotFoundError{msg: fmt.Sprintf("cannot find key pair in %s", m.keyStore)}
+}
+
+func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *extKeypairMgrLoadedKey) (*extKeypairMgrCachedKey, error) {
+	if loaded == nil {
+		return nil, fmt.Errorf("internal error: missing loaded key")
+	}
+	if loaded.name == "" {
+		return nil, fmt.Errorf("internal error: loaded key is missing a name")
+	}
+	if loaded.keyHandle == "" {
+		return nil, fmt.Errorf("internal error: loaded key %q is missing a key handle", loaded.name)
+	}
+	if loaded.pubKey == nil {
+		return nil, fmt.Errorf("internal error: loaded key %q is missing a public key", loaded.name)
+	}
+	if _, err := cryptoRSAPublicKey(loaded.pubKey); err != nil {
+		return nil, fmt.Errorf("loaded key %q has invalid public key: %v", loaded.name, err)
+	}
+
+	keyID := loaded.pubKey.ID()
+	entry := m.cache[keyID]
+	if entry == nil {
+		entry = &extKeypairMgrCachedKey{
+			name:      loaded.name,
+			keyHandle: loaded.keyHandle,
+			pubKey:    loaded.pubKey,
+		}
+		m.cache[keyID] = entry
+	} else {
+		entry.name = loaded.name
+		entry.keyHandle = loaded.keyHandle
+		entry.pubKey = loaded.pubKey
+	}
+	m.nameToID[loaded.name] = keyID
+	return entry, nil
+}
+
+func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, error) {
+	if keyID, ok := m.nameToID[name]; ok {
+		if entry := m.cache[keyID]; entry != nil {
+			return entry, nil
+		}
+	}
+	if byNameLookupBackend, ok := m.backend.(extKeypairMgrByNameLookupBackend); ok {
+		loaded, err := byNameLookupBackend.LoadByName(name)
+		if err != nil {
+			return nil, err
+		}
+		return m.cacheLoadedKey(loaded)
+	}
+
+	stop := errors.New("stop marker")
+	var hit *extKeypairMgrCachedKey
+	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
+		if loaded.name != name {
+			return nil
+		}
+		entry, err := m.cacheLoadedKey(loaded)
+		if err != nil {
+			return err
+		}
+		hit = entry
+		return stop
+	})
+	if err == stop {
+		return hit, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, m.keyNotFoundError()
+}
+
+func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, error) {
+	if entry := m.cache[keyID]; entry != nil {
+		return entry, nil
+	}
+
+	stop := errors.New("stop marker")
+	var hit *extKeypairMgrCachedKey
+	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
+		entry, err := m.cacheLoadedKey(loaded)
+		if err != nil {
+			return err
+		}
+		if entry.pubKey.ID() != keyID {
+			return nil
+		}
+		hit = entry
+		return stop
+	})
+	if err == stop {
+		return hit, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, m.keyNotFoundError()
+}
+
+func (m *extKeypairMgrImpl) visitAll() ([]*extKeypairMgrCachedKey, error) {
+	var entries []*extKeypairMgrCachedKey
+	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
+		entry, err := m.cacheLoadedKey(loaded)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (m *extKeypairMgrImpl) signOpenPGP(keyHandle string, content []byte) (*packet.Signature, error) {
+	out, err := m.backend.Sign(keyHandle, content)
+	if err != nil {
+		return nil, err
+	}
+
+	badSig := fmt.Sprintf("bad %s produced signature: ", m.signingWith)
+	sigpkt, err := packet.Read(bytes.NewReader(out))
+	if err != nil {
+		return nil, fmt.Errorf(badSig+"%v", err)
+	}
+
+	sig, ok := sigpkt.(*packet.Signature)
+	if !ok {
+		return nil, fmt.Errorf(badSig+"got %T", sigpkt)
+	}
+
+	return sig, nil
+}
+
+func (m *extKeypairMgrImpl) privateKey(entry *extKeypairMgrCachedKey) PrivateKey {
+	if entry.privKey != nil {
+		return entry.privKey
+	}
+	rsaPub, err := cryptoRSAPublicKey(entry.pubKey)
+	if err != nil {
+		panic(err)
+	}
+
+	switch m.signingMethod {
+	case extKeypairMgrSigningRSAPKCS:
+		signer := packet.NewSignerPrivateKey(v1FixedTimestamp, &rsaPKCSSigner{
+			keyHandle: entry.keyHandle,
+			publicKey: rsaPub,
+			signWith:  m.backend.RSAPKCSSign,
+		})
+		signk := openpgpPrivateKey{privk: signer}
+		entry.privKey = &extPGPPrivateKey{
+			pubKey:     entry.pubKey,
+			from:       m.signingWith,
+			externalID: entry.keyHandle,
+			bitLen:     rsaPub.N.BitLen(),
+			doSign:     signk.sign,
+		}
+	case extKeypairMgrSigningOpenPGP:
+		entry.privKey = &extPGPPrivateKey{
+			pubKey:     entry.pubKey,
+			from:       m.signingWith,
+			externalID: entry.keyHandle,
+			bitLen:     rsaPub.N.BitLen(),
+			doSign: func(content []byte) (*packet.Signature, error) {
+				return m.signOpenPGP(entry.keyHandle, content)
+			},
+		}
+	default:
+		panic(fmt.Sprintf("internal error: unsupported signing method %q", m.signingMethod))
+	}
+
+	return entry.privKey
+}
+
+func (m *extKeypairMgrImpl) GetByName(name string) (PrivateKey, error) {
+	entry, err := m.loadByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return m.privateKey(entry), nil
+}
+
+func (m *extKeypairMgrImpl) Get(keyID string) (PrivateKey, error) {
+	entry, err := m.loadByID(keyID)
+	if err != nil {
+		return nil, err
+	}
+	return m.privateKey(entry), nil
+}
+
+func (m *extKeypairMgrImpl) Export(name string) ([]byte, error) {
+	entry, err := m.loadByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return EncodePublicKey(entry.pubKey)
+}
+
+func (m *extKeypairMgrImpl) List() ([]ExternalKeyInfo, error) {
+	entries, err := m.visitAll()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]ExternalKeyInfo, len(entries))
+	for i, entry := range entries {
+		res[i] = ExternalKeyInfo{
+			Name: entry.name,
+			ID:   entry.pubKey.ID(),
+		}
+	}
+	return res, nil
+}
+
+// see https://datatracker.ietf.org/doc/html/rfc2313 and more recently
+// and more precisely about SHA-512:
+// https://datatracker.ietf.org/doc/html/rfc3447#section-9.2 Notes 1.
+var digestInfoSHA512Prefix = []byte{0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40}
+
+type rsaPKCSSigner struct {
+	keyHandle string
+	publicKey crypto.PublicKey
+	signWith  func(keyHandle string, prepared []byte) ([]byte, error)
+}
+
+func (es *rsaPKCSSigner) Public() crypto.PublicKey {
+	return es.publicKey
+}
+
+func (es *rsaPKCSSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if opts.HashFunc() != crypto.SHA512 {
+		return nil, fmt.Errorf("unexpected pgp signature digest")
+	}
+	toSign := &bytes.Buffer{}
+	toSign.Write(digestInfoSHA512Prefix)
+	toSign.Write(digest)
+	return es.signWith(es.keyHandle, toSign.Bytes())
+}

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -133,12 +133,13 @@ func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *extKeypairMgrLoadedKey) (*ext
 			pubKey:    loaded.pubKey,
 		}
 		m.cache[keyID] = entry
+		m.nameToID[loaded.name] = keyID
 	} else {
-		entry.name = loaded.name
-		entry.keyHandle = loaded.keyHandle
-		entry.pubKey = loaded.pubKey
+		// we expect and assume that for the same key ID (which represents the key content) the name and keyHandle will not change
+		if entry.keyHandle != loaded.keyHandle || entry.name != loaded.name {
+			return nil, fmt.Errorf("inconsistent external loaded key %q: cached name %q, cached handle %q, loaded name %q, loaded handle %q", keyID, entry.name, entry.keyHandle, loaded.name, loaded.keyHandle)
+		}
 	}
-	m.nameToID[loaded.name] = keyID
 	return entry, nil
 }
 

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -1,0 +1,497 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+
+	"golang.org/x/crypto/openpgp/packet"
+	check "gopkg.in/check.v1"
+)
+
+type extKeypairMgrImplSuite struct{}
+
+var _ = check.Suite(&extKeypairMgrImplSuite{})
+
+var fakeExtKeypairMgrConfig = extKeypairMgrConfig{signingWith: "fake", keyStore: "fake"}
+
+type fakeExtKeypairMgrBackendBase struct {
+	signingMethod   extKeypairMgrSigning
+	loadByName      map[string]*extKeypairMgrLoadedKey
+	visitKeys       []*extKeypairMgrLoadedKey
+	loadCalls       []string
+	visitCalls      int
+	visitConsidered [][]string
+	rsaSignHandles  []string
+	pgpSignHandles  []string
+	pgpSignResult   map[string][]byte
+	privByHandle    map[string]*rsa.PrivateKey
+}
+
+func (s *fakeExtKeypairMgrBackendBase) CheckFeatures() (extKeypairMgrSigning, error) {
+	return s.signingMethod, nil
+}
+
+func (s *fakeExtKeypairMgrBackendBase) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+	s.visitCalls++
+	considered := make([]string, 0, len(s.visitKeys))
+	for _, loaded := range s.visitKeys {
+		considered = append(considered, loaded.name)
+		if err := consider(loaded); err != nil {
+			s.visitConsidered = append(s.visitConsidered, considered)
+			return err
+		}
+	}
+	s.visitConsidered = append(s.visitConsidered, considered)
+	return nil
+}
+
+func (s *fakeExtKeypairMgrBackendBase) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+	s.rsaSignHandles = append(s.rsaSignHandles, keyHandle)
+	return rsa.SignPKCS1v15(rand.Reader, s.privByHandle[keyHandle], 0, prepared)
+}
+
+func (s *fakeExtKeypairMgrBackendBase) Sign(keyHandle string, content []byte) ([]byte, error) {
+	s.pgpSignHandles = append(s.pgpSignHandles, keyHandle)
+	if sig := s.pgpSignResult[keyHandle]; sig != nil {
+		return sig, nil
+	}
+	packetSig, err := openpgpPrivateKey{privk: packet.NewRSAPrivateKey(v1FixedTimestamp, s.privByHandle[keyHandle])}.sign(content)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = packetSig.Serialize(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type fakeExtKeypairMgrBackend struct {
+	fakeExtKeypairMgrBackendBase
+}
+
+func (s *fakeExtKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
+	s.loadCalls = append(s.loadCalls, name)
+	loaded := s.loadByName[name]
+	if loaded == nil {
+		return nil, &keyNotFoundError{msg: "missing key"}
+	}
+	return loaded, nil
+}
+
+type fakeExtKeypairMgrBackendWithoutByNameLookup struct {
+	fakeExtKeypairMgrBackendBase
+}
+
+func (s *extKeypairMgrImplSuite) newLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	c.Assert(err, check.IsNil)
+	return privKey, &extKeypairMgrLoadedKey{
+		name:      name,
+		keyHandle: keyHandle,
+		pubKey:    RSAPublicKey(&privKey.PublicKey),
+	}
+}
+
+func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*extKeypairMgrLoadedKey{
+				"default": loaded,
+			},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	key1, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	key2, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	exported, err := impl.Export("default")
+	c.Assert(err, check.IsNil)
+	expectedExport, err := EncodePublicKey(loaded.pubKey)
+	c.Assert(err, check.IsNil)
+
+	c.Check(key1, check.Equals, key2)
+	c.Check(backend.loadCalls, check.DeepEquals, []string{"default"})
+	c.Check(backend.visitCalls, check.Equals, 0)
+	c.Check(exported, check.DeepEquals, expectedExport)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetStopsAfterFirstMatchingVisitedKey(c *check.C) {
+	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
+	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	key1, err := impl.Get(loaded1.pubKey.ID())
+	c.Assert(err, check.IsNil)
+
+	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.pubKey.ID())
+	c.Check(backend.visitCalls, check.Equals, 1)
+	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default"}})
+	_, found := impl.cache[loaded2.pubKey.ID()]
+	c.Check(found, check.Equals, false)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetStopsAtMatchingVisitedKeyAndCachesVisitedPrefix(c *check.C) {
+	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
+	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	key2, err := impl.Get(loaded2.pubKey.ID())
+	c.Assert(err, check.IsNil)
+	key1, err := impl.Get(loaded1.pubKey.ID())
+	c.Assert(err, check.IsNil)
+
+	c.Check(key2.PublicKey().ID(), check.Equals, loaded2.pubKey.ID())
+	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.pubKey.ID())
+	c.Check(backend.visitCalls, check.Equals, 1)
+	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default", "models"}})
+	c.Check(impl.cache[loaded1.pubKey.ID()], check.NotNil)
+	c.Check(impl.cache[loaded2.pubKey.ID()], check.NotNil)
+
+	list, err := impl.List()
+	c.Assert(err, check.IsNil)
+	c.Check(backend.visitCalls, check.Equals, 2)
+	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default", "models"}, {"default", "models"}})
+	c.Check(list, check.DeepEquals, []ExternalKeyInfo{{Name: "default", ID: loaded1.pubKey.ID()}, {Name: "models", ID: loaded2.pubKey.ID()}})
+}
+
+func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPrefix(c *check.C) {
+	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
+	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.Get(loaded1.pubKey.ID())
+	c.Assert(err, check.IsNil)
+	_, err = impl.Get(loaded2.pubKey.ID())
+	c.Assert(err, check.IsNil)
+
+	c.Check(backend.visitCalls, check.Equals, 2)
+	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default"}, {"default", "models"}})
+}
+
+func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*extKeypairMgrLoadedKey{
+				"default": loaded,
+			},
+			visitKeys: []*extKeypairMgrLoadedKey{loaded},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+
+	c.Check(backend.loadCalls, check.DeepEquals, []string{"default"})
+	c.Check(backend.visitCalls, check.Equals, 0)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetByNamePropagatesNotFoundWithByNameLookup(c *check.C) {
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.GetByName("missing")
+	c.Assert(err, check.ErrorMatches, `missing key`)
+	c.Check(IsKeyNotFound(err), check.Equals, true)
+	c.Check(backend.loadCalls, check.DeepEquals, []string{"missing"})
+	c.Check(backend.visitCalls, check.Equals, 0)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetByNameFallsBackToVisitWithoutByNameLookup(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			visitKeys:     []*extKeypairMgrLoadedKey{loaded},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	c.Check(priv.PublicKey().ID(), check.Equals, loaded.pubKey.ID())
+	c.Check(backend.visitCalls, check.Equals, 1)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			visitKeys:     []*extKeypairMgrLoadedKey{loaded},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	key1, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	exported, err := impl.Export("default")
+	c.Assert(err, check.IsNil)
+	key2, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	expectedExport, err := EncodePublicKey(loaded.pubKey)
+	c.Assert(err, check.IsNil)
+
+	c.Check(key1, check.Equals, key2)
+	c.Check(exported, check.DeepEquals, expectedExport)
+	c.Check(backend.visitCalls, check.Equals, 1)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetByNameFallbackUsesKeyStoreError(c *check.C) {
+	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.GetByName("missing")
+	c.Assert(err, check.ErrorMatches, `cannot find key pair in fake`)
+	c.Check(IsKeyNotFound(err), check.Equals, true)
+	c.Check(backend.visitCalls, check.Equals, 1)
+}
+
+func (s *extKeypairMgrImplSuite) TestExportPropagatesNotFoundWithByNameLookup(c *check.C) {
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.Export("missing")
+	c.Assert(err, check.ErrorMatches, `missing key`)
+	c.Check(IsKeyNotFound(err), check.Equals, true)
+	c.Check(backend.loadCalls, check.DeepEquals, []string{"missing"})
+	c.Check(backend.visitCalls, check.Equals, 0)
+}
+
+func (s *extKeypairMgrImplSuite) TestExportFallbackUsesKeyStoreError(c *check.C) {
+	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.Export("missing")
+	c.Assert(err, check.ErrorMatches, `cannot find key pair in fake`)
+	c.Check(IsKeyNotFound(err), check.Equals, true)
+	c.Check(backend.visitCalls, check.Equals, 1)
+}
+
+type fakeNonRSAPublicKey struct {
+	id string
+}
+
+func (pk *fakeNonRSAPublicKey) ID() string                                         { return pk.id }
+func (pk *fakeNonRSAPublicKey) verify(content []byte, sig *packet.Signature) error { return nil }
+func (pk *fakeNonRSAPublicKey) cryptoPublicKey() crypto.PublicKey                  { return ed25519.PublicKey{} }
+func (pk *fakeNonRSAPublicKey) keyEncode(w io.Writer) error                        { return nil }
+
+func (s *extKeypairMgrImplSuite) TestCacheLoadedKeyInvalidPublicKeyErrorIsNotRepetitive(c *check.C) {
+	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+		},
+	}, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.cacheLoadedKey(&extKeypairMgrLoadedKey{
+		name:      "default",
+		keyHandle: "handle-default",
+		pubKey:    &fakeNonRSAPublicKey{id: "ZmFrZQ"},
+	})
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Matches, `loaded key "default" has invalid public key: internal error: expected RSA public key, got instead: .*`)
+	c.Check(err.Error(), check.Not(check.Matches), `internal error: loaded key .*: internal error: .*`)
+}
+
+func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			privByHandle:  map[string]*rsa.PrivateKey{},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.Get("missing-id")
+	c.Assert(err, check.ErrorMatches, `cannot find key pair in fake`)
+	c.Check(IsKeyNotFound(err), check.Equals, true)
+	c.Check(backend.visitCalls, check.Equals, 1)
+}
+
+func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "rsa-handle")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*extKeypairMgrLoadedKey{
+				"default": loaded,
+			},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"rsa-handle": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	sig, err := RawSignWithKey([]byte("hello"), priv)
+	c.Assert(err, check.IsNil)
+	err = RawVerifyWithKey([]byte("hello"), sig, priv.PublicKey())
+	c.Assert(err, check.IsNil)
+	c.Check(backend.rsaSignHandles, check.DeepEquals, []string{"rsa-handle"})
+}
+
+func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "pgp-handle")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningOpenPGP,
+			loadByName: map[string]*extKeypairMgrLoadedKey{
+				"default": loaded,
+			},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"pgp-handle": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	sig, err := RawSignWithKey([]byte("hello"), priv)
+	c.Assert(err, check.IsNil)
+	err = RawVerifyWithKey([]byte("hello"), sig, priv.PublicKey())
+	c.Assert(err, check.IsNil)
+	c.Check(backend.pgpSignHandles, check.DeepEquals, []string{"pgp-handle"})
+}
+
+func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithInError(c *check.C) {
+	_, loaded := s.newLoadedKey(c, "default", "pgp-handle")
+	backend := &fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningOpenPGP,
+			loadByName: map[string]*extKeypairMgrLoadedKey{
+				"default": loaded,
+			},
+			pgpSignResult: map[string][]byte{
+				"pgp-handle": []byte("broken"),
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.GetByName("default")
+	c.Assert(err, check.IsNil)
+	_, err = RawSignWithKey([]byte("hello"), priv)
+	c.Assert(err, check.ErrorMatches, `bad fake produced signature: .*`)
+	c.Check(backend.pgpSignHandles, check.DeepEquals, []string{"pgp-handle"})
+}

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -410,6 +410,31 @@ func (s *extKeypairMgrImplSuite) TestCacheLoadedKeyInvalidPublicKeyErrorIsNotRep
 	c.Check(err.Error(), check.Not(check.Matches), `internal error: loaded key .*: internal error: .*`)
 }
 
+func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.C) {
+	_, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+			visitKeys: []*extKeypairMgrLoadedKey{
+				loaded,
+				{
+					name:      "renamed",
+					keyHandle: loaded.keyHandle,
+					pubKey:    loaded.pubKey,
+				},
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.List()
+	c.Assert(err, check.ErrorMatches, `inconsistent external loaded key ".*": cached name "default", cached handle "handle-default", loaded name "renamed", loaded handle "handle-default"`)
+	c.Check(backend.visitCalls, check.Equals, 1)
+	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.pubKey.ID()})
+}
+
 func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -107,14 +107,22 @@ type fakeExtKeypairMgrBackendWithoutByNameLookup struct {
 	fakeExtKeypairMgrBackendBase
 }
 
-func (s *extKeypairMgrImplSuite) newLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
-	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+func (s *extKeypairMgrImplSuite) newLoadedKeyBits(c *check.C, name string, keyHandle string, bits int) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+	privKey, err := rsa.GenerateKey(rand.Reader, bits)
 	c.Assert(err, check.IsNil)
 	return privKey, &extKeypairMgrLoadedKey{
 		name:      name,
 		keyHandle: keyHandle,
 		pubKey:    RSAPublicKey(&privKey.PublicKey),
 	}
+}
+
+func (s *extKeypairMgrImplSuite) newLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+	return s.newLoadedKeyBits(c, name, keyHandle, 1024)
+}
+
+func (s *extKeypairMgrImplSuite) newSigningLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+	return s.newLoadedKeyBits(c, name, keyHandle, 4096)
 }
 
 func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *check.C) {
@@ -421,7 +429,7 @@ func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 }
 
 func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
-	privKey, loaded := s.newLoadedKey(c, "default", "rsa-handle")
+	privKey, loaded := s.newSigningLoadedKey(c, "default", "rsa-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: extKeypairMgrSigningRSAPKCS,
@@ -447,7 +455,7 @@ func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
 }
 
 func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
-	privKey, loaded := s.newLoadedKey(c, "default", "pgp-handle")
+	privKey, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: extKeypairMgrSigningOpenPGP,
@@ -473,7 +481,7 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
 }
 
 func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithInError(c *check.C) {
-	_, loaded := s.newLoadedKey(c, "default", "pgp-handle")
+	_, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: extKeypairMgrSigningOpenPGP,


### PR DESCRIPTION
This introduces  extKeypairMgrImpl as a shared implementation of most of the logic for external key managers. The plan is in subsequent PRs to refactor ExternalKeypairManager and GPGKeypairManager to use this.

This is the first PR in a series, the end goal is enabling this:  https://github.com/pedronis/lpsigning/blob/main/cmd/lpsigndemo/main.go#L54