### PR TITLE
t/l/s/s/test-snapd-kernel-module-consumer: update test-snapd-kernel-module-consumer snap to use kmod binary for kernel modules testing

### DIFF
--- a/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
@@ -7,16 +7,17 @@ base: core26
 confinement: strict
 grade: stable
 
+plugs:
+    kernel-module-control:
+      interface: kernel-module-control
+
 apps:
     lsmod:
         command: bin/lsmod
-        plugs: [kernel-module-control]
     insmod:
         command: bin/insmod
-        plugs: [kernel-module-control]
     rmmod:
         command: bin/rmmod
-        plugs: [kernel-module-control]
 
 parts:
   kmod-bundle:

--- a/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
@@ -13,11 +13,11 @@ plugs:
 
 apps:
     lsmod:
-        command: bin/lsmod
+        command: /usr/sbin/lsmod
     insmod:
-        command: bin/insmod
+        command: /usr/sbin/insmod
     rmmod:
-        command: bin/rmmod
+        command: /usr/sbin/rmmod
 
 parts:
   kmod-bundle:

--- a/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
@@ -23,9 +23,3 @@ parts:
     plugin: nil
     stage-packages:
       - kmod
-    override-prime: |
-      craftctl default
-      mkdir -p $CRAFT_PRIME/bin
-      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/lsmod
-      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/insmod
-      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/rmmod

--- a/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: test-snapd-kernel-module-consumer
+version: 2.0
+summary: Basic kernel-module-control consumer snap
+description: A basic snap declaring a plug on kernel-module-control
+type: app
+base: core26
+confinement: strict
+grade: stable
+
+apps:
+    lsmod:
+        command: bin/lsmod
+        plugs: [kernel-module-control]
+    insmod:
+        command: bin/insmod
+        plugs: [kernel-module-control]
+    rmmod:
+        command: bin/rmmod
+        plugs: [kernel-module-control]
+
+parts:
+  kmod-bundle:
+    plugin: nil
+    stage-packages:
+      - kmod
+    override-prime: |
+      craftctl default
+      mkdir -p $CRAFT_PRIME/bin
+      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/lsmod
+      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/insmod
+      ln -sf ../usr/bin/kmod $CRAFT_PRIME/bin/rmmod

--- a/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-kernel-module-consumer/snapcraft.yaml
@@ -4,8 +4,9 @@ summary: Basic kernel-module-control consumer snap
 description: A basic snap declaring a plug on kernel-module-control
 type: app
 base: core26
+build-base: devel
 confinement: strict
-grade: stable
+grade: devel
 
 plugs:
     kernel-module-control:


### PR DESCRIPTION
The existing `test-snapd-kernel-module-consumer` is used in the [`interfaces-kernel-module-control`](https://github.com/canonical/snapd/blob/master/tests/main/interfaces-kernel-module-control/task.yaml) spread test is not able to load/unload compressed kernel modules object files. This is limiting as core24, core26, ubuntu-24.04, ubuntu-25.10, ubuntu-26.04, and more store compressed kernel modules object files and are skipped. 

This PR bundles the kmod binary with the snap and allows for loading/unloading both compressed and uncompressed kernel module object files.

Tracked with: [SNAPDENG-36766](https://warthogs.atlassian.net/browse/SNAPDENG-36766?atlOrigin=eyJpIjoiZWQ4NWQ5ZWUyNzhjNGQ0Y2I5YTUxMjFjMWU2YmQwNWEiLCJwIjoiaiJ9)

[SNAPDENG-36766]: https://warthogs.atlassian.net/browse/SNAPDENG-36766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