### PR TITLE
workshop.yaml: add workshop.yaml and project-specific sdks

### DIFF
--- a/.workshop/redocly/hooks/check-health
+++ b/.workshop/redocly/hooks/check-health
@@ -1,0 +1,9 @@
+if ! output="$(npm exec -- @redocly/cli --version 2>&1)" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+if ! output="$(reuse --version 2>&1)" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+workshopctl set-health okay

--- a/.workshop/redocly/hooks/setup-base
+++ b/.workshop/redocly/hooks/setup-base
@@ -1,0 +1,2 @@
+apt update
+apt install -y reuse

--- a/.workshop/redocly/hooks/setup-base
+++ b/.workshop/redocly/hooks/setup-base
@@ -1,2 +1,2 @@
 apt update
-apt install -y reuse
+apt install -y reuse graphviz

--- a/.workshop/redocly/hooks/setup-project
+++ b/.workshop/redocly/hooks/setup-project
@@ -1,0 +1,1 @@
+npm install -g @redocly/cli@latest

--- a/.workshop/redocly/sdk.yaml
+++ b/.workshop/redocly/sdk.yaml
@@ -1,0 +1,5 @@
+name: redocly
+plugs:
+  node-modules:
+    interface: mount
+    workshop-target: /usr/local/lib/node_modules

--- a/.workshop/snapcraft/hooks/check-health
+++ b/.workshop/snapcraft/hooks/check-health
@@ -1,0 +1,10 @@
+if ! output="$(snapcraft --version 2>&1)" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+output="$(sudo -iu workshop command -v snapcraft)"
+if [ ! "$output" = /home/workshop/.local/bin/snapcraft ] ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+workshopctl set-health okay

--- a/.workshop/snapcraft/hooks/setup-base
+++ b/.workshop/snapcraft/hooks/setup-base
@@ -1,0 +1,19 @@
+snap install snapcraft --classic
+
+# Snapcraft can't use lxd containers to build within the workshop container,
+# so must use `--destructive-mode` and run as root.
+# If in the future workshop supports VMs instead of containers, this can all be
+# removed and instead simply install and initialize lxd alongside snapcraft.
+
+# /home/workshop/.local/bin is first in path, so create script there.
+LOCAL_BIN="/home/workshop/.local/bin"
+sudo -iu workshop mkdir -p "$LOCAL_BIN"
+
+# Using `cat <<EOF` mangles the $@, so echo manually
+echo 'sudo snap run snapcraft clean --destructive-mode' > "$LOCAL_BIN"/snapcraft
+echo 'sudo snap run snapcraft $@ --destructive-mode' >> "$LOCAL_BIN"/snapcraft
+echo 'sudo snap run snapcraft clean --destructive-mode' >> "$LOCAL_BIN"/snapcraft
+echo 'if [ -f snapd_*.snap ] ; then sudo chown workshop:workshop snapd_*.snap ; fi' >> "$LOCAL_BIN"/snapcraft
+
+chmod 755 "$LOCAL_BIN"/snapcraft
+chown workshop:workshop "$LOCAL_BIN"/snapcraft

--- a/.workshop/snapcraft/hooks/setup-base
+++ b/.workshop/snapcraft/hooks/setup-base
@@ -13,7 +13,7 @@ sudo -iu workshop mkdir -p "$LOCAL_BIN"
 echo 'sudo snap run snapcraft clean --destructive-mode' > "$LOCAL_BIN"/snapcraft
 echo 'sudo snap run snapcraft $@ --destructive-mode' >> "$LOCAL_BIN"/snapcraft
 echo 'sudo snap run snapcraft clean --destructive-mode' >> "$LOCAL_BIN"/snapcraft
-echo 'if [ -f snapd_*.snap ] ; then sudo chown workshop:workshop snapd_*.snap ; fi' >> "$LOCAL_BIN"/snapcraft
+echo 'for built_snap in snapd_*.snap ; do if [ -f "$built_snap" ] ; then sudo chown workshop:workshop "$built_snap" ; fi ; done' >> "$LOCAL_BIN"/snapcraft
 
 chmod 755 "$LOCAL_BIN"/snapcraft
 chown workshop:workshop "$LOCAL_BIN"/snapcraft

