### PR TITLE
cmd/autogen: pass explicit --sysconfdir

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -22,39 +22,39 @@ rm -f config.status
 autoreconf -i -f
 
 # Configure the build
-extra_opts=
+extra_opts="--sysconfdir=/etc"
 # shellcheck disable=SC1091
 . /etc/os-release
 case "$ID" in
 	arch)
-		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-apparmor --enable-nvidia-biarch --enable-merged-usr"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-apparmor --enable-nvidia-biarch --enable-merged-usr"
 		;;
 	debian)
-		extra_opts="--libexecdir=/usr/lib/snapd"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd"
 		;;
 	gentoo)
-		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-apparmor --enable-nvidia-biarch --enable-merged-usr"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-apparmor --enable-nvidia-biarch --enable-merged-usr"
 		;;
 	ubuntu)
-		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
 		if [ "$(dpkg-architecture -qDEB_HOST_ARCH)" = "amd64" ]; then
 			extra_opts="$extra_opts --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH)"
 		fi
 		;;
 	fedora|centos|rhel)
-		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor --enable-selinux"
+		extra_opts="$extra_opts --libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor --enable-selinux"
 		;;
 	opensuse-tumbleweed)
-		  extra_opts="--libexecdir=/usr/libexec/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
-		  ;;
+		extra_opts="$extra_opts --libexecdir=/usr/libexec/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
+		;;
 	opensuse)
-		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
 		;;
 	solus)
-		extra_opts="--enable-nvidia-biarch"
+		extra_opts="$extra_opts --enable-nvidia-biarch"
 		;;
 	altlinux)
-		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --disable-apparmor --enable-selinux --enable-nvidia-biarch --with-32bit-libdir=/usr/lib"
+		extra_opts="$extra_opts --libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --disable-apparmor --enable-selinux --enable-nvidia-biarch --with-32bit-libdir=/usr/lib"
 		;;
 esac
 


### PR DESCRIPTION
Noticed that recently the local development builds done using autogen.sh started defaulting to /usr/etc for sysconfdir, which is unexpected. Update the script to pass explicit path.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
