### PR TITLE
overlord/swfeats: show error when no snapd Go files have been found

### DIFF
--- a/overlord/swfeats/registry_test.go
+++ b/overlord/swfeats/registry_test.go
@@ -133,7 +133,7 @@ func (s *swfeatsSuite) TestCheckChangeRegistrations(c *C) {
 	}
 	goFiles, err := getGoFiles("../../", exclusions...)
 	if err != nil {
-		c.Error("Could not find any go files in snapd directory")
+		c.Errorf("Could not find any go files in snapd directory: %v", err)
 	}
 	var files []*ast.File
 	fset := token.NewFileSet()


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
