### PR TITLE
daemon, overlord: implement ShutDown for HookManager

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -560,6 +560,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		// stop running hooks first
 		d.overlord.HookManager().ShutDown()
 	}
+	d.snapListener.Close()
 	timeSpent := time.Since(ts)
 
 	// When shutting down the snapd listener wait until the rebootNoticeWait

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -553,9 +553,9 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	// connections.
 
 	// Daemon.Stop may be called before the operation that requested the restart
-	// (thereby triggering Daemon.Stop) released the state lock. Acquiring the
-	// lock here synchronizes with that operation, ensuring it has exited its
-	// critical section before the managers are shut down.
+	// (which would have triggered this invocation of Daemon.Stop) released the
+	// state lock. Acquiring the lock here synchronizes with that operation,
+	// ensuring it has exited its critical section before the managers are shutdown.
 	d.state.Lock()
 	d.state.Unlock()
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -552,6 +552,13 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	// it can pass the fds to the new process without ever having rejected incoming
 	// connections.
 
+	// Daemon.Stop may be called before the operation that requested the restart
+	// (thereby triggering Daemon.Stop) released the state lock. Acquiring the
+	// lock here synchronizes with that operation, ensuring it has exited its
+	// critical section before the managers are shut down.
+	d.state.Lock()
+	d.state.Unlock()
+
 	// take a timestamp before shutting down the snap listener, and
 	// use the time we may spend on waiting for hooks against the shutdown
 	// delay.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -556,11 +556,10 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	// use the time we may spend on waiting for hooks against the shutdown
 	// delay.
 	ts := time.Now()
+	d.overlord.ShutDown()
 	if d.snapListener != nil {
-		// stop running hooks first
-		d.overlord.HookManager().ShutDown()
+		d.snapListener.Close()
 	}
-	d.snapListener.Close()
 	timeSpent := time.Since(ts)
 
 	// When shutting down the snapd listener wait until the rebootNoticeWait

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -558,20 +558,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	ts := time.Now()
 	if d.snapListener != nil {
 		// stop running hooks first
-		// and do it more gracefully if we are restarting
-		hookMgr := d.overlord.HookManager()
-		// Don't proceed before the state lock has been released by the code
-		// path which may request a restart.
-		d.state.Lock()
-		restartType := d.overlord.RestartManager().Pending()
-		d.state.Unlock()
-		if restartType != restart.RestartUnset {
-			logger.Noticef("gracefully waiting for running hooks")
-			hookMgr.GracefullyWaitRunningHooks()
-			logger.Noticef("done waiting for running hooks")
-		}
-		hookMgr.StopHooks()
-		d.snapListener.Close()
+		d.overlord.HookManager().ShutDown()
 	}
 	timeSpent := time.Since(ts)
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -213,7 +213,7 @@ func (m *HookManager) Ensure() error {
 	return nil
 }
 
