### PR TITLE
interfaces/apparmor: add base prioritized snippets for strictly confined or jailed snaps

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -671,10 +671,11 @@ func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppS
 	content = make(map[string]osutil.FileState, len(runnables))
 	snapInfo := appSet.Info()
 
-	// add base snippets to the spec, unless it's an unjailed classic snap. These
-	// will be present in the final profile if no interface overrides them with a
-	// more specific snippet of the same key
-	if !opts.Classic || opts.JailMode {
+	// add base snippets to the spec, unless it's a strict snap in devmode or a
+	// classic snap without a jail. These will be present in the final profile
+	// if no interface overrides them with a more specific snippet of the same
+	// key
+	if (!opts.Classic && !opts.DevMode) || opts.JailMode {
 		for key, snippet := range basePrioritizedSnippets {
 			spec.AddBasePrioritizedSnippet(snippet, key)
 		}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -677,6 +677,8 @@ func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppS
 	// key
 	if (!opts.Classic && !opts.DevMode) || opts.JailMode {
 		for key, snippet := range basePrioritizedSnippets {
+			// TODO: pass confinement flags down if snippets need to be
+			// added conditionally
 			spec.AddBasePrioritizedSnippet(snippet, key)
 		}
 	}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1242,12 +1242,12 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// DevMode switches apparmor to non-enforcing (complain) mode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\nsnippet\n}\n",
 }, {
 	// JailMode switches apparmor to enforcing mode even in the presence of DevMode.
-	opts:    interfaces.ConfinementOptions{DevMode: true},
+	opts:    interfaces.ConfinementOptions{JailMode: true, DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted,complain) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" flags=(attach_disconnected,mediate_deleted) {\n" + mountInfoSnippet + "\nsnippet\n}\n",
 }, {
 	// Classic confinement (without jailmode) uses apparmor in complain mode by default and ignores all snippets.
 	opts:    interfaces.ConfinementOptions{Classic: true},


### PR DESCRIPTION
We identified a problem with
tests/nested/manual/devmode-snaps-can-run-other-snaps test, which got broken due to 0109cefcbb5c124d4ca29035709e7502c2f3fb24. Only add base snippets when the snap is a non-devmode strictly confined or a jailed snap. In other scenarios snippets, which may prefer to explicitly 'deny' certain operations would prevail over the complain mode.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
