### PR TITLE
sandbox, cmd/snap: add debug command for listing currently mediated devices for a given snap

### DIFF
--- a/cmd/snap/cmd_debug_device_cgroup.go
+++ b/cmd/snap/cmd_debug_device_cgroup.go
@@ -1,0 +1,211 @@
+// -*- Mode: Go; indent-tabs-mode: t; tab-width: 4 -*-
+//go:build !darwin
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/jessevdk/go-flags"
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/sandbox/cgroup"
+)
+
+var shortDeviceCgroupHelp = i18n.G("Inspect device cgroup state for a snap")
+
+var longDeviceCgroupHelp = i18n.G(`
+The device-cgroup command allows inspection of device cgroup filtering
+state for a snap.
+
+This command requires root privileges.
+`)
+
+type cmdDeviceCgroup struct{}
+
+type cmdDeviceCgroupDevices struct {
+	Positional struct {
+		Snap string `positional-arg-name:"<snap>" required:"yes"`
+	} `positional-args:"yes"`
+}
+
+func init() {
+	cmd := addDebugCommand("device-cgroup", shortDeviceCgroupHelp, longDeviceCgroupHelp, func() flags.Commander {
+		return &cmdDeviceCgroup{}
+	}, nil, nil)
+	cmd.hidden = true
+	cmd.extra = func(c *flags.Command) {
+		c.AddCommand("devices", i18n.G("Show allowed devices in a snap's device cgroup"), i18n.G(`
+The devices sub-command shows the devices currently allowed in
+the device cgroup for a given snap. On cgroup v1, this reads the
+devices.list file. On cgroup v2, this reads the BPF device hash map.
+
+Requires root.
+`), &cmdDeviceCgroupDevices{})
+	}
+}
+
+func (cmd *cmdDeviceCgroup) Execute(args []string) error {
+	return flag.ErrHelp
+}
+
+func (cmd *cmdDeviceCgroupDevices) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	snapName := cmd.Positional.Snap
+
+	tags, err := cgroup.FindActiveDeviceMediationForSnap(snapName)
+	if err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		return fmt.Errorf("no device cgroup found for snap %q", snapName)
+	}
+
+	w := tabWriter()
+	defer w.Flush()
+
+	for _, tag := range tags {
+		fmt.Fprintf(w, "Security tag: %s\n", tag)
+		var entries []cgroup.DeviceEntry
+		var err error
+		entries, err = cgroup.ListMediatedDevicesForSecurityTag(tag)
+		if err != nil {
+			fmt.Fprintf(w, "  error: %v\n", err)
+		} else {
+			printDeviceEntries(w, entries)
+		}
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+// devKey identifies a device by type and major:minor numbers.
+type devKey struct {
+	devType byte
+	major   uint32
+	minor   uint32
+}
+
+// wellKnownDevNodes maps well-known Linux device (major,minor) pairs to their
+// /dev paths. Sourced from udev-support.c (devices always allowed for snaps).
+var wellKnownDevNodes = map[devKey]string{
+	{'c', 1, 3}: "/dev/null",
+	{'c', 1, 5}: "/dev/zero",
+	{'c', 1, 7}: "/dev/full",
+	{'c', 1, 8}: "/dev/random",
+	{'c', 1, 9}: "/dev/urandom",
+	{'c', 5, 0}: "/dev/tty",
+	{'c', 5, 1}: "/dev/console",
+	{'c', 5, 2}: "/dev/ptmx",
+}
+
+// resolveDevNode tries to find the /dev path for a device with the given
+// major:minor numbers. Returns empty string if not found.
+func resolveDevNode(devType byte, major, minor uint32) string {
+	if path, ok := wellKnownDevNodes[devKey{devType, major, minor}]; ok {
+		return path
+	}
+	wantRdev := unix.Mkdev(major, minor)
+
+	var errSkip = errors.New("skip walk")
+	var result string
+
+	err := filepath.WalkDir("/dev", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Filter by device type cheaply using DirEntry.Type()
+		mode := d.Type()
+		isChar := mode&os.ModeCharDevice != 0 && mode&os.ModeDevice != 0
+		isBlock := mode&os.ModeDevice != 0 && mode&os.ModeCharDevice == 0
+		if devType == 'c' && !isChar {
+			return nil
+		}
+		if devType == 'b' && !isBlock {
+			return nil
+		}
+		// Only stat device nodes that match the type to get Rdev
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil
+		}
+		if stat.Rdev == wantRdev {
+			result = path
+			return errSkip
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errSkip) {
+		return ""
+	}
+	return result
+}
+
+func printDeviceEntries(w *tabwriter.Writer, entries []cgroup.DeviceEntry) {
+	// Sort by type, then major, then minor (lexicographic for wildcard compat)
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].DevType != entries[j].DevType {
+			return entries[i].DevType < entries[j].DevType
+		}
+		if entries[i].Major != entries[j].Major {
+			return entries[i].Major < entries[j].Major
+		}
+		return entries[i].Minor < entries[j].Minor
+	})
+
+	fmt.Fprintf(w, "TYPE\tMAJOR:MINOR\tACCESS\tDEVICE\n")
+
+	formatNodeNumber := func(n uint32) string {
+		if n == cgroup.AccessAny {
+			return "*"
+		}
+		return fmt.Sprintf("%d", n)
+	}
+
+	for _, e := range entries {
+		devNode := "-"
+		if e.Major != cgroup.AccessAny && e.Minor != cgroup.AccessAny {
+			// It only makes sense to find matching device if we have exact
+			// major/minor values
+			if n := resolveDevNode(e.DevType, e.Major, e.Minor); n != "" {
+				devNode = n
+			}
+		}
+		fmt.Fprintf(w, "%c\t%s:%s\t%s\t%s\n", e.DevType,
+			formatNodeNumber(e.Major), formatNodeNumber(e.Minor),
+			e.Access, devNode)
+	}
+}

