### PR TITLE
o/snapstate: refactor prerequisites task handler to enable proper seed-refresh integration

### DIFF
--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -174,11 +174,10 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	// can be installed together we add the tasks to the change.
 	var tss []*state.TaskSet
 	for prereqName, contentAttrs := range prereq {
-		var onInFlightErr error = nil
 		var err error
 		var ts *state.TaskSet
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install %q", prereqName), func(timings.Measurer) {
-			ts, err = installOneBaseOrRequired(t, prereqName, contentAttrs, defaultPrereqSnapsChannel(), onInFlightErr, opts)
+			ts, err = installOneBaseOrRequired(t, prereqName, contentAttrs, defaultPrereqSnapsChannel(), opts)
 		})
 		if err != nil {
 			return prereqError("prerequisite", prereqName, err)
@@ -188,10 +187,6 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		}
 		tss = append(tss, ts)
 	}
-
-	// for base snaps we need to wait until the change is done
-	// (either finished or failed)
-	onInFlightErr := &state.Retry{After: prerequisitesRetryTimeout}
 
 	var tsBase *state.TaskSet
 	var err error
@@ -203,7 +198,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 			opts := opts
 			opts.Flags.RequireTypeBase = true
 
-			tsBase, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), onInFlightErr, opts)
+			tsBase, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), opts)
 		})
 		if err != nil {
 			return prereqError("snap base", base, err)
@@ -217,7 +212,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	}
 	if installSnapd {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
-			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), onInFlightErr, opts)
+			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), opts)
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
@@ -253,8 +248,8 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 }
 
 // considerSnapdAsPrereq returns true if we should install snapd as a
-// prerequisite. Returns true on classic systems that are already seeded. Not
-// allowed on Ubuntu Core systems, this requires remodeling.
+// prerequisite, such as on classic systems that are already seeded. It returns
+// false on Ubuntu Core systems where this requires remodeling.
 func considerSnapdAsPrereq(st *state.State) (bool, error) {
 	installed, err := isInstalled(st, "snapd")
 	if err != nil {
@@ -270,7 +265,71 @@ func considerSnapdAsPrereq(st *state.State) (bool, error) {
 	return release.OnClassic && seeded && !installed, nil
 }
 
-func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, channel string, onInFlight error, opts Options) (*state.TaskSet, error) {
+type prereqInFlightAction int
+
+const (
+	prereqProceed prereqInFlightAction = iota
+	prereqSkip
+	prereqRetry
+)
+
+// checkForInFlightPrereqTasks checks whether a link-snap task for
+// prerequisiteName is already in flight and reports how the caller should handle
+// the prerequisite.
+func checkForInFlightPrereqTasks(prereqs *state.Task, prerequisiteName string, basePrerequisite bool) (prereqInFlightAction, error) {
+	st := prereqs.State()
+
+	link, err := findLinkSnapTaskForSnap(st, prerequisiteName)
+	if err != nil {
+		return 0, err
+	}
+
+	// no link-snap task is in flight for this prerequisite snap, proceed
+	if link == nil {
+		return prereqProceed, nil
+	}
+
+	isContentProvider := !basePrerequisite && prerequisiteName != "snapd"
+	if isContentProvider {
+		// the content-provider snap is already being linked by this change, so
+		// there is no need to add another prerequisite operation for it
+		if link.Change().ID() == prereqs.Change().ID() {
+			return prereqSkip, nil
+		}
+
+		// a different change contains a link-snap task for this prerequisite.
+		// retry the current task to avoid a conflict with that change.
+		return prereqRetry, nil
+	}
+
+	if basePrerequisite {
+		// if the base being installed by the prerequisites task is already ordered
+		// behind the in-flight prerequisite link task in the same lane, this task
+		// does not need to wait for that prerequisite out-of-band as well.
+		waiting, err := snapWaitsForLinkInSameLane(prereqs, link)
+		if err != nil {
+			return 0, err
+		}
+
+		if waiting {
+			return prereqSkip, nil
+		}
+	}
+
+	// avoid creating an infinite retry loop: a bug in snapd could cause the
+	// prerequisite's link task to already be ordered behind this
+	// "prerequisites" task. thus, we should fail rather than waiting forever.
+	if willWaitOn(link, prereqs) {
+		return 0, fmt.Errorf(
+			"internal error: prerequisites task cannot wait on task %[1]q because task %[1]q is waiting on the prerequisites task",
+			link.ID(),
+		)
+	}
+
+	return prereqRetry, nil
+}
+
+func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, channel string, opts Options) (*state.TaskSet, error) {
 	st := t.State()
 
 	// The core snap provides everything we need for core16.
@@ -288,40 +347,16 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 		return nil, err
 	}
 
-	shouldWaitForInFlightInstall := func(snapName string) (bool, error) {
-		linkTask, err := findLinkSnapTaskForSnap(st, snapName)
-		if err != nil {
-			return false, err
-		}
-
-		if linkTask == nil {
-			// snap is not being installed
-			return false, nil
-		}
-
-		if opts.Flags.RequireTypeBase {
-			// if this snap is already ordered behind the in-flight base refresh
-			// prerequisites does not need to wait for that base out-of-band as
-			// well.
-			alreadyOrdered, err := snapWaitsForBaseLinkInSameLane(t, linkTask)
-			if err != nil {
-				return false, err
-			}
-
-			if alreadyOrdered {
-				return false, nil
-			}
-		}
-
-		if onInFlight != nil && willWaitOn(linkTask, t) {
-			return false, fmt.Errorf(
-				"internal error: prerequisites task cannot wait on task %[1]q because task %[1]q is waiting on the prerequisites task",
-				linkTask.ID(),
-			)
-		}
-
-		// snap is being installed, retry later
-		return true, nil
+	// check for an existing link-snap task before creating prerequisite tasks.
+	action, err := checkForInFlightPrereqTasks(t, snapName, opts.Flags.RequireTypeBase)
+	if err != nil {
+		return nil, err
+	}
+	switch action {
+	case prereqSkip:
+		return nil, nil
+	case prereqRetry:
+		return nil, &state.Retry{After: prerequisitesRetryTimeout}
 	}
 
 	if isInstalled {
@@ -330,21 +365,7 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 			return updatePrereqIfOutdated(t, snapName, contentAttrs, opts)
 		}
 
-		// other kind of dependency, check if it's in progress
-		if ok, err := shouldWaitForInFlightInstall(snapName); err != nil {
-			return nil, err
-		} else if ok {
-			return nil, onInFlight
-		}
-
 		return nil, nil
-	}
-
-	// not installed, wait for it if it is. If not, we'll install it
-	if ok, err := shouldWaitForInFlightInstall(snapName); err != nil {
-		return nil, err
-	} else if ok {
-		return nil, onInFlight
 	}
 
 	// not installed, nor queued for install -> install it
@@ -376,14 +397,6 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 
 	// check if the default provider has all expected content tags
 	if ok, err := hasAllContentAttrs(st, snapName, contentAttrs); err != nil {
-		return nil, err
-	} else if ok {
-		return nil, nil
-	}
-
-	// this is an optimization since the Update would also detect a conflict
-	// but only after accessing the store
-	if ok, err := shouldSkipToAvoidConflict(t, snapName); err != nil {
 		return nil, err
 	} else if ok {
 		return nil, nil
@@ -422,31 +435,6 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 	}
 
 	return ts, nil
-}
-
-// shouldSkipToAvoidConflict checks for conflicting tasks. Returns true if the
-// operation should be skipped. The error can be a state.Retry if the operation
-// should be retried later.
-func shouldSkipToAvoidConflict(task *state.Task, snapName string) (bool, error) {
-	otherTask, err := findLinkSnapTaskForSnap(task.State(), snapName)
-	if err != nil {
-		return false, err
-	}
-
-	if otherTask == nil {
-		return false, nil
-	}
-
-	// it's in the same change, so the snap is already going to be installed
-	if otherTask.Change().ID() == task.Change().ID() {
-		return true, nil
-	}
-
-	// it's not in the same change, so retry to avoid conflicting changes to the snap
-	return true, &state.Retry{
-		After:  prerequisitesRetryTimeout,
-		Reason: fmt.Sprintf("conflicting changes on snap %q by task %q", snapName, otherTask.Kind()),
-	}
 }
 
 // hasAllContentAttrs checks if the snap has slots with "content" attributes
