### PR TITLE
tests: automatic rerun once the "auto rerun spread" label is added

### DIFF
--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -1,12 +1,9 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   triage:
-    if: github.event_name == 'pull_request_target'
     permissions:
       contents: read
       pull-requests: write
@@ -17,9 +14,6 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: "true"
 
-    - name: Checkout code
-      uses: actions/checkout@v6
-
     - name: Apply draft label using gh CLI
       env:
         GH_TOKEN: ${{ github.token }}
@@ -29,19 +23,11 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'Skip spread')
       run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Run only one system'
 
-  auto-rerun-label-on-approval:
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Add Auto rerun spread label after second approval
+    - name: Add Auto rerun spread label on creation
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      if: github.event.action == 'opened'
       run: |
         if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
           exit 0
@@ -52,7 +38,6 @@ jobs:
           exit 0
         fi
 
-        approvals=$(gh pr view "$PR_NUMBER" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .author.login' | sort -u | wc -l)
-        if [ "$approvals" -ge 2 ] && ! grep -q '^Auto rerun spread$' <<<"$labels"; then
+        if ! grep -q '^Auto rerun spread$' <<<"$labels"; then
           gh pr edit "$PR_NUMBER" --add-label 'Auto rerun spread'
         fi

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -9,6 +9,9 @@ on:
     workflows: [Tests]
     types:
       - completed
+  pull_request_target:
+    types:
+      - labeled
 
 jobs:
   rerun:
@@ -26,10 +29,13 @@ jobs:
           gh run rerun ${{ inputs.run_id }} --failed
 
   rerun-pr:
-    if: github.event.workflow_run && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 5
+    if: >
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 5) ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'Auto rerun spread')
     permissions:
       actions: write
     env:
+      AUTO_RERUN: 'false'
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     runs-on: ubuntu-latest
@@ -38,6 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Get PR number
+        if: github.event_name == 'workflow_run'
         uses: actions/github-script@v9
         with:
           script: |
@@ -69,11 +76,17 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
            
       - name: Unzip PR number
+        if: github.event_name == 'workflow_run'
         run: unzip pr_number.zip
 
       - name: Check for rerun eligibility
         run: |
-          pr=$(cat pr_number)
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            pr=$(cat pr_number)
+          else
+            pr="${{ github.event.pull_request.number }}"
+          fi
+
           if [ "$(gh pr view "$pr" --json isDraft --jq '.isDraft')" = "true" ]; then
             echo "setting auto rerun to false because the PR is a draft"
             echo "AUTO_RERUN=false" >> $GITHUB_ENV
@@ -97,7 +110,22 @@ jobs:
       - name: Set run ID
         if: env.AUTO_RERUN == 'true'
         run: |
-          run_id=$(awk -F'/' '{print $(NF-1)}' <<<"${{ github.event.workflow_run.rerun_url }}")
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            run_id=$(awk -F'/' '{print $(NF-1)}' <<<"${{ github.event.workflow_run.rerun_url }}")
+          else
+            run_id=$(gh api \
+              -X GET \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/runs?event=pull_request&head_sha=${{ github.event.pull_request.head.sha }}&per_page=100" \
+              --jq '.workflow_runs[] | select(.name == "Tests" and .conclusion == "failure" and .run_attempt < 5) | .id' | head -1)
+          fi
+
+          if [ -z "$run_id" ]; then
+            echo "No failed Tests run found for this PR head SHA"
+            echo "AUTO_RERUN=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
           echo "RUN_ID=$run_id" >> $GITHUB_ENV
 
       - name: Check number of fundamental failures

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -34,6 +34,7 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'Auto rerun spread')
     permissions:
       actions: write
+      pull-requests: read
     env:
       AUTO_RERUN: 'false'
       GH_REPO: ${{ github.repository }}
@@ -83,6 +84,7 @@ jobs:
           else
             pr="${{ github.event.pull_request.number }}"
           fi
+          echo "PR_NUMBER=$pr" >> $GITHUB_ENV
 
           if [ "$(gh pr view "$pr" --json isDraft --jq '.isDraft')" = "true" ]; then
             echo "setting auto rerun to false because the PR is a draft"
@@ -125,11 +127,29 @@ jobs:
 
           echo "RUN_ID=$run_id" >> $GITHUB_ENV
 
-      - name: Check number of fundamental failures
+      - name: Check number of required system failures
         if: env.AUTO_RERUN == 'true'
         run: |
-          failed_fund=$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("\\(fundamental\\)")) | select(.conclusion == "failure") | .databaseId')
-          for failed in $failed_fund; do
+          pr_base=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
+          required_spread_checks=$(gh api \
+            -X GET \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/rules/branches/$pr_base" \
+            --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+
+          if [ -z "$required_spread_checks" ]; then
+            echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
+            exit 0
+          fi
+
+          failed_required_system_targets=""
+          while IFS=$'\t' read -r failed_id failed_name; do
+            if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
+              failed_required_system_targets+="$failed_id "$'\n'
+            fi
+          done < <(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+
+          for failed in $failed_required_system_targets; do
 
             # The number of failed tasks are reported in the logs as a line with 
             # a date and timestamp, followed by "Failed tasks: " and the number
@@ -139,7 +159,7 @@ jobs:
             num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1)
             
             if [ -n "$num_failed" ] && [ $num_failed -ge 30 ]; then
-              echo "Setting rerun to false because there were 30 or more failures on a fundamental system"
+              echo "Setting rerun to false because there were 30 or more failures on a system target"
               echo "AUTO_RERUN=false" >> $GITHUB_ENV
             fi
           done

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -12,6 +12,9 @@ on:
   pull_request_target:
     types:
       - labeled
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   rerun:
@@ -31,7 +34,8 @@ jobs:
   rerun-pr:
     if: >
       (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 5) ||
-      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'Auto rerun spread')
+      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'Auto rerun spread') ||
+      (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'approved')
     permissions:
       actions: write
       pull-requests: read
@@ -99,7 +103,7 @@ jobs:
           fi
 
           num_approvals=$(gh pr view "$pr" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .author.login' | sort -u | wc -l)
-          if [ "$has_label" = "true" ] && [ "$num_approvals" -ge 1 ]; then
+          if [ "$has_label" = "true" ] && [ "$num_approvals" -ge 2 ]; then
             echo "AUTO_RERUN=true" >> $GITHUB_ENV
           else
             echo "setting auto rerun to false because it is missing the label or has insufficient approvals"

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -40,9 +40,6 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Get PR number
         if: github.event_name == 'workflow_run'
         uses: actions/github-script@v9


### PR DESCRIPTION
This will trigger automatically the tests once the label is added by the ci-labeler or manually.

The idea is to auto-trigger tests when a second approval is added.
