### PR TITLE
o/snapstate/backend: list non-snapctl mounts in snap data dirs

### DIFF
--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/wrappers"
 )
 
+type IsUnderAnyDirOptions = isUnderAnyDirOptions
+
 var (
 	AddMountUnit       = addMountUnit
 	RemoveMountUnit    = removeMountUnit

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -117,30 +117,31 @@ func isUnderAnyDir(path string, dirs []string, opts isUnderAnyDirOptions) bool {
 	return false
 }
 
-// ListNonMountControlMountsInSnapRevDataDirs returns the active mount points
+// ListNonSnapctlMountsInSnapRevDataDirs returns the active mount points
 // that are at or under the snap's revision-specific data directories and are
-// not of the mount-control origin.
-func (b Backend) ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+// not created using snapctl.
+func (b Backend) ListNonSnapctlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
 	revDirs, err := snapDataDirs(info, opts)
 	if err != nil {
 		return nil, err
 	}
-	return listNonMountControlMounts(info, revDirs)
+	return listNonSnapctlMounts(info, revDirs)
 }
 
-// ListNonMountControlMountsInSnapAllDataDirs returns the active mount points
-// that are at or under any of the snap's base data directories and are not of
-// the mount-control origin.
-func (b Backend) ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+// ListNonSnapctlMountsInSnapAllDataDirs returns the active mount points
+// that are at or under any of the snap's base data directories and are not
+// created using snapctl.
+func (b Backend) ListNonSnapctlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
 	baseDirs, err := snapBaseDataDirs(info.InstanceName(), opts)
 	if err != nil {
 		return nil, err
 	}
-	return listNonMountControlMounts(info, baseDirs)
+	return listNonSnapctlMounts(info, baseDirs)
 }
 
