### PR TITLE
many: centralize and use common systemd mock in snapshotmgr test

### DIFF
--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -32,33 +32,9 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
-
-type ResultForEnsureMountUnitFile struct {
-	path string
-	err  error
-}
-
-type FakeSystemdForMount struct {
-	systemd.Systemd
-
-	RemoveMountUnitFileCalls  []string
-	RemoveMountUnitFileResult error
-
-	EnsureMountUnitFileCalls  []*systemd.MountUnitOptions
-	EnsureMountUnitFileResult ResultForEnsureMountUnitFile
-}
-
-func (s *FakeSystemdForMount) RemoveMountUnitFile(baseDir string) error {
-	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, baseDir)
-	return s.RemoveMountUnitFileResult
-}
-
-func (s *FakeSystemdForMount) EnsureMountUnitFile(options *systemd.MountUnitOptions) (string, error) {
-	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls, options)
-	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err
-}
 
 func CopyMap(m map[string]any) map[string]any {
 	cp := make(map[string]any)
@@ -96,7 +72,7 @@ type mountSuite struct {
 	mockContext *hookstate.Context
 	mockHandler *hooktest.MockHandler
 	hookTask    *state.Task
-	sysd        *FakeSystemdForMount
+	sysd        *systemdtest.FakeSystemd
 	// A connection state for a snap using the mount interface with the plug
 	// properly configured, which we'll be reusing in different test cases
 	regularConnState map[string]any
@@ -158,7 +134,7 @@ func (s *mountSuite) SetUpTest(c *C) {
 	}
 	s.hookTask = task
 
-	s.sysd = &FakeSystemdForMount{}
+	s.sysd = &systemdtest.FakeSystemd{}
 	s.AddCleanup(systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
 		return s.sysd
 	}))
@@ -308,7 +284,7 @@ func (s *mountSuite) TestMissingProperPlug(c *C) {
 func (s *mountSuite) TestUnitCreationFailure(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"", errors.New("creation error")}
+	s.sysd.EnsureMountUnitFileResult.Err = errors.New("creation error")
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-t", "ext4", "/src", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot ensure mount unit: creation error`)
@@ -328,7 +304,7 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 func (s *mountSuite) TestHappy(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"/path/unit.mount", nil}
+	s.sysd.EnsureMountUnitFileResult.Path = "/path/unit.mount"
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0, nil)
 	c.Check(err, IsNil)
@@ -349,7 +325,7 @@ func (s *mountSuite) TestHappy(c *C) {
 func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"/path/unit.mount", nil}
+	s.sysd.EnsureMountUnitFileResult.Path = "/path/unit.mount"
 
 	// Now try with $SNAP_* variables in the paths
 	snapDataDir := filepath.Join(dirs.SnapDataDir, "snap1", "1")