--- a/.workshop/snapcraft/sdk.yaml
+++ b/.workshop/snapcraft/sdk.yaml
@@ -1,0 +1,1 @@
+name: snapcraft

--- a/.workshop/snapd-build-deps/hooks/check-health
+++ b/.workshop/snapd-build-deps/hooks/check-health
@@ -1,0 +1,5 @@
+if ! output="$(sudo -iu workshop bash -c 'cd /project && ./run-checks --verify-tools')" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+workshopctl set-health okay

--- a/.workshop/snapd-build-deps/hooks/setup-base
+++ b/.workshop/snapd-build-deps/hooks/setup-base
@@ -1,0 +1,18 @@
+apt update
+
+# For run-checks
+apt install -y shellcheck dbus-x11 clang-format
+snap install --classic golangci-lint
+
+# For building debian package
+apt install -y devscripts
+
+# For building with go-1.23
+apt install -y golang-1.23
+cat <<EOF >> /etc/profile.d/snapd-build-deps.sh
+PATH="/usr/lib/go-1.23/bin:\$PATH"
+EOF
+
+# Alternatively, install the go snap with a particular channel
+# snap install go --classic --channel=1.18/stable
+

--- a/.workshop/snapd-build-deps/hooks/setup-project
+++ b/.workshop/snapd-build-deps/hooks/setup-project
@@ -1,0 +1,7 @@
+if [ ! -e ./debian ]; then
+    ln -s packaging/ubuntu-16.04 debian
+fi
+sudo apt-get update
+sudo apt-get build-dep -y .
+
+./get-deps.sh

--- a/.workshop/snapd-build-deps/sdk.yaml
+++ b/.workshop/snapd-build-deps/sdk.yaml
@@ -1,0 +1,1 @@
+name: snapd-build-deps

--- a/.workshop/spread/hooks/check-health
+++ b/.workshop/spread/hooks/check-health
@@ -1,0 +1,9 @@
+if ! output="$(image-garden --version 2>&1)" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+if ! output="$(sudo -iu workshop spread --help 2>&1)" ; then
+    workshopctl set-health error "$output"
+    exit 1
+fi
+workshopctl set-health okay

--- a/.workshop/spread/hooks/setup-base
+++ b/.workshop/spread/hooks/setup-base
@@ -1,0 +1,25 @@
+# XXX: Workshop containers do not support kvm acceleration, so running spread
+# via image-garden causes qemu to fall back to tcg, which is to slow to
+# successfully provision a spread VM. Thus, this is broken until workshop
+# adds support for kvm (likely by allowing workshops themselves to be VMs
+# instead of containers).
+
+# The image-garden snap cannot access `/project` directory, so instead build
+# image-garden from source
+
+# Install image-garden dependencies
+apt update
+apt install -y make git wget qemu-system-x86 qemu-system-aarch64 qemu-system-riscv64 qemu-system-s390x qemu-utils xorriso
+
+# Install python dependency to make rulegen.py work on python 3.10
+apt install python3-pip
+pip install StrEnum
+
+# Build and install image-garden from source
+cd $HOME
+git clone https://gitlab.com/zygoon/image-garden.git
+cd image-garden
+# Patch to use `strenum` module for `StrEnum`
+sed -i '/import sys/i import strenum' rulegen.py
+sed -i 's/enum\.StrEnum/strenum.LowercaseStrEnum/' rulegen.py
+make && make install

--- a/.workshop/spread/hooks/setup-base
+++ b/.workshop/spread/hooks/setup-base
@@ -1,5 +1,5 @@
 # XXX: Workshop containers do not support kvm acceleration, so running spread
-# via image-garden causes qemu to fall back to tcg, which is to slow to
+# via image-garden causes qemu to fall back to tcg, which is too slow to
 # successfully provision a spread VM. Thus, this is broken until workshop
 # adds support for kvm (likely by allowing workshops themselves to be VMs
 # instead of containers).
@@ -12,7 +12,7 @@ apt update
 apt install -y make git wget qemu-system-x86 qemu-system-aarch64 qemu-system-riscv64 qemu-system-s390x qemu-utils xorriso
 
 # Install python dependency to make rulegen.py work on python 3.10
-apt install python3-pip
+apt install -y python3-pip
 pip install StrEnum
 
 # Build and install image-garden from source

