### PR TITLE
o/snapstate,  o/s/backend: clear-snap task errors early when user mounts in snap data dirs

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -120,6 +120,8 @@ type managerBackend interface {
 	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error
 	RemoveComponentDir(cpi snap.ContainerPlaceInfo) error
 	RemoveContainerMountUnits(cpi snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error
+	ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
+	ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
 	DiscardSnapNamespace(snapName string) error
 	DiscardLockedSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string, stateUnlocker runinhibit.Unlocker) error

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -120,8 +120,8 @@ type managerBackend interface {
 	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error
 	RemoveComponentDir(cpi snap.ContainerPlaceInfo) error
 	RemoveContainerMountUnits(cpi snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error
-	ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
-	ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
+	ListNonSnapctlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
+	ListNonSnapctlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error)
 	DiscardSnapNamespace(snapName string) error
 	DiscardLockedSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string, stateUnlocker runinhibit.Unlocker) error

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1081,7 +1081,7 @@ type fakeSnappyBackend struct {
 
 	infos map[string]map[snap.Revision]*snap.Info
 
-	nonMountControlMounts []string
+	nonSnapctlMounts []string
 }
 
 func (f *fakeSnappyBackend) maybeErrForLastOp() error {
@@ -1728,22 +1728,22 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+func (f *fakeSnappyBackend) ListNonSnapctlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
 	f.appendOp(&fakeOp{
-		op:    "list-non-mount-control-mounts-rev",
+		op:    "list-non-snapctl-mounts-rev",
 		name:  info.InstanceName(),
 		revno: info.Revision,
 	})
-	return f.nonMountControlMounts, f.maybeErrForLastOp()
+	return f.nonSnapctlMounts, f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+func (f *fakeSnappyBackend) ListNonSnapctlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
 	f.appendOp(&fakeOp{
-		op:    "list-non-mount-control-mounts-all",
+		op:    "list-non-snapctl-mounts-all",
 		name:  info.InstanceName(),
 		revno: info.Revision,
 	})
-	return f.nonMountControlMounts, f.maybeErrForLastOp()
+	return f.nonSnapctlMounts, f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1080,6 +1080,8 @@ type fakeSnappyBackend struct {
 	maybeInjectErr func(*fakeOp) error
 
 	infos map[string]map[snap.Revision]*snap.Info
+
+	nonMountControlMounts []string
 }
 
 func (f *fakeSnappyBackend) maybeErrForLastOp() error {
@@ -1724,6 +1726,24 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 		otherInstances: otherInstances,
 	})
 	return f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	f.appendOp(&fakeOp{
+		op:    "list-non-mount-control-mounts-rev",
+		name:  info.InstanceName(),
+		revno: info.Revision,
+	})
+	return f.nonMountControlMounts, f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	f.appendOp(&fakeOp{
+		op:    "list-non-mount-control-mounts-all",
+		name:  info.InstanceName(),
+		revno: info.Revision,
+	})
+	return f.nonMountControlMounts, f.maybeErrForLastOp()
 }
 
 func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3451,7 +3451,7 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 
 	dirOpts := opts.getSnapDirOpts()
 
-	// Detect any non-"mount-control" mounts that would prevent data removal.
+	// Detect any non-snapctl mounts that would prevent data removal.
 	// This must run before deleting any data, so that if any such mounts
 	// exist, the returned error can still appropriately undo the change.
 	// Such mounts could be created, for example, manually by a user.