@@ -584,12 +572,12 @@ func tasksShareLane(t, other *state.Task) bool {
 	return false
 }
 
-// snapWaitsForBaseLinkInSameLane reports whether another task for the same snap
-// in the same lane is already ordered behind the base's link-snap task.
-func snapWaitsForBaseLinkInSameLane(prereqs *state.Task, baseLink *state.Task) (bool, error) {
+// snapWaitsForLinkInSameLane reports whether another task for the same snap in
+// the same lane is already ordered behind the prerequisite's link-snap task.
+func snapWaitsForLinkInSameLane(prereqs *state.Task, link *state.Task) (bool, error) {
 	// if they don't share a change, then there won't be dependencies already
 	// established
-	if prereqs.Change().ID() != baseLink.Change().ID() {
+	if prereqs.Change().ID() != link.Change().ID() {
 		return false, nil
 	}
 
@@ -615,13 +603,13 @@ func snapWaitsForBaseLinkInSameLane(prereqs *state.Task, baseLink *state.Task) (
 		}
 
 		// this check could be made stronger by enforcing that the first local
-		// modification task for the snap waits on the base's link-snap task,
+		// modification task for the snap waits on the prereq's link-snap task,
 		// but we don't have a great way to find that task at this point in
 		// time, since we don't have access to edges any more.
 		//
 		// in short, this is somewhat of a heuristic. we'd need to enumerate all
 		// before-local-modification tasks if we want to make this check better.
-		if willWaitOn(t, baseLink) {
+		if willWaitOn(t, link) {
 			return true, nil
 		}
 	}

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -233,16 +233,12 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	}
 	// add the base if needed, prereqs else must wait on this
 	if baseTS != nil {
-		for _, t := range chg.Tasks() {
-			t.WaitAll(baseTS)
-		}
+		serializeTaskSetBeforeInProgressChange(baseTS, chg)
 		chg.AddAll(baseTS)
 	}
 	// add snapd if needed, everything must wait on this
 	if snapdTS != nil {
-		for _, t := range chg.Tasks() {
-			t.WaitAll(snapdTS)
-		}
+		serializeTaskSetBeforeInProgressChange(snapdTS, chg)
 		chg.AddAll(snapdTS)
 	}
 

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -170,23 +170,12 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, user
 		}
 	}
 
-	// On classic systems that are already seeded, automatically
-	// install snapd snap (covers LP: 1819318). Not allowed for
-	// Ubuntu Core systems - requires remodeling.
 	var tsSnapd *state.TaskSet
-	snapdSnapInstalled, err := isInstalled(st, "snapd")
+	installSnapd, err := considerSnapdAsPrereq(st)
 	if err != nil {
 		return err
 	}
