### PR TITLE
o/snapshotstate, o/s/backend: saving snapshot excludes mount-control mount points

### DIFF
--- a/overlord/snapshotstate/backend/mountunit.go
+++ b/overlord/snapshotstate/backend/mountunit.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import "github.com/snapcore/snapd/systemd"
+
+// ListMountControlMountPoints returns the active mount-control mount points for
+// the given snap instance name.
+func ListMountControlMountPoints(instanceName string) ([]string, error) {
+	sysd := systemd.New(systemd.SystemMode, nil)
+	return sysd.ListMountUnits(instanceName, "mount-control")
+}

--- a/overlord/snapshotstate/backend/mountunit_test.go
+++ b/overlord/snapshotstate/backend/mountunit_test.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type mountunitSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&mountunitSuite{})
+
+type fakeSystemd struct {
+	systemd.Systemd
+
+	listMountUnitsCalls  []listMountUnitsCall
+	listMountUnitsResult listMountUnitsResult
+}
+
+type listMountUnitsCall struct {
+	snapName, origin string
+}
+
+type listMountUnitsResult struct {
+	mountPoints []string
+	err         error
+}
+
+func (s *fakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) {
+	s.listMountUnitsCalls = append(s.listMountUnitsCalls, listMountUnitsCall{snapName, origin})
+	return s.listMountUnitsResult.mountPoints, s.listMountUnitsResult.err
+}
+
+func (s *mountunitSuite) TestListMountControlMountPointsHappy(c *C) {
+	returnedMounts := []string{"/var/snap/a-snap/x1/data/mymount", "/var/snap/a-snap/common/media"}
+
+	var sysd *fakeSystemd
+	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, mode systemd.InstanceMode, rep systemd.Reporter) systemd.Systemd {
+		sysd = &fakeSystemd{}
+		sysd.listMountUnitsResult = listMountUnitsResult{mountPoints: returnedMounts}
+		return sysd
+	})
+	defer restore()
+
+	mountPts, err := backend.ListMountControlMountPoints("a-snap")
+	c.Assert(err, IsNil)
+	c.Check(mountPts, DeepEquals, returnedMounts)
+
+	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+}
+
+func (s *mountunitSuite) TestListMountControlMountPointsError(c *C) {
+	expectedErr := errors.New("systemd failure")
+
+	var sysd *fakeSystemd
+	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, mode systemd.InstanceMode, rep systemd.Reporter) systemd.Systemd {
+		sysd = &fakeSystemd{}
+		sysd.listMountUnitsResult = listMountUnitsResult{err: expectedErr}
+		return sysd
+	})
+	defer restore()
+
+	mountPts, err := backend.ListMountControlMountPoints("a-snap")
+	c.Check(err, Equals, expectedErr)
+	c.Check(mountPts, IsNil)
+
+	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+}
+
+func (s *mountunitSuite) TestListMountControlMountPointsEmpty(c *C) {
+	var sysd *fakeSystemd
+	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
+		sysd = &fakeSystemd{}
+		sysd.listMountUnitsResult = listMountUnitsResult{mountPoints: []string{}}
+		return sysd
+	})
+	defer restore()
+
+	mountPts, err := backend.ListMountControlMountPoints("a-snap")
+	c.Assert(err, IsNil)
+	c.Check(mountPts, DeepEquals, []string{})
+
+	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+}