@@ -3459,12 +3459,12 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 	// otherwise only check the revision-specific directories.
 	var unknownMounts []string
 	if len(snapst.Sequence.Revisions) > 1 {
-		unknownMounts, err = m.backend.ListNonMountControlMountsInSnapRevDataDirs(info, dirOpts)
+		unknownMounts, err = m.backend.ListNonSnapctlMountsInSnapRevDataDirs(info, dirOpts)
 	} else {
-		unknownMounts, err = m.backend.ListNonMountControlMountsInSnapAllDataDirs(info, dirOpts)
+		unknownMounts, err = m.backend.ListNonSnapctlMountsInSnapAllDataDirs(info, dirOpts)
 	}
 	if err != nil {
-		logger.Noticef("cannot list mounts other than mount-control mounts: %v", err)
+		logger.Noticef("cannot list mounts other than snapctl mounts: %v", err)
 	}
 	if len(unknownMounts) > 0 {
 		mountList := "- " + strings.Join(unknownMounts, "\n- ")

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -3448,6 +3449,28 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	dirOpts := opts.getSnapDirOpts()
+
+	// Detect any non-"mount-control" mounts that would prevent data removal.
+	// This must run before deleting any data, so that if any such mounts
+	// exist, the returned error can still appropriately undo the change.
+	// Such mounts could be created, for example, manually by a user.
+	// When this is the last revision, check the entire snap data tree
+	// otherwise only check the revision-specific directories.
+	var unknownMounts []string
+	if len(snapst.Sequence.Revisions) > 1 {
+		unknownMounts, err = m.backend.ListNonMountControlMountsInSnapRevDataDirs(info, dirOpts)
+	} else {
+		unknownMounts, err = m.backend.ListNonMountControlMountsInSnapAllDataDirs(info, dirOpts)
+	}
+	if err != nil {
+		logger.Noticef("cannot list mounts other than mount-control mounts: %v", err)
+	}
+	if len(unknownMounts) > 0 {
+		mountList := "- " + strings.Join(unknownMounts, "\n- ")
+		return fmt.Errorf("cannot clear snap data due to unknown active mounts at:\n%s\nunmount them and try again", mountList)
+	}
+
 	// Remove mount-control mounts just before removing the data they may be
 	// mounted over. When this is the last revision, remove all mount-control
 	// units for the snap (nil mountBaseDirs = no path filter); otherwise restrict
@@ -3462,7 +3485,6 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	dirOpts := opts.getSnapDirOpts()
 	if err = m.backend.RemoveSnapData(info, dirOpts); err != nil {
 		return err
 	}

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -286,7 +286,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(7),
 		},
@@ -445,7 +445,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap_instance",
 			revno: snap.R(7),
 		},
@@ -610,7 +610,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			revno: snap.R(7),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap_instance",
 			revno: snap.R(7),
 		},
@@ -732,7 +732,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(3),
 		},
@@ -752,7 +752,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			stype: "app",
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(5),
 		},
@@ -772,7 +772,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			stype: "app",
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(7),
 		},
@@ -918,7 +918,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(3),
 		},
@@ -1048,7 +1048,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 			revno: snap.R(2),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1184,7 +1184,7 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 			revno: snap.R(2),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1821,7 +1821,7 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 			revno: snap.R(1),
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1916,7 +1916,7 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			revno: snap.R(1),
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1936,7 +1936,7 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			stype: "app",
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(1),
 		},
@@ -2666,7 +2666,7 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			revno: snap.R(1),
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "snap1",
 			revno: snap.R(2),
 		},
@@ -2714,7 +2714,7 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			stype: "app",
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "snap1",
 			revno: snap.R(1),
 		},
@@ -3050,7 +3050,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenRemoveMountUnitsErrors(c *
 	c.Check(chg.Err(), ErrorMatches, "(?s).*mock remove-snap-mount-units error.*")
 }
 
-func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInNonLastRevision(c *C) {
+func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonSnapctlMountsInNonLastRevision(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -3064,7 +3064,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInNon
 		SnapType: "app",
 	})
 
-	s.fakeBackend.nonMountControlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/3/sub/user-mount"}
+	s.fakeBackend.nonSnapctlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/3/sub/user-mount"}
 
 	chg := s.state.NewChange("remove", "remove snap revision")
 	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(3), nil)
@@ -3083,7 +3083,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInNon
 	c.Check(s.fakeBackend.ops.Filter("remove-snap-mount-units"), HasLen, 0)
 }
 
-func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInLastRevision(c *C) {
+func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonSnapctlMountsInLastRevision(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -3096,7 +3096,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInLas
 		SnapType: "app",
 	})
 
