### PR TITLE
daemon, o/snapstate: implement snapstate.InstallPath in terms of refresh

### DIFF
--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -579,7 +579,7 @@ func sideloadSnap(_ context.Context, st *state.State, upload *uploadedContainer,
 	message := fmt.Sprintf("%q snap", instanceName)
 	if compInfo == nil {
 		// TODO pass per request context
-		tset, _, err = snapstateInstallPath(st, &info.SideInfo, upload.tmpPath, instanceName, "", flags.Flags, nil)
+		tset, err = snapstateInstallPath(st, &info.SideInfo, upload.tmpPath, instanceName, "", flags.Flags, nil)
 		changeType = installSnapChangeKind
 	} else {
 		// It is a component

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -223,7 +223,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
-	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error) {
+	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, error) {
 		c.Check(flags, check.DeepEquals, expectedFlags)
 
 		c.Check(path, testutil.FileEquals, "xyzzy")
@@ -232,7 +232,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 
 		installQueue = append(installQueue, si.RealName+"::"+path)
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
-		return state.NewTaskSet(t), &snap.Info{SuggestedName: name}, nil
+		return state.NewTaskSet(t), nil
 	})()
 
 	buf := bytes.NewBufferString(content)
@@ -1059,7 +1059,7 @@ version: 1`, nil)
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
-	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error) {
+	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, error) {
 		c.Check(flags, check.Equals, snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap})
 		c.Check(si, check.DeepEquals, &snap.SideInfo{
 			RealName: "foo",
@@ -1067,7 +1067,7 @@ version: 1`, nil)
 			Revision: snap.R(41),
 		})
 
-		return state.NewTaskSet(), &snap.Info{SuggestedName: "foo"}, nil
+		return state.NewTaskSet(), nil
 	})()
 
 	rsp := s.asyncReq(c, req, nil, actionIsExpected)
@@ -1154,8 +1154,8 @@ func (s *sideloadSuite) TestSideloadSnapChangeConflict(c *check.C) {
 		return &snap.Info{SuggestedName: "foo"}, nil
 	})()
 
-	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error) {
-		return nil, nil, &snapstate.ChangeConflictError{Snap: "foo"}
+	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, error) {
+		return nil, &snapstate.ChangeConflictError{Snap: "foo"}
 	})()
 
 	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -203,7 +203,7 @@ func MockSnapstateStoreUpdateGoal(mock func(snaps ...snapstate.StoreUpdate) snap
 	}
 }
 
