### PR TITLE
many: remove unused AtomicWriteFlags type

### DIFF
--- a/asserts/fsentryutils.go
+++ b/asserts/fsentryutils.go
@@ -55,7 +55,7 @@ func atomicWriteEntry(data []byte, secret bool, top string, subpath ...string) e
 	if secret {
 		fperm = 0600
 	}
-	return osutil.AtomicWriteFile(fpath, data, os.FileMode(fperm), 0)
+	return osutil.AtomicWriteFile(fpath, data, os.FileMode(fperm))
 }
 
 func entryExists(top string, subpath ...string) bool {

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -89,7 +89,7 @@ func (c *trustedAssetsCache) Add(assetPath, blName, assetName string) (*trackedA
 	defer inf.Close()
 	// temporary output
 	tempPath := c.pathInCache(c.tempAssetRelPath(blName, assetName))
-	outf, err := osutil.NewAtomicFile(tempPath, 0644, 0, osutil.NoChown, osutil.NoChown)
+	outf, err := osutil.NewAtomicFile(tempPath, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create temporary cache file: %v", err)
 	}

--- a/boot/bootchain.go
+++ b/boot/bootchain.go
@@ -341,7 +341,7 @@ func WriteBootChains(pbc PredictableBootChains, path string, resealCount int) er
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("cannot create device fde state directory: %v", err)
 	}
-	outf, err := osutil.NewAtomicFile(path, 0600, 0, osutil.NoChown, osutil.NoChown)
+	outf, err := osutil.NewAtomicFile(path, 0600, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create a temporary boot chains file: %v", err)
 	}

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -341,7 +341,7 @@ func (m *Modeenv) WriteTo(rootdir string) error {
 		marshalModeenvEntryTo(buf, k, m.extrakeys[k])
 	}
 
-	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644); err != nil {
 		return err
 	}
 	return nil

--- a/boot/model.go
+++ b/boot/model.go
@@ -153,7 +153,7 @@ var writeModelToUbuntuBoot = writeModelToUbuntuBootImpl
 
 func writeModelToUbuntuBootImpl(model *asserts.Model) error {
 	modelPath := filepath.Join(InitramfsUbuntuBootDir, "device/model")
-	f, err := osutil.NewAtomicFile(modelPath, 0644, 0, osutil.NoChown, osutil.NoChown)
+	f, err := osutil.NewAtomicFile(modelPath, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}

--- a/boot/reboot.go
+++ b/boot/reboot.go
@@ -111,7 +111,7 @@ func Reboot(action RebootAction, rebootDelay time.Duration, rebootInfo *RebootIn
 	}
 	if rebArgs != "" {
 		if err := osutil.AtomicWriteFile(rebootArgsPath,
-			[]byte(rebArgs+"\n"), 0644, 0); err != nil {
+			[]byte(rebArgs+"\n"), 0644); err != nil {
 			return err
 		}
 	}

--- a/bootloader/androidbootenv/androidbootenv.go
+++ b/bootloader/androidbootenv/androidbootenv.go
@@ -86,5 +86,5 @@ func (a *Env) Save() error {
 		}
 	}
 
-	return osutil.AtomicWriteFile(a.path, w.Bytes(), 0644, 0)
+	return osutil.AtomicWriteFile(a.path, w.Bytes(), 0644)
 }

--- a/bootloader/assets/genasset/main.go
+++ b/bootloader/assets/genasset/main.go
@@ -105,7 +105,7 @@ func run(assetName, inputFile, outputFile string) error {
 		return fmt.Errorf("cannot copy input data: %v", err)
 	}
 
-	outf, err := osutil.NewAtomicFile(outputFile, 0644, 0, osutil.NoChown, osutil.NoChown)
+	outf, err := osutil.NewAtomicFile(outputFile, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot open output file: %v", err)
 	}

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -307,7 +307,7 @@ func genericSetBootConfigFromAsset(systemFile, assetName string) error {
 	if err := os.MkdirAll(filepath.Dir(systemFile), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(systemFile, bootConfig, 0644, 0)
+	return osutil.AtomicWriteFile(systemFile, bootConfig, 0644)
 }
 
 func genericUpdateBootConfigFromAssets(systemFile string, assetName string) (updated bool, err error) {
@@ -331,7 +331,7 @@ func genericUpdateBootConfigFromAssets(systemFile string, assetName string) (upd
 		// to one currently installed
 		return false, nil
 	}
-	if err := osutil.AtomicWriteFile(systemFile, bc.Raw(), 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(systemFile, bc.Raw(), 0644); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/bootloader/piboot.go
+++ b/bootloader/piboot.go
@@ -275,7 +275,7 @@ func (p *piboot) writeRPiCfgWithOsPrefix(prefix, inFile, outFile string) error {
 	}
 
 	output := strings.Join(lines, "\n")
-	return osutil.AtomicWriteFile(outFile, []byte(output), 0644, 0)
+	return osutil.AtomicWriteFile(outFile, []byte(output), 0644)
 }
 
 func (p *piboot) writeCmdline(env *ubootenv.Env, defaultsFile, outFile string) error {
@@ -301,7 +301,7 @@ func (p *piboot) writeCmdline(env *ubootenv.Env, defaultsFile, outFile string) e
 
 	logger.Debugf("writing kernel command line to %s", outFile)
 
-	return osutil.AtomicWriteFile(outFile, []byte(cmdline), 0644, 0)
+	return osutil.AtomicWriteFile(outFile, []byte(cmdline), 0644)
 }
 
 // Configure pi bootloader with a given os_prefix. cfgDir contains the

--- a/client/login.go
+++ b/client/login.go
@@ -140,7 +140,7 @@ func writeAuthData(user User) error {
 			return err
 		}
 
-		return osutil.AtomicWriteFile(targetFile, out, 0600, 0)
+		return osutil.AtomicWriteFile(targetFile, out, 0600)
 	})
 }
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -261,7 +261,7 @@ volumes:
 	gadgetDir := filepath.Join(boot.InitramfsRunMntDir, "gadget", "meta")
 	err = os.MkdirAll(gadgetDir, 0755)
 	c.Assert(err, IsNil)