-// ShutDown implements StateShutDowner.ShutDown.
+// ShutDown implements the ShutDowner interface for the HookManager.
 func (m *HookManager) ShutDown() {
 	// Don't proceed before the state lock has been released by the code
 	// path which may request a restart.

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -213,6 +213,22 @@ func (m *HookManager) Ensure() error {
 	return nil
 }
 
+// ShutDown implements StateShutDowner.ShutDown.
+func (m *HookManager) ShutDown() {
+	// Don't proceed before the state lock has been released by the code
+	// path which may request a restart.
+	m.state.Lock()
+	restartType := restart.Pending(m.state)
+	m.state.Unlock()
+	// stop hooks gracefully if we are restarting
+	if restartType != restart.RestartUnset {
+		logger.Noticef("gracefully waiting for running hooks")
+		m.GracefullyWaitRunningHooks()
+		logger.Noticef("done waiting for running hooks")
+	}
+	m.StopHooks()
+}
+
 // StopHooks kills all currently running hooks and returns after
 // that's done.
 func (m *HookManager) StopHooks() {

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -215,17 +215,10 @@ func (m *HookManager) Ensure() error {
 
 // ShutDown implements the ShutDowner interface for the HookManager.
 func (m *HookManager) ShutDown() {
-	// Don't proceed before the state lock has been released by the code
-	// path which may request a restart.
-	m.state.Lock()
-	restartType := restart.Pending(m.state)
-	m.state.Unlock()
-	// stop hooks gracefully if we are restarting
-	if restartType != restart.RestartUnset {
-		logger.Noticef("gracefully waiting for running hooks")
-		m.GracefullyWaitRunningHooks()
-		logger.Noticef("done waiting for running hooks")
-	}
+	// stop hooks gracefully
+	logger.Noticef("gracefully waiting for running hooks")
+	m.GracefullyWaitRunningHooks()
+	logger.Noticef("done waiting for running hooks")
 	m.StopHooks()
 }
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -485,6 +485,8 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookErrorAndIgnoresIt(c *C) {
 func (s *hookManagerSuite) TestHookTaskShutDownWithoutRestart(c *C) {
 	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
 	defer restore()
+	logbuf, restoreLog := logger.MockLogger()
+	defer restoreLog()
 	cmd := testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
 	defer cmd.Restore()
 
@@ -514,6 +516,8 @@ func (s *hookManagerSuite) TestHookTaskShutDownWithoutRestart(c *C) {
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
 	c.Check(s.change.Status(), Equals, state.ErrorStatus)
 	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+	c.Check(logbuf.String(), Not(testutil.Contains), "gracefully waiting for running hooks")
+	c.Check(logbuf.String(), Not(testutil.Contains), "done waiting for running hooks")
 }
 
 func (s *hookManagerSuite) TestHookTaskShutDownWithRestart(c *C) {

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -482,7 +482,7 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookErrorAndIgnoresIt(c *C) {
 	c.Check(s.manager.NumRunningHooks(), Equals, 0)
 }
 
-func (s *hookManagerSuite) TestHookTaskShutDownWithoutRestart(c *C) {
+func (s *hookManagerSuite) TestHookTaskShutDown(c *C) {
 	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
 	defer restore()
 	logbuf, restoreLog := logger.MockLogger()
@@ -503,48 +503,6 @@ func (s *hookManagerSuite) TestHookTaskShutDownWithoutRestart(c *C) {
 	case <-time.After(2 * time.Second):
 		c.Fatal("hook did not start")
 	}
-
-	s.se.ShutDown()
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	c.Check(s.mockHandler.BeforeCalled, Equals, true)
-	c.Check(s.mockHandler.DoneCalled, Equals, false)
-	c.Check(s.mockHandler.ErrorCalled, Equals, true)
-
-	c.Check(s.task.Kind(), Equals, "run-hook")
-	c.Check(s.task.Status(), Equals, state.ErrorStatus)
-	c.Check(s.change.Status(), Equals, state.ErrorStatus)
-	c.Check(s.manager.NumRunningHooks(), Equals, 0)
-	c.Check(logbuf.String(), Not(testutil.Contains), "gracefully waiting for running hooks")
-	c.Check(logbuf.String(), Not(testutil.Contains), "done waiting for running hooks")
-}
-
-func (s *hookManagerSuite) TestHookTaskShutDownWithRestart(c *C) {
-	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
-	defer restore()
-	logbuf, restoreLog := logger.MockLogger()
-	defer restoreLog()
-	cmd := testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
-	defer cmd.Restore()
-
-	// Signal when the hook has started running
-	started := make(chan struct{})
-	s.mockHandler.BeforeCallback = func() {
-		close(started)
-	}
-	// Start the hook (no restart pending)
-	s.se.Ensure()
-	// Wait for the hook to actually start
-	select {
-	case <-started:
-	case <-time.After(2 * time.Second):
-		c.Fatal("hook did not start")
-	}
-
-	s.state.Lock()
-	restart.MockPending(s.state, restart.RestartDaemon)
-	s.state.Unlock()
 
 	s.se.ShutDown()
 	s.state.Lock()

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -33,6 +33,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -481,6 +482,49 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookErrorAndIgnoresIt(c *C) {
 	c.Check(s.manager.NumRunningHooks(), Equals, 0)
 }
 
+func (s *hookManagerSuite) TestHookTaskShutDownWithRestart(c *C) {
+	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
+	defer restore()
+	logbuf, restoreLog := logger.MockLogger()
+	defer restoreLog()
+	cmd := testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
+	defer cmd.Restore()
+
+	// Signal when the hook has started running
+	started := make(chan struct{})
+	s.mockHandler.BeforeCallback = func() {
+		close(started)
+	}
+	// Start the hook (no restart pending)
+	s.se.Ensure()
+	// Wait for the hook to actually start
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		c.Fatal("hook did not start")
+	}
+
+	s.state.Lock()
+	restart.MockPending(s.state, restart.RestartDaemon)
+	s.state.Unlock()
+
+	s.se.ShutDown()
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.mockHandler.BeforeCalled, Equals, true)
+	c.Check(s.mockHandler.DoneCalled, Equals, false)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.ErrorStatus)
+	c.Check(s.change.Status(), Equals, state.ErrorStatus)
+	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+
+	c.Check(logbuf.String(), testutil.Contains, "gracefully waiting for running hooks")
+	c.Check(logbuf.String(), testutil.Contains, "done waiting for running hooks")
+}
+
 func (s *hookManagerSuite) TestHookTaskEnforcesTimeout(c *C) {
 	var hooksup hookstate.HookSetup
 
@@ -893,7 +937,6 @@ func (s *hookManagerSuite) TestOptionalHookWithMissingHandler(c *C) {
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.DoneStatus)
 	c.Check(s.change.Status(), Equals, state.DoneStatus)
-
 	c.Logf("Task log:\n%s\n", s.task.Log())
 }
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -482,6 +482,40 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookErrorAndIgnoresIt(c *C) {
 	c.Check(s.manager.NumRunningHooks(), Equals, 0)
 }
 
+func (s *hookManagerSuite) TestHookTaskShutDownWithoutRestart(c *C) {
+	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
+	defer restore()
+	cmd := testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
+	defer cmd.Restore()
+
+	// Signal when the hook has started running
+	started := make(chan struct{})
+	s.mockHandler.BeforeCallback = func() {
+		close(started)
+	}
+	// Start the hook (no restart pending)
+	s.se.Ensure()
+	// Wait for the hook to actually start
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		c.Fatal("hook did not start")
+	}
+
+	s.se.ShutDown()
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.mockHandler.BeforeCalled, Equals, true)
+	c.Check(s.mockHandler.DoneCalled, Equals, false)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.ErrorStatus)
+	c.Check(s.change.Status(), Equals, state.ErrorStatus)
+	c.Check(s.manager.NumRunningHooks(), Equals, 0)
+}
+
 func (s *hookManagerSuite) TestHookTaskShutDownWithRestart(c *C) {
 	restore := hookstate.MockDefaultHookTimeout(100 * time.Millisecond)
 	defer restore()
@@ -937,6 +971,7 @@ func (s *hookManagerSuite) TestOptionalHookWithMissingHandler(c *C) {
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.DoneStatus)
 	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
 	c.Logf("Task log:\n%s\n", s.task.Log())
 }
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -561,11 +561,6 @@ func (o *Overlord) CanStandby() bool {
 // to stop accepting new requests and finish handling existing requests.
 func (o *Overlord) ShutDown() {
 	o.stateEng.ShutDown()
-	if o.stateFLock != nil {
-		// This will also unlock the file
-		o.stateFLock.Close()
-		logger.Noticef("Released state lock file")
-	}
 }
 
 // Stop stops the ensure loop and the managers under the StateEngine.

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -557,6 +557,17 @@ func (o *Overlord) CanStandby() bool {
 	return run != 0
 }
 
+// ShutDown asks the manager that implement the ShutDowner interface
+// to stop accepting new requests and finish handling existing requests.
+func (o *Overlord) ShutDown() {
+	o.stateEng.ShutDown()
+	if o.stateFLock != nil {
+		// This will also unlock the file
+		o.stateFLock.Close()
+		logger.Noticef("Released state lock file")
+	}
+}
+
 // Stop stops the ensure loop and the managers under the StateEngine.
 func (o *Overlord) Stop() error {
 	o.loopTomb.Kill(nil)

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -52,7 +52,8 @@ type StateWaiter interface {
 }
 
 // StateShutDowner is optionally implemented by StateManagers that have
-// running activities that can be shutdown.
+// running activities that should be cleaned up prior to stopping the daemon's
+// HTTP server.
 type StateShutDowner interface {
 	// ShutDown asks the manager to stop accepting new requests and
 	// finish handling existing requests.

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -51,6 +51,14 @@ type StateWaiter interface {
 	Wait()
 }
 
+// StateShutDowner is optionally implemented by StateManagers that have
+// running activities that can be shutdown.
+type StateShutDowner interface {
+	// ShutDown asks the manager to stop accepting new requests and
+	// finish handling existing requests.
+	ShutDown()
+}
+
 // StateStopper is optionally implemented by StateManagers that have
 // running activities that can be terminated.
 type StateStopper interface {
@@ -70,6 +78,7 @@ type StateEngine struct {
 	state     *state.State
 	stopped   bool
 	startedUp bool
+	shutdown  bool
 	// managers in use
 	mgrLock  sync.Mutex
 	managers []StateManager
@@ -187,6 +196,22 @@ func (se *StateEngine) Wait() {
 			waiter.Wait()
 		}
 	}
+}
+
+// ShutDown asks all managers to stop accepting new requests and
+// finish handling existing requests.
+func (se *StateEngine) ShutDown() {
+	se.mgrLock.Lock()
+	defer se.mgrLock.Unlock()
+	if se.shutdown {
+		return
+	}
+	for _, m := range se.managers {
+		if shutdowner, ok := m.(StateShutDowner); ok {
+			shutdowner.ShutDown()
+		}
+	}
+	se.shutdown = true
 }
 
 // Stop asks all managers to terminate activities running concurrently.

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -55,6 +55,10 @@ func (fm *fakeManager) Ensure() error {
 	return fm.ensureError
 }
 
+func (fm *fakeManager) ShutDown() {
+	*fm.calls = append(*fm.calls, "shutdown:"+fm.name)
+}
+
 func (fm *fakeManager) Stop() {
 	*fm.calls = append(*fm.calls, "stop:"+fm.name)
 }
@@ -159,6 +163,27 @@ func (ses *stateEngineSuite) TestEnsureError(c *C) {
 	err := se.Ensure()
 	c.Check(err.Error(), DeepEquals, "state ensure errors: [boom1 boom2]")
 	c.Check(calls, DeepEquals, []string{"ensure:mgr1", "ensure:mgr2"})
+}
+
+func (ses *stateEngineSuite) TestShutDown(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	c.Assert(se.StartUp(), IsNil)
+	calls = []string{}
+
+	se.ShutDown()
+	c.Check(calls, DeepEquals, []string{"shutdown:mgr1", "shutdown:mgr2"})
+	se.ShutDown()
+	c.Check(calls, HasLen, 2)
 }
 
 func (ses *stateEngineSuite) TestStop(c *C) {


### PR DESCRIPTION
Create a new optional method `ShutDown` for `StateManagers` which is implemented for `HookManager`. It encapsulates the current special handling for hooks in the `Daemon.Stop()` code, including both graceful and non-graceful stopping of hooks.

The rationale for this new method is so that managers which need to do some cleanup before the HTTP server stops can do so.

Tracked with: [SNAPDENG-36591](https://warthogs.atlassian.net/browse/SNAPDENG-36591?atlOrigin=eyJpIjoiYjA2OGRiNTM2NWNkNDBjZGE5YzdkNjk3OTdiYWE0MDciLCJwIjoiaiJ9)


[SNAPDENG-36591]: https://warthogs.atlassian.net/browse/SNAPDENG-36591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