-
-	// consider the state of seeding to avoid seed conflict error
-	var seeded bool
-	err = st.Get("seeded", &seeded)
-	if err != nil && !errors.Is(err, state.ErrNoState) {
-		return err
-	}
-
-	if release.OnClassic && seeded && !snapdSnapInstalled {
+	if installSnapd {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
 			noTypeBaseCheck := false
 			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, noTypeBaseCheck, defaultSnapdSnapsChannel(), onInFlightErr, userID, Flags{
@@ -225,6 +214,24 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, user
 	t.SetStatus(state.DoneStatus)
 
 	return nil
+}
+
+// considerSnapdAsPrereq returns true if we should install snapd as a
+// prerequisite. Returns true on classic systems that are already seeded. Not
+// allowed on Ubuntu Core systems, this requires remodeling.
+func considerSnapdAsPrereq(st *state.State) (bool, error) {
+	installed, err := isInstalled(st, "snapd")
+	if err != nil {
+		return false, err
+	}
+
+	// consider the state of seeding to avoid seed conflict error
+	var seeded bool
+	if err := st.Get("seeded", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
+		return false, err
+	}
+
+	return release.OnClassic && seeded && !installed, nil
 }
 
 func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, requireTypeBase bool, channel string, onInFlight error, userID int, flags Flags) (*state.TaskSet, error) {

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -118,6 +118,13 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// remodeling requires that all snaps are accounted for in the initial
+	// operation. thus, none of the snaps will have prerequisites that must be
+	// pulled in by this task.
+	if dctx.ForRemodeling() {
+		return nil
+	}
+
 	if err := installPrereqs(t, base, snapsup.PrereqContentAttrs, tm, Options{
 		Flags:     flags,
 		UserID:    snapsup.UserID,
@@ -315,15 +322,6 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 
 		// snap is being installed, retry later
 		return true, nil
-	}
-
-	// if we are remodeling, then we should return early due to the way that
-	// tasks are ordered by the remodeling code. specifically, all snap
-	// downloads during a remodel happen prior to snap installation. thus,
-	// we cannot wait for snaps to be installed here. see remodelTasks for
-	// more information on how the tasks are ordered.
-	if opts.DeviceCtx.ForRemodeling() {
-		return nil, nil
 	}
 
 	if isInstalled {

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -44,8 +44,8 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	perfTimings := state.TimingsForTask(t)
-	defer perfTimings.Save(st)
+	tm := state.TimingsForTask(t)
+	defer tm.Save(st)
 
 	// check if we need to inject tasks to install core
 	snapsup, _, err := snapSetupAndState(t)
@@ -81,7 +81,54 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	if err := installPrereqs(t, base, snapsup.PrereqContentAttrs, snapsup.UserID, perfTimings, snapsup.Flags); err != nil {
+	// If transactional, use a single lane for all tasks, so when one fails the
+	// changes for all affected snaps will be undone. Otherwise, have different
+	// lanes per snap so failures only affect the culprit snap.
+	flags := Flags{
+		Transaction: snapsup.Transaction,
+
+		// TODO: as a temporary workaround for a bug that occurs when a snap updates
+		// a prereq, we disable rerefreshes.
+		//
+		// specifically, if the snap that pulls in the prereq contains a configure
+		// hook that creates some tasks via snapctl, then those tasks will end up
+		// waiting on the check-rerefresh task for the updated prereq. the
+		// check-rerefresh task panics if any tasks are found to be waiting on it.
+		NoReRefresh: true,
+
+		// we're calling an API facing call which would otherwise be normally
+		// expected to produce a delayed effects taskset, but since the desire
+		// is to inject the tasksets into the current change, set the flag to
+		// avoid generating one
+		NoDelayedSideEffects: true,
+	}
+	if flags.Transaction == client.TransactionAllSnaps {
+		lanes := t.Lanes()
+		if len(lanes) != 1 {
+			return fmt.Errorf("internal error: more than one lane (%d) on a transactional action", len(lanes))
+		}
+
+		flags.Lane = lanes[0]
+	} else {
+		flags.Transaction = client.TransactionPerSnap
+	}
+
+	dctx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := installPrereqs(t, base, snapsup.PrereqContentAttrs, tm, Options{
+		Flags:     flags,
+		UserID:    snapsup.UserID,
+		DeviceCtx: dctx,
+		ConflictOptions: ConflictOptions{
+			FromChange: t.Change().ID(),
+			// setting this lets us use snap update conflict detection, even
+			// though we're passing in the change ID
+			DoNotIgnoreFromChangeInTaskConflictCheck: true,
+		},
+	}); err != nil {
 		return err
 	}
 
@@ -112,23 +159,8 @@ func defaultPrereqSnapsChannel() string {
 	return channel
 }
 
-func installPrereqs(t *state.Task, base string, prereq map[string][]string, userID int, tm timings.Measurer, flags Flags) error {
+func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm timings.Measurer, opts Options) error {
 	st := t.State()
-
-	// If transactional, use a single lane for all tasks, so when
-	// one fails the changes for all affected snaps will be
-	// undone. Otherwise, have different lanes per snap so
-	// failures only affect the culprit snap.
-	if flags.Transaction == client.TransactionAllSnaps {
-		lanes := t.Lanes()
-		if len(lanes) != 1 {
-			return fmt.Errorf("internal error: more than one lane (%d) on a transactional action", len(lanes))
-		}
-
-		flags.Lane = lanes[0]
-	} else {
-		flags.Transaction = client.TransactionPerSnap
-	}
 
 	// We try to install all wanted snaps. If one snap cannot be installed
 	// because of change conflicts or similar we retry. Only if all snaps
@@ -139,8 +171,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, user
 		var err error
 		var ts *state.TaskSet
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install %q", prereqName), func(timings.Measurer) {
-			noTypeBaseCheck := false
-			ts, err = installOneBaseOrRequired(t, prereqName, contentAttrs, noTypeBaseCheck, defaultPrereqSnapsChannel(), onInFlightErr, userID, flags)
+			ts, err = installOneBaseOrRequired(t, prereqName, contentAttrs, defaultPrereqSnapsChannel(), onInFlightErr, opts)
 		})
 		if err != nil {
 			return prereqError("prerequisite", prereqName, err)
@@ -159,11 +190,13 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, user
 	var err error
 	if base != "none" {
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
-			requireTypeBase := true
-			tsBase, err = installOneBaseOrRequired(t, base, nil, requireTypeBase, defaultBaseSnapsChannel(), onInFlightErr, userID, Flags{
-				Transaction: flags.Transaction,
-				Lane:        flags.Lane,
-			})
+			// base prerequisites are installed with the same options as other
+			// prerequisites, except that they must be verified to have type
+			// base.
+			opts := opts
+			opts.Flags.RequireTypeBase = true
+
+			tsBase, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), onInFlightErr, opts)
 		})
 		if err != nil {
 			return prereqError("snap base", base, err)
@@ -177,11 +210,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, user
 	}
 	if installSnapd {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
-			noTypeBaseCheck := false
-			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, noTypeBaseCheck, defaultSnapdSnapsChannel(), onInFlightErr, userID, Flags{
-				Transaction: flags.Transaction,
-				Lane:        flags.Lane,
-			})
+			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), onInFlightErr, opts)
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
@@ -234,7 +263,7 @@ func considerSnapdAsPrereq(st *state.State) (bool, error) {
 	return release.OnClassic && seeded && !installed, nil
 }
 
