### PR TITLE
o/snapstate: omit channel from download task summary when revision is specified

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1324,6 +1324,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 					Action      string     `json:"action"`
 					SnapID      string     `json:"snap-id"`
 					Name        string     `json:"name"`
+					Channel     string     `json:"channel"`
 					InstanceKey string     `json:"instance-key"`
 					Epoch       snap.Epoch `json:"epoch"`
 					// assertions
@@ -1349,11 +1350,12 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 			}
 
 			type resultJSON struct {
-				Result      string          `json:"result"`
-				SnapID      string          `json:"snap-id"`
-				Name        string          `json:"name"`
-				Snap        json.RawMessage `json:"snap"`
-				InstanceKey string          `json:"instance-key"`
+				Result           string          `json:"result"`
+				SnapID           string          `json:"snap-id"`
+				Name             string          `json:"name"`
+				Snap             json.RawMessage `json:"snap"`
+				InstanceKey      string          `json:"instance-key"`
+				EffectiveChannel string          `json:"effective-channel,omitempty"`
 				// For assertions
 				Key           string   `json:"key"`
 				AssertionURLs []string `json:"assertion-stream-urls"`
@@ -1398,12 +1400,19 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 					revno = strconv.Itoa(a.Revision)
 				}
 
+				// The real store returns effective-channel when a
+				// channel is included in the request. When no channel
+				// is sent (e.g. revision-only or validation-set-pinned
+				// installs), no effective-channel is returned.
+				effectiveChannel := a.Channel
+
 				results = append(results, resultJSON{
-					Result:      a.Action,
-					SnapID:      a.SnapID,
-					InstanceKey: a.InstanceKey,
-					Name:        name,
-					Snap:        json.RawMessage(fillHit(snapV2, revno, info, rawInfo)),
+					Result:           a.Action,
+					SnapID:           a.SnapID,
+					InstanceKey:      a.InstanceKey,
+					Name:             name,
+					Snap:             json.RawMessage(fillHit(snapV2, revno, info, rawInfo)),
+					EffectiveChannel: effectiveChannel,
 				})
 			}
 			w.WriteHeader(200)
@@ -5139,7 +5148,11 @@ func validateDownloadCheckTasks(c *C, tasks []*state.Task, name, revno, channel 
 	var i int
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Ensure prerequisites for "%s" are available`, name))
 	i++
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Download snap "%s" (%s) from channel "%s"`, name, revno, channel))
+	if channel != "" {
+		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Download snap "%s" (%s) from channel "%s"`, name, revno, channel))
+	} else {
+		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Download snap "%s" (%s)`, name, revno))
+	}
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Fetch and check assertions for snap "%s" (%s)`, name, revno))
 	i++
@@ -10053,7 +10066,9 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 
 	var i int
 	// first all downloads/checks in sequential order
-	i += validateDownloadCheckTasks(c, tasks[i:], "pc-kernel", "33", "latest/stable")
+	// pc-kernel has its revision pinned by a validation set, so the channel
+	// is not sent to the store and not included in the summary.
+	i += validateDownloadCheckTasks(c, tasks[i:], "pc-kernel", "33", "")
 	i += validateDownloadCheckTasks(c, tasks[i:], "core22", "1", "latest/stable")
 	i += validateDownloadCheckTasks(c, tasks[i:], "pc", "34", "22/stable")
 	// then create recovery
@@ -14004,6 +14019,7 @@ func (s *mgrsSuite) TestDownload(c *C) {
 	c.Check(info.SideInfo, DeepEquals, snap.SideInfo{
 		RealName:          "foo",
 		SnapID:            fakeSnapID("foo"),
+		Channel:           "stable",
 		Revision:          snap.R(snapRev),
 		EditedSummary:     "Foo",
 		EditedDescription: "this is a description",
@@ -14067,6 +14083,7 @@ func (s *mgrsSuite) TestDownloadSpecificRevision(c *C) {
 	c.Check(info.SideInfo, DeepEquals, snap.SideInfo{
 		RealName:          "foo",
 		SnapID:            fakeSnapID("foo"),
+		Channel:           "stable",
 		Revision:          snap.R(snapOldRev),
 		EditedSummary:     "Foo",
 		EditedDescription: "this is a description",
@@ -14096,6 +14113,62 @@ func (s *mgrsSuite) TestDownloadSpecificRevision(c *C) {
 		"snap-sha3-384": digest,
 	})
 	c.Check(err, IsNil)
+}
+
+func (s *mgrsSuite) TestDownloadSpecificRevisionWithChannel(c *C) {
+	// When both a revision and a channel are specified, the store returns
+	// effective-channel, so the download task summary includes the channel.
+	s.prereqSnapAssertions(c)
+
+	const snapRev = "1"
+
+	testSnapPath, _ := s.makeStoreTestSnap(c, "{name: foo, version: 0}", snapRev)
+	s.serveSnap(testSnapPath, snapRev)
+
+	mockServer := s.mockStore(c)
+	defer mockServer.Close()
+
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	dir := c.MkDir()
+	ts, info, err := snapstate.Download(context.TODO(), st, "foo", nil, dir, snapstate.RevisionOptions{
+		Channel:  "edge",
+		Revision: snap.R(snapRev),
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("download-snap", "...")
+	chg.AddAll(ts)
+
+	// The store returns effective-channel even when a specific revision is
+	// requested, as long as a channel was sent in the request.
+	c.Check(info.SideInfo, DeepEquals, snap.SideInfo{
+		RealName:          "foo",
+		SnapID:            fakeSnapID("foo"),
+		Channel:           "edge",
+		Revision:          snap.R(snapRev),
+		EditedSummary:     "Foo",
+		EditedDescription: "this is a description",
+	})
+
+	st.Unlock()
+	err = s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("download-snap change failed with: %v", chg.Err()))
+
+	// Verify the download task summary includes the channel
+	var downloadTask *state.Task
+	for _, t := range chg.Tasks() {
+		if t.Kind() == "download-snap" {
+			downloadTask = t
+			break
+		}
+	}
+	c.Assert(downloadTask, NotNil)
+	c.Check(downloadTask.Summary(), Equals, `Download snap "foo" (1) from channel "edge"`)
 }
 
 const snapYamlMonitoredAppFormat = `