-func MockSnapstateInstallPath(mock func(*state.State, *snap.SideInfo, string, string, string, snapstate.Flags, snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error)) (restore func()) {
+func MockSnapstateInstallPath(mock func(*state.State, *snap.SideInfo, string, string, string, snapstate.Flags, snapstate.PrereqTracker) (*state.TaskSet, error)) (restore func()) {
 	oldSnapstateInstallPath := snapstateInstallPath
 	snapstateInstallPath = mock
 	return func() {

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -68,7 +68,7 @@ func installSeedSnap(st *state.State, sn *seed.Snap, flags snapstate.Flags, prqt
 
 	flags.NoDelayedSideEffects = true
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       sn.Path,
 		SideInfo:   sn.SideInfo,
 		Components: components,

--- a/overlord/fdestate/conflict_test.go
+++ b/overlord/fdestate/conflict_test.go
@@ -142,7 +142,7 @@ type: base
 	} {
 		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
 		s.st.Set("seeded", true)
-		ts, _, err := snapstate.InstallPath(s.st, &snap.SideInfo{
+		ts, err := snapstate.InstallPath(s.st, &snap.SideInfo{
 			RealName: sn.name,
 		}, path, "", "", snapstate.Flags{}, nil)
 		c.Assert(err, IsNil)

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -946,7 +946,7 @@ type: base
 	} {
 		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
 		s.st.Set("seeded", true)
-		ts, _, err := snapstate.InstallPath(s.st, &snap.SideInfo{
+		ts, err := snapstate.InstallPath(s.st, &snap.SideInfo{
 			RealName: sn.name,
 		}, path, "", "", snapstate.Flags{}, nil)
 		c.Assert(err, IsNil)
@@ -1021,7 +1021,7 @@ type: app
 		c.Logf("checking snap %s:\n%s", sn.name, sn.snapYaml)
 		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
 
-		_, _, err = snapstate.InstallPath(s.st, &snap.SideInfo{
+		_, err = snapstate.InstallPath(s.st, &snap.SideInfo{
 			RealName: sn.name,
 		}, path, "", "", snapstate.Flags{}, nil)
 

--- a/overlord/fdestate/secure_boot_update_test.go
+++ b/overlord/fdestate/secure_boot_update_test.go
@@ -1618,7 +1618,7 @@ type: app
 		c.Logf("checking snap %s:\n%s", sn.name, sn.snapYaml)
 		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
 
-		_, _, err = snapstate.InstallPath(st, &snap.SideInfo{
+		_, err = snapstate.InstallPath(st, &snap.SideInfo{
 			RealName: sn.name,
 		}, path, "", "", snapstate.Flags{}, nil)
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -734,7 +734,7 @@ apps:
 	st.Lock()
 	defer st.Unlock()
 
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "foo"}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "foo"}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -801,7 +801,7 @@ hooks:
 	st.Lock()
 	defer st.Unlock()
 
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "foo"}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "foo"}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2170,7 +2170,7 @@ apps:
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
 
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2235,7 +2235,7 @@ apps:
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
 
-	_, _, err = snapstate.InstallPath(st, si, snapPath, "bar_instance", "", snapstate.Flags{DevMode: true}, nil)
+	_, err = snapstate.InstallPath(st, si, snapPath, "bar_instance", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, ErrorMatches, `cannot install snap "bar_instance": instance name prefix does not match snap name: bar != foo`)
 }
 
@@ -2265,7 +2265,7 @@ apps:
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
 
-	_, _, err = snapstate.InstallPath(st, si, snapPath, "bar_invalid_instance_name", "", snapstate.Flags{DevMode: true}, nil)
+	_, err = snapstate.InstallPath(st, si, snapPath, "bar_invalid_instance_name", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "invalid_instance_name"`)
 }
 
@@ -2301,7 +2301,7 @@ slots:
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	defer restoreSanitize()
 
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2489,7 +2489,7 @@ type: os
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2568,7 +2568,7 @@ type: os
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2715,7 +2715,7 @@ type: kernel`
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -2817,7 +2817,7 @@ type: kernel`
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	terr := st.NewTask("error-trigger", "provoking total undo")
@@ -2975,7 +2975,7 @@ type: kernel`
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, kernelSnapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, kernelSnapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -3144,7 +3144,7 @@ type: kernel`
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, kernelSnapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, kernelSnapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	terr := st.NewTask("error-trigger", "provoking total undo")
@@ -3250,7 +3250,7 @@ func (s *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.Inf
 	var snapst snapstate.SnapState
 	snapstate.Get(st, snapName, &snapst)
 
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: snapName}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: snapName}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
 	chg.AddAll(ts)
@@ -4497,7 +4497,7 @@ func (s *mgrsSuite) TestRemoveAndInstallWithAutoconnectHappy(c *C) {
 
 	snapPath := makeTestSnap(c, snapYamlContent2+"version: 1.0")
 	chg2 := st.NewChange("install-snap", "...")
-	ts2, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "snap2", SnapID: fakeSnapID("snap2"), Revision: snap.R(3)}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
+	ts2, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "snap2", SnapID: fakeSnapID("snap2"), Revision: snap.R(3)}, snapPath, "", "", snapstate.Flags{DevMode: true}, nil)
 	chg2.AddAll(ts2)
 	c.Assert(err, IsNil)
 
@@ -6171,7 +6171,7 @@ func (ms *mgrsSuite) TestRefreshSimpleSameRevFromLocalFile(c *C) {
 
 	// now refresh from rev1 to rev1
 	flags := snapstate.Flags{RemoveSnapPath: true}
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "some-snap", Revision: snap.R(revStr)}, tmpSnapFile, "", "", flags, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "some-snap", Revision: snap.R(revStr)}, tmpSnapFile, "", "", flags, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("refresh", "...")
@@ -6234,7 +6234,7 @@ func (ms *mgrsSuite) TestRefreshSimpleRevertToLocalFromLocalFile(c *C) {
 
 	// now refresh from rev2 to rev1
 	flags := snapstate.Flags{RemoveSnapPath: true}
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "some-snap", Revision: snap.R(revStr)}, tmpSnapFile, "", "", flags, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "some-snap", Revision: snap.R(revStr)}, tmpSnapFile, "", "", flags, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("refresh", "...")
@@ -10497,7 +10497,7 @@ type: kernel`
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -10730,7 +10730,7 @@ NeedDaemonReload=no
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -10975,7 +10975,7 @@ NeedDaemonReload=no
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -11153,7 +11153,7 @@ volumes:
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -11310,7 +11310,7 @@ func (s *mgrsSuite) testNonUC20RunUpdateManagedBootConfig(c *C, snapPath string,
 
 	// InstallPath does not set any restart boundaries by itself, this is something
 	// that must be handled where we use it, and actually schedule the change.
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -11534,7 +11534,7 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 	})
 	defer r()
 
-	ts, _, err := snapstate.InstallPath(st, gadgetSideInfo, gadgetPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, gadgetSideInfo, gadgetPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")
@@ -14655,7 +14655,7 @@ type: snapd`
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
-	ts, _, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(st, si, snapPath, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("install-snap", "...")

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -200,7 +200,7 @@ func checkChangeConflictExclusiveKinds(st *state.State, newExclusiveChangeKind, 
 				ChangeKind: "remove-recovery-system",
 				ChangeID:   chg.ID(),
 			}
-		case "revert-snap", "refresh-snap":
+		case "revert-snap", "refresh-snap", "install-snap":
 			downgrading, err := changeIsSnapdDowngrade(st, chg)
 			if err != nil {
 				return err

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -134,7 +134,7 @@ func changeHasPendingSeedRefresh(chg *state.Change) bool {
 func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
 	// try mode doesn't actually install the snap, should never trigger a
 	// seed-refresh
-	if opts.Flags.TryMode {
+	if opts.Flags.TryMode || opts.NoSeedRefresh {
 		return nil, nil, nil
 	}
 

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -132,6 +132,12 @@ func changeHasPendingSeedRefresh(chg *state.Change) bool {
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
 func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
+	// try mode doesn't actually install the snap, should never trigger a
+	// seed-refresh
+	if opts.Flags.TryMode {
+		return nil, nil, nil
+	}
+
 	enabled, err := seedRefreshEnabled(st)
 	if err != nil {
 		return nil, nil, err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2128,10 +2128,20 @@ func firstNonEmpty(strs ...string) string {
 	return ""
 }
 
-// resolveChannel conditionally resolves the channel for the given snap. If the
-// the revision is set and the channel is empty, then we assume that the caller
-// wants to install by revision and do not mutate the channel.
+// resolveChannel resolves the channel for the given snap.
 func (r *RevisionOptions) resolveChannel(instanceName string, fallback string, deviceCtx DeviceContext) error {
+	resolved, err := resolveChannel(instanceName, fallback, r.Channel, deviceCtx)
+	if err != nil {
+		return err
+	}
+	r.Channel = resolved
+	return nil
+}
+
+// resolveChannelForStore conditionally resolves the channel for the given snap.
+// If the the revision is set and the channel is empty, then we assume that the
+// caller wants to install by revision and does not mutate the channel.
+func (r *RevisionOptions) resolveChannelForStore(instanceName string, fallback string, deviceCtx DeviceContext) error {
 	// if the revision is set and the caller didn't provide a channel, then we
 	// shouldn't mess with the channel. this is because we don't want the caller
 	// to have to pick the right channel when refreshing/installing by revision.
@@ -2141,14 +2151,7 @@ func (r *RevisionOptions) resolveChannel(instanceName string, fallback string, d
 
 	// otherwise, we know that the channel is either empty, or it is specified
 	// along with the revision. in either case, we need to resolve the channel.
-
-	resolved, err := resolveChannel(instanceName, fallback, r.Channel, deviceCtx)
-	if err != nil {
-		return err
-	}
-	r.Channel = resolved
-
-	return nil
+	return r.resolveChannel(instanceName, fallback, deviceCtx)
 }
 
 // initializeValidationSets ensures that r.ValidationSets is initialized with a

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -665,11 +665,6 @@ type PrereqTracker interface {
 // contain just a name which results in a local revision and sideloading, or
 // full metadata in which case it the snap will appear as installed from the
 // store.
-//
-// Note that this function results in task construction that more closely
-// matches a refresh, rather than simple snap installation. This means that this
-// function can trigger a seed refresh. Pure installation should consider using
-// InstallPath with a PathInstallGoal.
 func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel string, flags Flags, prqt PrereqTracker) (*state.TaskSet, error) {
 	target := PathUpdateGoal(PathSnap{
 		InstanceName: instanceName,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -665,6 +665,9 @@ type PrereqTracker interface {
 // contain just a name which results in a local revision and sideloading, or
 // full metadata in which case it the snap will appear as installed from the
 // store.
+//
+// This function should also be used when updating an already installed snap
+// from a local file.
 func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel string, flags Flags, prqt PrereqTracker) (*state.TaskSet, error) {
 	target := PathUpdateGoal(PathSnap{
 		InstanceName: instanceName,
@@ -957,6 +960,9 @@ func validatedInfoFromPathAndSideInfo(instanceName string, path string, si *snap
 // The provided SideInfos can contain just a name which results in a
 // local revision and sideloading, or full metadata in which case
 // the snaps will appear as installed from the store.
+//
+// This function should also be used when updating an already installed snap
+// from a local file.
 func InstallPathMany(ctx context.Context, st *state.State, sideInfos []*snap.SideInfo, paths []string, userID int, flags *Flags) ([]*state.TaskSet, error) {
 	if len(paths) != len(sideInfos) {
 		return nil, fmt.Errorf("internal error: number of paths and side infos must match: %d != %d", len(paths), len(sideInfos))

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -659,31 +659,43 @@ type PrereqTracker interface {
 	MissingProviderContentTags(info *snap.Info, repo snap.InterfaceRepo) map[string][]string
 }
 
-// InstallPath returns a set of tasks for installing a snap from a file path
-// and the snap.Info for the given snap.
+// InstallPath returns a set of tasks for installing a snap from a file path.
 //
-// Note that the state must be locked by the caller.
-// The provided SideInfo can contain just a name which results in a
-// local revision and sideloading, or full metadata in which case it
-// the snap will appear as installed from the store.
-func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel string, flags Flags, prqt PrereqTracker) (*state.TaskSet, *snap.Info, error) {
-	target := PathInstallGoal(PathSnap{
+// The state must be locked by the caller. The provided SideInfo can
+// contain just a name which results in a local revision and sideloading, or
+// full metadata in which case it the snap will appear as installed from the
+// store.
+//
+// Note that this function results in task construction that more closely
+// matches a refresh, rather than simple snap installation. This means that this
+// function can trigger a seed refresh. Pure installation should consider using
+// InstallPath with a PathInstallGoal.
+func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel string, flags Flags, prqt PrereqTracker) (*state.TaskSet, error) {
+	target := PathUpdateGoal(PathSnap{
 		InstanceName: instanceName,
 		Path:         path,
 		SideInfo:     si,
-		RevOpts:      RevisionOptions{Channel: channel},
+		RevOpts: RevisionOptions{
+			Channel: channel,
+
+			// setting the revision here makes this single-snap path install an
+			// explicit revision update. InstallPathMany intentionally does not
+			// do this, so same-revision local snaps can be handled differently
+			// by the two API entrypoints
+			Revision: si.Revision,
+		},
 	})
+
+	// since this is implemented in terms of a refresh, we always need to
+	// disable re-refresh
+	flags.NoReRefresh = true
 
 	// TODO have caller pass a context
-	info, ts, err := InstallOne(context.Background(), st, target, Options{
+	return UpdateOne(context.Background(), st, target, nil, Options{
 		Flags:         flags,
 		PrereqTracker: prqt,
+		ExpectOneSnap: true,
 	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return ts, info, nil
 }
 
 // TryPath returns a set of tasks for trying a snap from a file path.
@@ -691,7 +703,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 func TryPath(st *state.State, name, path string, flags Flags) (*state.TaskSet, error) {
 	flags.TryMode = true
 
-	ts, _, err := InstallPath(st, &snap.SideInfo{RealName: name}, path, "", "", flags, nil)
+	ts, err := InstallPath(st, &snap.SideInfo{RealName: name}, path, "", "", flags, nil)
 	return ts, err
 }
 
@@ -1631,6 +1643,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 			ConflictOptions:     opts.ConflictOptions,
 			DeviceCtx:           opts.DeviceCtx,
 			NoRestartBoundaries: true,
+			SkipConfigure:       opts.Flags.SkipConfigure,
 		})
 		if err != nil {
 			if errors.Is(err, &timedBusySnapError{}) && sts.ts != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -749,41 +749,6 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 	return ts, nil
 }
 
-// InstallPathWithDeviceContext returns a set of tasks for installing a local snap.
-// Note that the state must be locked by the caller.
-//
-// The returned TaskSet will contain a LastBeforeLocalModificationsEdge
-// identifying the last task before the first task that introduces system
-// modifications.
-func InstallPathWithDeviceContext(st *state.State, si *snap.SideInfo, path, name string,
-	opts *RevisionOptions, userID int, flags Flags, prqt PrereqTracker,
-	deviceCtx DeviceContext, fromChange string) (*state.TaskSet, error) {
-	logger.Debugf("installing from local file with device context %s", name)
-
-	if opts == nil {
-		opts = &RevisionOptions{}
-	}
-
-	target := PathInstallGoal(PathSnap{
-		InstanceName: name,
-		Path:         path,
-		SideInfo:     si,
-		RevOpts:      *opts,
-	})
-
-	_, ts, err := InstallOne(context.Background(), st, target, Options{
-		Flags:           flags,
-		UserID:          userID,
-		ConflictOptions: ConflictOptions{FromChange: fromChange},
-		PrereqTracker:   prqt,
-		DeviceCtx:       deviceCtx,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ts, nil
-}
-
 // Download returns a set of tasks for downloading a snap and components into
 // the given directory. The snap.Info for the snap that is downloaded is also
 // returned. The tasks that are returned also download and validate the snap's

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -561,57 +561,6 @@ func (s *snapmgrTestSuite) TestInstallWithDeviceContext(c *C) {
 	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
-func (s *snapmgrTestSuite) TestInstallPathWithDeviceContext(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// unset the global store, it will need to come via the device context
-	snapstate.ReplaceStore(s.state, nil)
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		CtxStore:    s.fakeStore,
-		DeviceModel: &asserts.Model{},
-	}
-
-	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(7)}
-	mockSnap := makeTestSnap(c, `name: some-snap
-version: 1.0
-`)
-
-	prqt := new(testPrereqTracker)
-
-	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
-	ts, err := snapstate.InstallPathWithDeviceContext(s.state, si, mockSnap, "some-snap", opts, 0, snapstate.Flags{}, prqt, deviceCtx, "")
-	c.Assert(err, IsNil)
-
-	verifyInstallTasks(c, snap.TypeApp, localSnap|mockDelayedEffects, 0, ts)
-	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-
-	c.Assert(prqt.infos, HasLen, 1)
-	c.Check(prqt.infos[0].SnapName(), Equals, "some-snap")
-	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
-}
-
-func (s *snapmgrTestSuite) TestInstallPathWithDeviceContextBadFile(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// unset the global store, it will need to come via the device context
-	snapstate.ReplaceStore(s.state, nil)
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{CtxStore: s.fakeStore}
-
-	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(7)}
-	path := filepath.Join(c.MkDir(), "some-snap_7.snap")
-	err := os.WriteFile(path, []byte(""), 0644)
-	c.Assert(err, IsNil)
-
-	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
-	ts, err := snapstate.InstallPathWithDeviceContext(s.state, si, path, "some-snap", opts, 0, snapstate.Flags{}, nil, deviceCtx, "")
-	c.Assert(err, ErrorMatches, `cannot open snap file: cannot process snap or snapdir: cannot read ".*/some-snap_7.snap": EOF`)
-	c.Assert(ts, IsNil)
-}
-
 func (s *snapmgrTestSuite) TestInstallWithDeviceContextNoRemodelConflict(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1194,7 +1194,7 @@ func (s *snapmgrTestSuite) TestInstallStateConflict(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
 }
 
-func (s *snapmgrTestSuite) TestInstallPathTooEarly(c *C) {
+func (s *snapmgrTestSuite) TestSeedingGoalTooEarly(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1202,7 +1202,7 @@ func (s *snapmgrTestSuite) TestInstallPathTooEarly(c *C) {
 	defer r()
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
-	t := snapstate.PathInstallGoal(snapstate.PathSnap{
+	t := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:     mockSnap,
 		SideInfo: &snap.SideInfo{RealName: "some-snap"},
 	})
@@ -7431,23 +7431,23 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, opts testInstal
 	}
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathNoneRunThrough(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithNoComponentsRunThrough(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName: "test-snap",
 		snapType: snap.TypeApp,
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathOneRunThrough(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithOneComponentRunThrough(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:   "test-snap",
 		snapType:   snap.TypeApp,
 		components: []string{"standard-component"},
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathOneRunThroughUndo(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithOneComponentRunThroughUndo(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:   "test-snap",
 		snapType:   snap.TypeApp,
 		components: []string{"standard-component"},
@@ -7455,8 +7455,8 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathOneRunThroughUndo(c *C) 
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathUnassertedRunThrough(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithUnassertedComponentRunThrough(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:   "test-snap",
 		snapType:   snap.TypeApp,
 		components: []string{"standard-component"},
@@ -7464,16 +7464,16 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathUnassertedRunThrough(c *
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathRunThrough(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithComponentsRunThrough(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:   "some-kernel",
 		snapType:   snap.TypeKernel,
 		components: []string{"standard-component", "kernel-modules-component"},
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathRunThroughUndo(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithComponentsRunThroughUndo(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:   "some-kernel",
 		snapType:   snap.TypeKernel,
 		components: []string{"standard-component", "kernel-modules-component"},
@@ -7481,8 +7481,8 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathRunThroughUndo(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyRemovePaths(c *C) {
-	s.testInstallComponentsFromPathRunThrough(c, testInstallComponentsFromPathRunThroughOpts{
+func (s *snapmgrTestSuite) TestSeedingGoalWithComponentsRemovePaths(c *C) {
+	s.testSeedingGoalWithComponentsRunThrough(c, testSeedingGoalWithComponentsRunThroughOpts{
 		snapName:    "some-kernel",
 		snapType:    snap.TypeKernel,
 		components:  []string{"standard-component", "kernel-modules-component"},
@@ -7490,7 +7490,7 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyRemovePaths(c *C) {
 	})
 }
 
-type testInstallComponentsFromPathRunThroughOpts struct {
+type testSeedingGoalWithComponentsRunThroughOpts struct {
 	snapName    string
 	snapType    snap.Type
 	instanceKey string
@@ -7500,7 +7500,7 @@ type testInstallComponentsFromPathRunThroughOpts struct {
 	unasserted  bool
 }
 
-func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, opts testInstallComponentsFromPathRunThroughOpts) {
+func (s *snapmgrTestSuite) testSeedingGoalWithComponentsRunThrough(c *C, opts testSeedingGoalWithComponentsRunThroughOpts) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7616,7 +7616,7 @@ components:
 		si.Revision = snap.Revision{}
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		InstanceName: instanceName,
 		Path:         snapPath,
 		SideInfo:     si,
@@ -7856,7 +7856,7 @@ func findLastTaskInTasks(tasks []*state.Task, kind string) *state.Task {
 	return last
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathInvalidComponentFile(c *C) {
+func (s *snapmgrTestSuite) TestSeedingGoalWithComponentsInvalidComponentFile(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7896,7 +7896,7 @@ components:
 		Revision: snapRevision,
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,
@@ -7905,7 +7905,7 @@ components:
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
 }
 
-func (s *snapmgrTestSuite) TestInstallComponentsFromPathInvalidComponentName(c *C) {
+func (s *snapmgrTestSuite) TestSeedingGoalWithComponentsInvalidComponentName(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7940,7 +7940,7 @@ components:
 		Revision: snapRevision,
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -435,7 +435,7 @@ version: 1.0
 	defer restorePreseeding()
 
 	for _, skipConfig := range []bool{false, true} {
-		ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{SkipConfigure: skipConfig}, nil)
+		ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{SkipConfigure: skipConfig}, nil)
 		c.Assert(err, IsNil)
 
 		te, err := ts.Edge(snapstate.BeginEdge)
@@ -704,7 +704,7 @@ func (s *snapmgrTestSuite) TestInstallHookNotRunForInstalledSnap(c *C) {
 version: 1.0
 epoch: 1*
 `)
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	runHooks := tasksWithKind(ts, "run-hook")
@@ -1274,7 +1274,7 @@ func (s *snapmgrTestSuite) TestInstallPathConflict(c *C) {
 	s.state.NewChange("install", "...").AddAll(ts)
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
-	_, _, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `snap "some-snap" has "install" change in progress`)
 }
 
@@ -1283,7 +1283,7 @@ func (s *snapmgrTestSuite) TestInstallPathMissingName(c *C) {
 	defer s.state.Unlock()
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
-	_, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`internal error: snap name to install %q not provided`, mockSnap))
 }
 
@@ -1292,7 +1292,7 @@ func (s *snapmgrTestSuite) TestInstallPathSnapIDRevisionUnset(c *C) {
 	defer s.state.Unlock()
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
-	_, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "snapididid"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "snapididid"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`internal error: snap id set to install %q but revision is unset`, mockSnap))
 }
 
@@ -1304,7 +1304,7 @@ func (s *snapmgrTestSuite) TestInstallPathValidateFlags(c *C) {
 version: 1.0
 confinement: devmode
 `)
-	_, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `.* requires devmode or confinement override`)
 }
 
@@ -1320,7 +1320,7 @@ version: 1.0
 confinement: strict
 `)
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{Classic: true}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{Classic: true}, nil)
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("install", "install snap")
@@ -1358,7 +1358,7 @@ version: 1.0
 epoch: 1
 `)
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "edge", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("install", "install snap")
@@ -1416,7 +1416,7 @@ func (s *snapmgrTestSuite) TestInstallPathFailsEarlyOnEpochMismatch(c *C) {
 
 	// try to install epoch 42
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0\nepoch: 42\n")
-	_, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `cannot refresh "some-snap" to local snap with epoch 42, because it can't read the current epoch of 1\*`)
 }
 