-func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, requireTypeBase bool, channel string, onInFlight error, userID int, flags Flags) (*state.TaskSet, error) {
+func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, channel string, onInFlight error, opts Options) (*state.TaskSet, error) {
 	st := t.State()
 
 	// The core snap provides everything we need for core16.
@@ -252,11 +281,6 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 		return nil, err
 	}
 
-	deviceCtx, err := DeviceCtx(st, t, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	shouldWaitForInFlightInstall := func(snapName string) (bool, error) {
 		linkTask, err := findLinkSnapTaskForSnap(st, snapName)
 		if err != nil {
@@ -268,7 +292,7 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 			return false, nil
 		}
 
-		if requireTypeBase {
+		if opts.Flags.RequireTypeBase {
 			// if this snap is already ordered behind the in-flight base refresh
 			// prerequisites does not need to wait for that base out-of-band as
 			// well.
@@ -298,14 +322,14 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 	// downloads during a remodel happen prior to snap installation. thus,
 	// we cannot wait for snaps to be installed here. see remodelTasks for
 	// more information on how the tasks are ordered.
-	if deviceCtx.ForRemodeling() {
+	if opts.DeviceCtx.ForRemodeling() {
 		return nil, nil
 	}
 
 	if isInstalled {
 		if len(contentAttrs) > 0 {
 			// the default provider is already installed, update it if it's missing content attributes the snap needs
-			return updatePrereqIfOutdated(t, snapName, contentAttrs, userID, flags)
+			return updatePrereqIfOutdated(t, snapName, contentAttrs, opts)
 		}
 
 		// other kind of dependency, check if it's in progress
@@ -326,16 +350,12 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 	}
 
 	// not installed, nor queued for install -> install it
-	ts, err := InstallWithDeviceContext(context.TODO(), st, snapName, &RevisionOptions{Channel: channel}, userID, Flags{
-		RequireTypeBase: requireTypeBase,
-		Transaction:     flags.Transaction,
-		Lane:            flags.Lane,
-		// we're calling an API facing call which would otherwise be normally
-		// expected to produce a delayed effects taskset, but since the desire
-		// is to inject the tasksets into the current change, set the flag to
-		// avoid generating one
-		NoDelayedSideEffects: true,
-	}, nil, deviceCtx, "")
+	_, ts, err := InstallOne(context.TODO(), st, StoreInstallGoal(StoreSnap{
+		InstanceName: snapName,
+		RevOpts: RevisionOptions{
+			Channel: channel,
+		},
+	}), opts)
 
 	// something might have triggered an explicit install while
 	// the state was unlocked -> deal with that here by simply
@@ -353,7 +373,7 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 }
 
 // updates a prerequisite, if it's not providing a content interface that a plug expects it to
-func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, userID int, flags Flags) (*state.TaskSet, error) {
+func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, opts Options) (*state.TaskSet, error) {
 	st := t.State()
 
 	// check if the default provider has all expected content tags
@@ -371,34 +391,10 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		return nil, nil
 	}
 
-	deviceCtx, err := DeviceCtx(st, t, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: as a temporary workaround for a bug that occurs when a snap updates
-	// a prereq, we disable rerefreshes.
-	//
-	// specifically, if the snap that pulls in the prereq contains a configure hook
-	// that creates some tasks via snapctl, then those tasks will end up waiting
-	// on the check-rerefresh task for the updated prereq. the check-rerefresh
-	// task panics if any tasks are found to be waiting on it.
-	flags.NoReRefresh = true
-
 	// default provider is missing some content tags (likely outdated) so update it
 	ts, err := UpdateOne(context.Background(), st, StoreUpdateGoal(StoreUpdate{
 		InstanceName: snapName,
-	}), nil, Options{
-		Flags:     flags,
-		UserID:    userID,
-		DeviceCtx: deviceCtx,
-		ConflictOptions: ConflictOptions{
-			FromChange: t.Change().ID(),
-			// setting this lets us use snap update conflict detection, even
-			// though we're passing in the change ID
-			DoNotIgnoreFromChangeInTaskConflictCheck: true,
-		},
-	})
+	}), nil, opts)
 	if err != nil {
 		if conflErr, ok := err.(*ChangeConflictError); ok {
 			// If we aren't seeded, then it's too early to do any updates and we cannot
@@ -423,7 +419,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		return nil, nil
 	}
 
-	if err := maybeMergeLateSeedRefreshPrereq(t.Change(), deviceCtx, ts); err != nil {
+	if err := maybeMergeLateSeedRefreshPrereq(t.Change(), opts.DeviceCtx, ts); err != nil {
 		return nil, err
 	}
 

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -53,22 +53,23 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// os/base/kernel/gadget cannot have prerequisites other
-	// than the models default base (or core) which is installed anyway
+	// snapd/os/base/kernel/gadget cannot have prerequisites other than the
+	// models default base (or core) which is installed anyway
 	switch snapsup.Type {
-	case snap.TypeOS, snap.TypeBase, snap.TypeKernel, snap.TypeGadget:
-		return nil
-	}
-	// snapd is special and has no prereqs
-	if snapsup.Type == snap.TypeSnapd {
+	case snap.TypeSnapd, snap.TypeOS, snap.TypeBase, snap.TypeKernel, snap.TypeGadget:
 		return nil
 	}
 
-	// we need to make sure we install all prereqs together in one
-	// operation
-	base := defaultCoreSnapName
-	if snapsup.Base != "" {
-		base = snapsup.Base
+	dctx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return err
+	}
+
+	// remodeling requires that all snaps are accounted for in the initial
+	// operation. thus, none of the snaps will have prerequisites that must be
+	// pulled in by this task.
+	if dctx.ForRemodeling() {
+		return nil
 	}
 
 	// if a previous version of snapd persisted Prereq only, fill the contentAttrs.
@@ -113,19 +114,12 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		flags.Transaction = client.TransactionPerSnap
 	}
 
-	dctx, err := DeviceCtx(st, t, nil)
-	if err != nil {
-		return err
+	base := defaultCoreSnapName
+	if snapsup.Base != "" {
+		base = snapsup.Base
 	}
 
-	// remodeling requires that all snaps are accounted for in the initial
-	// operation. thus, none of the snaps will have prerequisites that must be
-	// pulled in by this task.
-	if dctx.ForRemodeling() {
-		return nil
-	}
-
-	if err := installPrereqs(t, base, snapsup.PrereqContentAttrs, tm, Options{
+	return installPrereqs(t, base, snapsup.PrereqContentAttrs, tm, Options{
 		Flags:     flags,
 		UserID:    snapsup.UserID,
 		DeviceCtx: dctx,
@@ -135,11 +129,7 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 			// though we're passing in the change ID
 			DoNotIgnoreFromChangeInTaskConflictCheck: true,
 		},
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func defaultBaseSnapsChannel() string {
@@ -170,8 +160,8 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	st := t.State()
 
 	// We try to install all wanted snaps. If one snap cannot be installed
-	// because of change conflicts or similar we retry. Only if all snaps
-	// can be installed together we add the tasks to the change.
+	// because of change conflicts or similar we retry. Only if all snaps can be
+	// installed together we add the tasks to the change.
 	var tss []*state.TaskSet
 	for prereqName, contentAttrs := range prereq {
 		var err error
@@ -188,7 +178,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		tss = append(tss, ts)
 	}
 
-	var tsBase *state.TaskSet
+	var baseTS *state.TaskSet
 	var err error
 	if base != "none" {
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
@@ -198,21 +188,22 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 			opts := opts
 			opts.Flags.RequireTypeBase = true
 
-			tsBase, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), opts)
+			baseTS, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), opts)
 		})
 		if err != nil {
 			return prereqError("snap base", base, err)
 		}
 	}
 
-	var tsSnapd *state.TaskSet
 	installSnapd, err := considerSnapdAsPrereq(st)
 	if err != nil {
 		return err
 	}
+
+	var snapdTS *state.TaskSet
 	if installSnapd {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
-			tsSnapd, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), opts)
+			snapdTS, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), opts)
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
@@ -226,18 +217,18 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		chg.AddAll(ts)
 	}
 	// add the base if needed, prereqs else must wait on this