-	s.fakeBackend.nonMountControlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/common/sub/user-mount"}
+	s.fakeBackend.nonSnapctlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/common/sub/user-mount"}
 
 	chg := s.state.NewChange("remove", "remove snap")
 	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), &snapstate.RemoveFlags{Purge: true})
@@ -3115,7 +3115,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInLas
 	c.Check(s.fakeBackend.ops.Filter("remove-snap-mount-units"), HasLen, 0)
 }
 
-func (s *snapmgrTestSuite) TestClearSnapDataLogsWhenListNonMountControlMountsErrors(c *C) {
+func (s *snapmgrTestSuite) TestClearSnapDataLogsWhenListNonSnapctlMountsErrors(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -3132,7 +3132,7 @@ func (s *snapmgrTestSuite) TestClearSnapDataLogsWhenListNonMountControlMountsErr
 	defer restoreLogger()
 
 	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
-		if op.op == "list-non-mount-control-mounts-all" {
+		if op.op == "list-non-snapctl-mounts-all" {
 			return errors.New("mock error")
 		}
 		return nil
@@ -3148,5 +3148,5 @@ func (s *snapmgrTestSuite) TestClearSnapDataLogsWhenListNonMountControlMountsErr
 	// The listing error must not abort the task; removal proceeds normally.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	c.Check(logbuf.String(), testutil.Contains,
-		"cannot list mounts other than mount-control mounts: mock error")
+		"cannot list mounts other than snapctl mounts: mock error")
 }

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -285,6 +286,11 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -435,6 +441,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 		},
 		{
 			op:    "remove-profiles:Doing",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
 			name:  "some-snap_instance",
 			revno: snap.R(7),
 		},
@@ -599,6 +610,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			revno: snap.R(7),
 		},
 		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "some-snap_instance",
+			revno: snap.R(7),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap_instance",
 			origin: "mount-control",
@@ -716,6 +732,11 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			revno: snap.R(7),
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(3),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -731,6 +752,11 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			stype: "app",
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(5),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -744,6 +770,11 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/5"),
 			stype: "app",
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "some-snap",
+			revno: snap.R(7),
 		},
 		{
 			op:     "remove-snap-mount-units",
@@ -885,8 +916,12 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 3)
 	expected := fakeOps{
+		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(3),
+		},
 		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
@@ -904,6 +939,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 		},
 	}
 	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
@@ -1005,10 +1041,14 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 11)
 	expected := fakeOps{
 		{
 			op:    "auto-disconnect:Doing",
+			name:  "some-snap",
+			revno: snap.R(2),
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1058,6 +1098,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 		},
 	}
 	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
@@ -1123,7 +1164,6 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Check(len(s.fakeBackend.ops), Equals, 14)
 	expected := fakeOps{
 		{
 			op:    "auto-disconnect:Doing",
@@ -1140,6 +1180,11 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 		},
 		{
 			op:    "remove-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(2),
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
@@ -1189,6 +1234,7 @@ func (s *snapmgrTestSuite) TestRemoveLastActiveRevisionRunThrough(c *C) {
 		},
 	}
 	// start with an easier-to-read error if this fails:
+	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
@@ -1775,6 +1821,11 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(2),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -1865,6 +1916,11 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			revno: snap.R(1),
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(2),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -1878,6 +1934,11 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 			stype: "app",
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "some-snap",
+			revno: snap.R(1),
 		},
 		{
 			op:     "remove-snap-mount-units",
@@ -2605,6 +2666,11 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "snap1",
+			revno: snap.R(2),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "snap1",
 			origin: "mount-control",
@@ -2646,6 +2712,11 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "snap1/2"),
 			stype: "app",
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "snap1",
+			revno: snap.R(1),
 		},
 		{
 			op:     "remove-snap-mount-units",
@@ -2722,9 +2793,9 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 	}
 	// start with an easier-to-read error if this fails:
 	c.Assert(len(s.fakeBackend.ops), Equals, len(expected))