@@ -2630,18 +2630,16 @@ func (s *snapmgrTestSuite) TestInstallFirstLocalRunThrough(c *C) {
 	mockSnap := makeTestSnap(c, `name: mock
 version: 1.0`)
 	chg := s.state.NewChange("install", "install a local snap")
-	ts, info, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, prqt)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, prqt)
 	c.Assert(err, IsNil)
 
 	c.Assert(prqt.infos, HasLen, 1)
-	c.Check(prqt.infos[0], DeepEquals, info)
 	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 
 	chg.AddAll(ts)
 
-	// ensure the returned info is correct
-	c.Check(info.SideInfo.RealName, Equals, "mock")
-	c.Check(info.Version, Equals, "1.0")
+	c.Check(prqt.infos[0].SideInfo.RealName, Equals, "mock")
+	c.Check(prqt.infos[0].Version, Equals, "1.0")
 
 	s.settle(c)
 
@@ -2757,7 +2755,7 @@ version: 1.0
 epoch: 1*
 `)
 	chg := s.state.NewChange("install", "install a local snap")
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2908,7 +2906,7 @@ version: 1.0
 epoch: 1*
 `)
 	chg := s.state.NewChange("install", "install a local snap")
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "mock"}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -3022,7 +3020,7 @@ version: 1.0`)
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
 	}
-	ts, _, err := snapstate.InstallPath(s.state, si, someSnap, "", "", snapstate.Flags{Required: true}, nil)
+	ts, err := snapstate.InstallPath(s.state, si, someSnap, "", "", snapstate.Flags{Required: true}, nil)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -3089,7 +3087,7 @@ func (s *snapmgrTestSuite) TestInstallPathSkipConfigure(c *C) {
 
 	snapPath := makeTestSnap(c, "name: some-snap\nversion: 1.0")
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{SkipConfigure: true}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{SkipConfigure: true}, nil)
 	c.Assert(err, IsNil)
 
 	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
@@ -3848,7 +3846,7 @@ layout:
  /usr:
   bind: $SNAP/usr
 `)
