### PR TITLE
overlord/ifacestate: drop task logs for delayed effects

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -261,7 +261,6 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 			return fmt.Errorf("internal error: cannot delay backend effects without a handler task")
 		}
 		logger.Debugf("has delayed effects for snaps: %v", delayedEffects)
-		task.Logf("delayed effects for snaps:\n%v", delayedEffects)
 		err := DelayedBackendEffectsFor(delayedTask, triggeringSnap(snapsup.InstanceName()), delayedEffects)
 		if err != nil {
 			return err
@@ -2621,7 +2620,7 @@ func (m *InterfaceManager) doProcessDelayedSecurityBackendEffects(task *state.Ta
 	snapsWithDelayedEffects := newDelayedEffectsForSnaps()
 	for triggeredBySnap, affectedSnaps := range delayed.TriggeringSnaps {
 		if _, ok := successfulTriggeringSnaps[triggeredBySnap]; !ok {
-			task.Logf("skipping effects triggered by failed snap %q", triggeredBySnap)
+			logger.Noticef("skipping effects triggered by failed snap %q", triggeredBySnap)
 			continue
 		}
 
@@ -2646,7 +2645,7 @@ func (m *InterfaceManager) doProcessDelayedSecurityBackendEffects(task *state.Ta
 			continue
 		}
 
-		task.Logf("scheduling delayed effects for snap %q", affectedSnap)
+		logger.Noticef("scheduling delayed effects for snap %q", affectedSnap)
 
 		// One task per connected snap instance
 		updateTask := st.NewTask("apply-delayed-snap-security-backend-effects",

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -13746,9 +13746,7 @@ func (s *interfaceManagerSuite) TestDelayedEffectsSetupProfilesRunThroughProduce
 	effectsTasks := tsks[len(tsks)-4:]
 
 	c.Check(effectsTasks[0].Kind(), Equals, "process-delayed-security-backend-effects")
-	logs := strings.Join(effectsTasks[0].Log(), "\n")
-	c.Check(logs, testutil.Contains, `skipping effects triggered by failed snap "producer2"`)
-	c.Check(logs, testutil.Contains, `scheduling delayed effects for snap "consumer1"`)
+	c.Check(effectsTasks[0].Log(), HasLen, 0)
 
 	// setup-profiles will be automatically injected by auto-connect
 	// before apply-delayed-snap-security-backend-effects for both the


### PR DESCRIPTION
The task log contains debug information and does not look nice if it shows up on the terminal.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