-	c.Check(s.fakeBackend.ops[0:6], DeepEquals, expected[0:6])
-	c.Check(s.fakeBackend.ops[12:18], DeepEquals, expected[12:18])
-	c.Check(s.fakeBackend.ops[24:], DeepEquals, expected[24:])
+	c.Check(s.fakeBackend.ops[0:7], DeepEquals, expected[0:7])
+	c.Check(s.fakeBackend.ops[13:20], DeepEquals, expected[13:20])
+	c.Check(s.fakeBackend.ops[26:], DeepEquals, expected[26:])
 	// Check component tasks, that can run in parallel so the order is not
 	// deterministic, but still needs to follow an order per component.
 	checkComps := func(ops, exp1, exp2 fakeOps) {
@@ -2740,8 +2811,8 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 			}
 		}
 	}
-	checkComps(s.fakeBackend.ops[6:12], expected[6:9], expected[9:12])
-	checkComps(s.fakeBackend.ops[18:24], expected[18:21], expected[21:24])
+	checkComps(s.fakeBackend.ops[7:13], expected[7:10], expected[10:13])
+	checkComps(s.fakeBackend.ops[20:26], expected[20:23], expected[23:26])
 }
 
 func (s *snapmgrTestSuite) TestRemoveWithTerminate(c *C) {
@@ -2977,4 +3048,105 @@ func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenRemoveMountUnitsErrors(c *
 	// The change must have failed because clear-snap propagated the error.
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err(), ErrorMatches, "(?s).*mock remove-snap-mount-units error.*")
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInNonLastRevision(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)},
+		}),
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	s.fakeBackend.nonMountControlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/3/sub/user-mount"}
+
+	chg := s.state.NewChange("remove", "remove snap revision")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(3), nil)
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches,
+		"(?s).*cannot clear snap data due to unknown active mounts at:\\n"+
+			"- /var/snap/some-snap/3/user-mount\\n"+
+			"- /var/snap/some-snap/3/sub/user-mount\\n"+
+			"unmount them and try again.*")
+	// mount-control mount units must not have been removed.
+	c.Check(s.fakeBackend.ops.Filter("remove-snap-mount-units"), HasLen, 0)
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataAbortsWhenNonMountControlMountsInLastRevision(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
+		}),
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+
+	s.fakeBackend.nonMountControlMounts = []string{"/var/snap/some-snap/3/user-mount", "/var/snap/some-snap/common/sub/user-mount"}
+
+	chg := s.state.NewChange("remove", "remove snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), &snapstate.RemoveFlags{Purge: true})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches,
+		"(?s).*cannot clear snap data due to unknown active mounts at:\\n"+
+			"- /var/snap/some-snap/3/user-mount\\n"+
+			"- /var/snap/some-snap/common/sub/user-mount\\n"+
+			"unmount them and try again.*")
+	// mount-control mount units must not have been removed.
+	c.Check(s.fakeBackend.ops.Filter("remove-snap-mount-units"), HasLen, 0)
+}
+
+func (s *snapmgrTestSuite) TestClearSnapDataLogsWhenListNonMountControlMountsErrors(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)},
+		}),
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "list-non-mount-control-mounts-all" {
+			return errors.New("mock error")
+		}
+		return nil
+	}
+
+	chg := s.state.NewChange("remove", "remove snap")
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), &snapstate.RemoveFlags{Purge: true})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.settle(c)
+
+	// The listing error must not abort the task; removal proceeds normally.
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(logbuf.String(), testutil.Contains,
+		"cannot list mounts other than mount-control mounts: mock error")
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6115,6 +6115,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			revno: snap.R(1),
 		},
 		{
+			op:    "list-non-mount-control-mounts-all",
+			name:  "ubuntu-core",
+			revno: snap.R(1),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "ubuntu-core",
 			origin: "mount-control",
@@ -6221,6 +6226,11 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		},
 		{
 			op:    "remove-profiles:Doing",
+			name:  "ubuntu-core",
+			revno: snap.R(1),
+		},
+		{
+			op:    "list-non-mount-control-mounts-all",
 			name:  "ubuntu-core",
 			revno: snap.R(1),
 		},

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6115,7 +6115,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			revno: snap.R(1),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "ubuntu-core",
 			revno: snap.R(1),
 		},
