### PR TITLE
tests: retry when gh client fails and check last change time in auto-rerun workflow

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -9,14 +9,14 @@ export NOT_RERUN_REASON=""
 : "${GH_API_RETRY_DELAY_SECONDS:=2}"
 : "${GH_RETRY_CONTEXT:=}"
 
-gh_out_with_retry() {
+gh_retry() {
     local attempt=1
     local delay="$GH_API_RETRY_DELAY_SECONDS"
     local output
     local context="${GH_RETRY_CONTEXT:-}"
 
     while (( attempt <= GH_API_RETRIES )); do
-        if output="$("$@" 2>&1)"; then
+        if output="$(gh "$@" 2>&1)"; then
             printf '%s\n' "$output"
             return 0
         fi
@@ -110,7 +110,7 @@ pr_with_reviews_history() {
     fi
 
     GH_RETRY_CONTEXT="PR #$pr_number review history lookup"
-    if reviews_json=$(gh_out_with_retry gh pr view "$pr_number" --json reviews --jq '.reviews'); then
+    if reviews_json=$(gh_retry pr view "$pr_number" --json reviews --jq '.reviews'); then
         pr_json=$(jq -c --argjson reviews "$reviews_json" '. + {reviews: $reviews}' <<<"$pr_json")
     fi
     GH_RETRY_CONTEXT=""

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -16,7 +16,7 @@ gh_retry() {
     local context="${GH_RETRY_CONTEXT:-}"
 
     while (( attempt <= GH_API_RETRIES )); do
-        if output="$(gh "$@" 2>&1)"; then
+        if output="$(gh "$@")"; then
             printf '%s\n' "$output"
             return 0
         fi
@@ -208,7 +208,7 @@ required_spread_failure_threshold_allows_rerun() {
     # Encode the branch name for use in the API URL
     encoded_base=$(jq -Rr @uri <<< "$pr_base")
 
-    if ! required_spread_checks=$(gh api \
+    if ! required_spread_checks=$(gh_retry api \
         -X GET \
         -H "Accept: application/vnd.github+json" \
         "repos/$repo/rules/branches/$encoded_base" \
@@ -226,10 +226,10 @@ required_spread_failure_threshold_allows_rerun() {
         if grep -Fxq "$failed_name" <<<"$required_spread_checks"; then
             failed_required_system_targets+="$failed_id "$'\n'
         fi
-    done < <(gh run view "$run_id" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
+    done < <(gh_retry run view "$run_id" --json jobs --jq '.jobs[] | select(.name | test("^spread ")) | select(.conclusion == "failure") | [.databaseId, .name] | @tsv')
 
     for failed in $failed_required_system_targets; do
-        num_failed=$(gh run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
+        num_failed=$(gh_retry run view --log-failed --job "$failed" | grep -oP '(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) Failed tasks: \K\d+$' | head -1 || true)
 
         if [ -n "$num_failed" ] && [ "$num_failed" -ge "$max_failed_tasks" ]; then
             NOT_RERUN_REASON="there were $max_failed_tasks or more failures on a required system target"

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -60,7 +60,10 @@ ensure_auto_rerun_label() {
     fi
 
     echo "Adding $AUTO_RERUN_LABEL label to PR #$pr_number"
-    gh pr edit "$pr_number" --add-label "$AUTO_RERUN_LABEL"
+    if ! gh_retry pr edit "$pr_number" --add-label "$AUTO_RERUN_LABEL"; then
+        NOT_RERUN_REASON="failed to add label '$AUTO_RERUN_LABEL' to PR #$pr_number"
+        return 1
+    fi
 }
 
 # Returns a JSON object mapping each reviewer's login to their effective review

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -5,6 +5,35 @@ SKIP_SPREAD_LABEL="Skip spread"
 RUN_ONLY_ONE_SYSTEM_LABEL="Run only one system"
 export NOT_RERUN_REASON=""
 
+: "${GH_API_RETRIES:=3}"
+: "${GH_API_RETRY_DELAY_SECONDS:=2}"
+
+gh_out_with_retry() {
+    local attempt=1
+    local delay="$GH_API_RETRY_DELAY_SECONDS"
+    local output
+
+    while (( attempt <= GH_API_RETRIES )); do
+        if output="$($@ 2>&1)"; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+
+        if (( attempt == GH_API_RETRIES )); then
+            echo "Command failed after $GH_API_RETRIES attempts: $*" >&2
+            echo "$output" >&2
+            return 1
+        fi
+
+        echo "Transient failure on attempt $attempt/$GH_API_RETRIES for: $*" >&2
+        echo "$output" >&2
+
+        sleep "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+    done
+}
+
 pr_has_label() {
     local pr_json="$1"
     local label="$2"

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -51,13 +51,6 @@ pr_has_label() {
     jq -e --arg label "$label" '[.labels[]?.name] | index($label) != null' <<<"$pr_json" >/dev/null
 }
 
-pr_review_count() {
-    local pr_json="$1"
-    local review_state="$2"
-
-    jq -r --arg review_state "$review_state" '[.latestReviews[]? | select(.state == $review_state) | .author.login] | unique | length' <<<"$pr_json"
-}
-
 ensure_auto_rerun_label() {
     local pr_number="$1"
     local pr_json="$2"
@@ -70,10 +63,68 @@ ensure_auto_rerun_label() {
     gh pr edit "$pr_number" --add-label "$AUTO_RERUN_LABEL"
 }
 
+# Returns a JSON object mapping each reviewer's login to their effective review
+# state, determined by scanning the review history from newest to oldest and
+# skipping COMMENTED reviews.  The first non-comment review found (i.e. the
+# most recent actionable one) is the effective state:
+#   APPROVED           -> "APPROVED"
+#   CHANGES_REQUESTED  -> "CHANGES_REQUESTED"
+#   DISMISSED          -> "CHANGES_REQUESTED"
+pr_reviewer_effective_states() {
+    local pr_json="$1"
+    jq -r '
+            [
+                ((.reviews // .latestReviews // [])[]? | select(type == "object"))
+                | {
+                    login: (.author.login // ""),
+                    submittedAt: (.submittedAt // ""),
+                    state: (.state // "")
+                  }
+            ]
+            | sort_by(.submittedAt)
+            | reverse
+            | reduce .[] as $r ({};
+                if $r.login == "" or has($r.login) or $r.state == "COMMENTED" then
+                    .
+                else
+                    .[$r.login] = (if $r.state == "APPROVED" then "APPROVED" else "CHANGES_REQUESTED" end)
+                end
+            )
+    ' <<<"$pr_json" 2>/dev/null || echo '{}'
+}
+
+pr_with_reviews_history() {
+    local pr_json="$1"
+    local pr_number
+    local reviews_json
+
+    if [ "$(jq -r '(.reviews | type) == "array"' <<<"$pr_json" 2>/dev/null || echo false)" = "true" ]; then
+        echo "$pr_json"
+        return
+    fi
+
+    pr_number=$(jq -r '.number // empty' <<<"$pr_json")
+    if [ -z "$pr_number" ]; then
+        echo "$pr_json"
+        return
+    fi
+
+    GH_RETRY_CONTEXT="PR #$pr_number review history lookup"
+    if reviews_json=$(gh_out_with_retry gh pr view "$pr_number" --json reviews --jq '.reviews'); then
+        pr_json=$(jq -c --argjson reviews "$reviews_json" '. + {reviews: $reviews}' <<<"$pr_json")
+    fi
+    GH_RETRY_CONTEXT=""
+
+    echo "$pr_json"
+}
+
 pr_is_rerun_eligible() {
     local pr_json="$1"
     local min_approvals="$2"
     local require_auto_rerun_label="$3"
+    local effective_states
+    local changes_requested_count
+    local approved_count
 
     if [ "$(jq -r '.isDraft' <<<"$pr_json")" = "true" ]; then
         NOT_RERUN_REASON="PR is a draft"
@@ -90,12 +141,28 @@ pr_is_rerun_eligible() {
         return 1
     fi
 
-    if [ "$(pr_review_count "$pr_json" "CHANGES_REQUESTED")" -gt 0 ]; then
+    # gh pr list may omit full review history in some environments; fetch it on-demand.
+    pr_json=$(pr_with_reviews_history "$pr_json")
+
+    # Check if the PR has any reviews that would block a rerun
+    effective_states=$(pr_reviewer_effective_states "$pr_json")
+    if [ -z "$effective_states" ]; then
+        effective_states='{}'
+    fi
+    if ! jq -e . >/dev/null 2>&1 <<<"$effective_states"; then
+        effective_states='{}'
+    fi
+    echo "Effective reviewer states: $effective_states"
+
+    changes_requested_count=$(jq -r '[.[] | select(. == "CHANGES_REQUESTED")] | length' <<<"$effective_states")
+    approved_count=$(jq -r '[.[] | select(. == "APPROVED")] | length' <<<"$effective_states")
+
+    if [ "$changes_requested_count" -gt 0 ]; then
         NOT_RERUN_REASON="PR has requested changes"
         return 1
     fi
 
-    if [ "$(pr_review_count "$pr_json" "APPROVED")" -lt "$min_approvals" ]; then
+    if [ "$approved_count" -lt "$min_approvals" ]; then
         NOT_RERUN_REASON="PR has fewer than $min_approvals approvals"
         return 1
     fi

--- a/.github/scripts/rerun-common.sh
+++ b/.github/scripts/rerun-common.sh
@@ -7,25 +7,35 @@ export NOT_RERUN_REASON=""
 
 : "${GH_API_RETRIES:=3}"
 : "${GH_API_RETRY_DELAY_SECONDS:=2}"
+: "${GH_RETRY_CONTEXT:=}"
 
 gh_out_with_retry() {
     local attempt=1
     local delay="$GH_API_RETRY_DELAY_SECONDS"
     local output
+    local context="${GH_RETRY_CONTEXT:-}"
 
     while (( attempt <= GH_API_RETRIES )); do
-        if output="$($@ 2>&1)"; then
+        if output="$("$@" 2>&1)"; then
             printf '%s\n' "$output"
             return 0
         fi
 
         if (( attempt == GH_API_RETRIES )); then
-            echo "Command failed after $GH_API_RETRIES attempts: $*" >&2
+            if [[ -n "$context" ]]; then
+                echo "Command failed after $GH_API_RETRIES attempts for $context: $*" >&2
+            else
+                echo "Command failed after $GH_API_RETRIES attempts: $*" >&2
+            fi
             echo "$output" >&2
             return 1
         fi
 
-        echo "Transient failure on attempt $attempt/$GH_API_RETRIES for: $*" >&2
+        if [[ -n "$context" ]]; then
+            echo "Transient failure on attempt $attempt/$GH_API_RETRIES for $context: $*" >&2
+        else
+            echo "Transient failure on attempt $attempt/$GH_API_RETRIES for: $*" >&2
+        fi
         echo "$output" >&2
 
         sleep "$delay"

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -32,16 +32,16 @@ jobs:
           if ! checkpoint_runs=$(gh_retry run list \
             --workflow .github/workflows/ci-auto-trigger.yaml \
             --status completed \
-            --limit 2 \
-            --json createdAt \
-            --jq '.'); then
+            --limit 20 \
+            --json createdAt,conclusion \
+            --jq '[.[] | select(.conclusion == "success")][0:2]'); then
             echo "Warning: failed to fetch checkpoint after retries; processing all open PRs"
             checkpoint_runs='[]'
           fi
           GH_RETRY_CONTEXT=""
 
-          # Use the checkpoint from the most recent completed ci-auto-trigger run,
-          # or if there is only one completed run, use its checkpoint. This creates
+          # Use the checkpoint from the most recent successful ci-auto-trigger run,
+          # or if there is only one successful run, use its checkpoint. This creates
           # a rolling window of PR updates to consider for rerunning, while allowing
           # for some flexibility in timing and avoiding reliance on a single run's completion
           # time as the cutoff. 
@@ -55,12 +55,12 @@ jobs:
 
           if [[ -n "$checkpoint_time" ]]; then
             if [[ -n "$previous_checkpoint" ]]; then
-              echo "Using checkpoint from previous completed ci-auto-trigger run (2-run window): $checkpoint_time"
+              echo "Using checkpoint from previous successful ci-auto-trigger run (2-run window): $checkpoint_time"
             else
-              echo "Only one completed ci-auto-trigger run found; using its checkpoint: $checkpoint_time"
+              echo "Only one successful ci-auto-trigger run found; using its checkpoint: $checkpoint_time"
             fi
           else
-            echo "No previous completed ci-auto-trigger run found; processing all open PRs"
+            echo "No previous successful ci-auto-trigger run found; processing all open PRs"
           fi
 
           # Fetch all open PRs and inspect them for rerun eligibility

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -26,15 +26,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          source .github/scripts/rerun-common.sh
+          source .github/scripts/common.sh
 
           GH_RETRY_CONTEXT="ci-auto-trigger checkpoint lookup"
-          checkpoint_runs=$(gh_out_with_retry gh run list \
+          if ! checkpoint_runs=$(gh_retry run list \
             --workflow .github/workflows/ci-auto-trigger.yaml \
             --status completed \
             --limit 2 \
             --json createdAt \
-            --jq '.')
+            --jq '.'); then
+            echo "Warning: failed to fetch checkpoint after retries; processing all open PRs"
+            checkpoint_runs='[]'
+          fi
           GH_RETRY_CONTEXT=""
 
           # Use the checkpoint from the most recent completed ci-auto-trigger run,
@@ -61,7 +64,7 @@ jobs:
           fi
 
           # Fetch all open PRs and inspect them for rerun eligibility
-          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews,baseRefName,updatedAt)
+          prs=$(gh_retry pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews,baseRefName,updatedAt)
           echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
@@ -109,7 +112,7 @@ jobs:
             # calls, while still reliably determining whether the latest run for this
             # PR is eligible for rerunning.
             GH_RETRY_CONTEXT="PR #$pr_number run listing for head SHA $head_sha"
-            if ! run_list_json=$(gh_out_with_retry gh run list \
+            if ! run_list_json=$(gh_retry run list \
               --workflow .github/workflows/ci-test.yaml \
               --limit 100 \
               --json databaseId,attempt,status,conclusion,headSha); then
@@ -157,7 +160,7 @@ jobs:
             # and if so, whether the number of failed tasks on any required spread job exceeds our
             # threshold for rerunning
             GH_RETRY_CONTEXT="PR #$pr_number job listing for run_id=$last_run"
-            if ! run_jobs=$(gh_out_with_retry gh run view "$last_run" --json jobs --jq '.jobs'); then
+            if ! run_jobs=$(gh_retry run view "$last_run" --json jobs --jq '.jobs'); then
               echo "PR #$pr_number | Skip: could not fetch jobs for run_id=$last_run after retries"
               GH_RETRY_CONTEXT=""
               echo "----- End PR #$pr_number -----"
@@ -185,6 +188,13 @@ jobs:
             fi
 
             echo "PR #$pr_number | Action: triggering rerun workflow using run_id=$last_run (attempt $run_attempt)"
-            gh workflow run rerun.yaml -f run_id="$last_run"
+            GH_RETRY_CONTEXT="PR #$pr_number trigger rerun workflow for run_id=$last_run"
+            if ! gh_retry workflow run rerun.yaml -f run_id="$last_run"; then
+              echo "PR #$pr_number | Skip: failed to trigger rerun workflow after retries"
+              GH_RETRY_CONTEXT=""
+              echo "----- End PR #$pr_number -----"
+              continue
+            fi
+            GH_RETRY_CONTEXT=""
             echo "----- End PR #$pr_number -----"
           done

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -165,9 +165,9 @@ jobs:
             fi
             GH_RETRY_CONTEXT=""
 
-            # If there are no completed spread jobs, it's possible the run failed before reaching the spread stage, so we should
-            # still allow a rerun to be triggered in that case. But if there are completed spread jobs, we want to check the
-            # failure count on those jobs to determine rerun eligibility.
+            # If there are no completed spread jobs, the run likely failed before reaching the spread stage.
+            # In that case, we skip auto-rerun here to avoid rerunning failures outside the spread stage.
+            # If this policy changes, update the checks below accordingly.
             spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
             if [[ "$spread_jobs_ran" -lt 1 ]]; then
               echo "PR #$pr_number | Skip: no completed spread jobs found in run_id=$last_run"

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -28,7 +28,7 @@ jobs:
 
           source .github/scripts/rerun-common.sh
 
-          prs=$(gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName)
+          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName)
           echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
@@ -47,11 +47,18 @@ jobs:
               continue
             fi
 
-            last_run_json=$(gh run list \
+            GH_RETRY_CONTEXT="PR #$pr_number run listing for head SHA $head_sha"
+            if ! run_list_json=$(gh_out_with_retry gh run list \
               --workflow .github/workflows/ci-test.yaml \
               --limit 100 \
-              --json databaseId,attempt,status,conclusion,headSha \
-              | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
+              --json databaseId,attempt,status,conclusion,headSha); then
+              echo "Skipping PR #$pr_number: could not fetch workflow runs for head SHA $head_sha after retries"
+              GH_RETRY_CONTEXT=""
+              continue
+            fi
+            GH_RETRY_CONTEXT=""
+
+            last_run_json=$(echo "$run_list_json" | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
 
             if [[ -z "$last_run_json" || "$last_run_json" == "null" ]]; then
               echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
@@ -76,7 +83,14 @@ jobs:
               continue
             fi
 
-            run_jobs=$(gh run view "$last_run" --json jobs --jq '.jobs')
+            GH_RETRY_CONTEXT="PR #$pr_number job listing for run_id=$last_run"
+            if ! run_jobs=$(gh_out_with_retry gh run view "$last_run" --json jobs --jq '.jobs'); then
+              echo "Skipping PR #$pr_number: could not fetch jobs for run_id=$last_run after retries"
+              GH_RETRY_CONTEXT=""
+              continue
+            fi
+            GH_RETRY_CONTEXT=""
+
             spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
             if [[ "$spread_jobs_ran" -lt 1 ]]; then
               echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run"

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -28,25 +28,77 @@ jobs:
 
           source .github/scripts/rerun-common.sh
 
-          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName)
+          GH_RETRY_CONTEXT="ci-auto-trigger checkpoint lookup"
+          checkpoint_runs=$(gh_out_with_retry gh run list \
+            --workflow .github/workflows/ci-auto-trigger.yaml \
+            --status completed \
+            --limit 2 \
+            --json createdAt \
+            --jq '.')
+          GH_RETRY_CONTEXT=""
+
+          # Use the checkpoint from the most recent completed ci-auto-trigger run,
+          # or if there is only one completed run, use its checkpoint. This creates
+          # a rolling window of PR updates to consider for rerunning, while allowing
+          # for some flexibility in timing and avoiding reliance on a single run's completion
+          # time as the cutoff. 
+          latest_checkpoint=$(echo "$checkpoint_runs" | jq -r '.[0].createdAt // empty')
+          previous_checkpoint=$(echo "$checkpoint_runs" | jq -r '.[1].createdAt // empty')
+
+          checkpoint_time="$previous_checkpoint"
+          if [[ -z "$checkpoint_time" ]]; then
+            checkpoint_time="$latest_checkpoint"
+          fi
+
+          if [[ -n "$checkpoint_time" ]]; then
+            if [[ -n "$previous_checkpoint" ]]; then
+              echo "Using checkpoint from previous completed ci-auto-trigger run (2-run window): $checkpoint_time"
+            else
+              echo "Only one completed ci-auto-trigger run found; using its checkpoint: $checkpoint_time"
+            fi
+          else
+            echo "No previous completed ci-auto-trigger run found; processing all open PRs"
+          fi
+
+          # Fetch all open PRs and inspect them for rerun eligibility
+          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName,updatedAt)
           echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             pr_number=$(echo "$pr" | jq -r '.number')
             head_sha=$(echo "$pr" | jq -r '.headRefOid')
+            pr_updated_at=$(echo "$pr" | jq -r '.updatedAt // empty')
 
+            # Skip PRs that haven't been updated since the checkpoint time
+            if [[ -n "$checkpoint_time" && -n "$pr_updated_at" ]]; then
+              if [[ "$pr_updated_at" < "$checkpoint_time" || "$pr_updated_at" == "$checkpoint_time" ]]; then
+                echo "Skipping PR #$pr_number: not updated since checkpoint ($pr_updated_at <= $checkpoint_time)"
+                continue
+              fi
+            fi
+
+            # Check for general PR eligibility (draft status, required labels, reviews, etc.) before doing any more expensive operations
             if ! pr_is_rerun_eligible "$pr" 2 false; then
               echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
               continue
             fi
 
+            # Ensure the PR has the auto rerun label, to provide visibility and allow
+            # manual exclusion from future runs if needed
             ensure_auto_rerun_label "$pr_number" "$pr"
 
+            # Find the most recent workflow run for this PR's head SHA, and check if
+            # it's eligible for rerunning (completed, not successful, not already rerun
+            # too many times)
             if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
               echo "Skipping PR #$pr_number: missing head SHA"
               continue
             fi
 
+            # To avoid hitting GitHub API rate limits, we need to be careful about how we
+            # query for workflow runs and jobs. We want to minimize the number of API
+            # calls, while still reliably determining whether the latest run for this
+            # PR is eligible for rerunning.
             GH_RETRY_CONTEXT="PR #$pr_number run listing for head SHA $head_sha"
             if ! run_list_json=$(gh_out_with_retry gh run list \
               --workflow .github/workflows/ci-test.yaml \
@@ -58,6 +110,7 @@ jobs:
             fi
             GH_RETRY_CONTEXT=""
 
+            # Find the most recent run with a matching head SHA
             last_run_json=$(echo "$run_list_json" | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
 
             if [[ -z "$last_run_json" || "$last_run_json" == "null" ]]; then
@@ -65,6 +118,7 @@ jobs:
               continue
             fi
 
+            # Extract the run ID and attempt number for the most recent run with a matching head SHA
             last_run=$(echo "$last_run_json" | jq -r '.databaseId // empty')
             run_attempt=$(echo "$last_run_json" | jq -r '.attempt // 0')
 
@@ -73,6 +127,7 @@ jobs:
               continue
             fi
 
+            # Check if the most recent run is eligible for rerunning
             if ! run_is_completed "$last_run_json" "$last_run"; then
               echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
               continue
@@ -83,6 +138,9 @@ jobs:
               continue
             fi
 
+            # Check the jobs for the most recent run to see if there were any completed spread jobs,
+            # and if so, whether the number of failed tasks on any required spread job exceeds our
+            # threshold for rerunning
             GH_RETRY_CONTEXT="PR #$pr_number job listing for run_id=$last_run"
             if ! run_jobs=$(gh_out_with_retry gh run view "$last_run" --json jobs --jq '.jobs'); then
               echo "Skipping PR #$pr_number: could not fetch jobs for run_id=$last_run after retries"
@@ -91,12 +149,16 @@ jobs:
             fi
             GH_RETRY_CONTEXT=""
 
+            # If there are no completed spread jobs, it's possible the run failed before reaching the spread stage, so we should
+            # still allow a rerun to be triggered in that case. But if there are completed spread jobs, we want to check the
+            # failure count on those jobs to determine rerun eligibility.
             spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
             if [[ "$spread_jobs_ran" -lt 1 ]]; then
               echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run"
               continue
             fi
 
+            # Check if any required spread jobs have a number of failed tasks that exceeds our threshold for rerunning
             pr_base=$(echo "$pr" | jq -r '.baseRefName // empty')
             if ! required_spread_failure_threshold_allows_rerun "$last_run" "$pr_base" "$GH_REPO" "$MAX_FAILED_TASKS"; then
               echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -61,7 +61,7 @@ jobs:
           fi
 
           # Fetch all open PRs and inspect them for rerun eligibility
-          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,latestReviews,baseRefName,updatedAt)
+          prs=$(gh_out_with_retry gh pr list --state open --limit 200 --json number,isDraft,labels,headRefOid,reviews,baseRefName,updatedAt)
           echo "Inspecting $(echo "$prs" | jq 'length') open PRs for rerun..."
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
@@ -69,29 +69,38 @@ jobs:
             head_sha=$(echo "$pr" | jq -r '.headRefOid')
             pr_updated_at=$(echo "$pr" | jq -r '.updatedAt // empty')
 
+            echo
+            echo "===== PR #$pr_number ====="
+            echo "PR #$pr_number | Step: checkpoint freshness"
+
             # Skip PRs that haven't been updated since the checkpoint time
             if [[ -n "$checkpoint_time" && -n "$pr_updated_at" ]]; then
               if [[ "$pr_updated_at" < "$checkpoint_time" || "$pr_updated_at" == "$checkpoint_time" ]]; then
-                echo "Skipping PR #$pr_number: not updated since checkpoint ($pr_updated_at <= $checkpoint_time)"
+                echo "PR #$pr_number | Skip: not updated since checkpoint ($pr_updated_at <= $checkpoint_time)"
+                echo "----- End PR #$pr_number -----"
                 continue
               fi
             fi
 
             # Check for general PR eligibility (draft status, required labels, reviews, etc.) before doing any more expensive operations
+            echo "PR #$pr_number | Step: eligibility checks"
             if ! pr_is_rerun_eligible "$pr" 2 false; then
-              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
+              echo "PR #$pr_number | Skip: $NOT_RERUN_REASON"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
             # Ensure the PR has the auto rerun label, to provide visibility and allow
             # manual exclusion from future runs if needed
+            echo "PR #$pr_number | Step: ensure auto-rerun label"
             ensure_auto_rerun_label "$pr_number" "$pr"
 
             # Find the most recent workflow run for this PR's head SHA, and check if
             # it's eligible for rerunning (completed, not successful, not already rerun
             # too many times)
             if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
-              echo "Skipping PR #$pr_number: missing head SHA"
+              echo "PR #$pr_number | Skip: missing head SHA"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
@@ -104,8 +113,9 @@ jobs:
               --workflow .github/workflows/ci-test.yaml \
               --limit 100 \
               --json databaseId,attempt,status,conclusion,headSha); then
-              echo "Skipping PR #$pr_number: could not fetch workflow runs for head SHA $head_sha after retries"
+              echo "PR #$pr_number | Skip: could not fetch workflow runs for head SHA $head_sha after retries"
               GH_RETRY_CONTEXT=""
+              echo "----- End PR #$pr_number -----"
               continue
             fi
             GH_RETRY_CONTEXT=""
@@ -114,7 +124,8 @@ jobs:
             last_run_json=$(echo "$run_list_json" | jq -c --arg head_sha "$head_sha" 'map(select(.headSha == $head_sha)) | first // empty')
 
             if [[ -z "$last_run_json" || "$last_run_json" == "null" ]]; then
-              echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
+              echo "PR #$pr_number | Skip: no pull_request run found for head SHA $head_sha"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
@@ -123,18 +134,22 @@ jobs:
             run_attempt=$(echo "$last_run_json" | jq -r '.attempt // 0')
 
             if [[ -z "$last_run" ]]; then
-              echo "Skipping PR #$pr_number: no pull_request run found for head SHA $head_sha"
+              echo "PR #$pr_number | Skip: no pull_request run found for head SHA $head_sha"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
             # Check if the most recent run is eligible for rerunning
+            echo "PR #$pr_number | Step: run completion/conclusion checks (run_id=$last_run, attempt=$run_attempt)"
             if ! run_is_completed "$last_run_json" "$last_run"; then
-              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
+              echo "PR #$pr_number | Skip: $NOT_RERUN_REASON"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
             if [[ "$run_attempt" -ge "$MAX_RUN_ATTEMPTS" ]]; then
-              echo "Skipping PR #$pr_number: run_id=$last_run already at attempt $run_attempt"
+              echo "PR #$pr_number | Skip: run_id=$last_run already at attempt $run_attempt"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
@@ -143,8 +158,9 @@ jobs:
             # threshold for rerunning
             GH_RETRY_CONTEXT="PR #$pr_number job listing for run_id=$last_run"
             if ! run_jobs=$(gh_out_with_retry gh run view "$last_run" --json jobs --jq '.jobs'); then
-              echo "Skipping PR #$pr_number: could not fetch jobs for run_id=$last_run after retries"
+              echo "PR #$pr_number | Skip: could not fetch jobs for run_id=$last_run after retries"
               GH_RETRY_CONTEXT=""
+              echo "----- End PR #$pr_number -----"
               continue
             fi
             GH_RETRY_CONTEXT=""
@@ -154,17 +170,21 @@ jobs:
             # failure count on those jobs to determine rerun eligibility.
             spread_jobs_ran=$(echo "$run_jobs" | jq '[.[] | select(.name | test("^spread ")) | select(.status == "completed")] | length')
             if [[ "$spread_jobs_ran" -lt 1 ]]; then
-              echo "Skipping PR #$pr_number: no completed spread jobs found in run_id=$last_run"
+              echo "PR #$pr_number | Skip: no completed spread jobs found in run_id=$last_run"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
             # Check if any required spread jobs have a number of failed tasks that exceeds our threshold for rerunning
             pr_base=$(echo "$pr" | jq -r '.baseRefName // empty')
+            echo "PR #$pr_number | Step: required spread failure threshold checks"
             if ! required_spread_failure_threshold_allows_rerun "$last_run" "$pr_base" "$GH_REPO" "$MAX_FAILED_TASKS"; then
-              echo "Skipping PR #$pr_number: $NOT_RERUN_REASON"
+              echo "PR #$pr_number | Skip: $NOT_RERUN_REASON"
+              echo "----- End PR #$pr_number -----"
               continue
             fi
 
-            echo "Triggering rerun workflow for PR #$pr_number using run_id=$last_run (attempt $run_attempt)"
+            echo "PR #$pr_number | Action: triggering rerun workflow using run_id=$last_run (attempt $run_attempt)"
             gh workflow run rerun.yaml -f run_id="$last_run"
+            echo "----- End PR #$pr_number -----"
           done

--- a/.github/workflows/ci-auto-trigger.yaml
+++ b/.github/workflows/ci-auto-trigger.yaml
@@ -96,7 +96,11 @@ jobs:
             # Ensure the PR has the auto rerun label, to provide visibility and allow
             # manual exclusion from future runs if needed
             echo "PR #$pr_number | Step: ensure auto-rerun label"
-            ensure_auto_rerun_label "$pr_number" "$pr"
+            if ! ensure_auto_rerun_label "$pr_number" "$pr"; then
+               echo "PR #$pr_number | Skip: $NOT_RERUN_REASON"
+               echo "----- End PR #$pr_number -----"
+               continue
+             fi
 
             # Find the most recent workflow run for this PR's head SHA, and check if
             # it's eligible for rerunning (completed, not successful, not already rerun

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -79,10 +79,18 @@ jobs:
       - name: Check for rerun eligibility
         id: eligibility
         run: |
-          source .github/scripts/rerun-common.sh
+          source .github/scripts/common.sh
 
           pr_number=$(cat pr_number)
-          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,reviews,baseRefName)
+
+          GH_RETRY_CONTEXT="PR #$pr_number view lookup"
+          if ! pr_json=$(gh_retry pr view "$pr_number" --json number,isDraft,labels,reviews,baseRefName); then
+            echo "Failed to fetch PR details after retries"
+            echo "auto_rerun=false" >> "$GITHUB_OUTPUT"
+            GH_RETRY_CONTEXT=""
+            exit 0
+          fi
+          GH_RETRY_CONTEXT=""
 
           if ! pr_is_rerun_eligible "$pr_json" 1 true; then
             echo "setting auto rerun to false because $NOT_RERUN_REASON"
@@ -104,7 +112,7 @@ jobs:
         id: threshold
         if: steps.eligibility.outputs.auto_rerun == 'true'
         run: |
-          source .github/scripts/rerun-common.sh
+          source .github/scripts/common.sh
 
           if ! required_spread_failure_threshold_allows_rerun "$RUN_ID" "$PR_BASE" "$GH_REPO" "$MAX_FAILED_TASKS"; then
             echo "Setting rerun to false because $NOT_RERUN_REASON"
@@ -115,4 +123,12 @@ jobs:
       
       - name: Rerun workflow
         if: steps.eligibility.outputs.auto_rerun == 'true' && steps.threshold.outputs.threshold_ok == 'true'
-        run: gh run rerun "$RUN_ID" --failed
+        run: |
+          source .github/scripts/common.sh
+
+          GH_RETRY_CONTEXT="rerun workflow for run_id=$RUN_ID"
+          if ! gh_retry run rerun "$RUN_ID" --failed; then
+            GH_RETRY_CONTEXT=""
+            exit 1
+          fi
+          GH_RETRY_CONTEXT=""

--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -82,7 +82,7 @@ jobs:
           source .github/scripts/rerun-common.sh
 
           pr_number=$(cat pr_number)
-          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,latestReviews,baseRefName)
+          pr_json=$(gh pr view "$pr_number" --json number,isDraft,labels,reviews,baseRefName)
 
           if ! pr_is_rerun_eligible "$pr_json" 1 true; then
             echo "setting auto rerun to false because $NOT_RERUN_REASON"


### PR DESCRIPTION
The idea is to retry gh calls and skip in case a pr cannot be queried.
Also it is adding more details about the context of the execution in order to get better logs in case of errors.
Lookup the review status of each reviewer in the review history instead of last review
Improve logs

Last thing added is the capacity to check if the pr has change since last check, In practice, it changes on events like:
- New commits pushed to the PR branch (headRefOid changes)
- PR title/body/base branch edits
- Labels added/removed
- Assignees/reviewers/milestone changes
- New comments/reviews/review state changes
- PR open/close/reopen/synchronize events ()

See this example of a run I did locally, to check the logs formatting: https://pastebin.canonical.com/p/kthMZTphTP/
