### PR TITLE
o/h/ctlcmd: re-enable snapctl async functionality

### DIFF
--- a/overlord/hookstate/ctlcmd/install.go
+++ b/overlord/hookstate/ctlcmd/install.go
@@ -43,8 +43,7 @@ type installCommand struct {
 	Positional struct {
 		Names []string `positional-arg-name:"<snap|snap+comp|+comp>" required:"yes" description:"Components to be installed (snap must be the caller snap if specified)."`
 	} `positional-args:"yes"`
-	// TODO: temporarily disabled to prevent partial implementation in release
-	// NoWait bool `long:"no-wait" description:"Run the command in asynchronous mode, returning a change id that can be used to determine if the change is ready using the is-ready command."`
+	NoWait bool `long:"no-wait" description:"Run the command in asynchronous mode, returning a change id that can be used to determine if the change is ready using the is-ready command."`
 }
 
 func (c *installCommand) Execute([]string) error {
@@ -58,7 +57,7 @@ func (c *installCommand) Execute([]string) error {
 		return err
 	}
 
-	_, affectedComponents, err := runSnapManagementCommand(ctx, managementCommand{operation: installManagementCommand, components: comps, async: false})
+	id, affectedComponents, err := runSnapManagementCommand(ctx, managementCommand{operation: installManagementCommand, components: comps, async: c.NoWait})
 
 	if err != nil {
 		if _, ok := err.(*snap.AlreadyInstalledError); !ok {
@@ -73,6 +72,10 @@ func (c *installCommand) Execute([]string) error {
 				fmt.Fprintln(c.stderr, msg)
 			}
 		}
+	}
+
+	if c.NoWait {
+		fmt.Fprintf(c.stdout, "%s", id)
 	}
 
 	return nil

--- a/overlord/hookstate/ctlcmd/is_ready.go
+++ b/overlord/hookstate/ctlcmd/is_ready.go
@@ -37,8 +37,8 @@ const (
 	otherErrorExitCode
 )
 
-var _ = i18n.G(`Return the status of the associated change id.`)
-var _ = i18n.G(`
+var shortIsReadyHelp = i18n.G(`Return the status of the associated change id.`)
+var longIsReadyHelp = i18n.G(`
 The is-ready command is used to query the status of change ids that are returned
 by asynchronous snapctl commands.
 
@@ -52,10 +52,9 @@ stderr: empty for exit codes 0 and 1. Contains relevant errors for exit codes 2 
 `)
 
 func init() {
-	// TODO: temporarily disabled to prevent partial implementation in release
-	//addCommand("is-ready", shortIsReadyHelp, longIsReadyHelp, func() command {
-	//	return &isReadyCommand{}
-	//})
+	addCommand("is-ready", shortIsReadyHelp, longIsReadyHelp, func() command {
+		return &isReadyCommand{}
+	})
 }
 
 func (c *isReadyCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/is_ready_test.go
+++ b/overlord/hookstate/ctlcmd/is_ready_test.go
@@ -50,8 +50,6 @@ func (s *isReadySuite) SetUpTest(c *C) {
 // setupChangeAndContext creates a state, a change (with an optional initiator),
 // and a non-ephemeral hook context for "test-snap".
 func (s *isReadySuite) setupChangeAndContext(c *C, taskStatus state.Status, initiatorSnap string) (*state.State, *hookstate.Context, string) {
-	c.Skip("Content removed for release 2.76")
-
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
@@ -74,15 +72,11 @@ func (s *isReadySuite) setupChangeAndContext(c *C, taskStatus state.Status, init
 }
 
 func (s *isReadySuite) TestIsReadyNoContext(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	_, _, err := ctlcmd.Run(nil, []string{"is-ready", "1"}, 0, nil)
 	c.Assert(err, ErrorMatches, `cannot invoke snapctl operation commands.*from outside of a snap`)
 }
 
 func (s *isReadySuite) TestIsReadyArgCount(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	_, ctx, _ := s.setupChangeAndContext(c, state.DoneStatus, "test-snap")
 	_, _, err := ctlcmd.Run(ctx, []string{"is-ready"}, 0, nil)
 	c.Assert(err, ErrorMatches, `invalid number of arguments: expected 1, got 0`)
@@ -92,8 +86,6 @@ func (s *isReadySuite) TestIsReadyArgCount(c *C) {
 }
 
 func (s *isReadySuite) TestIsReadyChangeNotFound(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	_, ctx, _ := s.setupChangeAndContext(c, state.DoneStatus, "")
 	_, stderr, err := ctlcmd.Run(ctx, []string{"is-ready", "nonexistent-id"}, 0, nil)
 	c.Assert(err, DeepEquals, &ctlcmd.UnsuccessfulError{ExitCode: 3})
@@ -101,8 +93,6 @@ func (s *isReadySuite) TestIsReadyChangeNotFound(c *C) {
 }
 
 func (s *isReadySuite) TestIsReadyLogic(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	var logicTests = []struct {
 		taskStatus     state.Status
 		initiatorSnap  string // empty = don't set initiated-by-snap on the change
@@ -163,8 +153,6 @@ func (s *isReadySuite) TestIsReadyLogic(c *C) {
 
 // Rate-limiting tests
 func (s *isReadySuite) rateLimitSetup(c *C, taskStatus state.Status, lastAccessedTime any) (*hookstate.Context, string) {
-	c.Skip("Content removed for release 2.76")
-
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
@@ -191,8 +179,6 @@ func (s *isReadySuite) rateLimitSetup(c *C, taskStatus state.Status, lastAccesse
 // last-accessed cache entry (e.g. after a snapd restart) as a first access and
 // proceeds to report the real change status rather than returning an error.
 func (s *isReadySuite) TestIsReadyMissingLastAccessed(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	ctx, changeID := s.rateLimitSetup(c, state.DoneStatus, nil)
 
 	_, _, err := ctlcmd.Run(ctx, []string{"is-ready", changeID}, 0, nil)
@@ -204,8 +190,6 @@ func (s *isReadySuite) TestIsReadyMissingLastAccessed(c *C) {
 // 200 ms debounce window, is-ready sleeps for the remaining window duration
 // before checking the change status.
 func (s *isReadySuite) TestIsReadyRateLimitDelaysPolling(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	// A last-accessed time in the future guarantees we are within the debounce
 	// window, ensuring timeAfter is called with a positive duration.
 	ctx, changeID := s.rateLimitSetup(c, state.DoneStatus, time.Now().Add(time.Second).UnixNano())
@@ -227,8 +211,6 @@ func (s *isReadySuite) TestIsReadyRateLimitDelaysPolling(c *C) {
 // change is ready, is-ready reports DoingStatus (exit code 1) and the timer
 // channel is drained.
 func (s *isReadySuite) TestIsReadyRateLimitTimerFires(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	// A last-accessed time in the future puts us inside the debounce window.
 	// The task is left in DoingStatus so chg.Ready() never fires, ensuring
 	// the timer case is the only one that can win the select.
@@ -250,8 +232,6 @@ func (s *isReadySuite) TestIsReadyRateLimitTimerFires(c *C) {
 // TestIsReadyExpiredWindowSkipsTimeAfter verifies that when the debounce window
 // has already elapsed, is-ready returns the change status directly
 func (s *isReadySuite) TestIsReadyExpiredWindowSkipsTimeAfter(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	// A last-accessed time sufficiently in the past guarantees toWait <= 0.
 	ctx, changeID := s.rateLimitSetup(c, state.DoneStatus, time.Now().Add(-time.Second).UnixNano())
 

--- a/overlord/hookstate/ctlcmd/remove.go
+++ b/overlord/hookstate/ctlcmd/remove.go
@@ -20,6 +20,8 @@
 package ctlcmd
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/i18n"
 )
 
@@ -39,8 +41,7 @@ type removeCommand struct {
 	Positional struct {
 		Names []string `positional-arg-name:"<snap|snap+comp|+comp>" required:"yes" description:"Components to be removed (snap must be the caller snap if specified)."`
 	} `positional-args:"yes"`
-	// TODO: temporarily disabled to prevent partial implementation in release
-	// NoWait bool `long:"no-wait" description:"Run the command in asynchronous mode, returning a change id that can be used to determine if the change is ready using the is-ready command."`
+	NoWait bool `long:"no-wait" description:"Run the command in asynchronous mode, returning a change id that can be used to determine if the change is ready using the is-ready command."`
 }
 
 func (c *removeCommand) Execute([]string) error {
@@ -54,9 +55,13 @@ func (c *removeCommand) Execute([]string) error {
 		return err
 	}
 
-	_, _, err = runSnapManagementCommand(ctx, managementCommand{operation: removeManagementCommand, components: comps, async: false})
+	id, _, err := runSnapManagementCommand(ctx, managementCommand{operation: removeManagementCommand, components: comps, async: c.NoWait})
 	if err != nil {
 		return err
+	}
+
+	if c.NoWait {
+		fmt.Fprintf(c.stdout, "%s", id)
 	}
 
 	return nil

--- a/overlord/hookstate/ctlcmd/snap_management_test.go
+++ b/overlord/hookstate/ctlcmd/snap_management_test.go
@@ -303,8 +303,6 @@ func (s *installSuite) TestRemoveCommandBadCompName(c *C) {
 }
 
 func (s *installSuite) TestNoWaitNonEphemeralReturnsError(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	for _, cmd := range []string{"install", "remove"} {
 		s.st.Lock()
 		task := s.st.NewTask("test", "test task")
@@ -329,8 +327,6 @@ func (s *installSuite) TestNoWaitNonEphemeralReturnsError(c *C) {
 }
 
 func (s *installSuite) TestNoWaitInstallAndRemoveCommands(c *C) {
-	c.Skip("Content removed for release 2.76")
-
 	for _, cmd := range []string{"install", "remove"} {
 		s.st.Lock()
 		task := s.st.NewTask("test", "test task")


### PR DESCRIPTION
Reverts the disabling of the snapctl asynchronous functionality.