--- a/overlord/snapshotstate/export_test.go
+++ b/overlord/snapshotstate/export_test.go
@@ -51,7 +51,8 @@ var (
 
 	SetSnapshotOpInProgress = setSnapshotOpInProgress
 
-	DefaultAutomaticSnapshotExpiration = defaultAutomaticSnapshotExpiration
+	DefaultAutomaticSnapshotExpiration       = defaultAutomaticSnapshotExpiration
+	MapMountPointsInGlobalDataDirsToExcludes = mapMountPointsInGlobalDataDirsToExcludes
 )
 
 func (summaries snapshotSnapSummaries) AsMaps() []map[string]string {
@@ -213,5 +214,13 @@ func MockGetSnapDirOptions(f func(*state.State, string) (*dirs.SnapDirOptions, e
 	getSnapDirOpts = f
 	return func() {
 		getSnapDirOpts = old
+	}
+}
+
+func MockListMountControlMountPoints(f func(string) ([]string, error)) (restore func()) {
+	old := listMountControlMountPoints
+	listMountControlMountPoints = f
+	return func() {
+		listMountControlMountPoints = old
 	}
 }

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -235,7 +235,7 @@ func doSave(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	snapshot.Options = addMountControlExcludes(cur, snapshot.Options)
+	snapshot.excludeMountControlMountPoints(cur)
 	_, err = backendSave(tomb.Context(nil), snapshot.SetID, cur, cfg, snapshot.Users, snapshot.Options, opts)
 	if err != nil {
 		st.Lock()
@@ -267,28 +267,26 @@ func mapMountPointsInGlobalDataDirsToExcludes(si *snap.Info, mountPoints []strin
 	return excludes
 }
 
-// addMountControlExcludes returns snapshot options that additionally exclude
-// any currently-active mount-control mount points under the snap's data
-// directories. When opts is nil and there are excludes to add, a new
-// SnapshotOptions is created and returned. Errors from querying mount units
-// are logged and opts is returned unchanged, making the exclusion best-effort.
-func addMountControlExcludes(si *snap.Info, opts *snap.SnapshotOptions) *snap.SnapshotOptions {
+// excludeMountControlMountPoints appends any currently-active mount-control
+// mount points under the snap's data directories to s.Options. Errors from
+// querying mount units are logged and s.Options is left unchanged, making the
+// exclusion best-effort.
+func (s *snapshotSetup) excludeMountControlMountPoints(si *snap.Info) {
 	mountPts, err := listMountControlMountPoints(si.InstanceName())
 	if err != nil {
 		logger.Noticef("cannot list mount-control units for %q: %v", si.InstanceName(), err)
-		return opts
+		return
 	}
 	excludes := mapMountPointsInGlobalDataDirsToExcludes(si, mountPts)
 	if len(excludes) == 0 {
-		return opts
+		return
 	}
-	if opts == nil {
-		opts = &snap.SnapshotOptions{}
+	if s.Options == nil {
+		s.Options = &snap.SnapshotOptions{}
 	}
-	if err := opts.MergeDynamicExcludes(excludes); err != nil {
+	if err := s.Options.MergeDynamicExcludes(excludes); err != nil {
 		logger.Noticef("internal error: cannot add mount-control excludes for %q: %v", si.InstanceName(), err)
 	}
-	return opts
 }
 
 // prepareRestore does the steps of doRestore that require the state lock

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -235,7 +235,9 @@ func doSave(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	snapshot.excludeMountControlMountPoints(cur)
+	if err := snapshot.excludeMountControlMountPoints(cur); err != nil {
+		logger.Noticef("cannot exclude mount-control mount points: %v", err)
+	}
 	_, err = backendSave(tomb.Context(nil), snapshot.SetID, cur, cfg, snapshot.Users, snapshot.Options, opts)
 	if err != nil {
 		st.Lock()
@@ -268,25 +270,23 @@ func mapMountPointsInGlobalDataDirsToExcludes(si *snap.Info, mountPoints []strin
 }
 
 // excludeMountControlMountPoints appends any currently-active mount-control
-// mount points under the snap's data directories to s.Options. Errors from
-// querying mount units are logged and s.Options is left unchanged, making the
-// exclusion best-effort.
-func (s *snapshotSetup) excludeMountControlMountPoints(si *snap.Info) {
+// mount points under the snap's data directories to s.Options.
+func (s *snapshotSetup) excludeMountControlMountPoints(si *snap.Info) error {
 	mountPts, err := listMountControlMountPoints(si.InstanceName())
 	if err != nil {
-		logger.Noticef("cannot list mount-control units for %q: %v", si.InstanceName(), err)
-		return
+		return fmt.Errorf("cannot list mount-control units for %q: %v", si.InstanceName(), err)
 	}
 	excludes := mapMountPointsInGlobalDataDirsToExcludes(si, mountPts)
 	if len(excludes) == 0 {
-		return
+		return nil
 	}
 	if s.Options == nil {
 		s.Options = &snap.SnapshotOptions{}
 	}
 	if err := s.Options.MergeDynamicExcludes(excludes); err != nil {
-		logger.Noticef("internal error: cannot add mount-control excludes for %q: %v", si.InstanceName(), err)
+		return fmt.Errorf("internal error: cannot add mount-control excludes for %q: %v", si.InstanceName(), err)
 	}
+	return nil
 }
 
 // prepareRestore does the steps of doRestore that require the state lock

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -55,7 +56,8 @@ var (
 
 	autoExpirationInterval = time.Hour * 24 // interval between forgetExpiredSnapshots runs as part of Ensure()
 
-	getSnapDirOpts = snapstate.GetSnapDirOpts
+	getSnapDirOpts              = snapstate.GetSnapDirOpts
+	listMountControlMountPoints = backend.ListMountControlMountPoints
 )
 
 // SnapshotManager takes snapshots of active snaps
@@ -233,6 +235,7 @@ func doSave(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	snapshot.Options = addMountControlExcludes(cur, snapshot.Options)
 	_, err = backendSave(tomb.Context(nil), snapshot.SetID, cur, cfg, snapshot.Users, snapshot.Options, opts)
 	if err != nil {
 		st.Lock()
@@ -240,6 +243,52 @@ func doSave(task *state.Task, tomb *tomb.Tomb) error {
 		removeSnapshotState(st, snapshot.SetID)
 	}
 	return err
+}
+
+// mapMountPointsInGlobalDataDirsToExcludes converts absolute mount-control
+// mount-point paths for a snap to $SNAP_DATA/... or $SNAP_COMMON/... patterns
+// suitable for SnapshotOptions.Exclude. Only mount points under the global
+// data directories are considered because mount-control only supports mounts
+// under these directories. Paths outside the snap's data directories are
+// skipped because they are not included in the snapshot.
+func mapMountPointsInGlobalDataDirsToExcludes(si *snap.Info, mountPoints []string) []string {
+	snapDataPrefix := si.DataDir() + "/"
+	snapCommonPrefix := si.CommonDataDir() + "/"
+	var excludes []string
+	for _, where := range mountPoints {
+		where = strings.TrimRight(where, "/")
+		switch {
+		case strings.HasPrefix(where, snapDataPrefix):
+			excludes = append(excludes, "$SNAP_DATA/"+where[len(snapDataPrefix):])
+		case strings.HasPrefix(where, snapCommonPrefix):
+			excludes = append(excludes, "$SNAP_COMMON/"+where[len(snapCommonPrefix):])
+		}
+	}
+	return excludes
+}
+
+// addMountControlExcludes returns snapshot options that additionally exclude
+// any currently-active mount-control mount points under the snap's data
+// directories. When opts is nil and there are excludes to add, a new
+// SnapshotOptions is created and returned. Errors from querying mount units
+// are logged and opts is returned unchanged, making the exclusion best-effort.
+func addMountControlExcludes(si *snap.Info, opts *snap.SnapshotOptions) *snap.SnapshotOptions {
+	mountPts, err := listMountControlMountPoints(si.InstanceName())
+	if err != nil {
+		logger.Noticef("cannot list mount-control units for %q: %v", si.InstanceName(), err)
+		return opts
+	}
+	excludes := mapMountPointsInGlobalDataDirsToExcludes(si, mountPts)
+	if len(excludes) == 0 {
+		return opts
+	}
+	if opts == nil {
+		opts = &snap.SnapshotOptions{}
+	}
+	if err := opts.MergeDynamicExcludes(excludes); err != nil {
+		logger.Noticef("internal error: cannot add mount-control excludes for %q: %v", si.InstanceName(), err)
+	}
+	return opts
 }
 
 // prepareRestore does the steps of doRestore that require the state lock

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -279,6 +279,9 @@ func (snapshotSuite) TestDoSave(c *check.C) {
 		buf := json.RawMessage(`{"hello": "there"}`)
 		return &buf, nil
 	})()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		return nil, nil
+	})()
 
 	expectedOptions := &snap.SnapshotOptions{}
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string,
@@ -319,6 +322,227 @@ func (snapshotSuite) TestDoSave(c *check.C) {
 	}
 }
 
+func (snapshotSuite) TestMapMountPointsInGlobalDataDirsToExcludes(c *check.C) {
+	snapInfo := snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "a-snap",
+			Revision: snap.R(3),
+		},
+	}
+	snapDataDir := snapInfo.DataDir()
+	snapCommonDir := snapInfo.CommonDataDir()
+
+	tests := []struct {
+		mountPoints []string
+		expected    []string
+	}{
+		{nil, nil},
+		{[]string{}, nil},
+		// Path under SNAP_DATA
+		{[]string{snapDataDir + "/mymount"}, []string{"$SNAP_DATA/mymount"}},
+		// Path under SNAP_COMMON
+		{[]string{snapCommonDir + "/media"}, []string{"$SNAP_COMMON/media"}},
+		// Mixed
+		{
+			[]string{snapDataDir + "/data", snapCommonDir + "/shared"},
+			[]string{"$SNAP_DATA/data", "$SNAP_COMMON/shared"},
+		},
+		// Absolute path outside snap dirs: skipped
+		{[]string{"/media/external"}, nil},
+		// Path equal to snapDataDir itself (no trailing subpath): skipped
+		{[]string{snapDataDir}, nil},
+		// Path equal to snapCommonDir itself (no trailing subpath): skipped
+		{[]string{snapCommonDir}, nil},
+		// Path equal to snapDataDir with trailing slash: skipped
+		{[]string{snapDataDir + "/"}, nil},
+		// Path equal to snapCommonDir with trailing slash: skipped
+		{[]string{snapCommonDir + "/"}, nil},
+	}
+
+	for _, t := range tests {
+		result := snapshotstate.MapMountPointsInGlobalDataDirsToExcludes(&snapInfo, t.mountPoints)
+		c.Check(result, check.DeepEquals, t.expected, check.Commentf("mountPoints: %v", t.mountPoints))
+	}
+}
+
+func (snapshotSuite) TestDoSaveMountControlExcludes(c *check.C) {
+	snapInfo := snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "a-snap",
+			Revision: snap.R(3),
+		},
+	}
+	defer snapshotstate.MockSnapstateCurrentInfo(func(_ *state.State, snapname string) (*snap.Info, error) {
+		c.Check(snapname, check.Equals, "a-snap")
+		return &snapInfo, nil
+	})()
+	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
+		return nil, nil
+	})()
+
+	snapDataDir := snapInfo.DataDir()
+	snapCommonDir := snapInfo.CommonDataDir()
+	defer snapshotstate.MockListMountControlMountPoints(func(name string) ([]string, error) {
+		c.Check(name, check.Equals, "a-snap")
+		return []string{snapDataDir + "/mymount", "/outside/snap/dirs", snapCommonDir + "/media"}, nil
+	})()
+
+	var gotOptions *snap.SnapshotOptions
+	defer snapshotstate.MockBackendSave(func(_ context.Context, _ uint64, _ *snap.Info, _ map[string]any, _ []string,
+		opts *snap.SnapshotOptions, _ *dirs.SnapDirOptions) (*client.Snapshot, error) {
+		gotOptions = opts
+		return nil, nil
+	})()
+
+	st := state.New(nil)
+	st.Lock()
+	task := st.NewTask("save-snapshot", "...")
+	task.Set("snapshot-setup", map[string]any{
+		"set-id": 1,
+		"snap":   "a-snap",
+	})
+	st.Unlock()
+
+	err := snapshotstate.DoSave(task, &tomb.Tomb{})
+	c.Assert(err, check.IsNil)
+	c.Assert(gotOptions, check.NotNil)
+	c.Check(gotOptions.Exclude, check.DeepEquals, []string{"$SNAP_DATA/mymount", "$SNAP_COMMON/media"})
+}
+
+func (snapshotSuite) TestDoSaveMountControlExcludesPreservesSetupOptions(c *check.C) {
+	snapInfo := snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "a-snap",
+			Revision: snap.R(3),
+		},
+	}
+	defer snapshotstate.MockSnapstateCurrentInfo(func(_ *state.State, snapname string) (*snap.Info, error) {
+		c.Check(snapname, check.Equals, "a-snap")
+		return &snapInfo, nil
+	})()
+	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
+		return nil, nil
+	})()
+
+	snapCommonDir := snapInfo.CommonDataDir()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		return []string{snapCommonDir + "/media"}, nil
+	})()
+
+	var gotOptions *snap.SnapshotOptions
+	defer snapshotstate.MockBackendSave(func(_ context.Context, _ uint64, _ *snap.Info, _ map[string]any, _ []string,
+		opts *snap.SnapshotOptions, _ *dirs.SnapDirOptions) (*client.Snapshot, error) {
+		gotOptions = opts
+		return nil, nil
+	})()
+
+	st := state.New(nil)
+	st.Lock()
+	task := st.NewTask("save-snapshot", "...")
+	task.Set("snapshot-setup", map[string]any{
+		"set-id":  1,
+		"snap":    "a-snap",
+		"options": &snap.SnapshotOptions{Exclude: []string{"$SNAP_DATA/logs"}},
+	})
+	st.Unlock()
+
+	err := snapshotstate.DoSave(task, &tomb.Tomb{})
+	c.Assert(err, check.IsNil)
+	c.Assert(gotOptions, check.NotNil)
+	// Both setup-specified and mount-control excludes are present
+	c.Check(gotOptions.Exclude, check.DeepEquals, []string{"$SNAP_DATA/logs", "$SNAP_COMMON/media"})
+}
+
+func (snapshotSuite) TestDoSaveMountControlExcludesListMountsError(c *check.C) {
+	snapInfo := snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "a-snap",
+			Revision: snap.R(3),
+		},
+	}
+	defer snapshotstate.MockSnapstateCurrentInfo(func(_ *state.State, snapname string) (*snap.Info, error) {
+		c.Check(snapname, check.Equals, "a-snap")
+		return &snapInfo, nil
+	})()
+	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
+		return nil, nil
+	})()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		return nil, errors.New("mock ListMountControlMountPoints error")
+	})()
+
+	setupOptions := &snap.SnapshotOptions{Exclude: []string{"$SNAP_DATA/logs"}}
+	var gotOptions *snap.SnapshotOptions
+	defer snapshotstate.MockBackendSave(func(_ context.Context, _ uint64, _ *snap.Info, _ map[string]any, _ []string,
+		opts *snap.SnapshotOptions, _ *dirs.SnapDirOptions) (*client.Snapshot, error) {
+		gotOptions = opts
+		return nil, nil
+	})()
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	st := state.New(nil)
+	st.Lock()
+	task := st.NewTask("save-snapshot", "...")
+	task.Set("snapshot-setup", map[string]any{
+		"set-id":  1,
+		"snap":    "a-snap",
+		"options": setupOptions,
+	})
+	st.Unlock()
+
+	err := snapshotstate.DoSave(task, &tomb.Tomb{})
+	c.Assert(err, check.IsNil)
+	// Original setup options passed through unchanged despite list error
+	c.Check(gotOptions, check.DeepEquals, setupOptions)
+	// Verify error was logged
+	c.Check(logbuf.String(), testutil.Contains, "cannot list mount-control units for \"a-snap\": mock ListMountControlMountPoints error")
+}
+
+func (snapshotSuite) TestDoSaveNoMountControlMounts(c *check.C) {
+	snapInfo := snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "a-snap",
+			Revision: snap.R(3),
+		},
+	}
+	defer snapshotstate.MockSnapstateCurrentInfo(func(_ *state.State, snapname string) (*snap.Info, error) {
+		c.Check(snapname, check.Equals, "a-snap")
+		return &snapInfo, nil
+	})()
+	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
+		return nil, nil
+	})()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		// No active mount-control mounts
+		return []string{}, nil
+	})()
+
+	setupOptions := &snap.SnapshotOptions{Exclude: []string{"$SNAP_DATA/cache"}}
+	var gotOptions *snap.SnapshotOptions
+	defer snapshotstate.MockBackendSave(func(_ context.Context, _ uint64, _ *snap.Info, _ map[string]any, _ []string,
+		opts *snap.SnapshotOptions, _ *dirs.SnapDirOptions) (*client.Snapshot, error) {
+		gotOptions = opts
+		return nil, nil
+	})()
+
+	st := state.New(nil)
+	st.Lock()
+	task := st.NewTask("save-snapshot", "...")
+	task.Set("snapshot-setup", map[string]any{
+		"set-id":  1,
+		"snap":    "a-snap",
+		"options": setupOptions,
+	})
+	st.Unlock()
+
+	err := snapshotstate.DoSave(task, &tomb.Tomb{})
+	c.Assert(err, check.IsNil)
+	// Options unchanged when there are no mount-control mounts
+	c.Check(gotOptions, check.DeepEquals, setupOptions)
+}
+
 func (snapshotSuite) TestDoSaveGetsSnapDirOpts(c *check.C) {
 	restore := snapshotstate.MockGetSnapDirOptions(func(*state.State, string) (*dirs.SnapDirOptions, error) {
 		return &dirs.SnapDirOptions{HiddenSnapDataDir: true}, nil
@@ -335,6 +559,9 @@ func (snapshotSuite) TestDoSaveGetsSnapDirOpts(c *check.C) {
 	defer snapshotstate.MockSnapstateCurrentInfo(func(_ *state.State, snapname string) (*snap.Info, error) {
 		c.Check(snapname, check.Equals, "a-snap")
 		return &snapInfo, nil
+	})()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		return nil, nil
 	})()
 
 	var checkOpts bool
@@ -413,6 +640,9 @@ func (snapshotSuite) TestDoSaveFailsBackendError(c *check.C) {
 	}
 	defer snapshotstate.MockSnapstateCurrentInfo(func(*state.State, string) (*snap.Info, error) { return &snapInfo, nil })()
 	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) { return nil, nil })()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
