### PR TITLE
cmd/snap-confine, interfaces/apparmor: use profile and flags= in snap-confine and snap-update-ns' AppArmor profiles

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -3,7 +3,7 @@
 
 @{SNAP_MOUNT_DIR_LIST}="{,/var/lib/snapd}/snap"
 
-@LIBEXECDIR@/snap-confine (attach_disconnected) {
+profile @LIBEXECDIR@/snap-confine flags=(attach_disconnected) {
     # Include any additional files that snapd chose to generate.
     # - for $HOME on remote file system.
     # - for $HOME on encrypted media

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2737,7 +2737,7 @@ apps:
 
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "some-snap_instance", trivialSnapYaml, 1)
 	profileUpdateNS := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.some-snap_instance")
-	c.Check(profileUpdateNS, testutil.FileContains, `profile snap-update-ns.some-snap_instance (`)
+	c.Check(profileUpdateNS, testutil.FileContains, `profile snap-update-ns.some-snap_instance flags=(`)
 	c.Check(profileUpdateNS, testutil.FileContains, `
   # Allow parallel instance snap mount namespace adjustments
   mount options=(rw rbind) /snap/some-snap_instance/ -> /snap/some-snap/,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -989,7 +989,7 @@ var updateNSTemplate = `
 
 ###INCLUDE_SYSTEM_TUNABLES_HOME_D_WITH_VENDORED_APPARMOR###
 
-profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
+profile snap-update-ns.###SNAP_INSTANCE_NAME### flags=(attach_disconnected) {
   # The next four rules mirror those above. We want to be able to read
   # and map snap-update-ns into memory but it may come from a variety of places.
   /usr/lib{,exec,64}/snapd/snap-update-ns mr,


### PR DESCRIPTION
Snap profiles profiles are already consistently using:

     profile <name> flags=(...)

so let's do the same for snap-confine. This should also help to avoid
the need to patch the profile by CIS hardening tooling.

Also use flags=(..) syntax in dedicated profiles for snap-update-ns.

Reported: https://chat.canonical.com/canonical/pl/qo537d758fd3ip4tm4et1jbxqo 