@@ -372,7 +348,7 @@ func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"/path/unit.mount", nil}
+	s.sysd.EnsureMountUnitFileResult.Path = "/path/unit.mount"
 
 	// Now try with commas in the paths
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-o", "ro", "/dev/dma_heap/qcom,qseecom", "/dest,with,commas"}, 0, nil)
@@ -393,7 +369,7 @@ func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 func (s *mountSuite) TestHappyNFS(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"/path/unit.mount", nil}
+	s.sysd.EnsureMountUnitFileResult.Path = "/path/unit.mount"
 
 	// Now try with commas in the paths
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-o", "rw", "-t", "nfs", "localhost:/var/share", "/nfs-dest"}, 0, nil)
@@ -415,7 +391,7 @@ func (s *mountSuite) TestHappyNFS(c *C) {
 func (s *mountSuite) TestHappyCIFS(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"/path/unit.mount", nil}
+	s.sysd.EnsureMountUnitFileResult.Path = "/path/unit.mount"
 
 	// Now try with commas in the paths
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-o", "rw,guest", "-t", "cifs", "//10.0.0.1/share/path", "/cifs-dest"}, 0, nil)
@@ -437,7 +413,7 @@ func (s *mountSuite) TestHappyCIFS(c *C) {
 func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"", errors.New("some error")}
+	s.sysd.EnsureMountUnitFileResult.Err = errors.New("some error")
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot ensure mount unit: some error`)
@@ -460,7 +436,7 @@ func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
 func (s *mountSuite) TestEnsureMountUnitFailedRemoveFailed(c *C) {
 	s.injectSnapWithProperPlug(c)
 
-	s.sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"", errors.New("some error")}
+	s.sysd.EnsureMountUnitFileResult.Err = errors.New("some error")
 	s.sysd.RemoveMountUnitFileResult = errors.New("some other error")
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0, nil)

--- a/overlord/hookstate/ctlcmd/umount_test.go
+++ b/overlord/hookstate/ctlcmd/umount_test.go
@@ -31,39 +31,9 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
-
-type ParamsForListMountUnits struct {
-	snapName string
-	origin   string
-}
-
-type ResultForListMountUnits struct {
-	units []string
-	err   error
-}
-
-type FakeSystemdForUmount struct {
-	systemd.Systemd
-
-	RemoveMountUnitFileCalls       []string
-	RemoveMountUnitFileCallsResult error
-
-	ListMountUnitsCalls       []*ParamsForListMountUnits
-	ListMountUnitsCallsResult ResultForListMountUnits
-}
-
-func (s *FakeSystemdForUmount) RemoveMountUnitFile(mountedDir string) error {
-	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, mountedDir)
-	return s.RemoveMountUnitFileCallsResult
-}
-
-func (s *FakeSystemdForUmount) ListMountUnits(snapName, origin string) ([]string, error) {
-	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
-		&ParamsForListMountUnits{snapName, origin})
-	return s.ListMountUnitsCallsResult.units, s.ListMountUnitsCallsResult.err
-}
 
 type umountSuite struct {
 	testutil.BaseTest
@@ -71,7 +41,7 @@ type umountSuite struct {
 	mockContext *hookstate.Context
 	mockHandler *hooktest.MockHandler
 	hookTask    *state.Task
-	sysd        *FakeSystemdForUmount
+	sysd        *systemdtest.FakeSystemd
 }
 
 var _ = Suite(&umountSuite{})
@@ -94,7 +64,7 @@ func (s *umountSuite) SetUpTest(c *C) {
 
 	s.hookTask = task
 
-	s.sysd = &FakeSystemdForUmount{}
+	s.sysd = &systemdtest.FakeSystemd{}
 	s.AddCleanup(systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
 		return s.sysd
 	}))
@@ -111,39 +81,39 @@ func (s *umountSuite) TestMissingParameters(c *C) {
 }
 
 func (s *umountSuite) TestListUnitFailure(c *C) {
-	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{}, errors.New("list error")}
+	s.sysd.ListMountUnitsResult.Err = errors.New("list error")
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot retrieve list of mount units: list error`)
-	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
-		{"snap1", "mount-control"},
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "snap1", Origin: "mount-control"},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
 
 func (s *umountSuite) TestUnitNotFound(c *C) {
-	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{
+	s.sysd.ListMountUnitsResult.MountPoints = []string{
 		"/this/is",
 		"/not/our/mount/destination",
-	}, nil}
+	}
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot find the given mount`)
-	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
-		{"snap1", "mount-control"},
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "snap1", Origin: "mount-control"},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
 
 func (s *umountSuite) TestRemovalError(c *C) {
-	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{"/dest"}, nil}
+	s.sysd.ListMountUnitsResult.MountPoints = []string{"/dest"}
 
-	s.sysd.RemoveMountUnitFileCallsResult = errors.New("remove error")
+	s.sysd.RemoveMountUnitFileResult = errors.New("remove error")
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot remove mount unit: remove error`)
-	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
-		{"snap1", "mount-control"},
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "snap1", Origin: "mount-control"},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",
@@ -151,12 +121,12 @@ func (s *umountSuite) TestRemovalError(c *C) {
 }
 
 func (s *umountSuite) TestHappy(c *C) {
-	s.sysd.ListMountUnitsCallsResult = ResultForListMountUnits{[]string{"/dest"}, nil}
+	s.sysd.ListMountUnitsResult.MountPoints = []string{"/dest"}
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, IsNil)
-	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []*ParamsForListMountUnits{
-		{"snap1", "mount-control"},
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "snap1", Origin: "mount-control"},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",

