### PR TITLE
mkversion.sh: do describe in worktrees too

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -43,7 +43,7 @@ DIRTY=false
 # tracked by git. The script can be invoked when building distro packages in
 # which case, the source tree could be a tarball, but the distro packaging files
 # can be in git, so try not to confuse the two.
-if command -v git >/dev/null && [ -d "$(dirname "$0")/.git" ] ; then
+if command -v git >/dev/null && [ -e "$(dirname "$0")/.git" ] ; then
     # don't include --dirty here as we independently track whether the tree is
     # dirty and append that last, including it here will make dirty trees 
     # directly on top of tags show up with version_from_git as 2.46-dirty which


### PR DESCRIPTION
When in a worktree, `.git` is a file, not a directory. We should
also call `git describe` in that case.