### PR TITLE
t/m/interfaces-kernel-module-control: enable interfaces-kernel-module-control spread test for systems with compressed kernel module object files

### DIFF
--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -22,8 +22,7 @@ systems:
 
 environment:
     MODULE: minix
-    # some systems contain a compressed kernel module object file
-    MODULE_PATH: $(path="/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"; if [ -f "$path" ]; then echo "$path"; else echo "$path.zst" ; fi)
+    MODULE_PATH_FILE: "/home/test/module_path"
 
 skip:
     - reason: minix module not available in the system
@@ -52,6 +51,16 @@ prepare: |
     fi
     echo "Given a snap declaring a plug on the kernel-module-control interface is installed"
     snap install "$@" test-snapd-kernel-module-consumer
+
+    MODULE_PATH="/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"
+    if [ -f "$MODULE_PATH" ]; then
+        echo "$MODULE_PATH" > "$MODULE_PATH_FILE"
+    else
+        # Some systems contain a compressed kernel module object file.
+        # The test would have been skipped otherwise.
+        echo "$MODULE_PATH.zst" > "$MODULE_PATH_FILE"
+    fi
+
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_generic_consumer kernel-module-control
@@ -66,14 +75,18 @@ restore: |
     if lsmod | MATCH "$MODULE" && [ ! -f module_present ]; then
         rmmod "$MODULE"
     elif [ -f module_present ] && ! lsmod | MATCH "$MODULE" ; then
+        MODULE_PATH="$(cat "$MODULE_PATH_FILE")"
         insmod "$MODULE_PATH"
     fi
+
+    rm -f "$MODULE_PATH_FILE"
 
 debug: |
     lsmod
     ls -R /lib/modules/"$(uname -r)"/kernel/fs
 
 execute: |
+    MODULE_PATH="$(cat "$MODULE_PATH_FILE")"
     echo "The plug is disconnected by default"
     snap interfaces -i kernel-module-control | MATCH '^- +test-snapd-kernel-module-consumer:kernel-module-control'
 

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -22,12 +22,14 @@ systems:
 
 environment:
     MODULE: minix
-    MODULE_PATH: /lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko
+    # core24 and core26 contain compressed kernel module file
+    MODULE_PATH: $(if [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko" ]; then echo "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"; else echo "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko.zst" ; fi)
 
 skip:
     - reason: minix module not available in the system
       if: |
-        ! [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko" ]
+        ! [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko" ] &&
+        ! [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko.zst" ]
 
 prepare: |
     set -- --edge

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -22,8 +22,8 @@ systems:
 
 environment:
     MODULE: minix
-    # core24 and core26 contain compressed kernel module file
-    MODULE_PATH: $(if [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko" ]; then echo "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"; else echo "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko.zst" ; fi)
+    # some systems contain a compressed kernel module object file
+    MODULE_PATH: $(path="/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"; if [ -f "$path" ]; then echo "$path"; else echo "$path.zst" ; fi)
 
 skip:
     - reason: minix module not available in the system

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -23,12 +23,12 @@ systems:
 environment:
     MODULE: minix
     MODULE_PATH_FILE: "/home/test/module_path"
+    MODULE_BASE_PATH: "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"
 
 skip:
     - reason: minix module not available in the system
       if: |
-        ! [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko" ] &&
-        ! [ -f "/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko.zst" ]
+        ! [ -f "$MODULE_BASE_PATH" ] && ! [ -f "$MODULE_BASE_PATH.zst" ]
 
 prepare: |
     set -- --edge
@@ -52,13 +52,12 @@ prepare: |
     echo "Given a snap declaring a plug on the kernel-module-control interface is installed"
     snap install "$@" test-snapd-kernel-module-consumer
 
-    MODULE_PATH="/lib/modules/$(uname -r)/kernel/fs/$MODULE/$MODULE.ko"
-    if [ -f "$MODULE_PATH" ]; then
-        echo "$MODULE_PATH" > "$MODULE_PATH_FILE"
+    if [ -f "$MODULE_BASE_PATH" ]; then
+        echo "$MODULE_BASE_PATH" > "$MODULE_PATH_FILE"
     else
         # Some systems contain a compressed kernel module object file.
         # The test would have been skipped otherwise.
-        echo "$MODULE_PATH.zst" > "$MODULE_PATH_FILE"
+        echo "$MODULE_BASE_PATH.zst" > "$MODULE_PATH_FILE"
     fi
 
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
Enables the interfaces-kernel-module-control spread test for core24 and 26 and other systems with compressed kernel module object files. These systems are currently skipped since they contain only the compressed minix kernel module object file and not the uncompressed file. Using the snap from https://github.com/canonical/snapd/pull/17122 that can handle compressed object files, the test can be enabled.

Tracked with: [SNAPDENG-36766](https://warthogs.atlassian.net/browse/SNAPDENG-36766?atlOrigin=eyJpIjoiZWQ4NWQ5ZWUyNzhjNGQ0Y2I5YTUxMjFjMWU2YmQwNWEiLCJwIjoiaiJ9)

[SNAPDENG-36766]: https://warthogs.atlassian.net/browse/SNAPDENG-36766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