--- a/overlord/snapshotstate/backend/mountunit_test.go
+++ b/overlord/snapshotstate/backend/mountunit_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -35,34 +36,13 @@ type mountunitSuite struct {
 
 var _ = Suite(&mountunitSuite{})
 
-type fakeSystemd struct {
-	systemd.Systemd
-
-	listMountUnitsCalls  []listMountUnitsCall
-	listMountUnitsResult listMountUnitsResult
-}
-
-type listMountUnitsCall struct {
-	snapName, origin string
-}
-
-type listMountUnitsResult struct {
-	mountPoints []string
-	err         error
-}
-
-func (s *fakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) {
-	s.listMountUnitsCalls = append(s.listMountUnitsCalls, listMountUnitsCall{snapName, origin})
-	return s.listMountUnitsResult.mountPoints, s.listMountUnitsResult.err
-}
-
 func (s *mountunitSuite) TestListMountControlMountPointsHappy(c *C) {
 	returnedMounts := []string{"/var/snap/a-snap/x1/data/mymount", "/var/snap/a-snap/common/media"}
 
-	var sysd *fakeSystemd
-	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, mode systemd.InstanceMode, rep systemd.Reporter) systemd.Systemd {
-		sysd = &fakeSystemd{}
-		sysd.listMountUnitsResult = listMountUnitsResult{mountPoints: returnedMounts}
+	var sysd *systemdtest.FakeSystemd
+	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = returnedMounts
 		return sysd
 	})
 	defer restore()
@@ -71,16 +51,16 @@ func (s *mountunitSuite) TestListMountControlMountPointsHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(mountPts, DeepEquals, returnedMounts)
 
-	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{{SnapName: "a-snap", Origin: "mount-control"}})
 }
 
 func (s *mountunitSuite) TestListMountControlMountPointsError(c *C) {
 	expectedErr := errors.New("systemd failure")
 
-	var sysd *fakeSystemd
-	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, mode systemd.InstanceMode, rep systemd.Reporter) systemd.Systemd {
-		sysd = &fakeSystemd{}
-		sysd.listMountUnitsResult = listMountUnitsResult{err: expectedErr}
+	var sysd *systemdtest.FakeSystemd
+	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.Err = expectedErr
 		return sysd
 	})
 	defer restore()
@@ -89,14 +69,14 @@ func (s *mountunitSuite) TestListMountControlMountPointsError(c *C) {
 	c.Check(err, Equals, expectedErr)
 	c.Check(mountPts, IsNil)
 
-	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{{SnapName: "a-snap", Origin: "mount-control"}})
 }
 
 func (s *mountunitSuite) TestListMountControlMountPointsEmpty(c *C) {
-	var sysd *fakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
-		sysd = &fakeSystemd{}
-		sysd.listMountUnitsResult = listMountUnitsResult{mountPoints: []string{}}
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = []string{}
 		return sysd
 	})
 	defer restore()
@@ -105,5 +85,5 @@ func (s *mountunitSuite) TestListMountControlMountPointsEmpty(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(mountPts, DeepEquals, []string{})
 
-	c.Check(sysd.listMountUnitsCalls, DeepEquals, []listMountUnitsCall{{snapName: "a-snap", origin: "mount-control"}})
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{{SnapName: "a-snap", Origin: "mount-control"}})
 }

--- a/overlord/snapshotstate/export_test.go
+++ b/overlord/snapshotstate/export_test.go
@@ -216,11 +216,3 @@ func MockGetSnapDirOptions(f func(*state.State, string) (*dirs.SnapDirOptions, e
 		getSnapDirOpts = old
 	}
 }
-
-func MockListMountControlMountPoints(f func(string) ([]string, error)) (restore func()) {
-	old := listMountControlMountPoints
-	listMountControlMountPoints = f
-	return func() {
-		listMountControlMountPoints = old
-	}
-}

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -56,8 +56,7 @@ var (
 
 	autoExpirationInterval = time.Hour * 24 // interval between forgetExpiredSnapshots runs as part of Ensure()
 
-	getSnapDirOpts              = snapstate.GetSnapDirOpts
-	listMountControlMountPoints = backend.ListMountControlMountPoints
+	getSnapDirOpts = snapstate.GetSnapDirOpts
 )
 
 // SnapshotManager takes snapshots of active snaps