--- a/overlord/snapstate/snap.go
+++ b/overlord/snapstate/snap.go
@@ -134,9 +134,21 @@ func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *tas
 		prepare = st.NewTask("prepare-snap", fmt.Sprintf(
 			i18n.G("Prepare snap %q%s"), sc.snapsup.SnapPath, sc.revisionString()))
 	} else {
-		prepare = st.NewTask("download-snap", fmt.Sprintf(
-			i18n.G("Download snap %q%s from channel %q"),
-			sc.snapsup.InstanceName(), sc.revisionString(), sc.snapsup.Channel))
+		var summary string
+		// Use SideInfo.Channel (the store's effective-channel response) to
+		// decide whether to include the channel in the summary. snapsup.Channel
+		// is the requested/tracking channel which may default to "stable" even
+		// when a specific revision was requested and no channel is meaningful.
+		if sc.snapsup.SideInfo != nil && sc.snapsup.SideInfo.Channel != "" {
+			summary = fmt.Sprintf(
+				i18n.G("Download snap %q%s from channel %q"),
+				sc.snapsup.InstanceName(), sc.revisionString(), sc.snapsup.SideInfo.Channel)
+		} else {
+			summary = fmt.Sprintf(
+				i18n.G("Download snap %q%s"),
+				sc.snapsup.InstanceName(), sc.revisionString())
+		}
+		prepare = st.NewTask("download-snap", summary)
 	}
 	prepare.Set("snap-setup", sc.snapsup)
 	prepare.WaitFor(prereq)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -922,7 +922,18 @@ func downloadTasks(
 
 		revisionStr := fmt.Sprintf(" (%s)", snapsup.Revision())
 
-		download := st.NewTask("download-snap", fmt.Sprintf(i18n.G("Download snap %q%s from channel %q"), snapsup.InstanceName(), revisionStr, snapsup.Channel))
+		// Use SideInfo.Channel (the store's effective-channel response) to
+		// decide whether to include the channel in the summary. snapsup.Channel
+		// is the requested/tracking channel which may default to "stable" even
+		// when a specific revision was requested and no channel is meaningful.
+		var downloadSummary string
+		if snapsup.SideInfo != nil && snapsup.SideInfo.Channel != "" {
+			downloadSummary = fmt.Sprintf(i18n.G("Download snap %q%s from channel %q"), snapsup.InstanceName(), revisionStr, snapsup.SideInfo.Channel)
+		} else {
+			downloadSummary = fmt.Sprintf(i18n.G("Download snap %q%s"), snapsup.InstanceName(), revisionStr)
+		}
+
+		download := st.NewTask("download-snap", downloadSummary)
 		addTask(download)
 
 		validate := st.NewTask("validate-snap", fmt.Sprintf(i18n.G("Fetch and check assertions for snap %q%s"), snapsup.InstanceName(), revisionStr))

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2386,6 +2386,19 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 	snapID := snapName + "-id"
 	snapFileName := snapName + "_42.snap"
 
+	// effectiveChannel is what the store returns as effective-channel
+	// (becomes SideInfo.Channel). The store echoes back the requested
+	// channel as effective-channel. RedirectChannel is a separate field
+	// that tells the client to track a different channel, but doesn't
+	// change what SideInfo.Channel is set to.
+	var effectiveChannel string
+	switch {
+	case requestedChannel != "":
+		effectiveChannel = requestedChannel
+	default:
+		effectiveChannel = ""
+	}
+
 	chg := s.state.NewChange("install", "install a snap")
 	opts := &snapstate.RevisionOptions{Channel: requestedChannel, Revision: snap.R(42)}
 	ts, err := snapstate.Install(context.Background(), s.state, snapName, opts, s.user.ID, snapstate.Flags{})
@@ -2439,7 +2452,7 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 				RealName: snapName,
 				SnapID:   snapID,
 				Revision: snap.R(42),
-				Channel:  requestedChannel,
+				Channel:  effectiveChannel,
 			},
 		},
 		{
@@ -2468,7 +2481,7 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 				RealName: snapName,
 				SnapID:   snapID,
 				Revision: snap.R(42),
-				Channel:  requestedChannel,
+				Channel:  effectiveChannel,
 			},
 		},
 		{
@@ -2515,7 +2528,14 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 	_, cur, total := task.Progress()
 	c.Assert(cur, Equals, s.fakeStore.fakeCurrentProgress)
 	c.Assert(total, Equals, s.fakeStore.fakeTotalProgress)
-	c.Check(task.Summary(), Equals, fmt.Sprintf(`Download snap "%s" (42) from channel "%s"`, snapName, setupChannel))
+	if requestedChannel == "" && defaultTrack == "" {
+		// When only a revision is specified, the store does not report a channel.
+		c.Check(task.Summary(), Equals, fmt.Sprintf(`Download snap "%s" (42)`, snapName))
+	} else {
+		// The summary displays the store's effective-channel (SideInfo.Channel),
+		// not the tracked channel (which may differ due to redirect).
+		c.Check(task.Summary(), Equals, fmt.Sprintf(`Download snap "%s" (42) from channel "%s"`, snapName, effectiveChannel))
+	}
 
 	// check link/start snap summary
 	linkTask := findLastTaskInTasks(ta, "link-snap")
@@ -2546,7 +2566,7 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 		RealName: snapName,
 		Revision: snap.R(42),
 		SnapID:   snapID,
-		Channel:  requestedChannel,
+		Channel:  effectiveChannel,
 	})
 
 	// verify snaps in the system state