@@ -6230,7 +6230,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 			revno: snap.R(1),
 		},
 		{
-			op:    "list-non-mount-control-mounts-all",
+			op:    "list-non-snapctl-mounts-all",
 			name:  "ubuntu-core",
 			revno: snap.R(1),
 		},

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -434,7 +434,7 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			op: "update-aliases",
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(1),
 		},
@@ -454,7 +454,7 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			stype: "app",
 		},
 		{
-			op:    "list-non-mount-control-mounts-rev",
+			op:    "list-non-snapctl-mounts-rev",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -434,6 +434,11 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			op: "update-aliases",
 		},
 		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(1),
+		},
+		{
 			op:     "remove-snap-mount-units",
 			name:   "some-snap",
 			origin: "mount-control",
@@ -447,6 +452,11 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			op:    "remove-snap-files",
 			path:  filepath.Join(dirs.SnapMountDir, "some-snap/1"),
 			stype: "app",
+		},
+		{
+			op:    "list-non-mount-control-mounts-rev",
+			name:  "some-snap",
+			revno: snap.R(2),
 		},
 		{
 			op:     "remove-snap-mount-units",

--- a/tests/main/remove-impacted-by-mounts/task.yaml
+++ b/tests/main/remove-impacted-by-mounts/task.yaml
@@ -10,9 +10,9 @@ details: |
       are visible only in the snap's namespace (and not in the host's namespace)
     - snap remove succeeds if the mounts under snap's global data directories were
       created via the mount-control interface (snapctl mount)
-    - _currently_ snap remove fails if the mounts under snap's global/user data
-      directories were created directly by the user (not via mount-control).
-      This behavior needs to be fixed.
+    - snap remove fails if the mounts under snap's global/user data directories
+      were created directly by the user (not via mount-control), returning a clear
+      error message listing the blocking mounts.
 
 environment:
     SNAP_NAME: test-snapd-mount-control
@@ -31,24 +31,25 @@ environment:
     # each test variant will execute: test_$CASE $MOUNT_DEST
     CASE/v1,v2: remove_succeeds_when_slave_mount_in_snap_ns_under
     CASE/v3,v4: remove_succeeds_when_snapctl_mount_in_host_ns_under
-    CASE/v5,v6: remove_currently_fails_when_user_mount_in_host_ns_under
+    CASE/v5,v6,v7,v8: remove_fails_when_user_mount_in_host_ns_under
     MOUNT_DEST/v1,v3: $MOUNT_DEST_GLOBAL_COMMON
     MOUNT_DEST/v2,v4: $MOUNT_DEST_GLOBAL_DATA
     MOUNT_DEST/v5: $MOUNT_DEST_USER_COMMON
     MOUNT_DEST/v6: $MOUNT_DEST_USER_DATA
-
-restore: |
-    rm -rf "$MOUNT_SRC" "$MOUNT_DEST"
+    MOUNT_DEST/v7: $MOUNT_DEST_GLOBAL_COMMON
+    MOUNT_DEST/v8: $MOUNT_DEST_GLOBAL_DATA
 
 execute: |
     setup_src_data() {
         mkdir -p "$MOUNT_SRC/dir1"
+        tests.cleanup defer rm -rf "$MOUNT_SRC"
         echo "Something" > "$MOUNT_SRC/file1"
     }
 
     setup_test_snap() {
         echo "Install the test snap with mount-control interface"
         "$TESTSTOOLS"/snaps-state install-local "${SNAP_NAME}"
+        tests.cleanup defer snap remove --purge "${SNAP_NAME}"
         echo "Connect its mount-control interface"
         snap connect "${SNAP_NAME}":mntctl
     }
@@ -88,7 +89,9 @@ execute: |
         local mount_dest=$1
         echo "Create a mount under snap's $mount_dest data directory in the host's namespace"
         mkdir -p "$mount_dest"