-	_, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `feature flag validation failed for snap "some-snap": experimental feature disabled - test it by setting 'experimental.layouts' to true`)
 
 	// When layouts are enabled we can install a local snap depending on the feature.
@@ -3856,7 +3854,7 @@ layout:
 	tr.Set("core", "experimental.layouts", true)
 	tr.Commit()
 
-	_, _, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
+	_, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -3887,7 +3885,7 @@ version: 1.0`)
 		Revision: snap.R(42),
 		Channel:  "some-channel",
 	}
-	_, _, err := snapstate.InstallPath(s.state, si, someSnap, "", "some-channel", snapstate.Flags{Required: true}, nil)
+	_, err := snapstate.InstallPath(s.state, si, someSnap, "", "some-channel", snapstate.Flags{Required: true}, nil)
 	c.Assert(err, ErrorMatches, `cannot switch from kernel track "18" as specified for the \(device\) model to "some-channel"`)
 }
 
@@ -3918,7 +3916,7 @@ version: 1.0`)
 		Revision: snap.R(42),
 		Channel:  "some-channel",
 	}
-	_, _, err := snapstate.InstallPath(s.state, si, someSnap, "", "some-channel", snapstate.Flags{Required: true}, nil)
+	_, err := snapstate.InstallPath(s.state, si, someSnap, "", "some-channel", snapstate.Flags{Required: true}, nil)
 	c.Assert(err, ErrorMatches, `cannot switch from gadget track "18" as specified for the \(device\) model to "some-channel"`)
 }
 