-func listNonMountControlMounts(info *snap.Info, baseDirs []string) ([]string, error) {
+func listNonSnapctlMounts(info *snap.Info, baseDirs []string) ([]string, error) {
 	sysd := systemd.New(systemd.SystemMode, nil)
+	// mounts created using snapctl have the "mount-control" origin
 	mcMountPoints, err := sysd.ListMountUnits(info.ContainerName(), "mount-control")
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
@@ -77,7 +78,8 @@ func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter prog
 		return err
 	}
 	for _, mountPoint := range mountPoints {
-		if len(baseDirs) > 0 && !isUnderAnyDir(mountPoint, baseDirs) {
+		opts := isUnderAnyDirOptions{AllowExactMatch: false}
+		if len(baseDirs) > 0 && !isUnderAnyDir(mountPoint, baseDirs, opts) {
 			continue
 		}
 		if err := sysd.RemoveMountUnitFile(mountPoint); err != nil {
@@ -87,20 +89,84 @@ func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter prog
 	return nil
 }
 
-// isUnderAnyDir reports whether path is a strict subdirectory of any of the
-// provided candidate directories (the path itself being equal to a candidate
-// does not count).
-func isUnderAnyDir(path string, candidates []string) bool {
-	for _, c := range candidates {
-		rel, err := filepath.Rel(c, path)
+// isUnderAnyDirOptions configures the behavior of isUnderAnyDir.
+type isUnderAnyDirOptions struct {
+	// AllowExactMatch controls whether path == dir counts as a match.
+	AllowExactMatch bool
+}
+
+// isUnderAnyDir reports whether path is a subdirectory of any of the provided
+// directories. If opts.AllowExactMatch is true, an exact match (path == dir)
+// also counts.
+func isUnderAnyDir(path string, dirs []string, opts isUnderAnyDirOptions) bool {
+	for _, d := range dirs {
+		rel, err := filepath.Rel(d, path)
 		if err != nil {
 			continue
 		}
-		// rel is "." when path == c
-		// rel starts with ".." when path is outside c
-		if rel != "." && !strings.HasPrefix(rel, "..") {
-			return true
+		// rel starts with ".." when path is outside d
+		if strings.HasPrefix(rel, "..") {
+			continue
 		}
+		// rel is "." when path == d
+		if rel == "." && !opts.AllowExactMatch {
+			continue
+		}
+		return true
 	}
 	return false
+}
+
+// ListNonMountControlMountsInSnapRevDataDirs returns the active mount points
+// that are at or under the snap's revision-specific data directories and are
+// not of the mount-control origin.
+func (b Backend) ListNonMountControlMountsInSnapRevDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	revDirs, err := snapDataDirs(info, opts)
+	if err != nil {
+		return nil, err
+	}
+	return listNonMountControlMounts(info, revDirs)
+}
+
+// ListNonMountControlMountsInSnapAllDataDirs returns the active mount points
+// that are at or under any of the snap's base data directories and are not of
+// the mount-control origin.
+func (b Backend) ListNonMountControlMountsInSnapAllDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	baseDirs, err := snapBaseDataDirs(info.InstanceName(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return listNonMountControlMounts(info, baseDirs)
+}
+
+func listNonMountControlMounts(info *snap.Info, baseDirs []string) ([]string, error) {
+	sysd := systemd.New(systemd.SystemMode, nil)
+	mcMountPoints, err := sysd.ListMountUnits(info.ContainerName(), "mount-control")
+	if err != nil {
+		return nil, err
+	}
+	mcMounts := make(map[string]bool, len(mcMountPoints))
+	for _, mp := range mcMountPoints {
+		mcMounts[mp] = true
+	}
+
+	mountInfo, err := osutil.LoadMountInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	var nonmcMountPoints []string
+	for _, entry := range mountInfo {
+		mp := entry.MountDir
+		// also include mounts over the base dirs themselves
+		opts := isUnderAnyDirOptions{AllowExactMatch: true}
+		if !isUnderAnyDir(mp, baseDirs, opts) {
+			continue
+		}
+		if mcMounts[mp] {
+			continue
+		}
+		nonmcMountPoints = append(nonmcMountPoints, mp)
+	}
+	return nonmcMountPoints, nil
 }

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -293,27 +293,27 @@ func (s *mountunitSuite) TestIsUnderAnyDirAllowExactMatch(c *C) {
 	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}, allowExactMatch), Equals, false)
 }
 
-type listNonMountControlMountsFn func(*snap.Info, *dirs.SnapDirOptions) ([]string, error)
+type listNonSnapctlMountsFn func(*snap.Info, *dirs.SnapDirOptions) ([]string, error)
 
 type scope int
 
 const (
-	scopeRev scope = iota // tests ListNonMountControlMountsInSnapRevDataDirs
-	scopeAll              // tests ListNonMountControlMountsInSnapAllDataDirs
+	scopeRev scope = iota // tests ListNonSnapctlMountsInSnapRevDataDirs
+	scopeAll              // tests ListNonSnapctlMountsInSnapAllDataDirs
 )
 
-func (v scope) fn() listNonMountControlMountsFn {
+func (v scope) fn() listNonSnapctlMountsFn {
 	b := backend.Backend{}
 	switch v {
 	case scopeRev:
-		return b.ListNonMountControlMountsInSnapRevDataDirs
+		return b.ListNonSnapctlMountsInSnapRevDataDirs
 	case scopeAll:
-		return b.ListNonMountControlMountsInSnapAllDataDirs
+		return b.ListNonSnapctlMountsInSnapAllDataDirs
 	}
 	return nil
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsNoMounts(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsNoMounts(c *C, variant scope) {
 	var sysd *systemdtest.FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
 		sysd = &systemdtest.FakeSystemd{}
@@ -335,16 +335,16 @@ func (s *mountunitSuite) testListNonMountControlMountsNoMounts(c *C, variant sco
 	})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevNoMounts(c *C) {
-	s.testListNonMountControlMountsNoMounts(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevNoMounts(c *C) {
+	s.testListNonSnapctlMountsNoMounts(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllNoMounts(c *C) {
-	s.testListNonMountControlMountsNoMounts(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllNoMounts(c *C) {
+	s.testListNonSnapctlMountsNoMounts(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsAllMountControl(c *C, variant scope) {
-	// The mount-control mount is placed under current revision dir
+func (s *mountunitSuite) testListNonSnapctlMountsAllSnapctl(c *C, variant scope) {
+	// The snapctl mount is placed under current revision dir
 	// which lies within the scan scope of both the Rev and All variants.
 	snapRevDataDir := fmt.Sprintf("%s/var/snap/foo/3", dirs.GlobalRootDir)
 	mcMount := snapRevDataDir + "/mc-mount"
@@ -365,23 +365,23 @@ func (s *mountunitSuite) testListNonMountControlMountsAllMountControl(c *C, vari
 	fn := variant.fn()
 	mounts, err := fn(info, nil)
 	c.Assert(err, IsNil)
-	// All mounts are mount-control mounts, so nothing is returned.
+	// All mounts are snapctl mounts, so nothing is returned.
 	c.Check(mounts, HasLen, 0)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
 		{SnapName: "foo", Origin: "mount-control"},
 	})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevAllMountControl(c *C) {
-	s.testListNonMountControlMountsAllMountControl(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevAllSnapctl(c *C) {
+	s.testListNonSnapctlMountsAllSnapctl(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllMountControl(c *C) {
-	s.testListNonMountControlMountsAllMountControl(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllSnapctl(c *C) {
+	s.testListNonSnapctlMountsAllSnapctl(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsReturnsNonMountControl(c *C, variant scope) {
-	// The mount-control and user mounts are placed under current revision dir
+func (s *mountunitSuite) testListNonSnapctlMountsReturnsNonSnapctl(c *C, variant scope) {
+	// The snapctl and user mounts are placed under current revision dir
 	// which lie within the scan scope of both the Rev and All variants.
 	snapRevDataDir := fmt.Sprintf("%s/var/snap/foo/3", dirs.GlobalRootDir)
 	mcMount := snapRevDataDir + "/mc-mount"
@@ -408,22 +408,22 @@ func (s *mountunitSuite) testListNonMountControlMountsReturnsNonMountControl(c *
 	fn := variant.fn()
 	mounts, err := fn(info, nil)
 	c.Assert(err, IsNil)
-	// Only the non-mount-control mount is returned.
+	// Only the non-snapctl mount is returned.
 	c.Check(mounts, DeepEquals, []string{userMount})
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
 		{SnapName: "foo", Origin: "mount-control"},
 	})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevReturnsNonMountControl(c *C) {
-	s.testListNonMountControlMountsReturnsNonMountControl(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevReturnsNonSnapctl(c *C) {
+	s.testListNonSnapctlMountsReturnsNonSnapctl(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllReturnsNonMountControl(c *C) {
-	s.testListNonMountControlMountsReturnsNonMountControl(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllReturnsNonSnapctl(c *C) {
+	s.testListNonSnapctlMountsReturnsNonSnapctl(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsCrossRevision(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsCrossRevision(c *C, variant scope) {
 	otherRevMount := fmt.Sprintf("%s/var/snap/foo/1/data", dirs.GlobalRootDir)
 	currentRevMount := fmt.Sprintf("%s/var/snap/foo/3/data", dirs.GlobalRootDir)
 
@@ -456,15 +456,15 @@ func (s *mountunitSuite) testListNonMountControlMountsCrossRevision(c *C, varian
 	c.Check(mounts, DeepEquals, expectedMounts)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevIgnoresMountsInOtherRevisions(c *C) {
-	s.testListNonMountControlMountsCrossRevision(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevIgnoresMountsInOtherRevisions(c *C) {
+	s.testListNonSnapctlMountsCrossRevision(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllDetectsAllRevisionMounts(c *C) {
-	s.testListNonMountControlMountsCrossRevision(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllDetectsAllRevisionMounts(c *C) {
+	s.testListNonSnapctlMountsCrossRevision(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsAtExactDir(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsAtExactDir(c *C, variant scope) {
 	var mountPath string
 	switch variant {
 	case scopeRev:
@@ -489,15 +489,15 @@ func (s *mountunitSuite) testListNonMountControlMountsAtExactDir(c *C, variant s
 	c.Check(mounts, DeepEquals, []string{mountPath})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevAtRevisionDir(c *C) {
-	s.testListNonMountControlMountsAtExactDir(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevAtRevisionDir(c *C) {
+	s.testListNonSnapctlMountsAtExactDir(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllAtBaseDir(c *C) {
-	s.testListNonMountControlMountsAtExactDir(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllAtBaseDir(c *C) {
+	s.testListNonSnapctlMountsAtExactDir(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsInRootUserDir(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsInRootUserDir(c *C, variant scope) {
 	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
 
 	var mountPath string
@@ -524,15 +524,15 @@ func (s *mountunitSuite) testListNonMountControlMountsInRootUserDir(c *C, varian
 	c.Check(mounts, DeepEquals, []string{mountPath})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevInRootUserDir(c *C) {
-	s.testListNonMountControlMountsInRootUserDir(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevInRootUserDir(c *C) {
+	s.testListNonSnapctlMountsInRootUserDir(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllInRootUserDir(c *C) {
-	s.testListNonMountControlMountsInRootUserDir(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllInRootUserDir(c *C) {
+	s.testListNonSnapctlMountsInRootUserDir(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsInHomeUserDir(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsInHomeUserDir(c *C, variant scope) {
 	var userSnapDir, mountPath string
 	switch variant {
 	case scopeRev:
@@ -563,15 +563,15 @@ func (s *mountunitSuite) testListNonMountControlMountsInHomeUserDir(c *C, varian
 	c.Check(mounts, DeepEquals, []string{mountPath})
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevInHomeUserDir(c *C) {
-	s.testListNonMountControlMountsInHomeUserDir(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevInHomeUserDir(c *C) {
+	s.testListNonSnapctlMountsInHomeUserDir(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllInHomeUserDir(c *C) {
-	s.testListNonMountControlMountsInHomeUserDir(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllInHomeUserDir(c *C) {
+	s.testListNonSnapctlMountsInHomeUserDir(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsErrorOnListMountUnits(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsErrorOnListMountUnits(c *C, variant scope) {
 	expectedErr := errors.New("mock ListMountUnits error")
 
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
@@ -590,15 +590,15 @@ func (s *mountunitSuite) testListNonMountControlMountsErrorOnListMountUnits(c *C
 	c.Check(err, Equals, expectedErr)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevErrorOnListMountUnits(c *C) {
-	s.testListNonMountControlMountsErrorOnListMountUnits(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevErrorOnListMountUnits(c *C) {
+	s.testListNonSnapctlMountsErrorOnListMountUnits(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllErrorOnListMountUnits(c *C) {
-	s.testListNonMountControlMountsErrorOnListMountUnits(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllErrorOnListMountUnits(c *C) {
+	s.testListNonSnapctlMountsErrorOnListMountUnits(c, scopeAll)
 }
 
-func (s *mountunitSuite) testListNonMountControlMountsErrorOnLoadMountInfo(c *C, variant scope) {
+func (s *mountunitSuite) testListNonSnapctlMountsErrorOnLoadMountInfo(c *C, variant scope) {
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
 		return &systemdtest.FakeSystemd{}
 	})
@@ -614,10 +614,10 @@ func (s *mountunitSuite) testListNonMountControlMountsErrorOnLoadMountInfo(c *C,
 	c.Check(err, ErrorMatches, "incorrect number of fields, expected at least 10 but found 3")
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsRevErrorOnLoadMountInfo(c *C) {
-	s.testListNonMountControlMountsErrorOnLoadMountInfo(c, scopeRev)
+func (s *mountunitSuite) TestListNonSnapctlMountsRevErrorOnLoadMountInfo(c *C) {
+	s.testListNonSnapctlMountsErrorOnLoadMountInfo(c, scopeRev)
 }
 
-func (s *mountunitSuite) TestListNonMountControlMountsAllErrorOnLoadMountInfo(c *C) {
-	s.testListNonMountControlMountsErrorOnLoadMountInfo(c, scopeAll)
+func (s *mountunitSuite) TestListNonSnapctlMountsAllErrorOnLoadMountInfo(c *C) {
+	s.testListNonSnapctlMountsErrorOnLoadMountInfo(c, scopeAll)
 }

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -498,12 +498,14 @@ func (s *mountunitSuite) TestListNonMountControlMountsAllAtBaseDir(c *C) {
 }
 
 func (s *mountunitSuite) testListNonMountControlMountsInRootUserDir(c *C, variant scope) {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+
 	var mountPath string
 	switch variant {
 	case scopeRev:
-		mountPath = fmt.Sprintf("%s/root/snap/foo/3/data", dirs.GlobalRootDir)
+		mountPath = fmt.Sprintf("%s/root/.snap/data/foo/3/data", dirs.GlobalRootDir)
 	case scopeAll:
-		mountPath = fmt.Sprintf("%s/root/snap/foo/data", dirs.GlobalRootDir)
+		mountPath = fmt.Sprintf("%s/root/.snap/data/foo/data", dirs.GlobalRootDir)
 	}
 
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
@@ -517,7 +519,7 @@ func (s *mountunitSuite) testListNonMountControlMountsInRootUserDir(c *C, varian
 
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
 	fn := variant.fn()
-	mounts, err := fn(info, nil)
+	mounts, err := fn(info, opts)
 	c.Assert(err, IsNil)
 	c.Check(mounts, DeepEquals, []string{mountPath})
 }

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -22,10 +22,12 @@ package backend_test
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -251,27 +253,369 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
 	})
 }
 
-func (s *mountunitSuite) TestIsUnderAnyDir(c *C) {
+func (s *mountunitSuite) TestIsUnderAnyDirDisallowExactMatch(c *C) {
+	disallowExactMatch := backend.IsUnderAnyDirOptions{}
 	// Subdirectory matches.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1"}), Equals, true)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, true)
 	// Trailing slash on path must not affect matching.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1"}), Equals, true)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, true)
 	// Trailing slash on candidate must not affect matching.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1/"}), Equals, true)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1/"}, disallowExactMatch), Equals, true)
 	// Trailing slash on both must not affect matching.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1/"}), Equals, true)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar/", []string{"/var/snap/foo/1/"}, disallowExactMatch), Equals, true)
 	// Path equal to candidate must not match (strict subdirectory check).
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, false)
 	// Path equal to candidate with trailing slash on path must not match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/", []string{"/var/snap/foo/1"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, false)
 	// Path equal to candidate with trailing slash on candidate must not match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1/"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1/"}, disallowExactMatch), Equals, false)
 	// Unrelated path must not match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, false)
 	// Path with ".." components that escape the candidate after cleaning must not match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/../../bar", []string{"/var/snap/foo/1"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/../../bar", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, false)
 	// Path with internal double slash that normalizes to a subdirectory must match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo//1/bar", []string{"/var/snap/foo/1"}), Equals, true)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo//1/bar", []string{"/var/snap/foo/1"}, disallowExactMatch), Equals, true)
 	// Relative candidate causes filepath.Rel to error; must not match.
-	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"var/snap/foo/1"}), Equals, false)
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"var/snap/foo/1"}, disallowExactMatch), Equals, false)
+}
+
+func (s *mountunitSuite) TestIsUnderAnyDirAllowExactMatch(c *C) {
+	allowExactMatch := backend.IsUnderAnyDirOptions{AllowExactMatch: true}
+	// Subdirectory still matches.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/bar", []string{"/var/snap/foo/1"}, allowExactMatch), Equals, true)
+	// Path equal to candidate now matches.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1"}, allowExactMatch), Equals, true)
+	// Path equal to candidate with trailing slash on path also matches.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1/", []string{"/var/snap/foo/1"}, allowExactMatch), Equals, true)
+	// Path equal to candidate with trailing slash on candidate also matches.
+	c.Check(backend.IsUnderAnyDir("/var/snap/foo/1", []string{"/var/snap/foo/1/"}, allowExactMatch), Equals, true)
+	// Unrelated path still does not match.
+	c.Check(backend.IsUnderAnyDir("/var/snap/other/1/bar", []string{"/var/snap/foo/1"}, allowExactMatch), Equals, false)
+}
+
+type listNonMountControlMountsFn func(*snap.Info, *dirs.SnapDirOptions) ([]string, error)
+
+type scope int
+
+const (
+	scopeRev scope = iota // tests ListNonMountControlMountsInSnapRevDataDirs
+	scopeAll              // tests ListNonMountControlMountsInSnapAllDataDirs
+)
+
+func (v scope) fn() listNonMountControlMountsFn {
+	b := backend.Backend{}
+	switch v {
+	case scopeRev:
+		return b.ListNonMountControlMountsInSnapRevDataDirs
+	case scopeAll:
+		return b.ListNonMountControlMountsInSnapAllDataDirs
+	}
+	return nil
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsNoMounts(c *C, variant scope) {
+	var sysd *systemdtest.FakeSystemd
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = nil
+		return sysd
+	})
+	defer restore()
+
+	restoreMI := osutil.MockMountInfo("")
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(mounts, HasLen, 0)
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: "mount-control"},
+	})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevNoMounts(c *C) {
+	s.testListNonMountControlMountsNoMounts(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllNoMounts(c *C) {
+	s.testListNonMountControlMountsNoMounts(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsAllMountControl(c *C, variant scope) {
+	// The mount-control mount is placed under current revision dir
+	// which lies within the scan scope of both the Rev and All variants.
+	snapRevDataDir := fmt.Sprintf("%s/var/snap/foo/3", dirs.GlobalRootDir)
+	mcMount := snapRevDataDir + "/mc-mount"
+
+	var sysd *systemdtest.FakeSystemd
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = []string{mcMount}
+		return sysd
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf("36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n", mcMount)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	// All mounts are mount-control mounts, so nothing is returned.
+	c.Check(mounts, HasLen, 0)
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: "mount-control"},
+	})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevAllMountControl(c *C) {
+	s.testListNonMountControlMountsAllMountControl(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllMountControl(c *C) {
+	s.testListNonMountControlMountsAllMountControl(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsReturnsNonMountControl(c *C, variant scope) {
+	// The mount-control and user mounts are placed under current revision dir
+	// which lie within the scan scope of both the Rev and All variants.
+	snapRevDataDir := fmt.Sprintf("%s/var/snap/foo/3", dirs.GlobalRootDir)
+	mcMount := snapRevDataDir + "/mc-mount"
+	userMount := snapRevDataDir + "/user-mount"
+	unrelatedMount := "/tmp/unrelated"
+
+	var sysd *systemdtest.FakeSystemd
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd = &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.MountPoints = []string{mcMount}
+		return sysd
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf(
+		"36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n"+
+			"37 1 8:2 / %s rw - ext4 /dev/sda2 rw\n"+
+			"38 1 8:3 / %s rw - tmpfs tmpfs rw\n",
+		mcMount, userMount, unrelatedMount)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	// Only the non-mount-control mount is returned.
+	c.Check(mounts, DeepEquals, []string{userMount})
+	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		{SnapName: "foo", Origin: "mount-control"},
+	})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevReturnsNonMountControl(c *C) {
+	s.testListNonMountControlMountsReturnsNonMountControl(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllReturnsNonMountControl(c *C) {
+	s.testListNonMountControlMountsReturnsNonMountControl(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsCrossRevision(c *C, variant scope) {
+	otherRevMount := fmt.Sprintf("%s/var/snap/foo/1/data", dirs.GlobalRootDir)
+	currentRevMount := fmt.Sprintf("%s/var/snap/foo/3/data", dirs.GlobalRootDir)
+
+	var expectedMounts []string
+	switch variant {
+	case scopeRev:
+		// Rev only scans the current revision dir, so only currentRevMount is visible.
+		expectedMounts = []string{currentRevMount}
+	case scopeAll:
+		// All scans the snap base dir, so mounts from all revisions are visible.
+		expectedMounts = []string{otherRevMount, currentRevMount}
+	}
+
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf(
+		"36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n"+
+			"37 1 8:2 / %s rw - ext4 /dev/sda2 rw\n",
+		otherRevMount, currentRevMount)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(mounts, DeepEquals, expectedMounts)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevIgnoresMountsInOtherRevisions(c *C) {
+	s.testListNonMountControlMountsCrossRevision(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllDetectsAllRevisionMounts(c *C) {
+	s.testListNonMountControlMountsCrossRevision(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsAtExactDir(c *C, variant scope) {
+	var mountPath string
+	switch variant {
+	case scopeRev:
+		mountPath = fmt.Sprintf("%s/var/snap/foo/3", dirs.GlobalRootDir)
+	case scopeAll:
+		mountPath = fmt.Sprintf("%s/var/snap/foo", dirs.GlobalRootDir)
+	}
+
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf("36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n", mountPath)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(mounts, DeepEquals, []string{mountPath})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevAtRevisionDir(c *C) {
+	s.testListNonMountControlMountsAtExactDir(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllAtBaseDir(c *C) {
+	s.testListNonMountControlMountsAtExactDir(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsInRootUserDir(c *C, variant scope) {
+	var mountPath string
+	switch variant {
+	case scopeRev:
+		mountPath = fmt.Sprintf("%s/root/snap/foo/3/data", dirs.GlobalRootDir)
+	case scopeAll:
+		mountPath = fmt.Sprintf("%s/root/snap/foo/data", dirs.GlobalRootDir)
+	}
+
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf("36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n", mountPath)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(mounts, DeepEquals, []string{mountPath})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevInRootUserDir(c *C) {
+	s.testListNonMountControlMountsInRootUserDir(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllInRootUserDir(c *C) {
+	s.testListNonMountControlMountsInRootUserDir(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsInHomeUserDir(c *C, variant scope) {
+	var userSnapDir, mountPath string
+	switch variant {
+	case scopeRev:
+		userSnapDir = fmt.Sprintf("%s/home/user1/snap/foo/3", dirs.GlobalRootDir)
+		mountPath = userSnapDir + "/data"
+	case scopeAll:
+		userSnapDir = fmt.Sprintf("%s/home/user1/snap/foo", dirs.GlobalRootDir)
+		mountPath = userSnapDir + "/data"
+	}
+	// Create the user's snap directory so that the glob in snapDataDirs /
+	// snapBaseDataDirs expands to it.
+	c.Assert(os.MkdirAll(userSnapDir, 0755), IsNil)
+	defer os.RemoveAll(userSnapDir)
+
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restore()
+
+	mountInfoContent := fmt.Sprintf("36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n", mountPath)
+	restoreMI := osutil.MockMountInfo(mountInfoContent)
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	mounts, err := fn(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(mounts, DeepEquals, []string{mountPath})
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevInHomeUserDir(c *C) {
+	s.testListNonMountControlMountsInHomeUserDir(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllInHomeUserDir(c *C) {
+	s.testListNonMountControlMountsInHomeUserDir(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsErrorOnListMountUnits(c *C, variant scope) {
+	expectedErr := errors.New("mock ListMountUnits error")
+
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		sysd := &systemdtest.FakeSystemd{}
+		sysd.ListMountUnitsResult.Err = expectedErr
+		return sysd
+	})
+	defer restore()
+
+	restoreMI := osutil.MockMountInfo("")
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	_, err := fn(info, nil)
+	c.Check(err, Equals, expectedErr)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevErrorOnListMountUnits(c *C) {
+	s.testListNonMountControlMountsErrorOnListMountUnits(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllErrorOnListMountUnits(c *C) {
+	s.testListNonMountControlMountsErrorOnListMountUnits(c, scopeAll)
+}
+
+func (s *mountunitSuite) testListNonMountControlMountsErrorOnLoadMountInfo(c *C, variant scope) {
+	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restore()
+
+	// Inject a mountinfo line with less fields; the parser requires at least 10.
+	restoreMI := osutil.MockMountInfo("col1 col2 col3\n")
+	defer restoreMI()
+
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(3)}}
+	fn := variant.fn()
+	_, err := fn(info, nil)
+	c.Check(err, ErrorMatches, "incorrect number of fields, expected at least 10 but found 3")
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsRevErrorOnLoadMountInfo(c *C) {
+	s.testListNonMountControlMountsErrorOnLoadMountInfo(c, scopeRev)
+}
+
+func (s *mountunitSuite) TestListNonMountControlMountsAllErrorOnLoadMountInfo(c *C) {
+	s.testListNonMountControlMountsErrorOnLoadMountInfo(c, scopeAll)
 }


### PR DESCRIPTION
Precedes https://github.com/canonical/snapd/pull/17156
https://github.com/canonical/snapd/pull/17156 combines the overall functionality where this change is needed. It was split out of https://github.com/canonical/snapd/pull/17156 to help with reviews.

* Non-snapctl mounts (or rather any unknown mounts to snapd) are identified using `osutil.LoadMountInfo()`, which are all mounts under snap data dirs that are not created using `snapctl mount` (obtained via `sysd.ListMountUnits` with `mount-control` origin)
* Supports detecting such mounts under
  * either only the revision-specific data dirs
  * or the entire snap base data dir tree

[SNAPDENG-36947](https://warthogs.atlassian.net/browse/SNAPDENG-36947)

[SNAPDENG-36947]: https://warthogs.atlassian.net/browse/SNAPDENG-36947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