--- a/.workshop/spread/hooks/setup-project
+++ b/.workshop/spread/hooks/setup-project
@@ -1,0 +1,2 @@
+# Not using spread from image-garden snap, so install it from upstream
+GOPATH=/home/workshop/.local go install github.com/canonical/spread-plus/cmd/spread@latest

--- a/.workshop/spread/sdk.yaml
+++ b/.workshop/spread/sdk.yaml
@@ -1,0 +1,12 @@
+name: spread
+plugs:
+  # Not sure where cache lives for locally-built image-garden with unset $XDG_CACHE_HOME
+  #garden-snap-cache:
+    #interface: mount
+    #workshop-target: /var/snap/image-garden/common/cache
+  #garden-home-cache:
+    #interface: mount
+    #workshop-target: /home/workshop/snap/image-garden-common/cache
+  #garden-project-cache:
+    #interface: mount
+    #workshop-target: /project/.image-garden

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -1,0 +1,47 @@
+name: snapd-dev
+base: ubuntu@22.04
+sdks:
+  - name: project-snapd-build-deps
+  - name: project-snapcraft
+  - name: project-spread
+
+  # redocly
+  - name: node
+    channel: latest/stable
+  - name: project-redocly
+
+  # various options for LLM harnesses
+  - name: opencode
+    channel: latest/stable
+  - name: copilot
+    channel: latest/stable
+  - name: claude-code
+    channel: latest/stable
+  - name: codex
+    channel: latest/stable
+
+  - name: system
+    plugs:
+      lemonade: # local lemonade-server instance
+        interface: tunnel
+        endpoint: localhost:13305
+
+actions:
+  checks: ./run-checks "$@"
+  spread: ./run-spread "$@" # broken via garden without kvm
+  no-rebuild-spread: NO_REBUILD=1 ./run-spread "$@" # broken via garden without kvm
+  build-test-snapd-snap: tests/build-test-snapd-snap # uses --destructive-mode until lxd containers with snaps supported
+  snapcraft: snapcraft "$@" # uses --destructive-mode until lxd containers with snaps supported
+  debuild: debuild -us -uc # broken because it tries to write to /project/..
+  build-deb: debuild -us -uc # broken because it tries to write to /project/..
+  redocly: |
+    cd docs/api && make REDOCLY_CMD="npm exec -- @redocly/cli" REUSE_CMD="reuse" "$@"
+
+  # various options for LLM harnesses
+  opencode: opencode "$@"
+  claude: claude --dangerously-skip-permissions "$@"
+  claude-prompt: claude --dangerously-skip-permissions -p "$@"
+  copilot: copilot --yolo "$@"
+  copilot-prompt: copilot --yolo --prompt="$@"
+  codex: codex --yolo "$@"
+  codex-exec: codex exec --yolo "$@"


### PR DESCRIPTION
Workshop is a new tool which provides sandboxed development containers with project-specific tooling pre-installed, and which can be adjusted over time as the project requirements change.

The workshop is defined by the `workshop.yaml` file, which lists the project-specific and store-provided SDKs which are used by the project, as well as the additional plugs and slots used to connect SDKs to each other and the host system, and "actions", which are essentially aliases for key project-specific commands developers would expect to make frequently.

This PR adds the following project-specific SDKs:

* snapd-build-deps: dependencies to build snapd, run unit tests, and build the snapd .deb
  * building the snapd .deb via debuild does not seem to work at the moment because it tries to write to /project/.. where it lacks permissions
* snapcraft: installs the snapcraft snap
  * does not currently use lxd since the nested container used by snapcraft within the workshop breaks snap-confine
  * instead uses `--destructive-mode` to build directly in the workshop
* spread: gets spread-plus and builds image-garden from source
  * does not use the image-garden snap as it does not have permission to read `/project`
  * running spread via image-garden does not work at the moment, as qemu does not have kvm access, which means spread allocation is too slow and times out -- this will be fixed if/when workshop supports running workshops in VMs instead of just containers
* redocly: installs the redocly-cli npm package to build and lint the snapd api docs

Additionally, SDKs for various LLM harnesses are included, if the developer would like to run them within the workshop. The port of a local lemonade server (AMD's local LLM daemon) is passed into the workshop as well so that harnesses may use local models running on the host machine.

https://warthogs.atlassian.net/browse/SNAPDENG-37217