@@ -4174,7 +4172,7 @@ version: 1.0
 epoch: 1*
 `)
 	si := snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}
-	_, _, err = snapstate.InstallPath(s.state, &si, mockSnap, "some-snap_123_456", "", snapstate.Flags{}, nil)
+	_, err = snapstate.InstallPath(s.state, &si, mockSnap, "some-snap_123_456", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "123_456"`)
 }
 
@@ -4259,7 +4257,7 @@ func (s *snapmgrTestSuite) TestParallelInstallInstallPathExperimentalSwitch(c *C
 version: 1.0
 `)
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}
-	_, _, err := snapstate.InstallPath(s.state, si, mockSnap, "some-snap_foo", "", snapstate.Flags{}, nil)
+	_, err := snapstate.InstallPath(s.state, si, mockSnap, "some-snap_foo", "", snapstate.Flags{}, nil)
 	c.Assert(err, ErrorMatches, `feature flag validation failed for snap "some-snap_foo": experimental feature disabled - test it by setting 'experimental.parallel-instances' to true`)
 
 	// enable parallel instances
@@ -4267,7 +4265,7 @@ version: 1.0
 	tr.Set("core", "experimental.parallel-instances", true)
 	tr.Commit()
 
-	_, _, err = snapstate.InstallPath(s.state, si, mockSnap, "some-snap_foo", "", snapstate.Flags{}, nil)
+	_, err = snapstate.InstallPath(s.state, si, mockSnap, "some-snap_foo", "", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -4707,7 +4705,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 
 	snapPath := makeTestSnap(c, "name: some-snap\nversion: 1.0")
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}, snapPath, "", "edge", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	var m map[string]any
@@ -4745,7 +4743,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 
 	snapPath := makeTestSnap(c, "name: some-snap\nversion: 1.0")
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	var m map[string]any
@@ -4787,7 +4785,7 @@ version: 1.0
 `
 	snapPath := makeTestSnap(c, coreSnapYaml)
 
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "core", SnapID: "core-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "core", SnapID: "core-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
 	var m map[string]any
@@ -5715,7 +5713,7 @@ func (s *snapmgrTestSuite) TestCorrectNumRevisionsIfNoneAdded(c *C) {
 		func(si *snap.SideInfo) (*state.TaskSet, error) {
 			yaml := "name: some-snap\nversion: 1.0\nepoch: 1*"
 			path := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
-			ts, _, err := snapstate.InstallPath(s.state, si, path, "some-snap", "", snapstate.Flags{}, nil)
+			ts, err := snapstate.InstallPath(s.state, si, path, "some-snap", "", snapstate.Flags{}, nil)
 			return ts, err
 		}, func(si *snap.SideInfo) (*state.TaskSet, error) {
 			return snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: si.Revision}, s.user.ID, snapstate.Flags{})

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6955,16 +6955,20 @@ func (s *snapmgrTestSuite) TestConflictSeedRefresh(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	chg := s.state.NewChange("refresh-snap", "...")
-	chg.AddTask(s.state.NewTask("create-recovery-system", "..."))
-	chg.SetStatus(state.DoingStatus)
+	for _, kind := range []string{"refresh-snap", "revert-snap", "install-snap"} {
+		chg := s.state.NewChange(kind, "...")
+		chg.AddTask(s.state.NewTask("create-recovery-system", "..."))
+		chg.SetStatus(state.DoingStatus)
 
-	err := snapstate.CheckChangeConflictMany(s.state, []string{"a-snap"}, "")
-	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
-	c.Check(err, ErrorMatches, `seed refresh in progress, no other changes allowed until this is done`)
+		err := snapstate.CheckChangeConflictMany(s.state, []string{"a-snap"}, "")
+		c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{}, Commentf("change kind: %s", kind))
+		c.Check(err, ErrorMatches, `seed refresh in progress, no other changes allowed until this is done`, Commentf("change kind: %s", kind))
 
-	err = snapstate.CheckChangeConflictRunExclusively(s.state, "create-recovery-system")
-	c.Check(err, ErrorMatches, `seed refresh in progress, no other changes allowed until this is done`)
+		err = snapstate.CheckChangeConflictRunExclusively(s.state, "create-recovery-system")
+		c.Check(err, ErrorMatches, `seed refresh in progress, no other changes allowed until this is done`, Commentf("change kind: %s", kind))
+
+		chg.SetStatus(state.DoneStatus)
+	}
 }
 
 func (s *snapmgrTestSuite) TestConflictExclusive(c *C) {
@@ -11393,7 +11397,7 @@ version: 1.0
 
 	// For snaps that skip configure, we expect the end-edge to be set to either of
 	// cleanup task, or start snap services
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(8),
@@ -11433,7 +11437,7 @@ epoch: 1
 
 	// For snaps that skip configure, we expect the end-edge to be set to either of
 	// cleanup task, or start snap services
-	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "edge", snapstate.Flags{SkipConfigure: true}, nil)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "edge", snapstate.Flags{SkipConfigure: true}, nil)
 	c.Assert(err, IsNil)
 
 	var t *state.Task

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -21092,6 +21092,22 @@ func setupSeedRefreshRevertSnapOfType(c *C, st *state.State, spec seedRefreshSna
 	return oldSideInfo, newSideInfo
 }
 
+func makeSeedRefreshLocalSnapPath(c *C, spec seedRefreshSnap, rev snap.Revision) (*snap.SideInfo, string) {
+	sideInfo := &snap.SideInfo{RealName: spec.name, SnapID: spec.snapID, Revision: rev}
+
+	var snapYaml strings.Builder
+	fmt.Fprintf(&snapYaml, "name: %s\nversion: %s\nepoch: 1*\n", spec.name, rev)
+	if spec.snapType != "" {
+		fmt.Fprintf(&snapYaml, "type: %s\n", spec.snapType)
+	}
+	if spec.base != "" {
+		fmt.Fprintf(&snapYaml, "base: %s\n", spec.base)
+	}
+
+	path, _ := snaptest.MakeTestSnapInfoWithFiles(c, snapYaml.String(), nil, sideInfo)
+	return sideInfo, path
+}
+
 func (s *snapmgrTestSuite) testRevertSeedRefreshRunThrough(c *C, spec seedRefreshSnap, model map[string]any) {
 	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, model, []string{spec.name})
 	defer restore()
