### PR TITLE
cmd/libsnap-confine-private: improve loading of BPF programs, retry on failures to collect verifier logs

### DIFF
--- a/cmd/libsnap-confine-private/bpf-support.c
+++ b/cmd/libsnap-confine-private/bpf-support.c
@@ -122,23 +122,39 @@ int bpf_load_prog(enum bpf_prog_type type, const struct bpf_insn *insns, size_t 
     attr.insns = __ptr_as_u64(insns);
     attr.insn_cnt = (uint64_t)insns_cnt;
     attr.license = __ptr_as_u64("GPL");
-    if (log_buf != NULL) {
-        attr.log_buf = __ptr_as_u64(log_buf);
-        attr.log_size = log_buf_size;
-        attr.log_level = 1;
-    }
 
     if (prog_name != NULL) {
         strncpy(attr.prog_name, prog_name, sizeof(attr.prog_name) - 1);
     }
 
-    /* XXX: libbpf does a while loop checking for EAGAIN */
-    /* XXX: do we need to handle E2BIG? */
+    /* first attempt: load without requesting verifier */
     int fd = sys_bpf(BPF_PROG_LOAD, &attr, sizeof(attr));
-    if (fd < 0) {
-        return fd;
+    if (fd >= 0) {
+        return set_cloexec(fd);
     }
-    return set_cloexec(fd);
+
+    /* retry with log buffer to capture verifier diagnostics. This applies a
+     * similar, but way simpler, retry mechanism as libbpf's bpf_prog_load(),
+     * see:
+     * https://github.com/libbpf/libbpf/blob/5ee8863eaf3e948dd602f4bdfd2c256ae3804616/src/bpf.c#L371-L382
+     */
+    if (log_buf != NULL && log_buf_size > 0) {
+        int saved_errno = errno;
+        log_buf[0] = '\0';
+        attr.log_buf = __ptr_as_u64(log_buf);
+        attr.log_size = log_buf_size;
+        attr.log_level = 1;
+        /* note the log buffer may still be too small to hold the output, but
+         * since the initial loading failed there's not much we can do at this
+         * point. */
+        fd = sys_bpf(BPF_PROG_LOAD, &attr, sizeof(attr));
+        if (fd >= 0) {
+            return set_cloexec(fd);
+        }
+        errno = saved_errno;
+    }
+
+    return -1;
 }
 
 int bpf_prog_attach(enum bpf_attach_type type, int cgroup_fd, int prog_fd) {

--- a/cmd/libsnap-confine-private/device-cgroup-support.c
+++ b/cmd/libsnap-confine-private/device-cgroup-support.c
@@ -240,11 +240,13 @@ static int load_devcgroup_prog(int map_fd, const char *name) {
         BPF_EXIT_INSN(),
     };
 
-    char log_buf[4096] = {0};
+    /* 32kB, should be more than enough to store verifier logs if program
+       loading fails */
+    char log_buf[32768] = {0};
 
     int prog_fd = bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog, SC_ARRAY_SIZE(prog), log_buf, sizeof(log_buf), name);
     if (prog_fd < 0) {
-        die("cannot load program:\n%s\n", log_buf);
+        die("cannot load program, verifier output:\n%s\n", log_buf);
     }
     return prog_fd;
 }


### PR DESCRIPTION
Improve how BPF programs are loaded and follow practice established by libbpf's bpf_prog_load(). Specifically, when loading fails, retry to collect verifier output if an output buffer was provided by the caller.

Related: SNAPDENG-36962