-	err = osutil.AtomicWriteFile(filepath.Join(gadgetDir, "gadget.yaml"), []byte(gadgetYaml), 0644, 0)
+	err = osutil.AtomicWriteFile(filepath.Join(gadgetDir, "gadget.yaml"), []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/cmd/snap-repair/cmd_run_test.go
+++ b/cmd/snap-repair/cmd_run_test.go
@@ -63,7 +63,7 @@ func (r *repairSuite) TestOffline(c *C) {
 	err = os.MkdirAll(filepath.Dir(dirs.SnapRepairConfigFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, data, 0644, 0)
+	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, data, 0644)
 	c.Assert(err, IsNil)
 
 	origArgs := os.Args

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -118,7 +118,7 @@ func (r *Repair) Run() error {
 
 	baseName := fmt.Sprintf("r%d", r.Revision())
 	script := filepath.Join(rundir, baseName+".script")
-	err = osutil.AtomicWriteFile(script, r.Body(), 0700, 0)
+	err = osutil.AtomicWriteFile(script, r.Body(), 0700)
 	if err != nil {
 		return err
 	}
@@ -848,7 +848,7 @@ func (run *Runner) SaveState() error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal repair state: %v", err)
 	}
-	err = osutil.AtomicWriteFile(dirs.SnapRepairStateFile, m, 0600, 0)
+	err = osutil.AtomicWriteFile(dirs.SnapRepairStateFile, m, 0600)
 	if err != nil {
 		return fmt.Errorf("cannot save repair state: %v", err)
 	}
@@ -993,7 +993,7 @@ func (run *Runner) saveStream(brandID string, repairID int, repair *asserts.Repa
 		}
 	}
 	p := filepath.Join(d, fmt.Sprintf("r%d.repair", r[0].Revision()))
-	return osutil.AtomicWriteFile(p, buf.Bytes(), 0600, 0)
+	return osutil.AtomicWriteFile(p, buf.Bytes(), 0600)
 }
 
 func (run *Runner) readSavedStream(brandID string, repairID, revision int) (repair *asserts.Repair, aux []asserts.Assertion, err error) {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -2354,7 +2354,7 @@ func (s *runnerSuite) TestStoreOffline(c *C) {
 	err = os.MkdirAll(filepath.Dir(dirs.SnapRepairConfigFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, data, 0644, 0)
+	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, data, 0644)
 	c.Assert(err, IsNil)
 
 	_, _, err = runner.Fetch("canonical", 2, -1)
@@ -2397,7 +2397,7 @@ func (s *runnerSuite) TestStoreOnlineIfFileBroken(c *C) {
 	c.Assert(err, IsNil)
 
 	// file is invalid json
-	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, []byte("}{"), 0644, 0)
+	err = osutil.AtomicWriteFile(dirs.SnapRepairConfigFile, []byte("}{"), 0644)
 	c.Assert(err, IsNil)
 
 	_, _, err = runner.Fetch("canonical", 2, -1)

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -870,7 +870,7 @@ func writeUnrestrictedFilter(outFile string) error {
 		// tell snap-confine
 		Unrestricted: 0x1,
 	}
-	fout, err := osutil.NewAtomicFile(outFile, 0644, 0, osutil.NoChown, osutil.NoChown)
+	fout, err := osutil.NewAtomicFile(outFile, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}
@@ -883,7 +883,7 @@ func writeUnrestrictedFilter(outFile string) error {
 }
 
 func writeSeccompFilter(outFile string, filterAllow, filterDeny *seccomp.ScmpFilter) error {
-	fout, err := osutil.NewAtomicFile(outFile, 0644, 0, osutil.NoChown, osutil.NoChown)
+	fout, err := osutil.NewAtomicFile(outFile, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_warnings.go
+++ b/cmd/snap/cmd_warnings.go
@@ -173,7 +173,7 @@ func writeWarningTimestamp(t time.Time) error {
 		return err
 	}
 
-	aw, err := osutil.NewAtomicFile(filename, 0600, 0, uid, gid)
+	aw, err := osutil.NewAtomicFile(filename, 0600, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_whoami_test.go
+++ b/cmd/snap/cmd_whoami_test.go
@@ -60,7 +60,7 @@ func (s *SnapSuite) TestWhoamiEmptyAuthFile(c *C) {
 	s.Login(c)
 	defer s.Logout(c)
 
-	err := osutil.AtomicWriteFile(s.AuthFile, []byte(``), 0600, 0)
+	err := osutil.AtomicWriteFile(s.AuthFile, []byte(``), 0600)
 	c.Assert(err, IsNil)
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"whoami"})

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -144,7 +144,7 @@ func (s *BaseSnapSuite) RedirectClientToTestServer(handler func(http.ResponseWri
 }
 
 func (s *BaseSnapSuite) Login(c *C) {
-	err := osutil.AtomicWriteFile(s.AuthFile, []byte(TestAuthFileContents), 0600, 0)
+	err := osutil.AtomicWriteFile(s.AuthFile, []byte(TestAuthFileContents), 0600)
 	c.Assert(err, IsNil)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -495,7 +495,7 @@ func (d *Daemon) updateMaintenanceFile(rst restart.RestartType) error {
 		return err
 	}
 
-	return osutil.AtomicWrite(dirs.SnapdMaintenanceFile, bytes.NewBuffer(b), 0644, 0)
+	return osutil.AtomicWrite(dirs.SnapdMaintenanceFile, bytes.NewBuffer(b), 0644)
 }
 
 // Stop shuts down the Daemon

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -59,11 +59,11 @@ func ReadEncryptionMarkers(dataFDEDir, saveFDEDir string) ([]byte, []byte, error
 // WriteEncryptionMarkers writes the encryption marker files at the appropriate
 // locations.
 func WriteEncryptionMarkers(dataFDEDir, saveFDEDir string, markerSecret []byte) error {
-	err := osutil.AtomicWriteFile(encryptionMarkerUnder(dataFDEDir), markerSecret, 0600, 0)
+	err := osutil.AtomicWriteFile(encryptionMarkerUnder(dataFDEDir), markerSecret, 0600)
 	if err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(encryptionMarkerUnder(saveFDEDir), markerSecret, 0600, 0)
+	return osutil.AtomicWriteFile(encryptionMarkerUnder(saveFDEDir), markerSecret, 0600)
 }
 
 // DataSealedKeyUnder returns the path of the sealed key for ubuntu-data.
@@ -126,7 +126,7 @@ func StampSealedKeys(rootdir string, content SealingMethod) error {
 		return fmt.Errorf("cannot create device fde state directory: %v", err)
 	}
 
-	if err := osutil.AtomicWriteFile(stamp, []byte(content), 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(stamp, []byte(content), 0644); err != nil {
 		return fmt.Errorf("cannot create fde sealed keys stamp file: %v", err)
 	}
 	return nil

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -830,7 +830,7 @@ func SaveDiskVolumesDeviceTraits(dir string, mapping map[string]DiskVolumeDevice
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(filename, b, 0644, 0)
+	return osutil.AtomicWriteFile(filename, b, 0644)
 }
 
 // LoadDiskVolumesDeviceTraits loads the mapping of volumes to disk traits if

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -239,7 +239,7 @@ func writeFileOrSymlink(src, dst string, preserveInDst []string) error {
 
 		// do not follow sylimks, dst is a reflection of the src which
 		// is a file
-		if err := osutil.AtomicWriteFileCopy(dst, src, 0); err != nil {
+		if err := osutil.AtomicWriteFileCopy(dst, src); err != nil {
 			return fmt.Errorf("cannot copy %s: %v", src, err)
 		}
 	}
@@ -270,7 +270,7 @@ func newStampFile(stamp string) (*osutil.AtomicFile, error) {
 	if err := os.MkdirAll(filepath.Dir(stamp), 0755); err != nil {
 		return nil, fmt.Errorf("cannot create stamp file prefix: %v", err)
 	}
-	return osutil.NewAtomicFile(stamp, 0644, 0, osutil.NoChown, osutil.NoChown)
+	return osutil.NewAtomicFile(stamp, 0644, osutil.NoChown, osutil.NoChown)
 }
 
 func makeStamp(stamp string) error {

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -158,7 +158,7 @@ func (r *rawStructureUpdater) backupOrCheckpointContent(disk io.ReadSeeker, pc *
 	lr := io.LimitReader(disk, int64(pc.Size))
 
 	// backup the original content
-	backup, err := osutil.NewAtomicFile(backupName, 0644, 0, osutil.NoChown, osutil.NoChown)
+	backup, err := osutil.NewAtomicFile(backupName, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create backup file: %v", err)
 	}
@@ -186,7 +186,7 @@ func (r *rawStructureUpdater) backupOrCheckpointContent(disk io.ReadSeeker, pc *
 
 	if bytes.Equal(origDigest, updateDigest) {
 		// files are identical, no update needed
-		if err := osutil.AtomicWriteFile(sameName, nil, 0644, 0); err != nil {
+		if err := osutil.AtomicWriteFile(sameName, nil, 0644); err != nil {
 			return fmt.Errorf("cannot create a checkpoint file: %v", err)
 		}
 

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -344,7 +344,7 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreSame(c *C) {
 	c.Check(gadget.RawContentBackupPath(r.backup, ps, &ps.LaidOutContent[1])+".same", testutil.FilePresent)
 
 	emptyDiskPath := filepath.Join(r.dir, "disk-not-written.img")
-	err = osutil.AtomicWriteFile(emptyDiskPath, nil, 0644, 0)
+	err = osutil.AtomicWriteFile(emptyDiskPath, nil, 0644)
 	c.Assert(err, IsNil)
 	// update should be a noop now, use the same locations, point to a file
 	// of 0 size, so that seek fails and write would increase the size

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
@@ -67,7 +67,7 @@ func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDCloseInvalid(c *C) {
 		[]byte("1234567"),
 		[]byte("123456789"),
 	} {
-		osutil.AtomicWriteFile(s.maxIDPath, initial, 0600, 0)
+		osutil.AtomicWriteFile(s.maxIDPath, initial, 0600)
 		maxIDMmap, err = maxidmmap.OpenMaxIDMmap(s.maxIDPath)
 		c.Check(err, IsNil)
 		c.Check(maxIDMmap, NotNil)
@@ -108,7 +108,7 @@ func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDCloseValid(c *C) {
 	} {
 		var initialData [8]byte
 		*(*uint64)(unsafe.Pointer(&initialData[0])) = testCase.initial
-		osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600, 0)
+		osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600)
 		func() {
 			maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
 			c.Check(err, IsNil)

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -662,7 +662,7 @@ func (pdb *PromptDB) saveRequestMap() error {
 		logger.Noticef("cannot marshal mapping from request key to prompt ID: %v", err)
 		return fmt.Errorf("cannot marshal mapping from request key to prompt ID: %w", err)
 	}
-	if err := osutil.AtomicWriteFile(pdb.requestMapFilepath, b, 0o600, 0); err != nil {
+	if err := osutil.AtomicWriteFile(pdb.requestMapFilepath, b, 0o600); err != nil {
 		return fmt.Errorf("cannot save mapping from request key to prompt ID: %w", err)
 	}
 	return nil

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -144,7 +144,7 @@ func (s *requestpromptsSuite) TestNewValidMaxID(c *C) {
 	} {
 		var initialData [8]byte
 		*(*uint64)(unsafe.Pointer(&initialData[0])) = testCase.initial
-		c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0o600, 0), IsNil)
+		c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0o600), IsNil)
 		pdb, err := requestprompts.New(notifyPrompt)
 		c.Assert(err, IsNil)
 		defer pdb.Close()
@@ -180,7 +180,7 @@ func (s *requestpromptsSuite) TestNewInvalidMaxID(c *C) {
 		[]byte("1234567"),
 		[]byte("123456789"),
 	} {
-		c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initial, 0o600, 0), IsNil)
+		c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initial, 0o600), IsNil)
 		pdb, err := requestprompts.New(notifyPrompt)
 		c.Assert(err, IsNil)
 		defer pdb.Close()
@@ -198,7 +198,7 @@ func (s *requestpromptsSuite) TestNewNextIDUniqueIDs(c *C) {
 	var initialMaxID uint64 = 42
 	var initialData [8]byte
 	*(*uint64)(unsafe.Pointer(&initialData[0])) = initialMaxID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600), IsNil)
 
 	pdb1, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -263,7 +263,7 @@ func (s *requestpromptsSuite) TestNewNextIDCompatibility(c *C) {
 	var initialMaxID uint64 = 42
 	var initialData [8]byte
 	*(*uint64)(unsafe.Pointer(&initialData[0])) = initialMaxID
-	c.Assert(osutil.AtomicWriteFile(s.legacyMaxIDPath, initialData[:], 0600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.legacyMaxIDPath, initialData[:], 0600), IsNil)
 
 	pdb1, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -333,12 +333,12 @@ func (s *requestpromptsSuite) TestNewPendingHandleReadying(c *C) {
 	}
 	data, err := json.Marshal(jsonMapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	expectedID := uint64(2)
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = expectedID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -407,12 +407,12 @@ func (s *requestpromptsSuite) TestNewPendingReadyTimeout(c *C) {
 	}
 	data, err := json.Marshal(mapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	expectedID := uint64(2)
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = expectedID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -1016,12 +1016,12 @@ func (s *requestpromptsSuite) TestAddOrMergeInvalidMapping(c *C) {
 	}
 	data, err := json.Marshal(jsonMapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	expectedID := uint64(1)
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = expectedID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -1881,12 +1881,12 @@ func (s *requestpromptsSuite) TestCloseBeforeReady(c *C) {
 	}
 	data, err := json.Marshal(jsonMapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	expectedID := uint64(2)
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = expectedID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -1986,11 +1986,11 @@ func (s *requestpromptsSuite) TestRequestMappingAcrossRestarts(c *C) {
 	}
 	data, err := json.Marshal(mapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = uint64(2)
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)
@@ -2102,12 +2102,12 @@ func (s *requestpromptsSuite) TestHandleReadying(c *C) {
 	}
 	data, err := json.Marshal(mapping)
 	c.Assert(err, IsNil)
-	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.requestMapFilepath, data, 0o600), IsNil)
 	// Write max ID corresponding to mapping
 	expectedID := uint64(6)
 	var maxIDData [8]byte
 	*(*uint64)(unsafe.Pointer(&maxIDData)) = expectedID
-	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(s.maxIDPath, maxIDData[:], 0o600), IsNil)
 
 	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
 	c.Assert(err, IsNil)

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -356,7 +356,7 @@ func (rdb *RuleDB) save() error {
 		logger.Noticef("cannot marshal rule DB: %v", err)
 		return fmt.Errorf("cannot marshal rule DB: %w", err)
 	}
-	return osutil.AtomicWriteFile(rdb.dbPath, b, 0o600, 0)
+	return osutil.AtomicWriteFile(rdb.dbPath, b, 0o600)
 }
 
 // lookupRuleByPathPattern checks whether there is an existing rule for the

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -230,7 +230,7 @@ func WriteSystemKey(extraData SystemKeyExtraData) error {
 	if err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, sks, 0644, 0)
+	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, sks, 0644)
 }
 
 // SystemKeyMismatch checks if the running binary expects a different

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -120,9 +120,8 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 // AtomicWriteFileCopy writes to dst a copy of src using AtomicFile
 // internally to create the destination.
 // The destination path is always overwritten. The destination and
-// the owning directory are synced after copy completes. Pass additional flags
-// for AtomicFile wrapping the destination.
-func AtomicWriteFileCopy(dst, src string, flags AtomicWriteFlags) (err error) {
+// the owning directory are synced after copy completes.
+func AtomicWriteFileCopy(dst, src string) (err error) {
 	fin, err := openfile(src, os.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("unable to open source file %s: %v", src, err)
@@ -138,7 +137,7 @@ func AtomicWriteFileCopy(dst, src string, flags AtomicWriteFlags) (err error) {
 		return fmt.Errorf("unable to stat %s: %v", src, err)
 	}
 
-	fout, err := NewAtomicFile(dst, fi.Mode(), flags, NoChown, NoChown)
+	fout, err := NewAtomicFile(dst, fi.Mode(), NoChown, NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create atomic file: %v", err)
 	}

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -298,7 +298,7 @@ func (s *cpSuite) TestCopyPreserveAllSyncSyncFailure(c *C) {
 }
 
 func (s *cpSuite) TestAtomicWriteFileCopySimple(c *C) {
-	err := osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)
+	err := osutil.AtomicWriteFileCopy(s.f2, s.f1)
 	c.Assert(err, IsNil)
 	c.Assert(s.f2, testutil.FileEquals, s.data)
 
@@ -308,7 +308,7 @@ func (s *cpSuite) TestAtomicWriteFileCopyPreservesModTime(c *C) {
 	t := time.Date(2010, time.January, 1, 13, 0, 0, 0, time.UTC)
 	c.Assert(os.Chtimes(s.f1, t, t), IsNil)
 
-	err := osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)
+	err := osutil.AtomicWriteFileCopy(s.f2, s.f1)
 	c.Assert(err, IsNil)
 	c.Assert(s.f2, testutil.FileEquals, s.data)
 
@@ -325,7 +325,7 @@ func (s *cpSuite) TestAtomicWriteFileCopyOverwrites(c *C) {
 	err := os.WriteFile(s.f2, []byte("this is f2 content"), 0644)
 	c.Assert(err, IsNil)
 
-	err = osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)
+	err = osutil.AtomicWriteFileCopy(s.f2, s.f1)
 	c.Assert(err, IsNil)
 	c.Assert(s.f2, testutil.FileEquals, s.data)
 }
@@ -336,24 +336,24 @@ func (s *cpSuite) TestAtomicWriteFileCopySymlinks(c *C) {
 	c.Assert(err, IsNil)
 
 	// copy overwrites the symlink
-	err = osutil.AtomicWriteFileCopy(f2SymlinkNoFollow, s.f1, 0)
+	err = osutil.AtomicWriteFileCopy(f2SymlinkNoFollow, s.f1)
 	c.Assert(err, IsNil)
 	c.Check(osutil.IsSymlink(f2SymlinkNoFollow), Equals, false, Commentf("%q is not a file", f2SymlinkNoFollow))
 	c.Check(f2SymlinkNoFollow, testutil.FileEquals, s.data)
 }
 
 func (s *cpSuite) TestAtomicWriteFileCopyErrReal(c *C) {
-	err := osutil.AtomicWriteFileCopy(s.f2, filepath.Join(s.dir, "random-file"), 0)
+	err := osutil.AtomicWriteFileCopy(s.f2, filepath.Join(s.dir, "random-file"))
 	c.Assert(err, ErrorMatches, "unable to open source file .*/random-file: open .* no such file or directory")
 
 	dir := c.MkDir()
 
-	err = osutil.AtomicWriteFileCopy(filepath.Join(dir, "random-dir", "f3"), s.f1, 0)
+	err = osutil.AtomicWriteFileCopy(filepath.Join(dir, "random-dir", "f3"), s.f1)
 	c.Assert(err, ErrorMatches, `cannot create atomic file: open .*/random-dir/f3\.[a-zA-Z0-9]+~: no such file or directory`)
 
 	err = os.MkdirAll(filepath.Join(dir, "read-only"), 0000)
 	c.Assert(err, IsNil)
-	err = osutil.AtomicWriteFileCopy(filepath.Join(dir, "read-only", "f3"), s.f1, 0)
+	err = osutil.AtomicWriteFileCopy(filepath.Join(dir, "read-only", "f3"), s.f1)
 	c.Assert(err, ErrorMatches, `cannot create atomic file: open .*/read-only/f3\.[a-zA-Z0-9]+~: permission denied`)
 }
 
@@ -365,7 +365,7 @@ func (s *cpSuite) TestAtomicWriteFileCopyErrMockedCopy(c *C) {
 		errors.New("copy fail"),
 	}
 
-	err := osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)
+	err := osutil.AtomicWriteFileCopy(s.f2, s.f1)
 	c.Assert(err, ErrorMatches, `unable to copy .*/f1 to .*/f2\.[a-zA-Z0-9]+~: copy fail`)
 	entries, err := filepath.Glob(filepath.Join(s.dir, "*"))
 	c.Assert(err, IsNil)

--- a/osutil/faultinject.go
+++ b/osutil/faultinject.go
@@ -56,7 +56,7 @@ func injectFault(tagKind string) (injected bool) {
 		return false
 	}
 	makeStamp := func() bool {
-		if err := AtomicWriteFile(stampFile, nil, 0644, 0); err != nil {
+		if err := AtomicWriteFile(stampFile, nil, 0644); err != nil {
 			fmt.Fprintf(stderr, "cannot create stamp file for tag %q\n", tagKind)
 			return false
 		}

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -33,9 +33,6 @@ import (
 	"github.com/snapcore/snapd/randutil"
 )
 
-// AtomicWriteFlags are a bitfield of flags for AtomicWriteFile
-type AtomicWriteFlags uint
-
 // Allow disabling sync for testing. This brings massive improvements on
 // certain filesystems (like btrfs) and very much noticeable improvements in
 // all unit tests in genreal.
@@ -74,7 +71,7 @@ type AtomicFile struct {
 // Also note that there are a number of scenarios where Commit fails and then
 // Cancel also fails. In all these scenarios your filesystem was probably in a
 // rather poor state. Good luck.
-func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (aw *AtomicFile, err error) {
+func NewAtomicFile(filename string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) (aw *AtomicFile, err error) {
 	// The tilde is appended so that programs that inspect all files in some
 	// directory are more likely to ignore this file as an editor backup file.
 	//
@@ -219,20 +216,20 @@ func (aw *AtomicFile) CommitAs(filename string) error {
 // []byte, and so work exactly like io.WriteFile(); AtomicWrite and
 // AtomicWriteChown take an io.Reader which is copied into the file instead,
 // and so are more amenable to streaming.
-func AtomicWrite(filename string, reader io.Reader, perm os.FileMode, flags AtomicWriteFlags) (err error) {
-	return AtomicWriteChown(filename, reader, perm, flags, NoChown, NoChown)
+func AtomicWrite(filename string, reader io.Reader, perm os.FileMode) (err error) {
+	return AtomicWriteChown(filename, reader, perm, NoChown, NoChown)
 }
 
-func AtomicWriteFile(filename string, data []byte, perm os.FileMode, flags AtomicWriteFlags) (err error) {
-	return AtomicWriteChown(filename, bytes.NewReader(data), perm, flags, NoChown, NoChown)
+func AtomicWriteFile(filename string, data []byte, perm os.FileMode) (err error) {
+	return AtomicWriteChown(filename, bytes.NewReader(data), perm, NoChown, NoChown)
 }
 
-func AtomicWriteFileChown(filename string, data []byte, perm os.FileMode, flags AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (err error) {
-	return AtomicWriteChown(filename, bytes.NewReader(data), perm, flags, uid, gid)
+func AtomicWriteFileChown(filename string, data []byte, perm os.FileMode, uid sys.UserID, gid sys.GroupID) (err error) {
+	return AtomicWriteChown(filename, bytes.NewReader(data), perm, uid, gid)
 }
 
-func AtomicWriteChown(filename string, reader io.Reader, perm os.FileMode, flags AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (err error) {
-	aw, err := NewAtomicFile(filename, perm, flags, uid, gid)
+func AtomicWriteChown(filename string, reader io.Reader, perm os.FileMode, uid sys.UserID, gid sys.GroupID) (err error) {
+	aw, err := NewAtomicFile(filename, perm, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -44,7 +44,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFile(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := osutil.AtomicWriteFile(p, []byte("canary"), 0644, 0)
+	err := osutil.AtomicWriteFile(p, []byte("canary"), 0644)
 	c.Assert(err, IsNil)
 
 	c.Check(p, testutil.FileEquals, "canary")
@@ -59,7 +59,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFilePermissions(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte(""), 0600)
 	c.Assert(err, IsNil)
 
 	st, err := os.Stat(p)
@@ -71,7 +71,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 	tmpdir := c.MkDir()
 	p := filepath.Join(tmpdir, "foo")
 	c.Assert(os.WriteFile(p, []byte("hello"), 0644), IsNil)
-	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600), IsNil)
 
 	c.Assert(p, testutil.FileEquals, "hi")
 }
@@ -86,7 +86,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600)
 	c.Assert(err, NotNil)
 }
 
@@ -102,7 +102,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	err := os.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
+	err = osutil.AtomicWriteFile(p, []byte(""), 0600)
 	c.Assert(err, ErrorMatches, "open .*: file exists")
 }
 
@@ -119,7 +119,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, eUid, eGid)
+	aw, err := osutil.NewAtomicFile(p, 0644, eUid, eGid)
 	c.Assert(err, IsNil)
 	defer aw.Cancel()
 
@@ -132,7 +132,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(p, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 
 	c.Assert(aw.File.Close(), IsNil)
@@ -143,7 +143,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(p, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	defer aw.Close()
 
@@ -155,7 +155,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelNoClose(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(p, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	c.Assert(aw.Close(), IsNil)
 
@@ -166,7 +166,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(p, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	fn := aw.File.Name()
 	c.Check(osutil.FileExists(fn), Equals, true)
@@ -178,7 +178,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileModTime(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(p, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	t := time.Date(2010, time.January, 1, 13, 0, 0, 0, time.UTC)
 	aw.SetModTime(t)
@@ -194,7 +194,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {
 	initialTarget := filepath.Join(d, "foo")
 	actualTarget := filepath.Join(d, "bar")
 
-	aw, err := osutil.NewAtomicFile(initialTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(initialTarget, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	defer aw.Cancel()
 	fn := aw.File.Name()
@@ -211,7 +211,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {
 
 	// not confused when CommitAs uses the same name as initially
 	sameNameTarget := filepath.Join(d, "baz")
-	aw, err = osutil.NewAtomicFile(sameNameTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err = osutil.NewAtomicFile(sameNameTarget, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	defer aw.Cancel()
 	_, err = aw.WriteString("this is baz")
@@ -224,7 +224,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {
 	overwrittenTarget := filepath.Join(d, "will-overwrite")
 	err = os.WriteFile(overwrittenTarget, []byte("overwritten"), 0644)
 	c.Assert(err, IsNil)
-	aw, err = osutil.NewAtomicFile(filepath.Join(d, "temp-name"), 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err = osutil.NewAtomicFile(filepath.Join(d, "temp-name"), 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	defer aw.Cancel()
 	_, err = aw.WriteString("this will overwrite existing file")
@@ -239,7 +239,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAsDifferentDirErr(c *C) {
 	initialTarget := filepath.Join(d, "foo")
 	differentDirTarget := filepath.Join(c.MkDir(), "bar")
 
-	aw, err := osutil.NewAtomicFile(initialTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(initialTarget, 0644, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	_, err = aw.WriteString("this is test data")
 	c.Assert(err, IsNil)
@@ -531,7 +531,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicRenameDir(c *C) {
 	// put a file in the source directory
 	srcFile := filepath.Join(src, "file")
 	contents := []byte("contents")
-	err = osutil.AtomicWriteFile(srcFile, contents, 0644, 0)
+	err = osutil.AtomicWriteFile(srcFile, contents, 0644)
 	c.Assert(err, IsNil)
 
 	// the parent dir of the destination

--- a/osutil/keyboard/xkb_test.go
+++ b/osutil/keyboard/xkb_test.go
@@ -246,7 +246,7 @@ func (s *xkbTestSuite) TestXKBConfigListener(c *C) {
 	c.Assert(os.WriteFile(vconsoleConfPath, []byte("3"), 0644), IsNil)
 	<-cbChan
 	// Simulate replacement i.e. rename
-	c.Assert(osutil.AtomicWriteFile(vconsoleConfPath, []byte("4"), 0644, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(vconsoleConfPath, []byte("4"), 0644), IsNil)
 	<-cbChan
 	c.Assert(os.WriteFile(vconsoleConfPath, []byte("5"), 0644), IsNil)
 	<-cbChan

--- a/osutil/mountprofile_linux.go
+++ b/osutil/mountprofile_linux.go
@@ -73,7 +73,7 @@ func SaveMountProfile(p *MountProfile, fname string, uid sys.UserID, gid sys.Gro
 	if _, err := p.WriteTo(&buf); err != nil {
 		return err
 	}
-	return AtomicWriteFileChown(fname, buf.Bytes(), 0644, AtomicWriteFlags(0), uid, gid)
+	return AtomicWriteFileChown(fname, buf.Bytes(), 0644, uid, gid)
 }
 
 // ReadMountProfile reads and parses a mount profile.

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -253,7 +253,7 @@ func ensureRegularFileState(filePath string, state FileState) error {
 	if err != nil {
 		return err
 	}
-	return AtomicWrite(filePath, reader, mode, 0)
+	return AtomicWrite(filePath, reader, mode)
 }
 
 // symlinkFileStateEqualTo returns whether the symlink exists in the expected state.

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -243,7 +243,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 	}
 
 	if opts.Sudoer {
-		if err := AtomicWriteFile(sudoersFile(name), []byte(fmt.Sprintf(sudoersTemplate, name)), 0400, 0); err != nil {
+		if err := AtomicWriteFile(sudoersFile(name), []byte(fmt.Sprintf(sudoersTemplate, name)), 0400); err != nil {
 			return fmt.Errorf("cannot create file under sudoers.d: %s", err)
 		}
 	}
@@ -290,7 +290,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 	}
 	authKeys := filepath.Join(sshDir, "authorized_keys")
 	authKeysContent := strings.Join(opts.SSHKeys, "\n")
-	if err := AtomicWriteFileChown(authKeys, []byte(authKeysContent), 0600, 0, uid, gid); err != nil {
+	if err := AtomicWriteFileChown(authKeys, []byte(authKeysContent), 0600, uid, gid); err != nil {
 		return fmt.Errorf("cannot write %s: %s", authKeys, err)
 	}
 

--- a/overlord/backend.go
+++ b/overlord/backend.go
@@ -31,7 +31,7 @@ type overlordStateBackend struct {
 }
 
 func (osb *overlordStateBackend) Checkpoint(data []byte) error {
-	return osutil.AtomicWriteFile(osb.path, data, 0600, 0)
+	return osutil.AtomicWriteFile(osb.path, data, 0600)
 }
 
 func (osb *overlordStateBackend) EnsureBefore(d time.Duration) {

--- a/overlord/certstate/certs.go
+++ b/overlord/certstate/certs.go
@@ -258,7 +258,7 @@ func writeUniqueCACertificates(certs *certificates, out io.Writer) error {
 // output path.
 func generateCACertificates(certs *certificates, outputPath string) error {
 	certsPath := filepath.Join(outputPath, "ca-certificates.crt")
-	tmpFile, err := osutil.NewAtomicFile(certsPath, 0o644, 0, osutil.NoChown, osutil.NoChown)
+	tmpFile, err := osutil.NewAtomicFile(certsPath, 0o644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create temporary ca-certificates.crt: %v", err)
 	}

--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -94,7 +94,7 @@ func handleHostnameConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnly
 		if err := os.MkdirAll(filepath.Dir(hostnamePath), 0755); err != nil {
 			return err
 		}
-		if err := osutil.AtomicWriteFile(hostnamePath, []byte(hostname+"\n"), 0644, 0); err != nil {
+		if err := osutil.AtomicWriteFile(hostnamePath, []byte(hostname+"\n"), 0644); err != nil {
 			return fmt.Errorf("cannot write hostname: %v", err)
 		}
 	}

--- a/overlord/configstate/configcore/journal.go
+++ b/overlord/configstate/configcore/journal.go
@@ -75,7 +75,7 @@ func handleJournalConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyC
 		if err := os.MkdirAll(tempLogPath, 0755); err != nil {
 			return err
 		}
-		if err := osutil.AtomicWriteFile(filepath.Join(tempLogPath, marker), nil, 0700, 0); err != nil {
+		if err := osutil.AtomicWriteFile(filepath.Join(tempLogPath, marker), nil, 0700); err != nil {
 			return nil
 		}
 		if err := os.Rename(tempLogPath, logPath); err != nil {

--- a/overlord/configstate/configcore/motd.go
+++ b/overlord/configstate/configcore/motd.go
@@ -128,7 +128,7 @@ func handleMotdConfiguration(dev sysconfig.Device, tr ConfGetter, opts *fsOnlyCo
 		return fmt.Errorf("cannot set message of the day: %v", err)
 	}
 	motdBytes := []byte(motd + "\n")
-	if err := osutil.AtomicWriteFile(motdFilePath, motdBytes, 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(motdFilePath, motdBytes, 0644); err != nil {
 		return fmt.Errorf("cannot set message of the day: %v", err)
 	}
 	return nil

--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -89,7 +89,7 @@ func updatePiConfig(path string, config map[string]string) error {
 		s := strings.Join(toWrite, "\n")
 		// ensure we have a final newline in the file
 		s += "\n"
-		return osutil.AtomicWriteFile(path, []byte(s), 0644, 0)
+		return osutil.AtomicWriteFile(path, []byte(s), 0644)
 	}
 
 	return nil

--- a/overlord/configstate/configcore/powerbtn.go
+++ b/overlord/configstate/configcore/powerbtn.go
@@ -68,7 +68,7 @@ func switchHandlePowerKey(action string, opts *fsOnlyContext) error {
 	content := fmt.Sprintf(`[Login]
 HandlePowerKey=%s
 `, action)
-	return osutil.AtomicWriteFile(powerBtnCfg(opts), []byte(content), 0644, 0)
+	return osutil.AtomicWriteFile(powerBtnCfg(opts), []byte(content), 0644)
 }
 
 func handlePowerButtonConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {

--- a/overlord/configstate/configcore/store.go
+++ b/overlord/configstate/configcore/store.go
@@ -78,5 +78,5 @@ func handleStoreAccess(_ sysconfig.Device, cfg ConfGetter, opts *fsOnlyContext) 
 		return err
 	}
 
-	return osutil.AtomicWriteFile(configFilePath, data, 0644, 0)
+	return osutil.AtomicWriteFile(configFilePath, data, 0644)
 }

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -94,7 +94,7 @@ func handleTimezoneConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnly
 			return err
 		}
 		timezonePath := filepath.Join(opts.RootDir, "/etc/writable/timezone")
-		if err := osutil.AtomicWriteFile(timezonePath, []byte(timezone+"\n"), 0644, 0); err != nil {
+		if err := osutil.AtomicWriteFile(timezonePath, []byte(timezone+"\n"), 0644); err != nil {
 			return fmt.Errorf("cannot write timezone: %v", err)
 		}
 	}

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -549,7 +549,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 				if err = os.MkdirAll(dir, 0755); err != nil {
 					return fmt.Errorf("test error: MockSecbootSaveCheckResult failed to create dir %s", dir)
 				}
-				if err = osutil.AtomicWriteFile(filename, []byte{}, 0600, 0); err != nil {
+				if err = osutil.AtomicWriteFile(filename, []byte{}, 0600); err != nil {
 					return fmt.Errorf("test error: MockSecbootSaveCheckResult failed to create file %s", filename)
 				}
 				return nil

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -826,7 +826,7 @@ func writeFactoryResetMarker(marker string, hasEncryption bool) error {
 	} else {
 		logger.Noticef("writing factory-reset marker at %v", marker)
 	}
-	return osutil.AtomicWriteFile(marker, buf.Bytes(), 0644, 0)
+	return osutil.AtomicWriteFile(marker, buf.Bytes(), 0644)
 }
 
 func verifyFactoryResetMarkerInRun(marker string, hasEncryption bool) error {

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -87,7 +87,7 @@ func logNewSystemSnapFile(logfile, fileName string) error {
 	}
 	modifiedLog := bytes.NewBuffer(currentLog)
 	fmt.Fprintln(modifiedLog, fileName)
-	return osutil.AtomicWriteFile(logfile, modifiedLog.Bytes(), 0644, 0)
+	return osutil.AtomicWriteFile(logfile, modifiedLog.Bytes(), 0644)
 }
 
 func purgeNewSystemSnapFiles(logfile string) error {

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -327,7 +327,7 @@ func setupLocalUser(state *state.State, username, email string, expiration time.
 	if err != nil {
 		return fmt.Errorf("cannot marshal auth data: %s", err)
 	}
-	if err := osutil.AtomicWriteFileChown(authDataFn, []byte(outStr), 0600, 0, uid, gid); err != nil {
+	if err := osutil.AtomicWriteFileChown(authDataFn, []byte(outStr), 0600, uid, gid); err != nil {
 		return fmt.Errorf("cannot write auth file %q: %s", authDataFn, err)
 	}
 

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -633,5 +633,5 @@ func (ntb *noticeTypeBackend) save() error {
 		// Should not occur, marshalling should always succeed
 		return fmt.Errorf("cannot marshal %s notices: %w", ntb.namespace, err)
 	}
-	return osutil.AtomicWriteFile(ntb.filepath, b, 0o600, 0)
+	return osutil.AtomicWriteFile(ntb.filepath, b, 0o600)
 }

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -780,7 +780,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownBeforeReply(c *C) {
 	const requestMapping = `{"request-mapping":{"api:1000:audio-record:obs-studio:1234":{"prompt-id":"0000000000000001","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -885,7 +885,7 @@ func (s *apparmorpromptingSuite) TestAskShutdownViaChannelBeforeReply(c *C) {
 	const requestMapping = `{"request-mapping":{"api:1000:audio-record:obs-studio:1234":{"prompt-id":"0000000000000001","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -1768,7 +1768,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyAfterPromptsNotReady(c *C) {
 	const requestMapping = `{"request-mapping":{"api:foo":{"prompt-id":"0000000000000001","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -1812,7 +1812,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfN
 	const requestMapping = `{"request-mapping":{"kernel:0000000000000001":{"prompt-id":"0000000000000001","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -1857,7 +1857,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadyingIfO
 	const requestMapping = `{"request-mapping":{"kernel:0000000000000001":{"prompt-id":"0000000000000001","user-id":1000},"api:1000:audio-record:firefox:1234":{"prompt-id":"0000000000000002","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -1928,7 +1928,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyNotCausesPromptsHandleReadying
 	const requestMapping = `{"request-mapping":{"kernel:1":{"prompt-id":"0000000000000001","user-id":1000},"kernel:2":{"prompt-id":"0000000000000001","user-id":1000},"kernel:3":{"prompt-id":"0000000000000002","user-id":1000},"api:1000:audio-record:obs-studio:12345":{"prompt-id":"0000000000000003","user-id":1000},"api:1000:audio-record:signal-desktop:67890":{"prompt-id":"0000000000000004","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
@@ -2093,7 +2093,7 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	const requestMapping = `{"request-mapping":{"kernel:0000000000000001":{"prompt-id":"0000000000000001","user-id":1000}}}`
 	requestMapFilepath := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "request-key-mapping.json")
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o777), IsNil)
-	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(requestMapFilepath, []byte(requestMapping), 0o600), IsNil)
 
 	// Need a new noticeMgr each time so we can re-register backends with the same types
 	st := state.New(nil)

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -1005,7 +1005,7 @@ func (p *preseedSnapHandler) HandleAndDigestAssertedContainer(cpi snap.Container
 	}
 	defer srcFile.Close()
 
-	destFile, err := osutil.NewAtomicFile(targetPath, 0644, 0, osutil.NoChown, osutil.NoChown)
+	destFile, err := osutil.NewAtomicFile(targetPath, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return "", "", 0, fmt.Errorf("cannot create atomic file: %v", err)
 	}

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1873,7 +1873,7 @@ func (s *installSuite) testPrepareEncryptedSystemData(c *C, useTokens, hasCheckR
 			c.Assert(filename, Matches, ".*/run/mnt/ubuntu-save/device/fde/preinstall")
 			err := os.MkdirAll(filepath.Dir(filename), 0755)
 			c.Assert(err, IsNil)
-			err = osutil.AtomicWriteFile(filename, []byte("some content"), 0600, 0)
+			err = osutil.AtomicWriteFile(filename, []byte("some content"), 0600)
 			c.Assert(err, IsNil)
 			return nil
 		} else {

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -335,7 +335,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]any, use
 		}
 	}
 
-	aw, err := osutil.NewAtomicFile(Filename(snapshot), 0600, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(Filename(snapshot), 0600, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/backend/aux_store_info.go
+++ b/overlord/snapstate/backend/aux_store_info.go
@@ -87,7 +87,7 @@ func keepAuxStoreInfo(snapID string, aux AuxStoreInfo) error {
 		return fmt.Errorf("cannot create directory for auxiliary store info: %w", err)
 	}
 
-	af, err := osutil.NewAtomicFile(AuxStoreInfoFilename(snapID), 0644, 0, osutil.NoChown, osutil.NoChown)
+	af, err := osutil.NewAtomicFile(AuxStoreInfoFilename(snapID), 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create file for auxiliary store info: %w", err)
 	}

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -175,11 +175,11 @@ func refreshCatalogs(st *state.State, theStore StoreService) error {
 		return err
 	}
 	sort.Strings(sections)
-	if err := osutil.AtomicWriteFile(dirs.SnapSectionsFile, []byte(strings.Join(sections, "\n")), 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(dirs.SnapSectionsFile, []byte(strings.Join(sections, "\n")), 0644); err != nil {
 		return err
 	}
 
-	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, 0, osutil.NoChown, osutil.NoChown)
+	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/cookies.go
+++ b/overlord/snapstate/cookies.go
@@ -159,7 +159,7 @@ func createCookieFile(instanceName string) (cookieID string, err error) {
 		return "", err
 	}
 	path := filepath.Join(dirs.SnapCookieDir, fmt.Sprintf("snap.%s", instanceName))
-	err = osutil.AtomicWriteFile(path, []byte(cookieID), 0600, 0)
+	err = osutil.AtomicWriteFile(path, []byte(cookieID), 0600)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create cookie file %q: %s", path, err)
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2282,7 +2282,7 @@ func writeSeqFile(name string, snapst *SnapState) error {
 		return err
 	}
 
-	return osutil.AtomicWriteFile(p, b, 0644, 0)
+	return osutil.AtomicWriteFile(p, b, 0644)
 }
 
 type disabledServices struct {

--- a/overlord/state/copy.go
+++ b/overlord/state/copy.go
@@ -41,7 +41,7 @@ func (b *checkpointOnlyBackend) Checkpoint(data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(b.path), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(b.path, data, 0600, 0)
+	return osutil.AtomicWriteFile(b.path, data, 0600)
 }
 
 func (b *checkpointOnlyBackend) EnsureBefore(d time.Duration) {

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -1032,7 +1032,7 @@ func UpdateHomedirsTunable(homedirs []string) error {
 		}
 		contents.Write([]byte("\n"))
 	}
-	return osutilAtomicWrite(tunableFilePath, contents, 0644, 0)
+	return osutilAtomicWrite(tunableFilePath, contents, 0644)
 }
 
 // mocking

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -927,7 +927,7 @@ func (s *apparmorSuite) TestUpdateHomedirsTunableWriteFail(c *C) {
 	})
 	defer restore()
 
-	restore = apparmor.MockAtomicWrite(func(string, io.Reader, os.FileMode, osutil.AtomicWriteFlags) error {
+	restore = apparmor.MockAtomicWrite(func(string, io.Reader, os.FileMode) error {
 		return errors.New("write failure")
 	})
 	defer restore()

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -47,7 +46,7 @@ func MockMkdirAll(f func(string, os.FileMode) error) func() {
 	return r
 }
 
-func MockAtomicWrite(f func(string, io.Reader, os.FileMode, osutil.AtomicWriteFlags) error) func() {
+func MockAtomicWrite(f func(string, io.Reader, os.FileMode) error) func() {
 	r := testutil.Backup(&osutilAtomicWrite)
 	osutilAtomicWrite = f
 	return r

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -222,7 +222,7 @@ func saveListenerID(id uint64) error {
 		return err
 	}
 	logger.Debugf("saving listener ID to disk: %d", id)
-	return osutil.AtomicWriteFile(listenerIDFilepath(), buf[:], 0o600, 0)
+	return osutil.AtomicWriteFile(listenerIDFilepath(), buf[:], 0o600)
 }
 
 // removeSavedListenerID removes the file which stores the listener ID on disk.

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -340,7 +340,7 @@ func (s *notifySuite) TestRegisterFileDescriptorTimedOutOrNoAccess(c *C) {
 
 		// Write listener ID to disk
 		c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o755), IsNil)
-		c.Assert(osutil.AtomicWriteFile(filepath.Join(dirs.SnapInterfacesRequestsRunDir, "listener-id"), initialIDBytes[:], 0o600, 0), IsNil)
+		c.Assert(osutil.AtomicWriteFile(filepath.Join(dirs.SnapInterfacesRequestsRunDir, "listener-id"), initialIDBytes[:], 0o600), IsNil)
 
 		receivedVersion, pendingCount, err := notify.RegisterFileDescriptor(fakeFD)
 		c.Check(err, IsNil)
@@ -373,7 +373,7 @@ func (s *notifySuite) TestRegisterFileDescriptorTimedOutOrNoAccessThenRemoveFail
 
 	// Write listener ID to disk
 	c.Assert(os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o755), IsNil)
-	c.Assert(osutil.AtomicWriteFile(filepath.Join(dirs.SnapInterfacesRequestsRunDir, "listener-id"), initialIDBytes[:], 0o600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(filepath.Join(dirs.SnapInterfacesRequestsRunDir, "listener-id"), initialIDBytes[:], 0o600), IsNil)
 
 	for _, errorCode := range []error{unix.ENOENT, unix.EACCES} {
 		ioctlCalls := 0

--- a/secboot/keys/keys.go
+++ b/secboot/keys/keys.go
@@ -62,7 +62,7 @@ func (key EncryptionKey) Save(filename string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
+	return osutil.AtomicWriteFile(filename, key[:], 0600)
 }
 
 // RecoveryKey is a key used to unlock the encrypted partition when
@@ -82,7 +82,7 @@ func (key RecoveryKey) Save(filename string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
+	return osutil.AtomicWriteFile(filename, key[:], 0600)
 }
 
 func RecoveryKeyFromFile(recoveryKeyFile string) (*RecoveryKey, error) {

--- a/secboot/keys/plainkey.go
+++ b/secboot/keys/plainkey.go
@@ -55,7 +55,7 @@ func (key ProtectorKey) SaveToFile(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(path, key[:], 0600, 0)
+	return osutil.AtomicWriteFile(path, key[:], 0600)
 }
 
 // PlainKey is a wrapper for a secboot KeyData representing a plainkey.

--- a/secboot/keys/plainkey_nosb.go
+++ b/secboot/keys/plainkey_nosb.go
@@ -48,7 +48,7 @@ func (key ProtectorKey) SaveToFile(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(path, key[:], 0600, 0)
+	return osutil.AtomicWriteFile(path, key[:], 0600)
 }
 
 func (key ProtectorKey) CreateProtectedKey(primaryKey []byte) (*PlainKey, []byte, []byte, error) {

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -191,7 +191,7 @@ func (cr *PreinstallCheckResult) save(filename string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(filename, bytes, 0600, 0)
+	return osutil.AtomicWriteFile(filename, bytes, 0600)
 }
 
 // MarshalJSON implements the json.Marshaler interface for

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -203,7 +203,7 @@ func SealKeysWithProtector(kpf KeyProtectorFactory, keys []SealKeyRequest, param
 	}
 
 	if primaryKey != nil && params.AuxKeyFile != "" {
-		if err := osutil.AtomicWriteFile(params.AuxKeyFile, primaryKey, 0600, 0); err != nil {
+		if err := osutil.AtomicWriteFile(params.AuxKeyFile, primaryKey, 0600); err != nil {
 			return fmt.Errorf("cannot write the policy auth key file: %v", err)
 		}
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -592,7 +592,7 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 	}
 
 	if primaryKey != nil && params.TPMPolicyAuthKeyFile != "" {
-		if err := osutil.AtomicWriteFile(params.TPMPolicyAuthKeyFile, primaryKey, 0600, 0); err != nil {
+		if err := osutil.AtomicWriteFile(params.TPMPolicyAuthKeyFile, primaryKey, 0600); err != nil {
 			return nil, fmt.Errorf("cannot write the policy auth key file: %v", err)
 		}
 	}
@@ -1036,7 +1036,7 @@ func tpmProvision(tpm *sb_tpm2.Connection, mode TPMProvisionMode, lockoutAuthFil
 	if err != nil {
 		return fmt.Errorf("cannot create lockout authorization: %v", err)
 	}
-	if err := osutil.AtomicWriteFile(lockoutAuthFile, lockoutAuth, 0600, 0); err != nil {
+	if err := osutil.AtomicWriteFile(lockoutAuthFile, lockoutAuth, 0600); err != nil {
 		return fmt.Errorf("cannot write the lockout authorization file: %v", err)
 	}
 

--- a/seed/internal/options20.go
+++ b/seed/internal/options20.go
@@ -145,7 +145,7 @@ func (options *Options20) Write(optionsFn string) error {
 	if err != nil {
 		return err
 	}
-	if err := osutil.AtomicWriteFile(optionsFn, data, 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(optionsFn, data, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/seed/internal/seed_yaml.go
+++ b/seed/internal/seed_yaml.go
@@ -110,7 +110,7 @@ func (seed *Seed16) Write(seedFn string) error {
 	if err != nil {
 		return err
 	}
-	if err := osutil.AtomicWriteFile(seedFn, data, 0644, 0); err != nil {
+	if err := osutil.AtomicWriteFile(seedFn, data, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/snap/sysparams/export_test.go
+++ b/snap/sysparams/export_test.go
@@ -22,11 +22,10 @@ package sysparams
 import (
 	"os"
 
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
-func MockOsutilAtomicWriteFile(f func(filename string, data []byte, perm os.FileMode, flags osutil.AtomicWriteFlags) error) func() {
+func MockOsutilAtomicWriteFile(f func(filename string, data []byte, perm os.FileMode) error) func() {
 	r := testutil.Backup(&osutilAtomicWriteFile)
 	osutilAtomicWriteFile = f
 	return r

--- a/snap/sysparams/sysparams.go
+++ b/snap/sysparams/sysparams.go
@@ -116,7 +116,7 @@ func Open(rootdir string) (*SystemParams, error) {
 func (ssp *SystemParams) Write() error {
 	sspFile := sysparamsFile(ssp.rootdir)
 	contents := fmt.Sprintf("homedirs=%s\n", ssp.Homedirs)
-	if err := osutilAtomicWriteFile(sspFile, []byte(contents), 0644, 0); err != nil {
+	if err := osutilAtomicWriteFile(sspFile, []byte(contents), 0644); err != nil {
 		return fmt.Errorf("cannot write system-params: %v", err)
 	}
 	return nil

--- a/snap/sysparams/sysparams_test.go
+++ b/snap/sysparams/sysparams_test.go
@@ -28,7 +28,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap/sysparams"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -79,7 +78,7 @@ func (s *sysParamsTestSuite) TestWriteFailure(c *C) {
 	c.Assert(ssp, NotNil)
 	c.Check(dirs.SnapSystemParamsUnder(dirs.GlobalRootDir), testutil.FileAbsent)
 
-	r := sysparams.MockOsutilAtomicWriteFile(func(filename string, data []byte, perm os.FileMode, flags osutil.AtomicWriteFlags) error {
+	r := sysparams.MockOsutilAtomicWriteFile(func(filename string, data []byte, perm os.FileMode) error {
 		return errors.New("some write error")
 	})
 	defer r()

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -337,7 +337,7 @@ func (s *Store) DownloadIcon(ctx context.Context, name string, targetPath string
 	// once the download succeeds, thus leaving any previous icon linked to the
 	// original unchanged icon contents, until a future task re-links to the
 	// new contents.
-	aw, err := osutil.NewAtomicFile(targetPath, 0o644, 0, osutil.NoChown, osutil.NoChown)
+	aw, err := osutil.NewAtomicFile(targetPath, 0o644, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return fmt.Errorf("cannot create file for snap icon for snap %s: %v", name, err)
 	}


### PR DESCRIPTION
As a follow-up to #17092 , remove the unused `AtomicWriteFlags` type entirely.

This change will need to be propagated to other projects in the snapd ecosystem, including pebble and workshop. CC @jonathan-conder @hpidcock

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-36975