@@ -272,7 +271,7 @@ func mapMountPointsInGlobalDataDirsToExcludes(si *snap.Info, mountPoints []strin
 // excludeMountControlMountPoints appends any currently-active mount-control
 // mount points under the snap's data directories to s.Options.
 func (s *snapshotSetup) excludeMountControlMountPoints(si *snap.Info) error {
-	mountPts, err := listMountControlMountPoints(si.InstanceName())
+	mountPts, err := backend.ListMountControlMountPoints(si.InstanceName())
 	if err != nil {
 		return fmt.Errorf("cannot list mount-control units for %q: %v", si.InstanceName(), err)
 	}

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -279,8 +281,8 @@ func (snapshotSuite) TestDoSave(c *check.C) {
 		buf := json.RawMessage(`{"hello": "there"}`)
 		return &buf, nil
 	})()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return nil, nil
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
 	})()
 
 	expectedOptions := &snap.SnapshotOptions{}
@@ -382,9 +384,10 @@ func (snapshotSuite) TestDoSaveMountControlExcludes(c *check.C) {
 
 	snapDataDir := snapInfo.DataDir()
 	snapCommonDir := snapInfo.CommonDataDir()
-	defer snapshotstate.MockListMountControlMountPoints(func(name string) ([]string, error) {
-		c.Check(name, check.Equals, "a-snap")
-		return []string{snapDataDir + "/mymount", "/outside/snap/dirs", snapCommonDir + "/media"}, nil
+	var sysd systemdtest.FakeSystemd
+	sysd.ListMountUnitsResult.MountPoints = []string{snapDataDir + "/mymount", "/outside/snap/dirs", snapCommonDir + "/media"}
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &sysd
 	})()
 
 	var gotOptions *snap.SnapshotOptions
@@ -407,6 +410,7 @@ func (snapshotSuite) TestDoSaveMountControlExcludes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(gotOptions, check.NotNil)
 	c.Check(gotOptions.Exclude, check.DeepEquals, []string{"$SNAP_DATA/mymount", "$SNAP_COMMON/media"})
+	c.Check(sysd.ListMountUnitsCalls, check.DeepEquals, []systemdtest.ParamsForListMountUnits{{SnapName: "a-snap", Origin: "mount-control"}})
 }
 
 func (snapshotSuite) TestDoSaveMountControlExcludesPreservesSetupOptions(c *check.C) {
@@ -425,8 +429,10 @@ func (snapshotSuite) TestDoSaveMountControlExcludesPreservesSetupOptions(c *chec
 	})()
 
 	snapCommonDir := snapInfo.CommonDataDir()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return []string{snapCommonDir + "/media"}, nil
+	var sysd systemdtest.FakeSystemd
+	sysd.ListMountUnitsResult.MountPoints = []string{snapCommonDir + "/media"}
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &sysd
 	})()
 
 	var gotOptions *snap.SnapshotOptions
@@ -467,8 +473,10 @@ func (snapshotSuite) TestDoSaveMountControlExcludesListMountsError(c *check.C) {
 	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
 		return nil, nil
 	})()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return nil, errors.New("mock ListMountControlMountPoints error")
+	var sysd systemdtest.FakeSystemd
+	sysd.ListMountUnitsResult.Err = errors.New("mock ListMountUnits error")
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &sysd
 	})()
 
 	setupOptions := &snap.SnapshotOptions{Exclude: []string{"$SNAP_DATA/logs"}}
@@ -497,7 +505,7 @@ func (snapshotSuite) TestDoSaveMountControlExcludesListMountsError(c *check.C) {
 	// Original setup options passed through unchanged despite list error
 	c.Check(gotOptions, check.DeepEquals, setupOptions)
 	// Verify error was logged
-	c.Check(logbuf.String(), check.Matches, "(?s).*cannot exclude mount-control mount points.* mock ListMountControlMountPoints error.*")
+	c.Check(logbuf.String(), check.Matches, "(?s).*cannot exclude mount-control mount points.* mock ListMountUnits error.*")
 }
 
 func (snapshotSuite) TestDoSaveNoMountControlMounts(c *check.C) {
@@ -514,9 +522,10 @@ func (snapshotSuite) TestDoSaveNoMountControlMounts(c *check.C) {
 	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) {
 		return nil, nil
 	})()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		// No active mount-control mounts
-		return []string{}, nil
+	var sysd systemdtest.FakeSystemd
+	sysd.ListMountUnitsResult.MountPoints = []string{}
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &sysd
 	})()
 
 	setupOptions := &snap.SnapshotOptions{Exclude: []string{"$SNAP_DATA/cache"}}