--- a/cmd/snap/cmd_debug_device_cgroup.go
+++ b/cmd/snap/cmd_debug_device_cgroup.go
@@ -94,9 +94,7 @@ func (cmd *cmdDeviceCgroupDevices) Execute(args []string) error {
 
 	for _, tag := range tags {
 		fmt.Fprintf(w, "Security tag: %s\n", tag)
-		var entries []cgroup.DeviceEntry
-		var err error
-		entries, err = cgroup.ListMediatedDevicesForSecurityTag(tag)
+		entries, err := cgroup.ListMediatedDevicesForSecurityTag(tag)
 		if err != nil {
 			fmt.Fprintf(w, "  error: %v\n", err)
 		} else {

--- a/cmd/snap/cmd_debug_device_cgroup.go
+++ b/cmd/snap/cmd_debug_device_cgroup.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io/fs"
@@ -38,11 +37,11 @@ import (
 	"github.com/snapcore/snapd/sandbox/cgroup"
 )
 
-var shortDeviceCgroupHelp = i18n.G("Inspect device cgroup state for a snap")
+var shortDeviceCgroupHelp = i18n.G("Inspect device cgroup state of a snap")
 
 var longDeviceCgroupHelp = i18n.G(`
 The device-cgroup command allows inspection of device cgroup filtering
-state for a snap.
+state of a snap.
 
 This command requires root privileges.
 `)
@@ -134,7 +133,6 @@ func resolveDevNode(devType byte, major, minor uint32) string {
 	}
 	wantRdev := unix.Mkdev(major, minor)
 
-	var errSkip = errors.New("skip walk")
 	var result string
 
 	err := filepath.WalkDir("/dev", func(path string, d fs.DirEntry, err error) error {
@@ -143,7 +141,7 @@ func resolveDevNode(devType byte, major, minor uint32) string {
 		}
 		// Filter by device type cheaply using DirEntry.Type()
 		mode := d.Type()
-		isChar := mode&os.ModeCharDevice != 0 && mode&os.ModeDevice != 0
+		isChar := mode&os.ModeDevice != 0 && mode&os.ModeCharDevice != 0
 		isBlock := mode&os.ModeDevice != 0 && mode&os.ModeCharDevice == 0
 		if devType == 'c' && !isChar {
 			return nil
@@ -162,11 +160,11 @@ func resolveDevNode(devType byte, major, minor uint32) string {
 		}
 		if stat.Rdev == wantRdev {
 			result = path
-			return errSkip
+			return filepath.SkipDir
 		}
 		return nil
 	})
-	if err != nil && !errors.Is(err, errSkip) {
+	if err != nil && err != filepath.SkipDir {
 		return ""
 	}
 	return result

--- a/cmd/snap/cmd_debug_device_cgroup.go
+++ b/cmd/snap/cmd_debug_device_cgroup.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/fs"
 	"os"
@@ -37,44 +36,29 @@ import (
 	"github.com/snapcore/snapd/sandbox/cgroup"
 )
 
-var shortDeviceCgroupHelp = i18n.G("Inspect device cgroup state of a snap")
+var shortDeviceCgroupHelp = i18n.G("Show devices allowed in a snap's device cgroup")
 
 var longDeviceCgroupHelp = i18n.G(`
-The device-cgroup command allows inspection of device cgroup filtering
-state of a snap.
+The device-cgroup command shows the devices currently allowed in
+the device cgroup of a snap. On cgroup v1, this reads the devices.list
+file. On cgroup v2, this reads the BPF device hash map.
 
 This command requires root privileges.
 `)
 
-type cmdDeviceCgroup struct{}
-
-type cmdDeviceCgroupDevices struct {
+type cmdDeviceCgroup struct {
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>" required:"yes"`
 	} `positional-args:"yes"`
 }
 
 func init() {
-	cmd := addDebugCommand("device-cgroup", shortDeviceCgroupHelp, longDeviceCgroupHelp, func() flags.Commander {
+	addDebugCommand("device-cgroup", shortDeviceCgroupHelp, longDeviceCgroupHelp, func() flags.Commander {
 		return &cmdDeviceCgroup{}
 	}, nil, nil)
-	cmd.hidden = true
-	cmd.extra = func(c *flags.Command) {
-		c.AddCommand("devices", i18n.G("Show allowed devices in a snap's device cgroup"), i18n.G(`
-The devices sub-command shows the devices currently allowed in
-the device cgroup for a given snap. On cgroup v1, this reads the
-devices.list file. On cgroup v2, this reads the BPF device hash map.
-
-Requires root.
-`), &cmdDeviceCgroupDevices{})
-	}
 }
 
 func (cmd *cmdDeviceCgroup) Execute(args []string) error {
-	return flag.ErrHelp
-}
-
-func (cmd *cmdDeviceCgroupDevices) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}

--- a/tests/main/cgroup-devices-v1/task.sh
+++ b/tests/main/cgroup-devices-v1/task.sh
@@ -74,8 +74,8 @@ test 'c 1:3 rwm' = "$(head -n 1 "/sys/fs/cgroup/devices/snap.test-snapd-service.
 # The device cgroup made by snapd is, currently, still empty.
 test -z "$(cat "/sys/fs/cgroup/devices/snap.test-snapd-service.test-snapd-service/cgroup.procs")"
 
-echo "Verify snap debug device-cgroup devices shows the allowed devices (v1)"
-snap debug device-cgroup devices test-snapd-service > device-cgroup-devices.out
+echo "Verify snap debug device-cgroup shows the allowed devices (v1)"
+snap debug device-cgroup test-snapd-service > device-cgroup-devices.out
 MATCH 'Security tag: snap\.test-snapd-service\.test-snapd-service' < device-cgroup-devices.out
 MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices.out
 

--- a/tests/main/cgroup-devices-v1/task.sh
+++ b/tests/main/cgroup-devices-v1/task.sh
@@ -74,6 +74,11 @@ test 'c 1:3 rwm' = "$(head -n 1 "/sys/fs/cgroup/devices/snap.test-snapd-service.
 # The device cgroup made by snapd is, currently, still empty.
 test -z "$(cat "/sys/fs/cgroup/devices/snap.test-snapd-service.test-snapd-service/cgroup.procs")"
 
+echo "Verify snap debug device-cgroup devices shows the allowed devices (v1)"
+snap debug device-cgroup devices test-snapd-service > device-cgroup-devices.out
+MATCH 'Security tag: snap\.test-snapd-service\.test-snapd-service' < device-cgroup-devices.out
+MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices.out
+
 echo "Restart the test service"
 # See the comment for the similar code above.
 touch /var/snap/test-snapd-service/common/remove-me

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -108,8 +108,8 @@ execute: |
     # dump the map
     bpftool map dump pinned /sys/fs/bpf/snap/snap_test-snapd-service_sh > device-access.map-app
 
-    echo "Verify snap debug device-cgroup devices shows the allowed devices for the app"
-    snap debug device-cgroup devices test-snapd-service > device-cgroup-devices.out
+    echo "Verify snap debug device-cgroup shows the allowed devices for the app"
+    snap debug device-cgroup test-snapd-service > device-cgroup-devices.out
     MATCH 'Security tag: snap\.test-snapd-service\.sh' < device-cgroup-devices.out
     MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices.out
 
@@ -138,8 +138,8 @@ execute: |
     # dump the map
     bpftool map dump pinned /sys/fs/bpf/snap/snap_test-snapd-service_test-snapd-service > device-access.map-service
 
-    echo "Verify snap debug device-cgroup devices also shows the service's allowed devices"
-    snap debug device-cgroup devices test-snapd-service > device-cgroup-devices-service.out
+    echo "Verify snap debug device-cgroup also shows the service's allowed devices"
+    snap debug device-cgroup test-snapd-service > device-cgroup-devices-service.out
     MATCH 'Security tag: snap\.test-snapd-service\.test-snapd-service' < device-cgroup-devices-service.out
     MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices-service.out
 

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -108,6 +108,11 @@ execute: |
     # dump the map
     bpftool map dump pinned /sys/fs/bpf/snap/snap_test-snapd-service_sh > device-access.map-app
 
+    echo "Verify snap debug device-cgroup devices shows the allowed devices for the app"
+    snap debug device-cgroup devices test-snapd-service > device-cgroup-devices.out
+    MATCH 'Security tag: snap\.test-snapd-service\.sh' < device-cgroup-devices.out
+    MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices.out
+
     # NOTE: the actual permissions may drift over time. We just care about the fact
     # that there *are* some constraints here now and there were none before.
     echo "Verify the constraints in device cgroup imposed by snapd on the snap application"
@@ -132,6 +137,11 @@ execute: |
     test -e /sys/fs/bpf/snap/snap_test-snapd-service_test-snapd-service
     # dump the map
     bpftool map dump pinned /sys/fs/bpf/snap/snap_test-snapd-service_test-snapd-service > device-access.map-service
+
+    echo "Verify snap debug device-cgroup devices also shows the service's allowed devices"
+    snap debug device-cgroup devices test-snapd-service > device-cgroup-devices-service.out
+    MATCH 'Security tag: snap\.test-snapd-service\.test-snapd-service' < device-cgroup-devices-service.out
+    MATCH 'c +1:3 +rwm +/dev/null' < device-cgroup-devices-service.out
 
     # we use a hash map, and there may be a random element introduced affecting
     # the ordering, so just verify the basics


### PR DESCRIPTION
Extracted from: https://github.com/canonical/snapd/pull/17040

The PR adds required support infrastructure and a new debug command which lists the devices for which a snap is currently allowed access.

Related: [SNAPDENG-36949](https://warthogs.atlassian.net/browse/SNAPDENG-36949)

```
$ sudo snap debug device-cgroup ohmygiraffe
Security tag: snap.ohmygiraffe.ohmygiraffe
TYPE  MAJOR:MINOR  ACCESS  DEVICE
c     1:3          rwm     /dev/null
c     1:5          rwm     /dev/zero
c     1:7          rwm     /dev/full
c     1:8          rwm     /dev/random
c     1:9          rwm     /dev/urandom
c     5:0          rwm     /dev/tty
c     5:1          rwm     /dev/console
c     5:2          rwm     /dev/ptmx
c     10:200       rwm     /dev/net/tun
c     10:239       rwm     /dev/uhid
c     136:*        rwm     -
c     137:*        rwm     -
c     138:*        rwm     -
c     139:*        rwm     -
c     140:*        rwm     -
c     141:*        rwm     -
c     142:*        rwm     -
c     143:*        rwm     -
c     226:0        rwm     /dev/dri/card0
c     226:1        rwm     /dev/dri/card1
c     226:128      rwm     /dev/dri/renderD128
c     226:129      rwm     /dev/dri/renderD129
c     235:0        rwm     /dev/kfd
c     250:0        rwm     /dev/dma_heap/system

$ sudo snap debug device-cgroup image-garden
Security tag: snap.image-garden.apt-cacher-ng
TYPE  MAJOR:MINOR  ACCESS  DEVICE
c     1:3          rwm     /dev/null
c     1:5          rwm     /dev/zero
c     1:7          rwm     /dev/full
c     1:8          rwm     /dev/random
c     1:9          rwm     /dev/urandom
c     5:0          rwm     /dev/tty
c     5:1          rwm     /dev/console
c     5:2          rwm     /dev/ptmx
c     10:200       rwm     /dev/net/tun
c     10:239       rwm     /dev/uhid
c     136:*        rwm     -
c     137:*        rwm     -
c     138:*        rwm     -
c     139:*        rwm     -
c     140:*        rwm     -
c     141:*        rwm     -
c     142:*        rwm     -
c     143:*        rwm     -
```


[SNAPDENG-36949]: https://warthogs.atlassian.net/browse/SNAPDENG-36949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