-	if tsBase != nil {
+	if baseTS != nil {
 		for _, t := range chg.Tasks() {
-			t.WaitAll(tsBase)
+			t.WaitAll(baseTS)
 		}
-		chg.AddAll(tsBase)
+		chg.AddAll(baseTS)
 	}
 	// add snapd if needed, everything must wait on this
-	if tsSnapd != nil {
+	if snapdTS != nil {
 		for _, t := range chg.Tasks() {
-			t.WaitAll(tsSnapd)
+			t.WaitAll(snapdTS)
 		}
-		chg.AddAll(tsSnapd)
+		chg.AddAll(snapdTS)
 	}
 
 	// make sure that the new change is committed to the state

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -164,10 +164,15 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	// installed together we add the tasks to the change.
 	var tss []*state.TaskSet
 	for prereqName, contentAttrs := range prereq {
-		var err error
 		var ts *state.TaskSet
+		var err error
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install %q", prereqName), func(timings.Measurer) {
-			ts, err = installOneBaseOrRequired(t, prereqName, contentAttrs, defaultPrereqSnapsChannel(), opts)
+			ts, err = ensurePrerequisite(t, contentAttrs, StoreSnap{
+				InstanceName: prereqName,
+				RevOpts: RevisionOptions{
+					Channel: defaultPrereqSnapsChannel(),
+				},
+			}, opts)
 		})
 		if err != nil {
 			return prereqError("prerequisite", prereqName, err)
@@ -179,8 +184,8 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	}
 
 	var baseTS *state.TaskSet
-	var err error
 	if base != "none" {
+		var err error
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
 			// base prerequisites are installed with the same options as other
 			// prerequisites, except that they must be verified to have type
@@ -188,7 +193,12 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 			opts := opts
 			opts.Flags.RequireTypeBase = true
 
-			baseTS, err = installOneBaseOrRequired(t, base, nil, defaultBaseSnapsChannel(), opts)
+			baseTS, err = ensurePrerequisite(t, nil, StoreSnap{
+				InstanceName: base,
+				RevOpts: RevisionOptions{
+					Channel: defaultBaseSnapsChannel(),
+				},
+			}, opts)
 		})
 		if err != nil {
 			return prereqError("snap base", base, err)
@@ -203,7 +213,12 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	var snapdTS *state.TaskSet
 	if installSnapd {
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
-			snapdTS, err = installOneBaseOrRequired(t, "snapd", nil, defaultSnapdSnapsChannel(), opts)
+			snapdTS, err = ensurePrerequisite(t, nil, StoreSnap{
+				InstanceName: "snapd",
+				RevOpts: RevisionOptions{
+					Channel: defaultSnapdSnapsChannel(),
+				},
+			}, opts)
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
@@ -320,26 +335,26 @@ func checkForInFlightPrereqTasks(prereqs *state.Task, prerequisiteName string, b
 	return prereqRetry, nil
 }
 
-func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []string, channel string, opts Options) (*state.TaskSet, error) {
+func ensurePrerequisite(t *state.Task, contentAttrs []string, sn StoreSnap, opts Options) (*state.TaskSet, error) {
 	st := t.State()
 
-	// The core snap provides everything we need for core16.
-	coreInstalled, err := isInstalled(st, "core")
-	if err != nil {
-		return nil, err
-	}
-	if snapName == "core16" && coreInstalled {
-		return nil, nil
-	}
+	// as a special case, we allow the core snap to satisfy a core16 requirement
+	if sn.InstanceName == "core16" {
+		installed, err := isInstalled(st, "core")
+		if err != nil {
+			return nil, err
+		}
 
-	// installed already?
-	isInstalled, err := isInstalled(st, snapName)
-	if err != nil {
-		return nil, err
+		// this is safe since bases are not content-providers. thus, they will
+		// never need an update. note that this also skips any retry behavior,
+		// but is consistent with the current implementation.
+		if installed {
+			return nil, nil
+		}
 	}
 
 	// check for an existing link-snap task before creating prerequisite tasks.
-	action, err := checkForInFlightPrereqTasks(t, snapName, opts.Flags.RequireTypeBase)
+	action, err := checkForInFlightPrereqTasks(t, sn.InstanceName, opts.Flags.RequireTypeBase)
 	if err != nil {
 		return nil, err
 	}
@@ -350,69 +365,58 @@ func installOneBaseOrRequired(t *state.Task, snapName string, contentAttrs []str
 		return nil, &state.Retry{After: prerequisitesRetryTimeout}
 	}
 
-	if isInstalled {
-		if len(contentAttrs) > 0 {
-			// the default provider is already installed, update it if it's missing content attributes the snap needs
-			return updatePrereqIfOutdated(t, snapName, contentAttrs, opts)
-		}
-
-		return nil, nil
-	}
-
-	// not installed, nor queued for install -> install it
-	_, ts, err := InstallOne(context.TODO(), st, StoreInstallGoal(StoreSnap{
-		InstanceName: snapName,
-		RevOpts: RevisionOptions{
-			Channel: channel,
-		},
-	}), opts)
-
-	// something might have triggered an explicit install while
-	// the state was unlocked -> deal with that here by simply
-	// retrying the operation.
-	var conflErr *ChangeConflictError
-	if errors.As(err, &conflErr) {
-		// conflicted with an install in the same change, just skip
-		if conflErr.ChangeID == t.Change().ID() {
-			return nil, nil
-		}
-
-		return nil, &state.Retry{After: prerequisitesRetryTimeout}
-	}
-	return ts, err
-}
-
-// updates a prerequisite, if it's not providing a content interface that a plug expects it to
-func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, opts Options) (*state.TaskSet, error) {
-	st := t.State()
-
-	// check if the default provider has all expected content tags
-	if ok, err := hasAllContentAttrs(st, snapName, contentAttrs); err != nil {
-		return nil, err
-	} else if ok {
-		return nil, nil
-	}
-
-	// default provider is missing some content tags (likely outdated) so update it
-	ts, err := UpdateOne(context.Background(), st, StoreUpdateGoal(StoreUpdate{
-		InstanceName: snapName,
-	}), nil, opts)
+	installed, err := isInstalled(st, sn.InstanceName)
 	if err != nil {
-		if conflErr, ok := err.(*ChangeConflictError); ok {
-			// If we aren't seeded, then it's too early to do any updates and we cannot
-			// handle this during seeding, so expect the ChangeConflictError in this scenario.
-			if conflErr.ChangeKind == "seed" {
-				t.Logf("cannot update %q during seeding, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)
-				return nil, nil
-			}
+		return nil, err
+	}
 
-			// there's already an update for the same snap in this change,
-			// just skip this one
-			if conflErr.ChangeID == t.Change().ID() {
+	var ts *state.TaskSet
+	if !installed {
+		_, ts, err = InstallOne(context.TODO(), st, StoreInstallGoal(sn), opts)
+	} else {
+		ts, err = maybeUpdateContentProvider(t, sn.InstanceName, contentAttrs, opts)
+	}
+	if err != nil {
+		var cerr *ChangeConflictError
+		if errors.As(err, &cerr) {
+			// conflicted with an install in the same change, just skip
+			if cerr.ChangeID == t.Change().ID() {
 				return nil, nil
 			}
 
 			return nil, &state.Retry{After: prerequisitesRetryTimeout}
+		}
+		return nil, err
+	}
+
+	return ts, nil
+}
+
+func maybeUpdateContentProvider(t *state.Task, snapName string, contentAttrs []string, opts Options) (*state.TaskSet, error) {
+	st := t.State()
+	provided, err := hasAllContentAttrs(st, snapName, contentAttrs)
+	if err != nil {
+		return nil, err
+	}
+	if provided {
+		return nil, nil
+	}
+
+	ts, err := UpdateOne(context.TODO(), st, StoreUpdateGoal(StoreUpdate{
+		InstanceName: snapName,
+	}), nil, opts)
+	if err != nil {
+		var cerr *ChangeConflictError
+		if errors.As(err, &cerr) {
+			// if we aren't seeded, then it's too early to do any updates and we
+			// cannot handle this during seeding, so expect the
+			// ChangeConflictError in this scenario.
+			if cerr.ChangeKind == "seed" {
+				t.Logf("cannot update %q during seeding, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), cerr)
+				return nil, nil
+			}
+
+			return nil, err
 		}
 
 		// don't propagate error to avoid failing the main install since the
@@ -424,7 +428,6 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 	if err := maybeMergeLateSeedRefreshPrereq(t.Change(), opts.DeviceCtx, ts); err != nil {
 		return nil, err
 	}
-
 	return ts, nil
 }
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -467,6 +467,59 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 }
 
+func (s *prereqSuite) TestDoPrereqRetryWhenPrereqInstallInAnotherChange(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// keep the other change's link-snap pending
+	blocker := s.state.NewTask("blocker", "block prereq1 link task")
+	link := s.state.NewTask("link-snap", "pretend prereq1 gets installed")
+	link.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "prereq1",
+			Revision: snap.R(11),
+		},
+	})
+	link.WaitFor(blocker)
+
+	// install snapd so that prerequisites handler won't try to install it
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+	})
+
+	prereq := s.state.NewTask("prerequisites", "foo")
+	prereq.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+		},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"prereq1": nil},
+	})
+
+	linkChg := s.state.NewChange("install", "install prereq1")
+	linkChg.AddTask(blocker)
+	linkChg.AddTask(link)
+
+	prereqChg := s.state.NewChange("install", "install foo")
+	prereqChg.AddTask(prereq)
+
+	s.state.Unlock()
+	defer s.state.Lock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// doing + scheduled at-time means the handler returned state.Retry
+	c.Check(prereq.Status(), Equals, state.DoingStatus)
+	c.Check(prereq.AtTime().IsZero(), Equals, false)
+}
+
 func (s *prereqSuite) TestDoPrereqRetryWhenDifferentLaneWaitsOnBaseInFlight(c *C) {
 	restore := snapstate.MockPrerequisitesRetryTimeout(1 * time.Millisecond)
 	defer restore()

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -1167,6 +1167,58 @@ func (s *prereqSuite) TestPreReqContentAttrsNotSatisfied(c *C) {
 	}
 }
 