@@ -560,8 +569,8 @@ func (snapshotSuite) TestDoSaveGetsSnapDirOpts(c *check.C) {
 		c.Check(snapname, check.Equals, "a-snap")
 		return &snapInfo, nil
 	})()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return nil, nil
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
 	})()
 
 	var checkOpts bool
@@ -640,8 +649,8 @@ func (snapshotSuite) TestDoSaveFailsBackendError(c *check.C) {
 	}
 	defer snapshotstate.MockSnapstateCurrentInfo(func(*state.State, string) (*snap.Info, error) { return &snapInfo, nil })()
 	defer snapshotstate.MockConfigGetSnapConfig(func(*state.State, string) (*json.RawMessage, error) { return nil, nil })()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return nil, nil
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
 	})()
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string, _ *snap.SnapshotOptions, options *dirs.SnapDirOptions) (*client.Snapshot, error) {
 		return nil, errors.New("bzzt")
@@ -736,8 +745,8 @@ func (snapshotSuite) TestDoSaveFailureRemovesStateEntry(c *check.C) {
 	defer snapshotstate.MockConfigGetSnapConfig(func(_ *state.State, snapname string) (*json.RawMessage, error) {
 		return nil, nil
 	})()
-	defer snapshotstate.MockListMountControlMountPoints(func(string) ([]string, error) {
-		return nil, nil
+	defer systemd.MockNewSystemd(func(systemd.Backend, string, systemd.InstanceMode, systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
 	})()
 	defer snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string, _ *snap.SnapshotOptions, options *dirs.SnapDirOptions) (*client.Snapshot, error) {
 		var expirations map[uint64]any

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -30,85 +30,9 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
-
-type ParamsForConfigureMountUnitOptions struct {
-	what, fstype       string
-	startBeforeDrivers bool
-}
-
-type ResultForConfigureMountUnitOptions struct {
-	fsType        string
-	options       []string
-	mountUnitType systemd.MountUnitType
-}
-
-type ParamsForEnsureMountUnitFile struct {
-	description string
-	where       string
-	options     []string
-}
-
-type ResultForEnsureMountUnitFile struct {
-	path string
-	err  error
-}
-
-type FakeSystemd struct {
-	systemd.Systemd
-
-	ConfigureMountUnitOptionsCalls   []ParamsForConfigureMountUnitOptions
-	ConfigureMountUnitOptionsResults ResultForConfigureMountUnitOptions
-
-	EnsureMountUnitFileCalls  []ParamsForEnsureMountUnitFile
-	EnsureMountUnitFileResult ResultForEnsureMountUnitFile
-
-	RemoveMountUnitFileCalls  []string
-	RemoveMountUnitFileResult error
-
-	ListMountUnitsCalls  []ParamsForListMountUnits
-	ListMountUnitsResult ResultForListMountUnits
-}
-
-func (s *FakeSystemd) ConfigureMountUnitOptions(o *systemd.MountUnitOptions, fstype string, startBeforeDrivers bool) error {
-	s.ConfigureMountUnitOptionsCalls = append(s.ConfigureMountUnitOptionsCalls, ParamsForConfigureMountUnitOptions{o.What, fstype, startBeforeDrivers})
-
-	o.Fstype = s.ConfigureMountUnitOptionsResults.fsType
-	o.MountUnitType = s.ConfigureMountUnitOptionsResults.mountUnitType
-	o.Options = s.ConfigureMountUnitOptionsResults.options
-
-	return nil
-}
-
-func (s *FakeSystemd) EnsureMountUnitFile(mountOptions *systemd.MountUnitOptions) (string, error) {
-	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls, ParamsForEnsureMountUnitFile{
-		mountOptions.Description,
-		mountOptions.Where,
-		mountOptions.Options,
-	})
-	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err
-}
-
-func (s *FakeSystemd) RemoveMountUnitFile(mountDir string) error {
-	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, mountDir)
-	return s.RemoveMountUnitFileResult
-}
-
-type ParamsForListMountUnits struct {
-	snapName, origin string
-}
-
-type ResultForListMountUnits struct {
-	mountPoints []string
-	err         error
-}
-
-func (s *FakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) {
-	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
-		ParamsForListMountUnits{snapName, origin})
-	return s.ListMountUnitsResult.mountPoints, s.ListMountUnitsResult.err
-}
 
 type mountunitSuite struct {
 	testutil.BaseTest
@@ -135,10 +59,10 @@ func (s *mountunitSuite) TestAddBeforeDriversMountUnit(c *C) {
 func (s *mountunitSuite) testAddMountUnit(c *C, flags backend.MountUnitFlags) {
 	expectedErr := errors.New("creation error")
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
-		sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"", expectedErr}
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.EnsureMountUnitFileResult.Err = expectedErr
 		return sysd
 	})
 	defer restore()
@@ -155,21 +79,22 @@ func (s *mountunitSuite) testAddMountUnit(c *C, flags backend.MountUnitFlags) {
 	c.Check(err, Equals, expectedErr)
 
 	// ensure correct parameters
-	expectedMountUnitParameters := ParamsForConfigureMountUnitOptions{
-		what:               "/var/lib/snapd/snaps/foo_13.snap",
-		fstype:             "squashfs",
-		startBeforeDrivers: flags.StartBeforeDriversLoad,
+	expectedMountUnitParameters := systemdtest.ParamsForConfigureMountUnitOptions{
+		What:               "/var/lib/snapd/snaps/foo_13.snap",
+		Fstype:             "squashfs",
+		StartBeforeDrivers: flags.StartBeforeDriversLoad,
 	}
-	c.Check(sysd.ConfigureMountUnitOptionsCalls, DeepEquals, []ParamsForConfigureMountUnitOptions{
+	c.Check(sysd.ConfigureMountUnitOptionsCalls, DeepEquals, []systemdtest.ParamsForConfigureMountUnitOptions{
 		expectedMountUnitParameters,
 	})
 
-	expectedParameters := ParamsForEnsureMountUnitFile{
-		description: "Mount unit for foo, revision 13",
-		where:       fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
+	expectedParameters := &systemd.MountUnitOptions{
+		Lifetime:    systemd.Persistent,
+		Description: "Mount unit for foo, revision 13",
+		What:        "/var/lib/snapd/snaps/foo_13.snap",
+		Where:       fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
 	}
-
-	c.Check(sysd.EnsureMountUnitFileCalls, DeepEquals, []ParamsForEnsureMountUnitFile{
+	c.Check(sysd.EnsureMountUnitFileCalls, DeepEquals, []*systemd.MountUnitOptions{
 		expectedParameters,
 	})
 }
@@ -177,9 +102,9 @@ func (s *mountunitSuite) testAddMountUnit(c *C, flags backend.MountUnitFlags) {
 func (s *mountunitSuite) TestRemoveMountUnit(c *C) {
 	expectedErr := errors.New("removal error")
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
+		sysd = &systemdtest.FakeSystemd{}
 		sysd.RemoveMountUnitFileResult = expectedErr
 		return sysd
 	})
@@ -203,10 +128,10 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 
 	expectedErr := errors.New("listing error")
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
-		sysd.ListMountUnitsResult = ResultForListMountUnits{nil, expectedErr}
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.Err = expectedErr
 		return sysd
 	})
 	defer restore()
@@ -215,8 +140,8 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
-	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
-		{snapName: "foo", origin: ""},
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: ""},
 	})
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -234,10 +159,10 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	expectedErr := errors.New("removal error")
 	returnedMountPoints := []string{"/here", "/and/there"}
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
-		sysd.ListMountUnitsResult = ResultForListMountUnits{returnedMountPoints, nil}
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = returnedMountPoints
 		sysd.RemoveMountUnitFileResult = expectedErr
 		return sysd
 	})