@@ -21295,6 +21311,159 @@ func (s *snapmgrTestSuite) TestRevertSeedRefreshNoopWhenSnapNotSelected(c *C) {
 	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1, ReplaceLatest: true}})
 	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
 	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathSeedRefreshRunThrough(c *C) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	}, []string{"kernel"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+	)
+
+	newSideInfo, path := makeSeedRefreshLocalSnapPath(c, seedRefreshSnap{
+		name:     "kernel",
+		snapID:   "kernel-id",
+		snapType: "kernel",
+	}, snap.R(11))
+
+	ts, err := snapstate.InstallPath(s.state, newSideInfo, path, "kernel", "", snapstate.Flags{}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
+
+	chg := s.state.NewChange("install", "install snap from path")
+	chg.AddAll(ts)
+	c.Assert(chg.CheckTaskDependencies(), IsNil)
+
+	setupTask, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	snapsup, err := snapstate.TaskSnapSetup(setupTask)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.InstanceName(), Equals, "kernel")
+	c.Check(snapsup.Revision(), Equals, newSideInfo.Revision)
+	c.Check(snapsup.SnapPath, Equals, path)
+
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
+		InstanceName:     "kernel",
+		SnapSetupTaskIDs: []string{setupTask.ID()},
+	}})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
+
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, ts)
+	lastBeforeLocal, err := ts.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
+
+	endTask, err := ts.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	c.Check(waitsOnTransitively(seedFinalize, endTask), Equals, true)
+
+	linkTask, err := ts.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	c.Check(hasDoRestartBoundary(seedCreate), Equals, true)
+	c.Check(hasDoRestartBoundary(linkTask), Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathSeedRefreshNoopWhenSnapNotSelected(c *C) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	}, nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+	)
+
+	newSideInfo, path := makeSeedRefreshLocalSnapPath(c, seedRefreshSnap{
+		name:     "kernel",
+		snapID:   "kernel-id",
+		snapType: "kernel",
+	}, snap.R(11))
+
+	ts, err := snapstate.InstallPath(s.state, newSideInfo, path, "kernel", "", snapstate.Flags{}, nil)
+	c.Assert(err, IsNil)
+
+	setupTask, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	c.Assert(observed.initial, HasLen, 1)
+	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{{
+		InstanceName:     "kernel",
+		SnapSetupTaskIDs: []string{setupTask.ID()},
+	}})
+	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
+	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
+	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathSeedRefreshBlockedByOtherChanges(c *C) {
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	}, []string{"kernel"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+	)
+
+	newSideInfo, path := makeSeedRefreshLocalSnapPath(c, seedRefreshSnap{
+		name:     "kernel",
+		snapID:   "kernel-id",
+		snapType: "kernel",
+	}, snap.R(11))
+
+	chg := s.state.NewChange("unrelated", "...")
+	chg.AddTask(s.state.NewTask("task", "..."))
+
+	_, err := snapstate.InstallPath(s.state, newSideInfo, path, "kernel", "", snapstate.Flags{}, nil)
+	c.Assert(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Check(err, ErrorMatches, `other changes in progress \(conflicting change "unrelated"\), change "seed refresh" not allowed until they are done`)
+}
+
+func (s *snapmgrTestSuite) TestTryPathSkipsSeedRefresh(c *C) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	}, []string{"some-app"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+	)
+
+	tryDir := c.MkDir()
+	c.Assert(os.Chmod(tryDir, 0755), IsNil)
+	snapYaml := filepath.Join(tryDir, "meta", "snap.yaml")
+	c.Assert(os.MkdirAll(filepath.Dir(snapYaml), 0755), IsNil)
+	c.Assert(os.WriteFile(snapYaml, []byte("name: some-app\nversion: 1.0\nbase: core18\n"), 0644), IsNil)
+
+	ts, err := snapstate.TryPath(s.state, "some-app", tryDir, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
+	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
+	c.Check(observed.initial, HasLen, 0)
+	c.Check(observed.evictions, HasLen, 0)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAdditionalComponents(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -21794,3 +21794,40 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshDisabled(c *C) {
 	c.Check(firstLocalModApp.WaitTasks(), Not(testutil.Contains), lastBeforeLocalBase)
 	c.Check(firstLocalModApp.WaitTasks(), Not(testutil.Contains), lastBeforeLocalKernel)
 }
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoSeedRefreshOption(c *C) {
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel": "kernel",
+		"base":   "core18",
+	}, []string{"kernel", "core18"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+	)
+
+	goal := snapstate.StoreUpdateGoal(
+		snapstate.StoreUpdate{InstanceName: "kernel"},
+		snapstate.StoreUpdate{InstanceName: "core18"},
+	)
+	_, uts, err := snapstate.UpdateWithGoal(context.Background(), s.state, goal, nil, snapstate.Options{
+		UserID:        s.user.ID,
+		NoSeedRefresh: true,
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Check(seedTS, IsNil)
+	c.Check(observed.initial, HasLen, 0)
+	c.Check(observed.prerequisites, HasLen, 0)
+}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14188,15 +14188,6 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextLocalRevisionMismatch(
 	c.Check(err, ErrorMatches, `cannot install local snap "some-snap": 7 != 8 \(revision mismatch\)`)
 }
 
-func (s *snapmgrTestSuite) TestInstallPathWithDeviceContextLocalRevisionMismatch(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(8)}
-	_, err := snapstate.InstallPathWithDeviceContext(s.state, si, "path", "some-snap", &snapstate.RevisionOptions{Revision: snap.R(7)}, s.user.ID, snapstate.Flags{}, nil, nil, "")
-	c.Check(err, ErrorMatches, `cannot install local snap "some-snap": 7 != 8 \(revision mismatch\)`)
-}
-
 func (s *snapmgrTestSuite) TestUpdateManyRevOptsOrder(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1637,8 +1637,12 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 		trackingChannel = snapst.TrackingChannel
 	}
 
+	// resolveChannel leaves an empty channel untouched for explicit revision
+	// updates, since store-backed by-revision refreshes should not require a
+	// channel. path installs still need to preserve the channel recorded in the
+	// snap state, so set that fallback before resolving.
 	if update.RevOpts.Channel == "" {
-		update.RevOpts.Channel = update.SideInfo.Channel
+		update.RevOpts.Channel = firstNonEmpty(update.SideInfo.Channel, trackingChannel)
 	}
 
 	if err := update.RevOpts.resolveChannel(update.InstanceName, trackingChannel, opts.DeviceCtx); err != nil {
@@ -1655,6 +1659,10 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 			SnapPath:  update.Path,
 			Channel:   update.RevOpts.Channel,
 			CohortKey: update.RevOpts.CohortKey,
+
+			// mirror store-backed by-revision refresh: an explicit revision should
+			// run the full update path even if the revision is already current.
+			AlwaysUpdate: !update.RevOpts.Revision.Unset(),
 		},
 		info:       info,
 		snapst:     snapst,

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -77,6 +77,8 @@ type Options struct {
 	// pre-existing behavior of calling InstallMany with one snap vs calling
 	// Install.
 	ExpectOneSnap bool
+	// NoSeedRefresh prevents creating seed-refresh tasks for this operation.
+	NoSeedRefresh bool
 }
 
 func (opts *Options) setDefaultLane(st *state.State) error {

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -69,6 +69,9 @@ type Options struct {
 	// Seed should be true while seeding the device. This indicates that we
 	// shouldn't require that the device is seeded before installing/updating
 	// snaps.
+	//
+	// TODO: we should figure out how to get rid of this flag since we have a
+	// seeding-specific goal
 	Seed bool
 	// ExpectOneSnap is a boolean flag indicating that this operation is expected
 	// to only operate on one snap (excluding any prerequisite snaps that may be
@@ -977,25 +980,27 @@ func setDefaultSnapstateOptions(st *state.State, opts *Options) error {
 	return nil
 }
 
-// pathInstallGoal represents a single snap to be installed from a path on disk.
-type pathInstallGoal struct {
+// seedingGoal represents a single snap to be installed from a path on disk
+// during seeding.
+type seedingGoal struct {
 	snap PathSnap
 }
 
-// PathInstallGoal creates a new InstallGoal to install a snap from a given from
-// a path on disk. If instanceName is not provided, si.RealName will be used.
-func PathInstallGoal(sn PathSnap) InstallGoal {
+// SeedingGoal creates a new InstallGoal to install a snap from a path on disk
+// during seeding. If InstanceName is not provided, SideInfo.RealName will be
+// used.
+func SeedingGoal(sn PathSnap) InstallGoal {
 	if sn.InstanceName == "" {
 		sn.InstanceName = sn.SideInfo.RealName
 	}
 
-	return &pathInstallGoal{
+	return &seedingGoal{
 		snap: sn,
 	}
 }
 
 // toInstall returns the data needed to setup the snap from disk.
-func (p *pathInstallGoal) toInstall(ctx context.Context, st *state.State, opts Options) ([]target, error) {
+func (p *seedingGoal) toInstall(ctx context.Context, st *state.State, opts Options) ([]target, error) {
 	var snapst SnapState
 	if err := Get(st, p.snap.InstanceName, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -786,7 +786,7 @@ func (s *storeInstallGoal) validateAndPrune(st *state.State, installedSnaps map[
 			sn.RevOpts.Channel = "stable"
 		}
 
-		if err := sn.RevOpts.resolveChannel(sn.InstanceName, "stable", opts.DeviceCtx); err != nil {
+		if err := sn.RevOpts.resolveChannelForStore(sn.InstanceName, "stable", opts.DeviceCtx); err != nil {
 			return err
 		}
 
@@ -1006,7 +1006,7 @@ func (p *seedingGoal) toInstall(ctx context.Context, st *state.State, opts Optio
 		return nil, err
 	}
 
-	t, err := targetForPathSnap(p.snap, snapst, opts)
+	t, err := targetFromPathSnap(p.snap, snapst, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1479,7 +1479,7 @@ func validateAndInitStoreUpdates(st *state.State, allSnaps map[string]*SnapState
 			fallback = "stable"
 		}
 
-		if err := sn.RevOpts.resolveChannel(sn.InstanceName, fallback, opts.DeviceCtx); err != nil {
+		if err := sn.RevOpts.resolveChannelForStore(sn.InstanceName, fallback, opts.DeviceCtx); err != nil {
 			return err
 		}
 
@@ -1585,7 +1585,7 @@ func (p *pathUpdateGoal) toUpdate(_ context.Context, st *state.State, opts Optio
 			return updatePlan{}, err
 		}
 
-		t, err := targetForPathSnap(sn, snapst, opts)
+		t, err := targetFromPathSnap(sn, snapst, opts)
 		if err != nil {
 			return updatePlan{}, err
 		}
@@ -1605,7 +1605,7 @@ func (*pathUpdateGoal) filterGatedSnaps(*state.State, *updatePlan, Options) erro
 	return nil
 }
 
-func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target, error) {
+func targetFromPathSnap(update PathSnap, snapst SnapState, opts Options) (target, error) {
 	si := update.SideInfo
 
 	if si.RealName == "" {
@@ -1644,12 +1644,8 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 		trackingChannel = snapst.TrackingChannel
 	}
 
-	// resolveChannel leaves an empty channel untouched for explicit revision
-	// updates, since store-backed by-revision refreshes should not require a
-	// channel. path installs still need to preserve the channel recorded in the
-	// snap state, so set that fallback before resolving.
 	if update.RevOpts.Channel == "" {
-		update.RevOpts.Channel = firstNonEmpty(update.SideInfo.Channel, trackingChannel)
+		update.RevOpts.Channel = update.SideInfo.Channel
 	}
 
 	if err := update.RevOpts.resolveChannel(update.InstanceName, trackingChannel, opts.DeviceCtx); err != nil {

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -1170,6 +1170,69 @@ version: 1.0
 	verifyUpdateTasksWithComponents(c, snap.TypeApp, doesReRefresh|localSnap|updatesGadgetAssets|mockDelayedEffects, 0, 0, []string{compName}, ts)
 }
 
+func (s *targetTestSuite) TestPathUpdateGoalExplicitRevisionAlwaysUpdates(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+	)
+
+	rev := snap.R(7)
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: snapName,
+			SnapID:   snapID,
+			Revision: rev,
+		}}),
+		Current:  rev,
+		SnapType: "app",
+	})
+
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: rev,
+	}
+	snapPath := makeTestSnap(c, `name: some-snap
+version: 1.0
+epoch: 1
+`)
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+	})
+
+	// without the revision set, the same-revision update is already satisfied.
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, Equals, store.ErrNoUpdateAvailable)
+
+	goal = snapstate.PathUpdateGoal(snapstate.PathSnap{
+		InstanceName: snapName,
+		Path:         snapPath,
+		SideInfo:     si,
+		RevOpts: snapstate.RevisionOptions{
+			Revision: rev,
+		},
+	})
+
+	// with the revision set, the same-revision update runs the full update path.
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	setupTask, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	snapsup, err := snapstate.TaskSnapSetup(setupTask)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.InstanceName(), Equals, snapName)
+	c.Check(snapsup.Revision(), Equals, rev)
+	c.Check(snapsup.SnapPath, Equals, snapPath)
+}
+
 func (s *targetTestSuite) TestUpdateComponentsFromPathInvalidComponentFile(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -1175,13 +1175,15 @@ func (s *targetTestSuite) TestPathUpdateGoalExplicitRevisionAlwaysUpdates(c *C) 
 	defer s.state.Unlock()
 
 	const (
-		snapName = "some-snap"
-		snapID   = "some-snap-id"
+		snapName       = "some-snap"
+		snapID         = "some-snap-id"
+		trackedChannel = "latest/edge"
 	)
 
 	rev := snap.R(7)
 	snapstate.Set(s.state, snapName, &snapstate.SnapState{
-		Active: true,
+		Active:          true,
+		TrackingChannel: trackedChannel,
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: snapName,
 			SnapID:   snapID,
@@ -1231,6 +1233,7 @@ epoch: 1
 	c.Check(snapsup.InstanceName(), Equals, snapName)
 	c.Check(snapsup.Revision(), Equals, rev)
 	c.Check(snapsup.SnapPath, Equals, snapPath)
+	c.Check(snapsup.Channel, Equals, trackedChannel)
 }
 
 func (s *targetTestSuite) TestUpdateComponentsFromPathInvalidComponentFile(c *C) {

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -232,7 +232,7 @@ func (s *targetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
 }
 
-func (s *targetTestSuite) TestInstallWithComponentsFromPath(c *C) {
+func (s *targetTestSuite) TestSeedingGoalWithComponents(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -273,7 +273,7 @@ version: 1.0
 		Path:     snaptest.MakeTestComponent(c, componentYaml),
 	}}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,
@@ -288,7 +288,7 @@ version: 1.0
 	verifyInstallTasksWithComponents(c, snap.TypeKernel, localSnap|updatesGadgetAssets|mockDelayedEffects, 0, []string{compName}, ts)
 }
 
-func (s *targetTestSuite) TestInstallWithComponentsMixedAssertedCompsAndUnassertedSnap(c *C) {
+func (s *targetTestSuite) TestSeedingGoalWithComponentsMixedAssertedCompsAndUnassertedSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -327,7 +327,7 @@ version: 1.0
 		Path:     snaptest.MakeTestComponent(c, componentYaml),
 	}}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,
@@ -337,7 +337,7 @@ version: 1.0
 	c.Assert(err, ErrorMatches, "cannot mix unasserted snap and asserted components")
 }
 
-func (s *targetTestSuite) TestInstallWithComponentsMixedUnassertedCompsAndAssertedSnap(c *C) {
+func (s *targetTestSuite) TestSeedingGoalWithComponentsMixedUnassertedCompsAndAssertedSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -378,7 +378,7 @@ version: 1.0
 		Path:     snaptest.MakeTestComponent(c, componentYaml),
 	}}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,
@@ -687,7 +687,7 @@ func (s *targetTestSuite) TestInvalidPathGoals(c *C) {
 		_, err := snapstate.UpdateOne(context.Background(), s.state, update, nil, snapstate.Options{})
 		c.Check(err, ErrorMatches, t.err)
 
-		install := snapstate.PathInstallGoal(snapstate.PathSnap{
+		install := snapstate.SeedingGoal(snapstate.PathSnap{
 			InstanceName: t.snap.InstanceName,
 			Path:         t.snap.Path,
 			SideInfo:     t.snap.SideInfo,
@@ -717,7 +717,7 @@ func (s *targetTestSuite) TestInstallFromStoreDefaultChannel(c *C) {
 	c.Check(snapsup.Channel, Equals, "stable")
 }
 
-func (s *targetTestSuite) TestInstallFromPathDefaultChannel(c *C) {
+func (s *targetTestSuite) TestSeedingGoalDefaultChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -733,7 +733,7 @@ components:
 		Revision: snap.R(1),
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		InstanceName: si.RealName,
 		Path:         snapPath,
 		SideInfo:     si,
@@ -750,7 +750,7 @@ components:
 	c.Check(snapsup.Channel, Equals, "")
 }
 
-func (s *targetTestSuite) TestInstallComponentsFromPathInvalidComponentFile(c *C) {
+func (s *targetTestSuite) TestSeedingGoalWithComponentsInvalidComponentFile(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -790,7 +790,7 @@ components:
 		Revision: snapRevision,
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:       snapPath,
 		SideInfo:   si,
 		Components: components,
@@ -799,7 +799,7 @@ components:
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
 }
 
-func (s *targetTestSuite) TestInstallFromPathSideInfoChannel(c *C) {
+func (s *targetTestSuite) TestSeedingGoalSideInfoChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -816,7 +816,7 @@ components:
 		Channel:  "edge",
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		InstanceName: si.RealName,
 		Path:         snapPath,
 		SideInfo:     si,
@@ -833,7 +833,7 @@ components:
 	c.Check(snapsup.Channel, Equals, "edge")
 }
 
-func (s *targetTestSuite) TestInstallFromPathRevOptsChannel(c *C) {
+func (s *targetTestSuite) TestSeedingGoalRevOptsChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -849,7 +849,7 @@ components:
 		Revision: snap.R(1),
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:     snapPath,
 		SideInfo: si,
 		RevOpts:  snapstate.RevisionOptions{Channel: "edge"},
@@ -869,7 +869,7 @@ components:
 	c.Check(snapsup.Channel, Equals, "edge")
 }
 
-func (s *targetTestSuite) TestInstallFromPathRevOptsSideInfoChannelMismatch(c *C) {
+func (s *targetTestSuite) TestSeedingGoalRevOptsSideInfoChannelMismatch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -886,7 +886,7 @@ components:
 		Channel:  "stable",
 	}
 
-	goal := snapstate.PathInstallGoal(snapstate.PathSnap{
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
 		Path:     snapPath,
 		SideInfo: si,
 		RevOpts:  snapstate.RevisionOptions{Channel: "edge"},

--- a/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
+++ b/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
@@ -2,8 +2,8 @@ summary: refresh seed when a model snap moves back to an existing revision
 
 details: |
   Verify that moving a model snap back to an existing revision triggers a
-  seed-refresh on Ubuntu Core. Covers snap refresh --revision and revert
-  for kernel, gadget, base, and app snaps.
+  seed-refresh on Ubuntu Core. Covers snap refresh --revision, snap install from
+  a local path, and revert for kernel, gadget, base, and app snaps.
 
 systems:
   - -ubuntu-1*
@@ -41,6 +41,9 @@ environment:
   SNAP_UNDER_TEST/refresh_app: app
   BACK_TO_REVISION_METHOD/revert_app: revert
   SNAP_UNDER_TEST/revert_app: app
+
+  BACK_TO_REVISION_METHOD/install_path_kernel: install-path
+  SNAP_UNDER_TEST/install_path_kernel: kernel
 
 skip:
   - reason: This test needs test keys to be trusted
@@ -199,6 +202,7 @@ execute: |
   run_seed_refresh_change() {
     local command="$1"
     local local_revision="${2:-}"
+    local source_kind="${3:-store-or-existing}"
     local change_id boot_id
 
     boot_id="$(tests.nested boot-id)"
@@ -209,8 +213,12 @@ execute: |
     remote.exec 'sudo snap changes' | MATCH "^${change_id}\\s+Done"
     remote.exec "sudo snap tasks ${change_id}" | MATCH 'Create recovery system with label'
     if [ -n "${local_revision}" ]; then
-      remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .*/${snap_name}_${local_revision}.snap"
       remote.exec "sudo snap tasks ${change_id}" | NOMATCH "Download snap \"${snap_name}\""
+      if [ "${source_kind}" = install-path ]; then
+        remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .+ \(${local_revision}\)"
+      else
+        remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .*/${snap_name}_${local_revision}.snap"
+      fi
     fi
   }
 
@@ -271,6 +279,11 @@ execute: |
     refresh)
       assert_snap_revision_in_sequence "${snap_name}" 2
       run_seed_refresh_change "sudo snap refresh --revision=2 --no-wait ${snap_name}" 2
+      ;;
+    install-path)
+      assert_snap_revision_in_sequence "${snap_name}" 2
+      remote.push "./${snap_name}-rev2.snap"
+      run_seed_refresh_change "sudo snap install --no-wait ./${snap_name}-rev2.snap" 2 install-path
       ;;
     *)
       echo "unexpected BACK_TO_REVISION_METHOD: ${BACK_TO_REVISION_METHOD}"


### PR DESCRIPTION
This lets us use the existing seed-refresh implementation for free during single-path installation. Tests are added for this behavior.