+func (s *prereqSuite) TestPreReqContentAttrsRefreshKeepsTrackedChannel(c *C) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
+		return nil, nil
+	}
+	s.AddCleanup(func() { snapstate.AutoAliases = nil })
+
+	st := s.state
+	st.Lock()
+
+	mockInstalledSnap(c, st, `name: some-snap`, false)
+
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(st, "some-snap", &snapst), IsNil)
+	snapst.TrackingChannel = "latest/edge"
+	snapstate.Set(st, "some-snap", &snapst)
+
+	snapstate.Set(st, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	t := st.NewTask("prerequisites", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+		},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"some-snap": {"this-does-not-match"}},
+	})
+	chg := st.NewChange("sample", "...")
+	chg.AddTask(t)
+	st.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action:action"), Equals, 1)
+	op := s.fakeBackend.ops.MustFindOp(c, "storesvc-snap-action:action")
+	c.Check(op.action.InstanceName, Equals, "some-snap")
+	c.Check(op.action.Action, Equals, "refresh")
+	c.Check(op.action.Channel, Equals, "latest/edge")
+}
+
 func (s *prereqSuite) TestPreReqContentAttrsNotSatisfiedSeeding(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -170,6 +170,8 @@ func (s *prereqSuite) TestDoPrereqWithBaseNone(c *C) {
 		},
 		Base:               "none",
 		PrereqContentAttrs: map[string][]string{"prereq1": {"some-content"}},
+		// set devmode to prove that prerequisites don't inherit these flags
+		Flags: snapstate.Flags{DevMode: true},
 	})
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
@@ -190,6 +192,8 @@ func (s *prereqSuite) TestDoPrereqWithBaseNone(c *C) {
 		if t.Kind() == "link-snap" {
 			snapsup, err := snapstate.TaskSnapSetup(t)
 			c.Assert(err, IsNil)
+			// prerequisites are installed with sanitized flags
+			c.Check(snapsup.DevMode, Equals, false)
 			linkedSnaps = append(linkedSnaps, snapsup.InstanceName())
 		} else if t.Kind() == "prerequisites" {
 			c.Assert(t.Lanes(), DeepEquals, []int{lane})

--- a/overlord/snapstate/task_chain_builder.go
+++ b/overlord/snapstate/task_chain_builder.go
@@ -260,3 +260,27 @@ func serializeTaskSets(prev, next *state.TaskSet) {
 		}
 	}
 }
