### PR TITLE
cmd/snap-bootstrap: fix trailing newlines and wording in error messages

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -602,7 +602,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	}
 
 	if err := bootEnsureNextBootToRunMode(mst.recoverySystem); err != nil {
-		return fmt.Errorf("failed to set system to run mode: %v\n", err)
+		return fmt.Errorf("cannot set system to run mode: %v", err)
 	}
 
 	mst.mode = "run"

--- a/cmd/snap-bootstrap/cmd_scan_disk.go
+++ b/cmd/snap-bootstrap/cmd_scan_disk.go
@@ -109,7 +109,7 @@ func scanDiskNodeFallback(output io.Writer, node string) error {
 
 	disk, err := probeDisk(node, probeDiskOpts{probeFsAlways: false})
 	if err != nil {
-		return fmt.Errorf("cannot get partitions: %s\n", err)
+		return fmt.Errorf("cannot get partitions: %v", err)
 	}
 
 	/*
@@ -144,7 +144,7 @@ func scanDiskNodeFallback(output io.Writer, node string) error {
 	 */
 	values, err := kcmdline.KeyValues("snapd_system_disk")
 	if err != nil {
-		return fmt.Errorf("cannot read kernel command line: %s\n", err)
+		return fmt.Errorf("cannot read kernel command line: %v", err)
 	}
 
 	if value, ok := values["snapd_system_disk"]; ok {
@@ -162,7 +162,7 @@ func scanDiskNodeFallback(output io.Writer, node string) error {
 		same, err := samePath(filepath.Join(dirs.GlobalRootDir, expectedPath),
 			filepath.Join(dirs.GlobalRootDir, currentPath))
 		if err != nil {
-			return fmt.Errorf("cannot check snapd_system_disk kernel parameter: %s\n", err)
+			return fmt.Errorf("cannot check snapd_system_disk kernel parameter: %v", err)
 		}
 		if !same {
 			/*
@@ -216,7 +216,7 @@ func scanDiskNode(output io.Writer, node string) error {
 
 	disk, err := probeDisk(node, probeDiskOpts{probeFsAlways: false})
 	if err != nil {
-		return fmt.Errorf("cannot get partitions: %s\n", err)
+		return fmt.Errorf("cannot get partitions: %v", err)
 	}
 
 	/*
@@ -268,6 +268,6 @@ func ScanDisk(output io.Writer) error {
 	if osGetenv("DEVTYPE") == "disk" {
 		return scanDiskNode(output, devname)
 	} else {
-		return fmt.Errorf("unknown type for block device %s\n", devname)
+		return fmt.Errorf("unknown type for block device %s", devname)
 	}
 }


### PR DESCRIPTION
- [x] Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)? - yes

---

`cmd_scan_disk.go` and `cmd_initramfs_mounts.go` had error messages with a trailing `\n`, which is against Go conventions and the project style guide. Also one message used "failed to" instead of "cannot".

The trailing `\n` causes an extra blank line when the error gets printed by the go-flags CLI or logged during boot — easy to reproduce by triggering the error path (e.g. calling `snap-bootstrap scan-disk` with `DEVTYPE` not set to `disk`).

Changes:
- remove trailing `\n` from 5 error strings in `cmd_scan_disk.go`
- change `%s` to `%v` for error args (more idiomatic)
- fix `cmd_initramfs_mounts.go:605`: "failed to set system to run mode" -> "cannot set system to run mode", also drops the `\n`

No behavior change, no tests needed updating.