### PR TITLE
asserts: refactor GPG and external keypair managers to use extKeypairMgrImpl

### DIFF
--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -406,25 +406,6 @@ func readOpenPGPRSAPublicKey(exportedPubKeyStream io.Reader) (PublicKey, string,
 	return RSAPublicKey(rsaPubKey), fmt.Sprintf("%X", pubKey.Fingerprint), nil
 }
 
-func newExtPGPPrivateKey(exportedPubKeyStream io.Reader, from string, sign func(content []byte) (*packet.Signature, error)) (*extPGPPrivateKey, error) {
-	pubKey, fingerprint, err := readOpenPGPRSAPublicKey(exportedPubKeyStream)
-	if err != nil {
-		return nil, err
-	}
-	rsaPubKey, err := cryptoRSAPublicKey(pubKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return &extPGPPrivateKey{
-		pubKey:     pubKey,
-		from:       from,
-		externalID: fingerprint,
-		bitLen:     rsaPubKey.N.BitLen(),
-		doSign:     sign,
-	}, nil
-}
-
 func (expk *extPGPPrivateKey) PublicKey() PublicKey {
 	return expk.pubKey
 }

--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -21,15 +21,11 @@ package asserts
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os/exec"
-
-	"golang.org/x/crypto/openpgp/packet"
 
 	"github.com/snapcore/snapd/strutil"
 )