+
+// serializeTaskSetBeforeInProgressChange makes the tasks in chg that still need
+// to run (in the do direction) wait on ts without creating superfluous
+// dependencies.
+func serializeTaskSetBeforeInProgressChange(ts *state.TaskSet, chg *state.Change) {
+	tasks := make([]*state.Task, 0, len(chg.Tasks()))
+	for _, t := range chg.Tasks() {
+		// only consider tasks that still need to be done, everything else can
+		// be skipped
+		switch t.Status() {
+		case state.DoStatus:
+		case state.WaitStatus:
+			if t.WaitedStatus() != state.DoStatus {
+				continue
+			}
+		default:
+			continue
+		}
+
+		tasks = append(tasks, t)
+	}
+
+	serializeTaskSets(ts, state.NewTaskSet(tasks...))
+}

--- a/overlord/snapstate/task_chain_builder_internal_test.go
+++ b/overlord/snapstate/task_chain_builder_internal_test.go
@@ -524,6 +524,67 @@ func (s *taskChainBuilderTestSuite) TestFindHeadAndTailTasksLinearChain(c *C) {
 	c.Check(remainder, DeepEquals, []*state.Task{t2})
 }
 
+func (s *taskChainBuilderTestSuite) TestSerializeTaskSetBeforeInProgressChangeSkipsDoingTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	prev1 := st.NewTask("prev-1", "first previous task")
+	prev2 := st.NewTask("prev-2", "second previous task")
+	prev2.WaitFor(prev1)
+	prevTS := state.NewTaskSet(prev1, prev2)
+
+	next1 := st.NewTask("next-1", "first next task")
+	next2 := st.NewTask("next-2", "second next task")
+	next3 := st.NewTask("next-3", "third next task")
+	next2.WaitFor(next1)
+	next3.WaitFor(next2)
+	next1.SetStatus(state.DoingStatus)
+
+	chg := st.NewChange("sample", "...")
+	chg.AddTask(next1)
+	chg.AddTask(next2)
+	chg.AddTask(next3)
+
+	serializeTaskSetBeforeInProgressChange(prevTS, chg)
+
+	// the running task cannot be gated anymore, so the pending frontier waits
+	// on the previous task set instead.
+	c.Check(next1.WaitTasks(), HasLen, 0)
+	c.Check(next2.WaitTasks(), DeepEquals, []*state.Task{next1, prev2})
+	c.Check(next3.WaitTasks(), DeepEquals, []*state.Task{next2})
+	c.Check(prev2.HaltTasks(), DeepEquals, []*state.Task{next2})
+}
+
+func (s *taskChainBuilderTestSuite) TestSerializeTaskSetBeforeInProgressChangeIncludesWaitStatusForDo(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	prev1 := st.NewTask("prev-1", "first previous task")
+	prev2 := st.NewTask("prev-2", "second previous task")
+	prev2.WaitFor(prev1)
+	prevTS := state.NewTaskSet(prev1, prev2)
+
+	// a task waiting to resume in DoStatus still needs forward dependencies.
+	waitingDo := st.NewTask("waiting-do", "waiting to do")
+	waitingDo.SetToWait(state.DoStatus)
+
+	// a task waiting to finish as DoneStatus must not be gated again.
+	waitingDone := st.NewTask("waiting-done", "waiting to finish")
+	waitingDone.SetToWait(state.DoneStatus)
+
+	chg := st.NewChange("sample", "...")
+	chg.AddTask(waitingDo)
+	chg.AddTask(waitingDone)
+
+	serializeTaskSetBeforeInProgressChange(prevTS, chg)
+
+	c.Check(waitingDo.WaitTasks(), DeepEquals, []*state.Task{prev2})
+	c.Check(waitingDone.WaitTasks(), HasLen, 0)
+	c.Check(prev2.HaltTasks(), DeepEquals, []*state.Task{waitingDo})
+}
+
 func (s *taskChainBuilderTestSuite) TestFindHeadAndTailTasksDiamond(c *C) {
 	st := state.New(nil)
 	st.Lock()


### PR DESCRIPTION
This is an attempt at simplifying the current `prerequisites` task handler.

This is somewhat of a full rewrite, so the diff might not be super helpful sadly. A main motivation was to simplify and combine some of the retry logic, since that was spread across a lot of the previous implementation.

No functional changes, though I've added a couple tests that caught regressions I introduced while working on the refactor.

I've also gotten rid of the `WaitAll` usage that was used when organizing the task sets created by `prerequisites`. Now the graph is a bit more readable. I'll attach some examples.