@@ -2563,7 +2583,7 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 		RealName: snapName,
 		SnapID:   snapID,
 		Revision: snap.R(42),
-		Channel:  requestedChannel,
+		Channel:  effectiveChannel,
 	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 }

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -1824,6 +1824,102 @@ func (s *storeActionSuite) testSnapActionGetWithRevision(action string, c *C) {
 	c.Assert(results[0].Channel, Equals, "")
 }
 
+func (s *storeActionSuite) TestSnapActionInstallWithRevisionAndChannel(c *C) {
+	s.testSnapActionGetWithRevisionAndChannel("install", c)
+}
+
+func (s *storeActionSuite) TestSnapActionDownloadWithRevisionAndChannel(c *C) {
+	s.testSnapActionGetWithRevisionAndChannel("download", c)
+}
+
+func (s *storeActionSuite) testSnapActionGetWithRevisionAndChannel(action string, c *C) {
+	// When both a revision and a channel are specified in the request, the
+	// store serves the specific revision and returns effective-channel
+	// reflecting the requested channel.
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+
+		jsonReq, err := io.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		// both channel and revision are sent in the request
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
+			"action":       action,
+			"instance-key": action + "-1",
+			"name":         "hello-world",
+			"channel":      "beta",
+			"revision":     float64(28),
+			"epoch":        nil,
+		})
+
+		// The store returns the requested revision and reports
+		// the effective-channel.
+		fmt.Fprintf(w, `{
+  "results": [{
+     "result": "%s",
+     "instance-key": "%[1]s-1",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "effective-channel": "beta",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 28,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`, action)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	results, _, err := sto.SnapAction(s.ctx, nil,
+		[]*store.SnapAction{
+			{
+				Action:       action,
+				InstanceName: "hello-world",
+				Channel:      "beta",
+				Revision:     snap.R(28),
+			},
+		}, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].InstanceName(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(28))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].Publisher.ID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+	// effective-channel is set even when a revision is specified, as long
+	// as a channel was included in the request
+	c.Assert(results[0].Channel, Equals, "beta")
+}
+
 func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", snapActionPath)


### PR DESCRIPTION
Omit channel from download task summary when revision is specified.

**Example:**

**Detail:**
When a snap is installed or refreshed by specifying a revision, the
store does not report an effective channel in its response. Previously,
the download task summary would display the tracking channel (defaulting
to "stable"), which is misleading since it does not reflect where the
revision was actually downloaded from.

Use SideInfo.Channel (the store's effective-channel response) as a gate
to determine whether to include the channel in the task summary. When
the store reports no channel, the summary now shows only the snap name
and revision.

IT TURNS OUT [THERE IS A LOT MORE WRONG](https://docs.google.com/spreadsheets/d/1xU72g7C1F7Hf6QO5iCR31YQ4u50GRniRYcogD2OnfX8/edit?usp=sharing)... DISCUSSION REQUIRED.


Jira: https://warthogs.atlassian.net/browse/SNAPDENG-36986