+		return nil, nil
+	})()
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string, _ *snap.SnapshotOptions, options *dirs.SnapDirOptions) (*client.Snapshot, error) {
 		return nil, errors.New("bzzt")
 	})()
@@ -504,6 +734,9 @@ func (snapshotSuite) TestDoSaveFailureRemovesStateEntry(c *check.C) {
 		return &snapInfo, nil
 	})()
 	defer snapshotstate.MockConfigGetSnapConfig(func(_ *state.State, snapname string) (*json.RawMessage, error) {
+		return nil, nil
+	})()
+	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
 		return nil, nil
 	})()
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string, _ *snap.SnapshotOptions, options *dirs.SnapDirOptions) (*client.Snapshot, error) {

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -497,7 +497,7 @@ func (snapshotSuite) TestDoSaveMountControlExcludesListMountsError(c *check.C) {
 	// Original setup options passed through unchanged despite list error
 	c.Check(gotOptions, check.DeepEquals, setupOptions)
 	// Verify error was logged
-	c.Check(logbuf.String(), testutil.Contains, "cannot list mount-control units for \"a-snap\": mock ListMountControlMountPoints error")
+	c.Check(logbuf.String(), check.Matches, "(?s).*cannot exclude mount-control mount points.* mock ListMountControlMountPoints error.*")
 }
 
 func (snapshotSuite) TestDoSaveNoMountControlMounts(c *check.C) {

--- a/tests/main/snapshot-excludes-mount-control-mounts/task.yaml
+++ b/tests/main/snapshot-excludes-mount-control-mounts/task.yaml
@@ -1,0 +1,134 @@
+summary: Snapshot excludes active mount-control mount points
+
+details: |
+    When taking a snapshot of a snap that has active mount-control mounts
+    under its global data directories ($SNAP_DATA, $SNAP_COMMON), snapd
+    automatically excludes those mount points from the snapshot. This
+    prevents capturing data that was mounted into snap's data directories.
+
+systems: [-ubuntu-14.04-*]
+
+environment:
+    SNAP_NAME: test-snapd-mount-control
+    SNAP_COMMON: /var/snap/$SNAP_NAME/common
+    SNAP_DATA: /var/snap/$SNAP_NAME/x1
+    MOUNT_SRC: /var/tmp/$SNAP_NAME
+    MOUNT_DEST_COMMON: $SNAP_COMMON/target1
+    MOUNT_DEST_DATA: $SNAP_DATA/target1
+    # tar invoked when creating snapshots triggers OOM
+    SNAPD_NO_MEMORY_LIMIT: 1
+    TEST_CASE/v1: snap_save
+    TEST_CASE/v2: snap_remove
+
+prepare: |
+    echo "Install test snap with mount-control interface"
+    "${TESTSTOOLS}"/snaps-state install-local "${SNAP_NAME}"
+    tests.cleanup defer snap remove --purge "${SNAP_NAME}"
+    snap connect "${SNAP_NAME}":mntctl
+
+    echo "Create mount source with some data"
+    mkdir -p "${MOUNT_SRC}"
+    tests.cleanup defer rm -rf "${MOUNT_SRC}"
+    echo "mounted-data" > "${MOUNT_SRC}/mounted-data.txt"
+
+    echo "Write some files in the snap's data dirs (not under any mount point)"
+    echo "snap-common-data" > "${SNAP_COMMON}/data.txt"
+    echo "snap-data-data" > "${SNAP_DATA}/data.txt"
+
+    echo "Create mount target dirs and bind mount the source into them"
+    mkdir -p "${MOUNT_DEST_COMMON}" "${MOUNT_DEST_DATA}"
+    tests.cleanup defer rm -rf "${MOUNT_DEST_COMMON}" "${MOUNT_DEST_DATA}"
+    "${SNAP_NAME}".cmd snapctl mount -o bind,rw "${MOUNT_SRC}" "${MOUNT_DEST_COMMON}"
+    tests.cleanup defer "\"${SNAP_NAME}\".cmd snapctl umount \"${MOUNT_DEST_COMMON}\" || true"
+    "${SNAP_NAME}".cmd snapctl mount -o bind,rw "${MOUNT_SRC}" "${MOUNT_DEST_DATA}"
+    tests.cleanup defer "\"${SNAP_NAME}\".cmd snapctl umount \"${MOUNT_DEST_DATA}\" || true"
+
+    echo "Verify mounts are active in the host namespace"
+    MATCH "${MOUNT_DEST_COMMON}" < /proc/self/mountinfo
+    MATCH "${MOUNT_DEST_DATA}" < /proc/self/mountinfo
+
+    echo "Write some files into the mount points; this data should NOT be snapshotted"
+    echo "should-not-appear-in-snapshot" > "${MOUNT_DEST_COMMON}/excluded-file.txt"
+    echo "should-not-appear-in-snapshot" > "${MOUNT_DEST_DATA}/excluded-file.txt"
+
+execute: |
+    then_snapshot_is_valid() {
+        local set_id=$1
+        echo "Verify snapshot ${set_id} is valid"
+        echo "${set_id}" | MATCH "^[0-9]+$"
+        snap saved --id="${set_id}" | MATCH "${SNAP_NAME}"
+        snap check-snapshot "${set_id}"
+    }
+
+    then_snapshot_has_mount_point_excludes() {
+        local set_id=$1
+        echo "Verify snapshot ${set_id} has excludes for active mount-control mount points"
+        timeout 5 snap debug api "/v2/snapshots?set=${set_id}" | gojq -r '.result[0].snapshots[0].options.exclude[]' > options-exclude
+        tests.cleanup defer rm -f options-exclude
+        #shellcheck disable=SC2016
+        MATCH '^\$SNAP_COMMON/target1$' < options-exclude
+        #shellcheck disable=SC2016
+        MATCH '^\$SNAP_DATA/target1$' < options-exclude
+    }
+
+    then_restore_and_verify_excludes() {
+        local set_id=$1
+        echo "Restore snapshot ${set_id} and verify that data outside mount points is present"
+        snap restore "${set_id}" "${SNAP_NAME}"
+        MATCH "snap-common-data" < "${SNAP_COMMON}/data.txt"
+        MATCH "snap-data-data" < "${SNAP_DATA}/data.txt"
+        
+        echo "and data inside mount points was not captured"
+        not test -e "${MOUNT_DEST_COMMON}/excluded-file.txt"
+        not test -e "${MOUNT_DEST_DATA}/excluded-file.txt"
+    }
+
+    test_snap_save() {
+        echo "Take a snapshot using snap save"
+        local set_id
+        set_id=$(snap save "${SNAP_NAME}" | cut -d\  -f1 | tail -n1)
+        tests.cleanup defer snap forget "${set_id}"
+
+        then_snapshot_is_valid "${set_id}"
+        then_snapshot_has_mount_point_excludes "${set_id}"
+
+        echo "Unmount before restoring snapshot"
+        "${SNAP_NAME}".cmd snapctl umount "${MOUNT_DEST_COMMON}"
+        "${SNAP_NAME}".cmd snapctl umount "${MOUNT_DEST_DATA}"
+        echo "Remove files to test restore"
+        rm "${SNAP_COMMON}/data.txt" "${SNAP_DATA}/data.txt"
+
+        then_restore_and_verify_excludes "${set_id}"
+    }
+
+    test_snap_remove() {
+        if os.query is-core; then
+            echo "Enable automatic snapshot creation on remove"
+            snap set core snapshots.automatic.retention=24h
+            tests.cleanup defer snap unset core snapshots.automatic.retention
+        fi
+
+        local max_set_id_before
+        max_set_id_before=$(snap saved | tail -n+2 | cut -d\  -f1 | tail -n1)
+        max_set_id_before=${max_set_id_before:-0}
+
+        echo "Remove the snap; this should create an automatic snapshot"
+        snap remove "${SNAP_NAME}"
+        
+        local set_id
+        set_id=$(snap saved | tail -n+2 | cut -d\  -f1 | tail -n1)
+        set_id=${set_id:-0}
+        test "${set_id}" -gt "${max_set_id_before}"
+        tests.cleanup defer snap forget "${set_id}"
+
+        then_snapshot_is_valid "${set_id}"
+        then_snapshot_has_mount_point_excludes "${set_id}"
+
+        echo "Reinstall the snap to test restoring the snapshot taken on remove"
+        "${TESTSTOOLS}"/snaps-state install-local "${SNAP_NAME}"
+
+        then_restore_and_verify_excludes "${set_id}"
+    }
+
+    echo "Executing test_${TEST_CASE}"
+    test_${TEST_CASE}


### PR DESCRIPTION
This excludes `snapctl` created mount points under snap's data dirs while saving snapshots (automatic or manual).

* Uses `snapd/systemd` in `o/snapshotstate/backend` to list current active mount units for a snap with `mount-control` origin
* Maps active mount points to snapshot's `Exclude` pattern and appends them to `SnapshotOptions`'s dynamic `Exclude` list

[SNAPDENG-36904](https://warthogs.atlassian.net/browse/)

[SNAPDENG-36904]: https://warthogs.atlassian.net/browse/SNAPDENG-36904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