@@ -247,8 +172,8 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
-	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
-		{snapName: "foo", origin: ""},
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: ""},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 1)
@@ -267,11 +192,10 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 
 	returnedMountPoints := []string{"/here", "/and/there", "/here/too"}
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
-		sysd.ListMountUnitsResult = ResultForListMountUnits{returnedMountPoints, nil}
-		sysd.RemoveMountUnitFileResult = nil
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = returnedMountPoints
 		return sysd
 	})
 	defer restore()
@@ -280,8 +204,8 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 	err := b.RemoveContainerMountUnits(info, progress.Null, "", nil)
 	c.Check(err, IsNil)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
-	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
-		{snapName: "foo", origin: ""},
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: ""},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 3)
@@ -304,10 +228,10 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
 		"/var/snap/other-snap/1/target",  // unrelated snap: not matched
 	}
 
-	var sysd *FakeSystemd
+	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		sysd = &FakeSystemd{}
-		sysd.ListMountUnitsResult = ResultForListMountUnits{mountPoints, nil}
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = mountPoints
 		return sysd
 	})
 	defer restore()
@@ -316,8 +240,8 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
 	err := b.RemoveContainerMountUnits(info, progress.Null, "mount-control", baseDirs)
 	c.Assert(err, IsNil)
 
-	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
-		{snapName: "some-snap", origin: "mount-control"},
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "some-snap", Origin: "mount-control"},
 	})
 	// Only the two matching mount points should have been removed.
 	c.Assert(sysd.RemoveMountUnitFileCalls, HasLen, 2)

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
 )
 
 type ServiceState struct {
@@ -97,4 +98,77 @@ FragmentPath=%s
 `, mountInfo.Description, mountInfo.Where, mountInfo.FragmentPath))...)
 	}
 	return output, true
+}
+
+type FakeSystemd struct {
+	systemd.Systemd
+
+	ConfigureMountUnitOptionsCalls   []ParamsForConfigureMountUnitOptions
+	ConfigureMountUnitOptionsResults ResultForConfigureMountUnitOptions
+
+	EnsureMountUnitFileCalls  []*systemd.MountUnitOptions
+	EnsureMountUnitFileResult ResultForEnsureMountUnitFile
+
+	RemoveMountUnitFileCalls  []string
+	RemoveMountUnitFileResult error
+
+	ListMountUnitsCalls  []ParamsForListMountUnits
+	ListMountUnitsResult ResultForListMountUnits
+}
+
+type ParamsForConfigureMountUnitOptions struct {
+	What               string
+	Fstype             string
+	StartBeforeDrivers bool
+}
+
+type ResultForConfigureMountUnitOptions struct {
+	Fstype        string
+	Options       []string
+	MountUnitType systemd.MountUnitType
+}
+
+type ResultForEnsureMountUnitFile struct {
+	Path string
+	Err  error
+}
+
+type ParamsForListMountUnits struct {
+	SnapName string
+	Origin   string
+}
+
+type ResultForListMountUnits struct {
+	MountPoints []string
+	Err         error
+}
+
+func (s *FakeSystemd) ConfigureMountUnitOptions(o *systemd.MountUnitOptions, fstype string, startBeforeDrivers bool) error {
+	s.ConfigureMountUnitOptionsCalls = append(s.ConfigureMountUnitOptionsCalls, ParamsForConfigureMountUnitOptions{
+		What:               o.What,
+		Fstype:             fstype,
+		StartBeforeDrivers: startBeforeDrivers,
+	})
+
+	o.Fstype = s.ConfigureMountUnitOptionsResults.Fstype
+	o.MountUnitType = s.ConfigureMountUnitOptionsResults.MountUnitType
+	o.Options = s.ConfigureMountUnitOptionsResults.Options
+
+	return nil
+}
+
+func (s *FakeSystemd) EnsureMountUnitFile(mountOptions *systemd.MountUnitOptions) (string, error) {
+	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls, mountOptions)
+	return s.EnsureMountUnitFileResult.Path, s.EnsureMountUnitFileResult.Err
+}
+
+func (s *FakeSystemd) RemoveMountUnitFile(mountDir string) error {
+	s.RemoveMountUnitFileCalls = append(s.RemoveMountUnitFileCalls, mountDir)
+	return s.RemoveMountUnitFileResult
+}
+
+func (s *FakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) {
+	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
+		ParamsForListMountUnits{SnapName: snapName, Origin: origin})
+	return s.ListMountUnitsResult.MountPoints, s.ListMountUnitsResult.Err
 }


### PR DESCRIPTION
Follows the conversation in https://github.com/canonical/snapd/pull/17119#discussion_r3323806244
* [many: centralize and reuse the common systemd mock in tests](https://github.com/canonical/snapd/pull/17139/commits/f1428e5fca65619cb8abe863a93bc6994008bada)
* [o/snapshotstate: use systemd mock in snapshotmgr test](https://github.com/canonical/snapd/pull/17139/commits/6b1482d788f4a85da240a5d8ee6ced890ec348a2)