### PR TITLE
o/snapstate: ensure existing snap confinement flags are not dropped when installing or removing components

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -833,6 +833,11 @@ func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.C
 		CompType:     compst.CompType,
 	}
 
+	// TODO: assess if there are other flags we need to copy from the current
+	// snap's set of flags. we know that just removing components should not
+	// impact confinement of the snap itself.
+	copyConfinementFlagsFromSnapState(&snapSup.Flags, snapst)
+
 	removeHook := SetupRemoveComponentHook(st, instName, compst.SideInfo.Component.ComponentName)
 	removeHook.Set("component-setup", compSetup)
 	removeHook.Set("snap-setup", snapSup)

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -114,6 +114,11 @@ func InstallComponents(
 		return nil, err
 	}
 
+	// TODO: assess if there are other flags we need to copy from the current
+	// snap's set of flags. we know that just adding components should not
+	// impact confinement of the snap itself.
+	copyConfinementFlagsFromSnapState(&opts.Flags, &snapst)
+
 	snapsup := SnapSetup{
 		Base:                        info.Base,
 		SideInfo:                    &info.SideInfo,
@@ -176,6 +181,16 @@ func InstallComponents(
 	ts.JoinLane(lane)
 
 	return append(tss, ts), nil
+}
+
+// copyConfinementFlagsFromSnapState ensures that the flag set used for a
+// component installation carries the flags that define the snap's current
+// confinement. This ensures that task handlers that consume the flags (example,
+// setup-profiles) see the proper set of flags.
+func copyConfinementFlagsFromSnapState(flags *Flags, snapst *SnapState) {
+	flags.Classic = snapst.Classic
+	flags.DevMode = snapst.DevMode
+	flags.JailMode = snapst.JailMode
 }
 
 func componentSetupsForInstall(ctx context.Context, st *state.State, names []string, snapst SnapState, revOpts RevisionOptions, opts Options) ([]ComponentSetup, error) {
@@ -290,6 +305,11 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: assess if there are other flags we need to copy from the current
+	// snap's set of flags. we know that just adding components should not
+	// impact confinement of the snap itself.
+	copyConfinementFlagsFromSnapState(&opts.Flags, &snapst)
 
 	snapsup := SnapSetup{
 		Base:                        info.Base,

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -422,7 +422,7 @@ func (s *snapmgrTestSuite) testInstallComponentPath(c *C, opts testInstallCompon
 
 	// ensure that we didn't drop persistent classic flag when installing the
 	// component
-	c.Assert(snapsup.Classic, DeepEquals, opts.snapIsClassic)
+	c.Assert(snapsup.Classic, Equals, opts.snapIsClassic)
 }
 
 func (s *snapmgrTestSuite) TestInstallUnassertedComponentFailsWithAssertedSnap(c *C) {
@@ -1165,7 +1165,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 
 	// ensure that we didn't drop persistent classic flag when installing the
 	// component
-	c.Assert(snapsup.Classic, DeepEquals, opts.snapIsClassic)
+	c.Assert(snapsup.Classic, Equals, opts.snapIsClassic)
 
 	for _, ts := range tss[0 : len(tss)-1] {
 		task := ts.Tasks()[0]

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -319,6 +319,12 @@ func (s *snapmgrTestSuite) TestInstallComponentPathUnasserted(c *C) {
 	})
 }
 
+func (s *snapmgrTestSuite) TestInstallComponentWithExistingClassic(c *C) {
+	s.testInstallComponentPath(c, testInstallComponentPathOpts{
+		snapIsClassic: true,
+	})
+}
+
 func (s *snapmgrTestSuite) TestInstallComponentPathWithLane(c *C) {
 	s.testInstallComponentPath(c, testInstallComponentPathOpts{
 		lane:        1,
@@ -339,9 +345,10 @@ func (s *snapmgrTestSuite) TestInstallComponentPathTransactionPerSnap(c *C) {
 }
 
 type testInstallComponentPathOpts struct {
-	lane        int
-	unasserted  bool
-	transaction client.TransactionType
+	lane          int
+	unasserted    bool
+	transaction   client.TransactionType
+	snapIsClassic bool
 }
 
 func (s *snapmgrTestSuite) testInstallComponentPath(c *C, opts testInstallComponentPathOpts) {
@@ -354,12 +361,28 @@ func (s *snapmgrTestSuite) testInstallComponentPath(c *C, opts testInstallCompon
 		compRev = snap.Revision{}
 	}
 	info := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	if opts.snapIsClassic {
+		info.Confinement = snap.ClassicConfinement
+	}
+
 	_, compPath := createTestComponent(c, snapName, compName, info)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	setStateWithOneSnap(s.state, snapName, snapRev)
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev,
+		SnapID: "some-snap-id"}
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(ssi, nil)}),
+		Current:         snapRev,
+		TrackingChannel: "channel-for-components",
+		Flags: snapstate.Flags{
+			Classic: opts.snapIsClassic,
+		},
+	})
 
 	csi := snap.NewComponentSideInfo(naming.ComponentRef{
 		SnapName: snapName, ComponentName: compName}, compRev)
@@ -372,7 +395,6 @@ func (s *snapmgrTestSuite) testInstallComponentPath(c *C, opts testInstallCompon
 	}
 
 	ts, err := snapstate.InstallComponentPath(s.state, csi, info, compPath, installOpts)
-
 	c.Assert(err, IsNil)
 
 	expectedLane := opts.lane
@@ -394,6 +416,13 @@ func (s *snapmgrTestSuite) testInstallComponentPath(c *C, opts testInstallCompon
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	// File is not deleted
 	c.Assert(osutil.FileExists(compPath), Equals, true)
+
+	var snapsup snapstate.SnapSetup
+	c.Assert(ts.Tasks()[0].Get("snap-setup", &snapsup), IsNil)
+
+	// ensure that we didn't drop persistent classic flag when installing the
+	// component
+	c.Assert(snapsup.Classic, DeepEquals, opts.snapIsClassic)
 }
 
 func (s *snapmgrTestSuite) TestInstallUnassertedComponentFailsWithAssertedSnap(c *C) {
@@ -963,6 +992,12 @@ func (s *snapmgrTestSuite) TestInstallComponentsWithLane(c *C) {
 	})
 }
 
+func (s *snapmgrTestSuite) TestInstallComponentsWithExistingClassic(c *C) {
+	s.testInstallComponents(c, testInstallComponentsOpts{
+		snapIsClassic: true,
+	})
+}
+
 func (s *snapmgrTestSuite) TestInstallComponentsTransactionAllSnaps(c *C) {
 	s.testInstallComponents(c, testInstallComponentsOpts{
 		transaction: client.TransactionAllSnaps,
@@ -999,6 +1034,7 @@ type testInstallComponentsOpts struct {
 	transaction       client.TransactionType
 	userIDInstallOpts int
 	userIDSnapState   int
+	snapIsClassic     bool
 }
 
 func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponentsOpts) {
@@ -1011,6 +1047,9 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	}
 
 	info := createTestSnapInfoForComponents(c, snapName, snapRev, compNamesToType)
+	if opts.snapIsClassic {
+		info.Confinement = snap.ClassicConfinement
+	}
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1029,6 +1068,9 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 		Current:         snapRev,
 		TrackingChannel: "channel-for-components",
 		UserID:          opts.userIDSnapState,
+		Flags: snapstate.Flags{
+			Classic: opts.snapIsClassic,
+		},
 	})
 
 	components := []string{"standard-component", "kernel-modules-component"}
@@ -1120,6 +1162,10 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, NotNil)
 	c.Assert(snapsup.ComponentExclusiveOperation, Equals, true)
