### PR TITLE
confdb: literal subkeys are sorted after placeholders

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -2165,6 +2165,7 @@ type requestMatch struct {
 // no entry is an exact match, one or more entries that the request matches a
 // prefix of. If no match is found, a NoMatchError is returned.
 func (v *View) matchGetRequest(accessors []Accessor) (matches []requestMatch, err error) {
+	requestToAccs := make(map[string][]Accessor)
 	for _, rule := range v.rules {
 		placeholders, unmatchedSuffix, ok := rule.match(accessors)
 		if !ok {
@@ -2174,13 +2175,18 @@ func (v *View) matchGetRequest(accessors []Accessor) (matches []requestMatch, er
 		if !rule.isReadable() {
 			continue
 		}
-
 		m := requestMatch{
 			storagePath:     rule.storagePath(placeholders),
 			unmatchedSuffix: unmatchedSuffix,
 			request:         rule.originalRequest,
 		}
 		matches = append(matches, m)
+
+		reqAccs := make([]Accessor, len(rule.request))
+		for i, acc := range rule.request {
+			reqAccs[i] = acc.(Accessor)
+		}
+		requestToAccs[rule.originalRequest] = reqAccs
 	}
 
 	if len(matches) == 0 {
@@ -2188,9 +2194,8 @@ func (v *View) matchGetRequest(accessors []Accessor) (matches []requestMatch, er
 		return nil, NewNoMatchError(v, "get", []string{request})
 	}
 
-	// sort matches by namespace (unmatched suffix) to ensure that nested matches
-	// are read after
-	getAccs := func(i int) []Accessor { return matches[i].unmatchedSuffix }
+	// sort matches by request to ensure that more specific and nested matches are read after
+	getAccs := func(i int) []Accessor { return requestToAccs[matches[i].request] }
 	sort.Slice(matches, byAccessor(getAccs))
 
 	return matches, nil

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1222,13 +1222,20 @@ func byAccessor(getAccs accGetter) func(x, y int) bool {
 
 		minLen := int(math.Min(float64(len(xPath)), float64(len(yPath))))
 		for i := 0; i < minLen; i++ {
-			partAcc := xPath[i].Access()
-			otherPart := yPath[i].Access()
-			if partAcc == otherPart {
+			xAcc := xPath[i]
+			yAcc := yPath[i]
+			if xAcc.Access() == yAcc.Access() {
 				continue
 			}
 
-			return partAcc < otherPart
+			// sort placeholders before literals so the latter override the former
+			xPlaceholder := xAcc.Type() == KeyPlaceholderType || xAcc.Type() == IndexPlaceholderType
+			yPlaceholder := yAcc.Type() == KeyPlaceholderType || yAcc.Type() == IndexPlaceholderType
+			if xPlaceholder != yPlaceholder {
+				return xPlaceholder
+			}
+
+			return xAcc.Access() < yAcc.Access()
 		}
 
 		return len(xPath) < len(yPath)

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -22,6 +22,7 @@ package confdb_test
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
@@ -1938,26 +1939,41 @@ func (s *viewSuite) TestRuleOrderingBySpecificityAndNestedness(c *C) {
 	// ones. We're building a virtual document from locations in the storage that
 	// may evolve over time so this allows us to replace "old" paths.
 	databag := confdb.NewJSONDatabag()
+	rules := []any{
+		map[string]any{"request": "{foo}", "storage": "generic.{foo}"},
+		map[string]any{"request": "foo", "storage": "specific"},
+		map[string]any{"request": "foo.bar", "storage": "nested"},
+	}
+
+	// test that the sorting works regardless of how the rules are passed in
+	rand.Shuffle(len(rules), func(i, j int) {
+		rules[i], rules[j] = rules[j], rules[i]
+	})
+
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{
-			"rules": []any{
-				map[string]any{"request": "{foo}", "storage": "generic.{foo}"},
-				map[string]any{"request": "foo", "storage": "specific"},
-				map[string]any{"request": "foo.bar", "storage": "nested"},
-			},
+			"rules": rules,
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = databag.Set(parsePath(c, "generic"), map[string]any{"bar": "first"})
+	// only the generic path has data, so that's what we get
+	err = databag.Set(parsePath(c, "generic.foo"), map[string]any{"bar": "first"})
 	c.Assert(err, IsNil)
+
+	value, err := view.Get(databag, "foo", nil, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]any{
+		"bar": "first",
+	})
+
+	// a literal path is sorted after a placeholder one so it replaces that data
 	err = databag.Set(parsePath(c, "specific"), map[string]any{"bar": "second"})
 	c.Assert(err, IsNil)
 
-	// a literal path is sorted after a placeholder one
-	value, err := view.Get(databag, "foo", nil, confdb.AdminAccess)
+	value, err = view.Get(databag, "foo", nil, confdb.AdminAccess)
 	c.Assert(err, IsNil)
 	c.Assert(value, DeepEquals, map[string]any{
 		"bar": "second",

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -1932,41 +1932,45 @@ func (s *viewSuite) TestSetValueMissingNestedLevels(c *C) {
 	}
 }
 
-func (s *viewSuite) TestGetReadsStorageLessNestedNamespaceBefore(c *C) {
-	// Get reads by order of namespace (not path) nestedness. This test explicitly
-	// tests for this and showcases why it matters. In Get we care about building
-	// a virtual document from locations in the storage that may evolve over time.
-	// In this example, the storage evolve to have version data in a different place
+func (s *viewSuite) TestRuleOrderingBySpecificityAndNestedness(c *C) {
+	// Get reads by order of namespace (not path) nestedness and specificity.
+	// More specific and more nested paths are sorted after less nested placeholder
+	// ones. We're building a virtual document from locations in the storage that
+	// may evolve over time so this allows us to replace "old" paths.
 	databag := confdb.NewJSONDatabag()
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{
 			"rules": []any{
-				map[string]any{"request": "snaps.snapd", "storage": "snaps.snapd"},
-				map[string]any{"request": "snaps.snapd.version", "storage": "anewversion"},
+				map[string]any{"request": "{foo}", "storage": "generic.{foo}"},
+				map[string]any{"request": "foo", "storage": "specific"},
+				map[string]any{"request": "foo.bar", "storage": "nested"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
-
-	err = databag.Set(parsePath(c, "snaps"), map[string]any{
-		"snapd": map[string]any{
-			"version": 1,
-		},
-	})
-	c.Assert(err, IsNil)
-
-	err = databag.Set(parsePath(c, "anewversion"), 2)
-	c.Assert(err, IsNil)
-
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	data, err := view.Get(databag, "snaps", nil, confdb.AdminAccess)
+	err = databag.Set(parsePath(c, "generic"), map[string]any{"bar": "first"})
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]any{
-		"snapd": map[string]any{
-			"version": float64(2),
-		},
+	err = databag.Set(parsePath(c, "specific"), map[string]any{"bar": "second"})
+	c.Assert(err, IsNil)
+
+	// a literal path is sorted after a placeholder one
+	value, err := view.Get(databag, "foo", nil, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]any{
+		"bar": "second",
+	})
+
+	err = databag.Set(parsePath(c, "nested"), "third")
+	c.Assert(err, IsNil)
+
+	// a more specific path is sorted after a less nested one
+	value, err = view.Get(databag, "foo", nil, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]any{
+		"bar": "third",
 	})
 }
 


### PR DESCRIPTION
Specific paths should be sorted after generic ones such that we can create new rules for specific values and they replace the corresponding path in the general value (see test).

https://warthogs.atlassian.net/browse/SNAPDENG-36973