+        tests.cleanup defer rm -rf "$mount_dest"
         "${SNAP_NAME}".cmd snapctl mount -o bind,rw "$MOUNT_SRC" "$mount_dest"
+        tests.cleanup defer "umount \"$mount_dest\" || true"
         echo "Verify that the mount has been performed in the host's namespace"
         MATCH "$mount_dest" < /proc/self/mountinfo
         echo "and that it's also visible in the snap's namespace"
@@ -124,7 +127,9 @@ execute: |
         local mount_dest=$1
         echo "Create a mount under snap's $mount_dest data directory in the host's namespace"
         mkdir -p "$mount_dest"
+        tests.cleanup defer rm -rf "$mount_dest"
         mount -o bind,rw "$MOUNT_SRC" "$mount_dest"
+        tests.cleanup defer "umount \"$mount_dest\" || true"
         echo "Verify that the mount has been performed in the host's namespace"
         MATCH "$mount_dest" < /proc/self/mountinfo
         echo "and that it's also visible in the snap's namespace"
@@ -135,7 +140,6 @@ execute: |
 
     cleaning_up_user_mount_should_make_remove_successful() {
         local mount_dest=$1
-        echo "Below steps can be removed once the above snap remove issues are fixed"
         echo "Unmount the user created mount"
         umount "$mount_dest"
         echo "and unmount should have succeeded"
@@ -144,25 +148,29 @@ execute: |
         snap remove "${SNAP_NAME}"
     }
 
-    then_remove_currently_fails_mount_remains_src_data_lost () {
+    then_remove_fails_mount_remains_src_data_intact () {
         local mount_dest=$1
-        echo "Currently snap remove will fail due to the mount being present in the snap's data directory"
-        echo "THIS NEEDS TO BE FIXED!"
-        not snap remove "${SNAP_NAME}"
+        echo "snap remove fails because a user-created mount is present in the snap's data directory"
+        if snap remove "${SNAP_NAME}" &> remove_output; then
+            echo "snap remove should have failed but succeeded"
+            exit 1
+        fi
+        echo "and the error message lists the blocking mount"
+        MATCH "cannot clear snap data due to unknown active mounts at:" < remove_output
+        MATCH "^- $mount_dest" < remove_output
+        tests.cleanup defer rm -f remove_output
         echo "and the mount is still active"
-        echo "THIS NEEDS TO BE FIXED!"
         MATCH "$mount_dest" < /proc/self/mountinfo
-        echo "and currently the mount's source data is unfortunately removed"
-        echo "THIS NEEDS TO BE FIXED!"
-        test ! -e "$MOUNT_SRC/file1"
+        echo "and the mount's source data is still there"
+        test -e "$MOUNT_SRC/file1"
     }
 
-    test_remove_currently_fails_when_user_mount_in_host_ns_under() {
+    test_remove_fails_when_user_mount_in_host_ns_under() {
         local mount_dest=$1
         setup_src_data
         setup_test_snap
         when_user_mount_in_host_ns "$mount_dest"
-        then_remove_currently_fails_mount_remains_src_data_lost "$mount_dest"
+        then_remove_fails_mount_remains_src_data_intact "$mount_dest"
         cleaning_up_user_mount_should_make_remove_successful "$mount_dest"
         echo
     }


### PR DESCRIPTION
Follows https://github.com/canonical/snapd/pull/17160

* This improves the error handling and reporting for the `snap remove` case when any user created mounts are present in the snap data dirs.
  * Now `snap remove` will inform the user of the list of such mounts and ask them to unmount these before re-trying remove.
* It also helps with preventing any data loss from such user created mounts during `snap remove`.
* When `clear-snap` task is requested for the revision which is not the last revision, then only that revision-specific data dirs are checked for such mounts, otherwise when it is requested for the last revision, then the entire snap base data dir tree is checked

[SNAPDENG-36947](https://warthogs.atlassian.net/browse/SNAPDENG-36947)

[SNAPDENG-36947]: https://warthogs.atlassian.net/browse/SNAPDENG-36947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