### PR TITLE
tests: new auto trigger workflow

### DIFF
--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -46,17 +46,17 @@ pr_is_rerun_eligible() {
         return 1
     fi
 
-    if [[ "$require_auto_rerun_label" == "true" ]] && ! pr_has_label "$pr_json" "$AUTO_RERUN_LABEL"; then
+    if [ "$require_auto_rerun_label" = "true" ] && ! pr_has_label "$pr_json" "$AUTO_RERUN_LABEL"; then
         NOT_RERUN_REASON="PR is missing the $AUTO_RERUN_LABEL label"
         return 1
     fi
 
-    if [[ "$(pr_review_count "$pr_json" "CHANGES_REQUESTED")" -gt 0 ]]; then
+    if [ "$(pr_review_count "$pr_json" "CHANGES_REQUESTED")" -gt 0 ]; then
         NOT_RERUN_REASON="PR has requested changes"
         return 1
     fi
 
-    if [[ "$(pr_review_count "$pr_json" "APPROVED")" -lt "$min_approvals" ]]; then
+    if [ "$(pr_review_count "$pr_json" "APPROVED")" -lt "$min_approvals" ]; then
         NOT_RERUN_REASON="PR has fewer than $min_approvals approvals"
         return 1
     fi
@@ -73,12 +73,12 @@ run_is_completed() {
     run_status=$(jq -r '.status // empty' <<<"$run_json")
     run_conclusion=$(jq -r '.conclusion // empty' <<<"$run_json")
 
-    if [[ "$run_status" != "completed" ]]; then
+    if [ "$run_status" != "completed" ]; then
         NOT_RERUN_REASON="latest run_id=$run_id status=$run_status"
         return 1
     fi
 
-    if [[ "$run_conclusion" == "success" ]]; then
+    if [ "$run_conclusion" = "success" ]; then
         NOT_RERUN_REASON="latest run_id=$run_id completed successfully"
         return 1
     fi
@@ -108,7 +108,7 @@ required_spread_failure_threshold_allows_rerun() {
         return 1
     fi
 
-    if [[ -z "$required_spread_checks" ]]; then
+    if [ -z "$required_spread_checks" ]; then
         echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
         return 0
     fi
@@ -122,7 +122,7 @@ required_spread_failure_threshold_allows_rerun() {
     for failed in $failed_required_system_targets; do
         num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
 
-        if [[ -n "$num_failed" && "$num_failed" -ge "$max_failed_tasks" ]]; then
+        if [ -n "$num_failed" ] && [ "$num_failed" -ge "$max_failed_tasks" ]; then
             NOT_RERUN_REASON="there were $max_failed_tasks or more failures on a required system target"
             return 1
         fi

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+AUTO_RERUN_LABEL="Auto rerun spread"
+SKIP_SPREAD_LABEL="Skip spread"
+RUN_ONLY_ONE_SYSTEM_LABEL="Run only one system"
+export RERUN_REASON=""
+
+pr_has_label() {
+    local pr_json="$1"
+    local label="$2"
+
+    jq -e --arg label "$label" '[.labels[]?.name] | index($label) != null' <<<"$pr_json" >/dev/null
+}
+
+pr_review_count() {
+    local pr_json="$1"
+    local review_state="$2"
+
+    jq -r --arg review_state "$review_state" '[.reviews[]? | select(.state == $review_state) | .author.login] | unique | length' <<<"$pr_json"
+}
+
+ensure_auto_rerun_label() {
+    local pr_number="$1"
+    local pr_json="$2"
+
+    if pr_has_label "$pr_json" "$AUTO_RERUN_LABEL"; then
+        return 0
+    fi
+
+    echo "Adding $AUTO_RERUN_LABEL label to PR #$pr_number"
+    gh pr edit "$pr_number" --add-label "$AUTO_RERUN_LABEL"
+}
+
+pr_is_rerun_eligible() {
+    local pr_json="$1"
+    local min_approvals="$2"
+    local require_auto_rerun_label="$3"
+
+    if [[ "$(jq -r '.isDraft' <<<"$pr_json")" == "true" ]]; then
+        RERUN_REASON="PR is a draft"
+        return 1
+    fi
+
+    if pr_has_label "$pr_json" "$SKIP_SPREAD_LABEL" || pr_has_label "$pr_json" "$RUN_ONLY_ONE_SYSTEM_LABEL"; then
+        RERUN_REASON="PR has blocking labels ($SKIP_SPREAD_LABEL or $RUN_ONLY_ONE_SYSTEM_LABEL)"
+        return 1
+    fi
+
+    if [[ "$require_auto_rerun_label" == "true" ]] && ! pr_has_label "$pr_json" "$AUTO_RERUN_LABEL"; then
+        RERUN_REASON="PR is missing the $AUTO_RERUN_LABEL label"
+        return 1
+    fi
+
+    if [[ "$(pr_review_count "$pr_json" "CHANGES_REQUESTED")" -gt 0 ]]; then
+        RERUN_REASON="PR has requested changes"
+        return 1
+    fi
+
+    if [[ "$(pr_review_count "$pr_json" "APPROVED")" -lt "$min_approvals" ]]; then
+        RERUN_REASON="PR has fewer than $min_approvals approvals"
+        return 1
+    fi
+
+    return 0
+}
+
+run_is_completed() {
+    local run_json="$1"
+    local run_id="$2"
+    local run_status
+
+    run_status=$(jq -r '.status // empty' <<<"$run_json")
+
+    if [[ "$run_status" != "completed" ]]; then
+        RERUN_REASON="latest run_id=$run_id status=$run_status"
+        return 1
+    fi
+
+    return 0
+}
+
+required_spread_failure_threshold_allows_rerun() {
+    local run_id="$1"
+    local pr_base="$2"
+    local repo="$3"
+    local max_failed_tasks="$4"
+    local required_spread_checks
+    local failed_required_system_targets=""
+    local num_failed
+
+    required_spread_checks=$(gh api \
+        -X GET \
+        -H "Accept: application/vnd.github+json" \
+        "repos/$repo/rules/branches/$pr_base" \
+        --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+
+    if [[ -z "$required_spread_checks" ]]; then
+        echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
+        return 0
+    fi
+
+    while IFS=$'\t' read -r failed_id failed_name; do
+        if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
+            failed_required_system_targets+="$failed_id "$'\n'
+        fi
+    done < <(gh run view "$run_id" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+
+    for failed in $failed_required_system_targets; do
+        num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
+
+        if [[ -n "$num_failed" && "$num_failed" -ge "$max_failed_tasks" ]]; then
+            RERUN_REASON="there were $max_failed_tasks or more failures on a required system target"
+            return 1
+        fi
+    done
+
+    return 0
+}

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -3,7 +3,7 @@
 AUTO_RERUN_LABEL="Auto rerun spread"
 SKIP_SPREAD_LABEL="Skip spread"
 RUN_ONLY_ONE_SYSTEM_LABEL="Run only one system"
-export RERUN_REASON=""
+export NOT_RERUN_REASON=""
 
 pr_has_label() {
     local pr_json="$1"
@@ -36,28 +36,28 @@ pr_is_rerun_eligible() {
     local min_approvals="$2"
     local require_auto_rerun_label="$3"
 
-    if [[ "$(jq -r '.isDraft' <<<"$pr_json")" == "true" ]]; then
-        RERUN_REASON="PR is a draft"
+    if [ "$(jq -r '.isDraft' <<<"$pr_json")" = "true" ]; then
+        NOT_RERUN_REASON="PR is a draft"
         return 1
     fi
 
     if pr_has_label "$pr_json" "$SKIP_SPREAD_LABEL" || pr_has_label "$pr_json" "$RUN_ONLY_ONE_SYSTEM_LABEL"; then
-        RERUN_REASON="PR has blocking labels ($SKIP_SPREAD_LABEL or $RUN_ONLY_ONE_SYSTEM_LABEL)"
+        NOT_RERUN_REASON="PR has blocking labels ($SKIP_SPREAD_LABEL or $RUN_ONLY_ONE_SYSTEM_LABEL)"
         return 1
     fi
 
     if [[ "$require_auto_rerun_label" == "true" ]] && ! pr_has_label "$pr_json" "$AUTO_RERUN_LABEL"; then
-        RERUN_REASON="PR is missing the $AUTO_RERUN_LABEL label"
+        NOT_RERUN_REASON="PR is missing the $AUTO_RERUN_LABEL label"
         return 1
     fi
 
     if [[ "$(pr_review_count "$pr_json" "CHANGES_REQUESTED")" -gt 0 ]]; then
-        RERUN_REASON="PR has requested changes"
+        NOT_RERUN_REASON="PR has requested changes"
         return 1
     fi
 
     if [[ "$(pr_review_count "$pr_json" "APPROVED")" -lt "$min_approvals" ]]; then
-        RERUN_REASON="PR has fewer than $min_approvals approvals"
+        NOT_RERUN_REASON="PR has fewer than $min_approvals approvals"
         return 1
     fi
 
@@ -72,7 +72,7 @@ run_is_completed() {
     run_status=$(jq -r '.status // empty' <<<"$run_json")
 
     if [[ "$run_status" != "completed" && "$run_status" != "failure" ]]; then
-        RERUN_REASON="latest run_id=$run_id status=$run_status"
+        NOT_RERUN_REASON="latest run_id=$run_id status=$run_status"
         return 1
     fi
 
@@ -109,7 +109,7 @@ required_spread_failure_threshold_allows_rerun() {
         num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
 
         if [[ -n "$num_failed" && "$num_failed" -ge "$max_failed_tasks" ]]; then
-            RERUN_REASON="there were $max_failed_tasks or more failures on a required system target"
+            NOT_RERUN_REASON="there were $max_failed_tasks or more failures on a required system target"
             return 1
         fi
     done

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -71,7 +71,7 @@ run_is_completed() {
 
     run_status=$(jq -r '.status // empty' <<<"$run_json")
 
-    if [[ "$run_status" != "completed" ]]; then
+    if [[ "$run_status" != "completed" && "$run_status" != "failure" ]]; then
         RERUN_REASON="latest run_id=$run_id status=$run_status"
         return 1
     fi

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -68,11 +68,18 @@ run_is_completed() {
     local run_json="$1"
     local run_id="$2"
     local run_status
+    local run_conclusion
 
     run_status=$(jq -r '.status // empty' <<<"$run_json")
+    run_conclusion=$(jq -r '.conclusion // empty' <<<"$run_json")
 
-    if [[ "$run_status" != "completed" && "$run_status" != "failure" ]]; then
+    if [[ "$run_status" != "completed" ]]; then
         NOT_RERUN_REASON="latest run_id=$run_id status=$run_status"
+        return 1
+    fi
+
+    if [[ "$run_conclusion" == "success" ]]; then
+        NOT_RERUN_REASON="latest run_id=$run_id completed successfully"
         return 1
     fi
 
@@ -84,15 +91,22 @@ required_spread_failure_threshold_allows_rerun() {
     local pr_base="$2"
     local repo="$3"
     local max_failed_tasks="$4"
+    local encoded_base
     local required_spread_checks
     local failed_required_system_targets=""
     local num_failed
 
-    required_spread_checks=$(gh api \
+    # Encode the branch name for use in the API URL
+    encoded_base=$(jq -Rr @uri <<< "$pr_base")
+
+    if ! required_spread_checks=$(gh api \
         -X GET \
         -H "Accept: application/vnd.github+json" \
-        "repos/$repo/rules/branches/$pr_base" \
-        --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+        "repos/$repo/rules/branches/$encoded_base" \
+        --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]'); then
+        NOT_RERUN_REASON="could not fetch branch protection rules for $pr_base"
+        return 1
+    fi
 
     if [[ -z "$required_spread_checks" ]]; then
         echo "No required checks detected for branch $pr_base; skipping required spread target filtering"

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -16,7 +16,7 @@ pr_review_count() {
     local pr_json="$1"
     local review_state="$2"
 
-    jq -r --arg review_state "$review_state" '[.reviews[]? | select(.state == $review_state) | .author.login] | unique | length' <<<"$pr_json"
+    jq -r --arg review_state "$review_state" '[.latestReviews[]? | select(.state == $review_state) | .author.login] | unique | length' <<<"$pr_json"
 }
 
 ensure_auto_rerun_label() {

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -82,6 +82,13 @@ jobs:
               continue
             fi
 
+            run_jobs=$(gh run view "$last_run_id" --json jobs --jq '.jobs')
+            spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
+            if [[ "$spread_jobs_ran" -lt 1 ]]; then
+              echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run_id"
+              continue
+            fi
+
             # Check if any required spread system targets failed, and if so, inspect the logs to see if we should block the rerun based on failure count.
             auto_rerun=true
             pr_base=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
@@ -99,7 +106,7 @@ jobs:
                 if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
                   failed_required_system_targets+="$failed_id "$'\n'
                 fi
-              done < <(gh run view "$last_run_id" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+              done < <(echo "$run_jobs" | jq -r '.[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
 
               for failed in $failed_required_system_targets; do
                 # Grab the first spread "Failed tasks" count from logs and block rerun if too high.

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -36,7 +36,7 @@ jobs:
             head_sha=$(echo "$pr" | jq -r '.headRefOid')
 
             if ! pr_is_rerun_eligible "$pr" 2 false; then
-              echo "Skipping PR #$pr_number: $RERUN_REASON"
+              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
               continue
             fi
 
@@ -47,48 +47,48 @@ jobs:
               continue
             fi
 
-            last_run=$(gh run list \
+            last_run_json=$(gh run list \
               --workflow .github/workflows/ci-test.yaml \
-              --branch "$head_sha" \
-              --limit 1 \
-              --json databaseId -q '.[0].databaseId // empty')
+              --limit 100 \
+              --json databaseId,attempt,status,headSha \
+              | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
 
-            if [[ -z "$last_run" || "$last_run" == "null" ]]; then
+            if [[ -z "$last_run_json" || "$last_run_json" == "null" ]]; then
               echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
               continue
             fi
 
-            last_run_id=$(echo "$last_run" | jq -r '.id // empty')
-            run_attempt=$(echo "$last_run" | jq -r '.run_attempt // 0')
+            last_run=$(echo "$last_run_json" | jq -r '.databaseId // empty')
+            run_attempt=$(echo "$last_run_json" | jq -r '.attempt // 0')
 
-            if [[ -z "$last_run_id" ]]; then
+            if [[ -z "$last_run" ]]; then
               echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
               continue
             fi
 
-            if ! run_is_completed "$last_run" "$last_run_id"; then
-              echo "Skipping PR #$pr_number: $RERUN_REASON"
+            if ! run_is_completed "$last_run_json" "$last_run"; then
+              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
               continue
             fi
 
             if [[ "$run_attempt" -ge "$MAX_RUN_ATTEMPTS" ]]; then
-              echo "Skipping PR #$pr_number: run_id=$last_run_id already at attempt $run_attempt"
+              echo "Skipping PR #$pr_number: run_id=$last_run already at attempt $run_attempt"
               continue
             fi
 
-            run_jobs=$(gh run view "$last_run_id" --json jobs --jq '.jobs')
+            run_jobs=$(gh run view "$last_run" --json jobs --jq '.jobs')
             spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
             if [[ "$spread_jobs_ran" -lt 1 ]]; then
-              echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run_id"
+              echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run"
               continue
             fi
 
             pr_base=$(echo "$pr" | jq -r '.baseRefName // empty')
-            if ! required_spread_failure_threshold_allows_rerun "$last_run_id" "$pr_base" "$GH_REPO" "$MAX_FAILED_TASKS"; then
-              echo "Skipping PR #$pr_number: $RERUN_REASON"
+            if ! required_spread_failure_threshold_allows_rerun "$last_run" "$pr_base" "$GH_REPO" "$MAX_FAILED_TASKS"; then
+              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
               continue
             fi
 
-            echo "Triggering rerun workflow for PR #$pr_number using run_id=$last_run_id (attempt $run_attempt)"
-            gh workflow run rerun.yaml -f run_id="$last_run_id"
+            echo "Triggering rerun workflow for PR #$pr_number using run_id=$last_run (attempt $run_attempt)"
+            gh workflow run rerun.yaml -f run_id="$last_run"
           done

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -50,7 +50,7 @@ jobs:
             last_run_json=$(gh run list \
               --workflow .github/workflows/ci-test.yaml \
               --limit 100 \
-              --json databaseId,attempt,status,headSha \
+              --json databaseId,attempt,status,conclusion,headSha \
               | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
 
             if [[ -z "$last_run_json" || "$last_run_json" == "null" ]]; then

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -19,32 +19,28 @@ jobs:
       MAX_RUN_ATTEMPTS: 5
       MAX_FAILED_TASKS: 30
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Scan open PRs and trigger reruns
         run: |
           set -euo pipefail
 
-          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews --jq '[.[]
-            | .approvals = ([.reviews[]? | select(.state == "APPROVED") | .author.login] | unique | length)
-            | .requested_changes = ([.reviews[]? | select(.state == "CHANGES_REQUESTED") | .author.login] | unique | length)
-            | select(.isDraft == false and .approvals >= 2 and .requested_changes == 0)
-          ]')
-          echo "Inspecting $(echo "$prs" | jq 'length') eligible PRs for rerun..."
+          source .github/scripts/rerun-common.sh
+
+          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews,baseRefName)
+          echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             pr_number=$(echo "$pr" | jq -r '.number')
-            is_draft=$(echo "$pr" | jq -r '.isDraft')
             head_sha=$(echo "$pr" | jq -r '.headRefOid')
-            has_label=$(echo "$pr" | jq -r '[.labels[].name] | index("Auto rerun spread") != null')
 
-            if [[ "$is_draft" == "true" ]]; then
-              echo "Skipping draft PR #$pr_number"
+            if ! pr_is_rerun_eligible "$pr" 2 false; then
+              echo "Skipping PR #$pr_number: $RERUN_REASON"
               continue
             fi
 
-            if [[ "$has_label" != "true" ]]; then
-              echo "Adding Auto rerun spread label to PR #$pr_number"
-              gh pr edit "$pr_number" --add-label 'Auto rerun spread'
-            fi
+            ensure_auto_rerun_label "$pr_number" "$pr"
 
             if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
               echo "Skipping PR #$pr_number: missing head SHA"
@@ -65,15 +61,14 @@ jobs:
 
             last_run_id=$(echo "$last_run" | jq -r '.id // empty')
             run_attempt=$(echo "$last_run" | jq -r '.run_attempt // 0')
-            run_status=$(echo "$last_run" | jq -r '.status // empty')
 
             if [[ -z "$last_run_id" ]]; then
               echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
               continue
             fi
 
-            if [[ "$run_status" != "completed" ]]; then
-              echo "Skipping PR #$pr_number: latest run_id=$last_run_id is still $run_status"
+            if ! run_is_completed "$last_run" "$last_run_id"; then
+              echo "Skipping PR #$pr_number: $RERUN_REASON"
               continue
             fi
 
@@ -89,38 +84,9 @@ jobs:
               continue
             fi
 
-            # Check if any required spread system targets failed, and if so, inspect the logs to see if we should block the rerun based on failure count.
-            auto_rerun=true
-            pr_base=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
-            required_spread_checks=$(gh api \
-              -X GET \
-              -H "Accept: application/vnd.github+json" \
-              "repos/$GH_REPO/rules/branches/$pr_base" \
-              --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
-
-            if [[ -z "$required_spread_checks" ]]; then
-              echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
-            else
-              failed_required_system_targets=""
-              while IFS=$'\t' read -r failed_id failed_name; do
-                if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
-                  failed_required_system_targets+="$failed_id "$'\n'
-                fi
-              done < <(echo "$run_jobs" | jq -r '.[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
-
-              for failed in $failed_required_system_targets; do
-                # Grab the first spread "Failed tasks" count from logs and block rerun if too high.
-                num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
-
-                if [[ -n "$num_failed" && "$num_failed" -ge "$MAX_FAILED_TASKS" ]]; then
-                  echo "Skipping PR #$pr_number: there were $MAX_FAILED_TASKS or more failures on a required system target"
-                  auto_rerun=false
-                  break
-                fi
-              done
-            fi
-
-            if [[ "$auto_rerun" != "true" ]]; then
+            pr_base=$(echo "$pr" | jq -r '.baseRefName // empty')
+            if ! required_spread_failure_threshold_allows_rerun "$last_run_id" "$pr_base" "$GH_REPO" "$MAX_FAILED_TASKS"; then
+              echo "Skipping PR #$pr_number: $RERUN_REASON"
               continue
             fi
 

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -3,7 +3,7 @@ name: Auto Rerun Approved PRs
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '*/20 * * * *'
 
 permissions:
   contents: read
@@ -16,6 +16,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      MAX_RUN_ATTEMPTS: 5
+      MAX_FAILED_TASKS: 30
     steps:
       - name: Scan open PRs and trigger reruns
         run: |
@@ -26,6 +28,7 @@ jobs:
             | .requested_changes = ([.reviews[]? | select(.state == "CHANGES_REQUESTED") | .author.login] | unique | length)
             | select(.isDraft == false and .approvals >= 2 and .requested_changes == 0)
           ]')
+          echo "Inspecting $(echo "$prs" | jq 'length') eligible PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             pr_number=$(echo "$pr" | jq -r '.number')
@@ -74,8 +77,43 @@ jobs:
               continue
             fi
 
-            if [[ "$run_attempt" -ge 5 ]]; then
+            if [[ "$run_attempt" -ge "$MAX_RUN_ATTEMPTS" ]]; then
               echo "Skipping PR #$pr_number: run_id=$last_run_id already at attempt $run_attempt"
+              continue
+            fi
+
+            # Check if any required spread system targets failed, and if so, inspect the logs to see if we should block the rerun based on failure count.
+            auto_rerun=true
+            pr_base=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
+            required_spread_checks=$(gh api \
+              -X GET \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$GH_REPO/rules/branches/$pr_base" \
+              --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+
+            if [[ -z "$required_spread_checks" ]]; then
+              echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
+            else
+              failed_required_system_targets=""
+              while IFS=$'\t' read -r failed_id failed_name; do
+                if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
+                  failed_required_system_targets+="$failed_id "$'\n'
+                fi
+              done < <(gh run view "$last_run_id" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+
+              for failed in $failed_required_system_targets; do
+                # Grab the first spread "Failed tasks" count from logs and block rerun if too high.
+                num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
+
+                if [[ -n "$num_failed" && "$num_failed" -ge "$MAX_FAILED_TASKS" ]]; then
+                  echo "Skipping PR #$pr_number: there were $MAX_FAILED_TASKS or more failures on a required system target"
+                  auto_rerun=false
+                  break
+                fi
+              done
+            fi
+
+            if [[ "$auto_rerun" != "true" ]]; then
               continue
             fi
 

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -28,7 +28,7 @@ jobs:
 
           source .github/scripts/rerun-common.sh
 
-          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews,baseRefName)
+          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName)
           echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
@@ -47,12 +47,11 @@ jobs:
               continue
             fi
 
-            last_run=$(gh api \
-              "repos/$GH_REPO/actions/runs" \
-              -f event='pull_request' \
-              -f head_sha="$head_sha" \
-              -f per_page='1' \
-              --jq '.workflow_runs[0] // empty')
+            last_run=$(gh run list \
+              --workflow .github/workflows/ci-test.yaml \
+              --branch "$head_sha" \
+              --limit 1 \
+              --json databaseId -q '.[0].databaseId // empty')
 
             if [[ -z "$last_run" || "$last_run" == "null" ]]; then
               echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -1,0 +1,84 @@
+name: Auto Rerun Approved PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/30 * * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+
+jobs:
+  scan-open-prs:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Scan open PRs and trigger reruns
+        run: |
+          set -euo pipefail
+
+          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews --jq '[.[]
+            | .approvals = ([.reviews[]? | select(.state == "APPROVED") | .author.login] | unique | length)
+            | .requested_changes = ([.reviews[]? | select(.state == "CHANGES_REQUESTED") | .author.login] | unique | length)
+            | select(.isDraft == false and .approvals >= 2 and .requested_changes == 0)
+          ]')
+
+          echo "$prs" | jq -c '.[]' | while read -r pr; do
+            pr_number=$(echo "$pr" | jq -r '.number')
+            is_draft=$(echo "$pr" | jq -r '.isDraft')
+            head_sha=$(echo "$pr" | jq -r '.headRefOid')
+            has_label=$(echo "$pr" | jq -r '[.labels[].name] | index("Auto rerun spread") != null')
+
+            if [[ "$is_draft" == "true" ]]; then
+              echo "Skipping draft PR #$pr_number"
+              continue
+            fi
+
+            if [[ "$has_label" != "true" ]]; then
+              echo "Adding Auto rerun spread label to PR #$pr_number"
+              gh pr edit "$pr_number" --add-label 'Auto rerun spread'
+            fi
+
+            if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
+              echo "Skipping PR #$pr_number: missing head SHA"
+              continue
+            fi
+
+            last_run=$(gh api \
+              "repos/$GH_REPO/actions/runs" \
+              -f event='pull_request' \
+              -f head_sha="$head_sha" \
+              -f per_page='1' \
+              --jq '.workflow_runs[0] // empty')
+
+            if [[ -z "$last_run" || "$last_run" == "null" ]]; then
+              echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
+              continue
+            fi
+
+            last_run_id=$(echo "$last_run" | jq -r '.id // empty')
+            run_attempt=$(echo "$last_run" | jq -r '.run_attempt // 0')
+            run_status=$(echo "$last_run" | jq -r '.status // empty')
+
+            if [[ -z "$last_run_id" ]]; then
+              echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
+              continue
+            fi
+
+            if [[ "$run_status" != "completed" ]]; then
+              echo "Skipping PR #$pr_number: latest run_id=$last_run_id is still $run_status"
+              continue
+            fi
+
+            if [[ "$run_attempt" -ge 5 ]]; then
+              echo "Skipping PR #$pr_number: run_id=$last_run_id already at attempt $run_attempt"
+              continue
+            fi
+
+            echo "Triggering rerun workflow for PR #$pr_number using run_id=$last_run_id (attempt $run_attempt)"
+            gh workflow run rerun.yaml -f run_id="$last_run_id"
+          done

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -81,7 +81,7 @@ jobs:
           pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,latestReviews,baseRefName)
 
           if ! pr_is_rerun_eligible "$pr_json" 1 true; then
-            echo "setting auto rerun to false because $RERUN_REASON"
+            echo "setting auto rerun to false because $NOT_RERUN_REASON"
             echo "auto_rerun=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -102,11 +102,11 @@ jobs:
         run: |
           source .github/scripts/rerun-common.sh
 
-          echo "threshold_ok=true" >> "$GITHUB_OUTPUT"
-
           if ! required_spread_failure_threshold_allows_rerun "$RUN_ID" "$PR_BASE" "$GH_REPO" "$MAX_FAILED_TASKS"; then
-            echo "Setting rerun to false because $RERUN_REASON"
+            echo "Setting rerun to false because $NOT_RERUN_REASON"
             echo "threshold_ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "threshold_ok=true" >> "$GITHUB_OUTPUT"
           fi
       
       - name: Rerun workflow

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -32,6 +32,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
+      MAX_FAILED_TASKS: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -72,71 +73,42 @@ jobs:
         run: unzip pr_number.zip
 
       - name: Check for rerun eligibility
+        id: eligibility
         run: |
-          pr=$(cat pr_number)
-          if [ "$(gh pr view "$pr" --json isDraft --jq '.isDraft')" = "true" ]; then
-            echo "setting auto rerun to false because the PR is a draft"
-            echo "AUTO_RERUN=false" >> $GITHUB_ENV
+          source .github/scripts/rerun-common.sh
+
+          pr_number=$(cat pr_number)
+          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,reviews,baseRefName)
+
+          if ! pr_is_rerun_eligible "$pr_json" 1 true; then
+            echo "setting auto rerun to false because $RERUN_REASON"
+            echo "auto_rerun=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          labels=$(gh pr view "$pr" --json labels --jq '.labels[].name')
-          has_label=false
-          if grep -q '^Auto rerun spread$' <<<$labels; then
-            has_label=true
-          fi
-
-          num_approvals=$(gh pr view "$pr" --json reviews --jq '.reviews[] | select(.state == "APPROVED") | .author.login' | sort -u | wc -l)
-          if [ "$has_label" = "true" ] && [ "$num_approvals" -ge 1 ]; then
-            echo "AUTO_RERUN=true" >> $GITHUB_ENV
-          else
-            echo "setting auto rerun to false because it is missing the label or has insufficient approvals"
-            echo "AUTO_RERUN=false" >> $GITHUB_ENV
-          fi
+          echo "auto_rerun=true" >> "$GITHUB_OUTPUT"
+          echo "PR_NUMBER=$pr_number" >> "$GITHUB_ENV"
+          echo "PR_BASE=$(echo "$pr_json" | jq -r '.baseRefName // empty')" >> "$GITHUB_ENV"
       
       - name: Set run ID
-        if: env.AUTO_RERUN == 'true'
+        if: steps.eligibility.outputs.auto_rerun == 'true'
         run: |
           run_id=$(awk -F'/' '{print $(NF-1)}' <<<"${{ github.event.workflow_run.rerun_url }}")
           echo "RUN_ID=$run_id" >> $GITHUB_ENV
 
       - name: Check number of required system failures
-        if: env.AUTO_RERUN == 'true'
+        id: threshold
+        if: steps.eligibility.outputs.auto_rerun == 'true'
         run: |
-          pr_base=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
-          required_spread_checks=$(gh api \
-            -X GET \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/rules/branches/$pr_base" \
-            --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+          source .github/scripts/rerun-common.sh
 
-          if [ -z "$required_spread_checks" ]; then
-            echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
-            exit 0
+          echo "threshold_ok=true" >> "$GITHUB_OUTPUT"
+
+          if ! required_spread_failure_threshold_allows_rerun "$RUN_ID" "$PR_BASE" "$GH_REPO" "$MAX_FAILED_TASKS"; then
+            echo "Setting rerun to false because $RERUN_REASON"
+            echo "threshold_ok=false" >> "$GITHUB_OUTPUT"
           fi
-
-          failed_required_system_targets=""
-          while IFS=$'\t' read -r failed_id failed_name; do
-            if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
-              failed_required_system_targets+="$failed_id "$'\n'
-            fi
-          done < <(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
-
-          for failed in $failed_required_system_targets; do
-
-            # The number of failed tasks are reported in the logs as a line with 
-            # a date and timestamp, followed by "Failed tasks: " and the number
-            # ex: 2025-07-03 08:31:46 Failed tasks: 2
-            # That line will appear multiple times in the logs since the spread
-            # analyzer will echo out that same line, so grab the first occurrence.
-            num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1)
-            
-            if [ -n "$num_failed" ] && [ $num_failed -ge 30 ]; then
-              echo "Setting rerun to false because there were 30 or more failures on a system target"
-              echo "AUTO_RERUN=false" >> $GITHUB_ENV
-            fi
-          done
       
       - name: Rerun workflow
-        if: env.AUTO_RERUN == 'true'
+        if: steps.eligibility.outputs.auto_rerun == 'true' && steps.threshold.outputs.threshold_ok == 'true'
         run: gh run rerun "$RUN_ID" --failed

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -78,7 +78,7 @@ jobs:
           source .github/scripts/rerun-common.sh
 
           pr_number=$(cat pr_number)
-          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,reviews,baseRefName)
+          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,latestReviews,baseRefName)
 
           if ! pr_is_rerun_eligible "$pr_json" 1 true; then
             echo "setting auto rerun to false because $RERUN_REASON"

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -100,11 +100,29 @@ jobs:
           run_id=$(awk -F'/' '{print $(NF-1)}' <<<"${{ github.event.workflow_run.rerun_url }}")
           echo "RUN_ID=$run_id" >> $GITHUB_ENV
 
-      - name: Check number of fundamental failures
+      - name: Check number of required system failures
         if: env.AUTO_RERUN == 'true'
         run: |
-          failed_fund=$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("\\(fundamental\\)")) | select(.conclusion == "failure") | .databaseId')
-          for failed in $failed_fund; do
+          pr_base=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
+          required_spread_checks=$(gh api \
+            -X GET \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/rules/branches/$pr_base" \
+            --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | map(select(startswith("spread "))) | unique | .[]')
+
+          if [ -z "$required_spread_checks" ]; then
+            echo "No required checks detected for branch $pr_base; skipping required spread target filtering"
+            exit 0
+          fi
+
+          failed_required_system_targets=""
+          while IFS=$'\t' read -r failed_id failed_name; do
+            if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
+              failed_required_system_targets+="$failed_id "$'\n'
+            fi
+          done < <(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+
+          for failed in $failed_required_system_targets; do
 
             # The number of failed tasks are reported in the logs as a line with 
             # a date and timestamp, followed by "Failed tasks: " and the number
@@ -114,7 +132,7 @@ jobs:
             num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1)
             
             if [ -n "$num_failed" ] && [ $num_failed -ge 30 ]; then
-              echo "Setting rerun to false because there were 30 or more failures on a fundamental system"
+              echo "Setting rerun to false because there were 30 or more failures on a system target"
               echo "AUTO_RERUN=false" >> $GITHUB_ENV
             fi
           done

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -13,8 +13,10 @@ on:
 jobs:
   rerun:
     if: github.event_name == 'workflow_dispatch'
-    permissions: 
+    permissions:
       actions: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: rerun ${{ inputs.run_id }}
@@ -29,6 +31,8 @@ jobs:
     if: github.event.workflow_run && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 5
     permissions:
       actions: write
+      contents: read
+      pull-requests: read
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This new workflow is checking on the open prs, in order to trigger tests
once the number of approvals are 2 or higher and the failing tests are
less than 30 in required systems.