@@ -43,20 +39,20 @@ type ExternalKeyInfo struct {
 // TODO: points to interface docs
 type ExternalKeypairManager struct {
 	keyMgrPath string
-	nameToID   map[string]string
-	cache      map[string]*cachedExtKey
+	impl       *extKeypairMgrImpl
 }
 
 // NewExternalKeypairManager creates a new ExternalKeypairManager using the program at keyMgrPath.
 func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, error) {
-	em := &ExternalKeypairManager{
-		keyMgrPath: keyMgrPath,
-		nameToID:   make(map[string]string),
-		cache:      make(map[string]*cachedExtKey),
-	}
-	if err := em.checkFeatures(); err != nil {
+	em := &ExternalKeypairManager{keyMgrPath: keyMgrPath}
+	impl, err := newExtKeypairMgrImpl(&externalKeypairMgrBackend{manager: em}, extKeypairMgrConfig{
+		signingWith: fmt.Sprintf("external keypair manager %q", keyMgrPath),
+		keyStore:    "external keypair manager",
+	})
+	if err != nil {
 		return nil, err
 	}
+	em.impl = impl
 	return em, nil
 }
 
@@ -114,80 +110,29 @@ func (em *ExternalKeypairManager) keyNames() ([]string, error) {
 	return knames.Names, nil
 }
 
-func (em *ExternalKeypairManager) findByName(name string) (PublicKey, *rsa.PublicKey, error) {
+func (em *ExternalKeypairManager) findByName(name string) (PublicKey, error) {
 	var k []byte
 	err := em.keyMgr("get-public-key", []string{"-f", "DER", "-k", name}, nil, &k)
 	if err != nil {
-		return nil, nil, &keyNotFoundError{msg: fmt.Sprintf("cannot find external key pair: %v", err)}
+		return nil, &keyNotFoundError{msg: fmt.Sprintf("cannot find external key pair: %v", err)}
 	}
 	pubk, err := x509.ParsePKIXPublicKey(k)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot decode external key %q: %v", name, err)
+		return nil, fmt.Errorf("cannot decode external key %q: %v", name, err)
 	}
 	rsaPub, ok := pubk.(*rsa.PublicKey)
 	if !ok {
-		return nil, nil, fmt.Errorf("expected RSA public key, got instead: %T", pubk)
+		return nil, fmt.Errorf("expected RSA public key, got instead: %T", pubk)
 	}
-	pubKey := RSAPublicKey(rsaPub)
-	return pubKey, rsaPub, nil
+	return RSAPublicKey(rsaPub), nil
 }
 
 func (em *ExternalKeypairManager) Export(keyName string) ([]byte, error) {
-	pubKey, _, err := em.findByName(keyName)
-	if err != nil {
-		return nil, err
-	}
-	return EncodePublicKey(pubKey)
-}
-
-func (em *ExternalKeypairManager) loadKey(name string) (*cachedExtKey, error) {
-	id, ok := em.nameToID[name]
-	if ok {
-		return em.cache[id], nil
-	}
-	pubKey, rsaPub, err := em.findByName(name)
-	if err != nil {
-		return nil, err
-	}
-	id = pubKey.ID()
-	em.nameToID[name] = id
-	cachedKey := &cachedExtKey{
-		pubKey: pubKey,
-		signer: &extSigner{
-			keyName: name,
-			rsaPub:  rsaPub,
-			// signWith is filled later
-		},
-	}
-	em.cache[id] = cachedKey
-	return cachedKey, nil
-}
-
-func (em *ExternalKeypairManager) privateKey(cachedKey *cachedExtKey) PrivateKey {
-	if cachedKey.privKey == nil {
-		extSigner := cachedKey.signer
-		// fill signWith
-		extSigner.signWith = em.signWith
-		signer := packet.NewSignerPrivateKey(v1FixedTimestamp, extSigner)
-		signk := openpgpPrivateKey{privk: signer}
-		extKey := &extPGPPrivateKey{
-			pubKey:     cachedKey.pubKey,
-			from:       fmt.Sprintf("external keypair manager %q", em.keyMgrPath),
-			externalID: extSigner.keyName,
-			bitLen:     extSigner.rsaPub.N.BitLen(),
-			doSign:     signk.sign,
-		}
-		cachedKey.privKey = extKey
-	}
-	return cachedKey.privKey
+	return em.impl.Export(keyName)
 }
 
 func (em *ExternalKeypairManager) GetByName(keyName string) (PrivateKey, error) {
-	cachedKey, err := em.loadKey(keyName)
-	if err != nil {
-		return nil, err
-	}
-	return em.privateKey(cachedKey), nil
+	return em.impl.GetByName(keyName)
 }
 
 // ExternalUnsupportedOpError represents the error situation of operations
@@ -216,82 +161,73 @@ func (em *ExternalKeypairManager) Generate(keyName string) error {
 	return &ExternalUnsupportedOpError{"no support to mediate generating an external keypair manager key"}
 }
 
-func (em *ExternalKeypairManager) loadAllKeys() ([]string, error) {
-	names, err := em.keyNames()
-	if err != nil {
-		return nil, err
-	}
-	for _, name := range names {
-		if _, err := em.loadKey(name); err != nil {
-			return nil, err
-		}
-	}
-	return names, nil
-}
-
 func (em *ExternalKeypairManager) Get(keyID string) (PrivateKey, error) {
-	cachedKey, ok := em.cache[keyID]
-	if !ok {
-		// try to load all keys
-		if _, err := em.loadAllKeys(); err != nil {
-			return nil, err
-		}
-		cachedKey, ok = em.cache[keyID]
-		if !ok {
-			return nil, &keyNotFoundError{msg: "cannot find external key pair"}
-		}
-	}
-	return em.privateKey(cachedKey), nil
+	return em.impl.Get(keyID)
 }
 
 func (em *ExternalKeypairManager) List() ([]ExternalKeyInfo, error) {
-	names, err := em.loadAllKeys()
+	return em.impl.List()
+}
+
+// externalKeypairMgrBackend implements extKeypairMgrBackend and
+// extKeypairMgrByNameLookupBackend as a thin wrapper around
+// ExternalKeypairManager, allowing it to be used as the backend for an
+// extKeypairMgrImpl.
+type externalKeypairMgrBackend struct {
+	manager *ExternalKeypairManager
+}
+
+// expected interfaces are implemented
+var (
+	_ extKeypairMgrBackend             = (*externalKeypairMgrBackend)(nil)
+	_ extKeypairMgrByNameLookupBackend = (*externalKeypairMgrBackend)(nil)
+)
+
+func (s *externalKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
+	if err := s.manager.checkFeatures(); err != nil {
+		return "", err
+	}
+	return extKeypairMgrSigningRSAPKCS, nil
+}
+
+func (s *externalKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
+	pubKey, err := s.manager.findByName(name)
 	if err != nil {
 		return nil, err
 	}
-	res := make([]ExternalKeyInfo, len(names))
-	for i, name := range names {
-		res[i].Name = name
-		res[i].ID = em.cache[em.nameToID[name]].pubKey.ID()
-	}
-	return res, nil
+	return &extKeypairMgrLoadedKey{
+		name:      name,
+		keyHandle: name,
+		pubKey:    pubKey,
+	}, nil
 }
 
-func (em *ExternalKeypairManager) signWith(keyName string, digest []byte) (signature []byte, err error) {
-	// wrap the digest into the needed DigestInfo, the RSA-PKCS
-	// mechanism or equivalent is expected not to do this on its
-	// own
-	toSign := &bytes.Buffer{}
-	toSign.Write(digestInfoSHA512Prefix)
-	toSign.Write(digest)
+func (s *externalKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+	names, err := s.manager.keyNames()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		loaded, err := s.LoadByName(name)
+		if err != nil {
+			return err
+		}
+		if err := consider(loaded); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	err = em.keyMgr("sign", []string{"-m", "RSA-PKCS", "-k", keyName}, toSign.Bytes(), &signature)
+func (s *externalKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+	var signature []byte
+	err := s.manager.keyMgr("sign", []string{"-m", "RSA-PKCS", "-k", keyHandle}, prepared, &signature)
 	if err != nil {
 		return nil, err
 	}
 	return signature, nil
 }
 
-type cachedExtKey struct {
-	pubKey  PublicKey
-	signer  *extSigner
-	privKey PrivateKey
-}
-
-type extSigner struct {
-	keyName  string
-	rsaPub   *rsa.PublicKey
-	signWith func(keyName string, digest []byte) (signature []byte, err error)
-}
-
-func (es *extSigner) Public() crypto.PublicKey {
-	return es.rsaPub
-}
-
-func (es *extSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-	if opts.HashFunc() != crypto.SHA512 {
-		return nil, fmt.Errorf("unexpected pgp signature digest")
-	}
-
-	return es.signWith(es.keyName, digest)
+func (s *externalKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
+	return nil, fmt.Errorf("internal error: external keypair manager does not support OpenPGP signing")
 }

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -181,11 +181,13 @@ func (s *extKeypairMgrSuite) TestGet(c *C) {
 	c.Check(s.pgm.Calls(), DeepEquals, [][]string{
 		{"keymgr", "key-names"},
 		{"keymgr", "get-public-key", "-f", "DER", "-k", "default"},
+		{"keymgr", "key-names"},
+		{"keymgr", "get-public-key", "-f", "DER", "-k", "default"},
 		{"keymgr", "get-public-key", "-f", "DER", "-k", "models"},
 	})
 
 	_, err = kmgr.Get("unknown-id")
-	c.Check(err, ErrorMatches, `cannot find external key pair`)
+	c.Check(err, ErrorMatches, `cannot find key pair in external keypair manager`)
 	c.Check(asserts.IsKeyNotFound(err), Equals, true)
 }
 

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -143,6 +143,13 @@ func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *extKeypairMgrLoadedKey) (*ext
 	return entry, nil
 }
 
+func (m *extKeypairMgrImpl) dropCachedKey(keyID string) {
+	if entry := m.cache[keyID]; entry != nil {
+		delete(m.nameToID, entry.name)
+	}
+	delete(m.cache, keyID)
+}
+
 func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, error) {
 	if keyID, ok := m.nameToID[name]; ok {
 		if entry := m.cache[keyID]; entry != nil {

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -435,6 +435,42 @@ func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.
 	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.pubKey.ID()})
 }
 
+func (s *extKeypairMgrImplSuite) TestDropCachedKeyRemovesCachedAndNamedEntries(c *check.C) {
+	_, loaded := s.newLoadedKey(c, "default", "handle-default")
+	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+		},
+	}, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	_, err = impl.cacheLoadedKey(loaded)
+	c.Assert(err, check.IsNil)
+
+	impl.dropCachedKey(loaded.pubKey.ID())
+
+	c.Check(impl.cache, check.DeepEquals, map[string]*extKeypairMgrCachedKey{})
+	c.Check(impl.nameToID, check.DeepEquals, map[string]string{})
+}
+
+func (s *extKeypairMgrImplSuite) TestDropCachedKeyMissingKeyLeavesCacheUntouched(c *check.C) {
+	_, loaded := s.newLoadedKey(c, "default", "handle-default")
+	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: extKeypairMgrSigningRSAPKCS,
+		},
+	}, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	entry, err := impl.cacheLoadedKey(loaded)
+	c.Assert(err, check.IsNil)
+
+	impl.dropCachedKey("missing-id")
+
+	c.Check(impl.cache, check.DeepEquals, map[string]*extKeypairMgrCachedKey{loaded.pubKey.ID(): entry})
+	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.pubKey.ID()})
+}
+
 func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -21,14 +21,11 @@ package asserts
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/crypto/openpgp/packet"
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
@@ -125,7 +122,9 @@ func runGPGImpl(input []byte, args ...string) ([]byte, error) {
 var runGPG = runGPGImpl
 
 // A key pair manager backed by a local GnuPG setup.
-type GPGKeypairManager struct{}
+type GPGKeypairManager struct {
+	impl *extKeypairMgrImpl
+}
 
 func (gkm *GPGKeypairManager) gpg(input []byte, args ...string) ([]byte, error) {
 	return runGPG(input, args...)
@@ -136,10 +135,19 @@ func (gkm *GPGKeypairManager) gpg(input []byte, args ...string) ([]byte, error) 
 // suppored.
 // Main purpose is allowing signing using keys from a GPG setup.
 func NewGPGKeypairManager() *GPGKeypairManager {
-	return &GPGKeypairManager{}
+	gkm := &GPGKeypairManager{}
+	impl, err := newExtKeypairMgrImpl(&gpgKeypairMgrBackend{manager: gkm}, extKeypairMgrConfig{
+		signingWith: "GPG",
+		keyStore:    "GPG keyring",
+	})
+	if err != nil {
+		panic(fmt.Sprintf("internal error: cannot setup keypair manager: %v", err))
+	}
+	gkm.impl = impl
+	return gkm
 }
 
-func (gkm *GPGKeypairManager) retrieve(fpr string) (PrivateKey, error) {
+func (gkm *GPGKeypairManager) retrieveLoadedKey(fpr string, uid string) (*extKeypairMgrLoadedKey, error) {
 	out, err := gkm.gpg(nil, "--batch", "--export", "--export-options", "export-minimal,export-clean,no-export-attributes", "0x"+fpr)
 	if err != nil {
 		return nil, err
@@ -148,22 +156,21 @@ func (gkm *GPGKeypairManager) retrieve(fpr string) (PrivateKey, error) {
 		return nil, fmt.Errorf("cannot retrieve key with fingerprint %q in GPG keyring", fpr)
 	}
 
-	pubKeyBuf := bytes.NewBuffer(out)
-	privKey, err := newExtPGPPrivateKey(pubKeyBuf, "GPG", func(content []byte) (*packet.Signature, error) {
-		return gkm.sign(fpr, content)
-	})
+	pubKey, gotFingerprint, err := readOpenPGPRSAPublicKey(bytes.NewBuffer(out))
 	if err != nil {
 		return nil, fmt.Errorf("cannot load GPG public key with fingerprint %q: %v", fpr, err)
 	}
-	gotFingerprint := privKey.externalID
 	if gotFingerprint != fpr {
 		return nil, fmt.Errorf("got wrong public key from GPG, expected fingerprint %q: %s", fpr, gotFingerprint)
 	}
-	return privKey, nil
+	return &extKeypairMgrLoadedKey{
+		name:      uid,
+		keyHandle: fpr,
+		pubKey:    pubKey,
+	}, nil
 }
 
-// Walk iterates over all the RSA private keys in the local GPG setup calling the provided callback until this returns an error
-func (gkm *GPGKeypairManager) Walk(consider func(privk PrivateKey, fingerprint string, uid string) error) error {
+func (gkm *GPGKeypairManager) walkSecretKeys(consider func(fingerprint string, uid string) error) error {
 	// see GPG source doc/DETAILS
 	out, err := gkm.gpg(nil, "--batch", "--list-secret-keys", "--fingerprint", "--with-colons", "--fixed-list-mode")
 	if err != nil {
@@ -194,7 +201,6 @@ func (gkm *GPGKeypairManager) Walk(consider func(privk PrivateKey, fingerprint s
 		keyID := secFields[4]
 		uid := ""
 		fpr := ""
-		var privKey PrivateKey
 		// look for fpr:, uid: lines, order may vary and gpg2.1
 		// may springle additional lines in (like gpr:)
 	Loop:
@@ -209,11 +215,7 @@ func (gkm *GPGKeypairManager) Walk(consider func(privk PrivateKey, fingerprint s
 				}
 				fpr = fprFields[9]
 				if !strings.HasSuffix(fpr, keyID) {
-					break // strange, skip
-				}
-				privKey, err = gkm.retrieve(fpr)
-				if err != nil {
-					return err
+					break Loop // strange, skip
 				}
 			case strings.HasPrefix(lines[k], "uid:"):
 				uidFields := strings.Split(lines[k], ":")
@@ -225,11 +227,11 @@ func (gkm *GPGKeypairManager) Walk(consider func(privk PrivateKey, fingerprint s
 			}
 		}
 		// validity checking
-		if privKey == nil || uid == "" {
+		if fpr == "" || uid == "" {
 			continue
 		}
 		// collected it all
-		err = consider(privKey, fpr, uid)
+		err = consider(fpr, uid)
 		if err != nil {
 			return err
 		}
@@ -242,106 +244,34 @@ func (gkm *GPGKeypairManager) Put(privKey PrivateKey) error {
 	return fmt.Errorf("cannot import private key into GPG keyring")
 }
 
-type gpgKeypairInfo struct {
-	privKey     PrivateKey
-	fingerprint string
-}
-
-var errKeypairNotFoundInGPGKeyring = &keyNotFoundError{msg: "cannot find key pair in GPG keyring"}
-
-func (gkm *GPGKeypairManager) findByID(keyID string) (*gpgKeypairInfo, error) {
-	stop := errors.New("stop marker")
-	var hit *gpgKeypairInfo
-	match := func(privk PrivateKey, fpr string, uid string) error {
-		if privk.PublicKey().ID() == keyID {
-			hit = &gpgKeypairInfo{
-				privKey:     privk,
-				fingerprint: fpr,
-			}
-			return stop
-		}
-		return nil
-	}
-	err := gkm.Walk(match)
-	if err == stop {
-		return hit, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return nil, errKeypairNotFoundInGPGKeyring
-}
-
 func (gkm *GPGKeypairManager) Get(keyID string) (PrivateKey, error) {
-	keyInfo, err := gkm.findByID(keyID)
-	if err != nil {
-		return nil, err
-	}
-	return keyInfo.privKey, nil
+	return gkm.impl.Get(keyID)
 }
 
 func (gkm *GPGKeypairManager) Delete(keyID string) error {
-	keyInfo, err := gkm.findByID(keyID)
+	entry, err := gkm.impl.loadByID(keyID)
 	if err != nil {
 		return err
 	}
-	_, err = gkm.gpg(nil, "--batch", "--delete-secret-and-public-key", "0x"+keyInfo.fingerprint)
+	_, err = gkm.gpg(nil, "--batch", "--delete-secret-and-public-key", "0x"+entry.keyHandle)
 	if err != nil {
 		return err
 	}
+	gkm.impl.dropCachedKey(keyID)
 	return nil
 }
 
-func (gkm *GPGKeypairManager) sign(fingerprint string, content []byte) (*packet.Signature, error) {
+func (gkm *GPGKeypairManager) sign(fingerprint string, content []byte) ([]byte, error) {
 	out, err := gkm.gpg(content, "--personal-digest-preferences", "SHA512", "--default-key", "0x"+fingerprint, "--detach-sign")
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign using GPG: %v", err)
 	}
-
-	const badSig = "bad GPG produced signature: "
-	sigpkt, err := packet.Read(bytes.NewBuffer(out))
-	if err != nil {
-		return nil, fmt.Errorf(badSig+"%v", err)
-	}
-
-	sig, ok := sigpkt.(*packet.Signature)
-	if !ok {
-		return nil, fmt.Errorf(badSig+"got %T", sigpkt)
-	}
-
-	return sig, nil
-}
-
-func (gkm *GPGKeypairManager) findByName(name string) (*gpgKeypairInfo, error) {
-	stop := errors.New("stop marker")
-	var hit *gpgKeypairInfo
-	match := func(privk PrivateKey, fpr string, uid string) error {
-		if uid == name {
-			hit = &gpgKeypairInfo{
-				privKey:     privk,
-				fingerprint: fpr,
-			}
-			return stop
-		}
-		return nil
-	}
-	err := gkm.Walk(match)
-	if err == stop {
-		return hit, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return nil, errKeypairNotFoundInGPGKeyring
+	return out, nil
 }
 
 // GetByName looks up a private key by name and returns it.
 func (gkm *GPGKeypairManager) GetByName(name string) (PrivateKey, error) {
-	keyInfo, err := gkm.findByName(name)
-	if err != nil {
-		return nil, err
-	}
-	return keyInfo.privKey, nil
+	return gkm.impl.GetByName(name)
 }
 
 var generateTemplate = `
@@ -363,7 +293,7 @@ func (gkm *GPGKeypairManager) parametersForGenerate(passphrase string, name stri
 
 // Generate creates a new key with the given passphrase and name.
 func (gkm *GPGKeypairManager) Generate(passphrase string, name string) error {
-	_, err := gkm.findByName(name)
+	_, err := gkm.impl.loadByName(name)
 	if err == nil {
 		return fmt.Errorf("key named %q already exists in GPG keyring", name)
 	}
@@ -377,37 +307,56 @@ func (gkm *GPGKeypairManager) Generate(passphrase string, name string) error {
 
 // Export returns the encoded text of the named public key.
 func (gkm *GPGKeypairManager) Export(name string) ([]byte, error) {
-	keyInfo, err := gkm.findByName(name)
-	if err != nil {
-		return nil, err
-	}
-	return EncodePublicKey(keyInfo.privKey.PublicKey())
+	return gkm.impl.Export(name)
 }
 
 // DeleteByName removes the named key pair from GnuPG's storage.
 func (gkm *GPGKeypairManager) DeleteByName(name string) error {
-	keyInfo, err := gkm.findByName(name)
+	entry, err := gkm.impl.loadByName(name)
 	if err != nil {
 		return err
 	}
-	_, err = gkm.gpg(nil, "--batch", "--delete-secret-and-public-key", "0x"+keyInfo.fingerprint)
+	keyID := entry.pubKey.ID()
+	_, err = gkm.gpg(nil, "--batch", "--delete-secret-and-public-key", "0x"+entry.keyHandle)
 	if err != nil {
 		return err
 	}
+	gkm.impl.dropCachedKey(keyID)
 	return nil
 }
 
 func (gkm *GPGKeypairManager) List() (res []ExternalKeyInfo, err error) {
-	collect := func(privk PrivateKey, fpr string, uid string) error {
-		key := ExternalKeyInfo{
-			Name: uid,
-			ID:   privk.PublicKey().ID(),
+	return gkm.impl.List()
+}
+
+// gpgKeypairMgrBackend implements the extKeypairMgrBackend interface
+// as a thin wrapper around GPGKeypairManager, allowing it to be used as the backend
+// for an extKeypairMgrImpl.
+type gpgKeypairMgrBackend struct {
+	manager *GPGKeypairManager
+}
+
+// expected interface is implemented
+var _ extKeypairMgrBackend = (*gpgKeypairMgrBackend)(nil)
+
+func (s *gpgKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
+	return extKeypairMgrSigningOpenPGP, nil
+}
+
+func (s *gpgKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+	return s.manager.walkSecretKeys(func(fpr string, uid string) error {
+		loaded, err := s.manager.retrieveLoadedKey(fpr, uid)
+		if err != nil {
+			return err
 		}
-		res = append(res, key)
-		return nil
-	}
-	if err := gkm.Walk(collect); err != nil {
-		return nil, err
-	}
-	return res, nil
+		return consider(loaded)
+	})
+}
+
+func (s *gpgKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+	return nil, fmt.Errorf("internal error: GPG keypair manager does not support RSA-PKCS signing")
+}
+
+func (s *gpgKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
+	return s.manager.sign(keyHandle, content)
 }

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -203,8 +203,9 @@ func (gkm *GPGKeypairManager) walkSecretKeys(consider func(fingerprint string, u
 		fpr := ""
 		// look for fpr:, uid: lines, order may vary and gpg2.1
 		// may springle additional lines in (like gpr:)
+		// stop at the next primary key or any subkey record so we only collect metadata for this sec: entry.
 	Loop:
-		for k := j + 1; k < n && !strings.HasPrefix(lines[k], "sec:"); k++ {
+		for k := j + 1; k < n && !strings.HasPrefix(lines[k], "sec:") && !strings.HasPrefix(lines[k], "ssb:") && !strings.HasPrefix(lines[k], "sub:"); k++ {
 			switch {
 			case strings.HasPrefix(lines[k], "fpr:"):
 				fprFields := strings.Split(lines[k], ":")

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -26,6 +26,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"os"
+	"os/exec"
 	"time"
 
 	"golang.org/x/crypto/openpgp/packet"
@@ -51,6 +52,26 @@ func (gkms *gpgKeypairMgrSuite) SetUpSuite(c *C) {
 
 func (gkms *gpgKeypairMgrSuite) importKey(key string) {
 	assertstest.GPGImportKey(gkms.homedir, key)
+}
+
+func (gkms *gpgKeypairMgrSuite) addSigningSubkey(c *C, fingerprint string) {
+	path, err := exec.LookPath("gpg")
+	if err != nil {
+		c.Skip("gpg with --quick-add-key support not installed")
+	}
+	gpg := exec.Command(path,
+		"--homedir", gkms.homedir,
+		"-q",
+		"--batch",
+		"--pinentry-mode", "loopback",
+		"--passphrase", "",
+		"--quick-add-key", fingerprint,
+		"rsa4096",
+		"sign",
+		"0",
+	)
+	out, err := gpg.CombinedOutput()
+	c.Assert(err, IsNil, Commentf("cannot add test subkey: %q", out))
 }
 
 func (gkms *gpgKeypairMgrSuite) SetUpTest(c *C) {
@@ -341,6 +362,17 @@ Preferences: SHA512
 func (gkms *gpgKeypairMgrSuite) TestList(c *C) {
 	gpgKeypairMgr := gkms.keypairMgr.(*asserts.GPGKeypairManager)
 
+	keys, err := gpgKeypairMgr.List()
+	c.Assert(err, IsNil)
+	c.Check(keys, HasLen, 1)
+	c.Check(keys[0].ID, Equals, assertstest.DevKeyID)
+	c.Check(keys[0].Name, Not(Equals), "")
+}
+
+func (gkms *gpgKeypairMgrSuite) TestListWithSubkey(c *C) {
+	gkms.addSigningSubkey(c, assertstest.DevKeyPGPFingerprint)
+
+	gpgKeypairMgr := gkms.keypairMgr.(*asserts.GPGKeypairManager)
 	keys, err := gpgKeypairMgr.List()
 	c.Assert(err, IsNil)
 	c.Check(keys, HasLen, 1)


### PR DESCRIPTION
the organistation of externalKeypairMgrBackend as thin wrapper around the manager will be changed in future branches such that it can actually be plugged in instead