+
+	// ensure that we didn't drop persistent classic flag when installing the
+	// component
+	c.Assert(snapsup.Classic, DeepEquals, opts.snapIsClassic)
 
 	for _, ts := range tss[0 : len(tss)-1] {
 		task := ts.Tasks()[0]

--- a/overlord/snapstate/component_remove_test.go
+++ b/overlord/snapstate/component_remove_test.go
@@ -52,14 +52,21 @@ func verifyComponentRemoveTasks(c *C, opts int, ts *state.TaskSet) {
 }
 
 func (s *snapmgrTestSuite) TestRemoveComponent(c *C) {
-	s.testRemoveComponent(c, snapstate.RemoveComponentsOpts{})
+	const classicSnap = false
+	s.testRemoveComponent(c, snapstate.RemoveComponentsOpts{}, classicSnap)
 }
 
 func (s *snapmgrTestSuite) TestRemoveComponentRefreshProf(c *C) {
-	s.testRemoveComponent(c, snapstate.RemoveComponentsOpts{RefreshProfile: true})
+	const classicSnap = false
+	s.testRemoveComponent(c, snapstate.RemoveComponentsOpts{RefreshProfile: true}, classicSnap)
 }
 
-func (s *snapmgrTestSuite) testRemoveComponent(c *C, opts snapstate.RemoveComponentsOpts) {
+func (s *snapmgrTestSuite) TestRemoveComponentClassicSnap(c *C) {
+	const classicSnap = true
+	s.testRemoveComponent(c, snapstate.RemoveComponentsOpts{RefreshProfile: true}, classicSnap)
+}
+
+func (s *snapmgrTestSuite) testRemoveComponent(c *C, opts snapstate.RemoveComponentsOpts, classicSnap bool) {
 	const snapName = "mysnap"
 	const compName = "mycomp"
 	snapRev := snap.R(1)
@@ -68,7 +75,21 @@ func (s *snapmgrTestSuite) testRemoveComponent(c *C, opts snapstate.RemoveCompon
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	setStateWithOneComponent(s.state, snapName, snapRev, compName, compRev)
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), compRev)
+	ssi := &snap.SideInfo{RealName: snapName, Revision: snapRev,
+		SnapID: "some-snap-id"}
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(ssi, []*sequence.ComponentState{
+					sequence.NewComponentState(csi, snap.StandardComponent),
+				})}),
+		Current: snapRev,
+		Flags: snapstate.Flags{
+			Classic: classicSnap,
+		},
+	})
 
 	tss, err := snapstate.RemoveComponents(s.state, snapName, []string{compName}, opts)
 	c.Assert(err, IsNil)
@@ -102,6 +123,13 @@ func (s *snapmgrTestSuite) testRemoveComponent(c *C, opts snapstate.RemoveCompon
 	}
 
 	c.Assert(s.state.TaskCount(), Equals, totalTasks)
+
+	var snapsup snapstate.SnapSetup
+	c.Assert(s.state.Task(snapsupID).Get("snap-setup", &snapsup), IsNil)
+
+	// ensure that we didn't drop persistent classic flag when installing the
+	// component
+	c.Assert(snapsup.Classic, Equals, classicSnap)
 }
 
 func (s *snapmgrTestSuite) TestRemoveComponents(c *C) {


### PR DESCRIPTION
This impacts things like classic and devmode.