### PR TITLE
seclog: add seclog API for administrative actions (part 5.1)

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -88,7 +88,7 @@ var isEmailish = regexp.MustCompile(`.@.*\..`).MatchString
 // unchanged. It is a convenience wrapper so that each error return path in
 // loginUser can log with a single call.
 func apiLoginError(resp *apiError, snapdUser seclog.SnapdUser) *apiError {
-	seclog.LogLoginFailure(snapdUser, resp.reason())
+	seclog.LogLoginFailure(snapdUser, resp.seclogReason())
 	return resp
 }
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -84,14 +84,11 @@ type userResponseData struct {
 
 var isEmailish = regexp.MustCompile(`.@.*\..`).MatchString
 
-// apiLoginError logs a login failure to the security audit log and returns resp
+// apiLoginError logs a login failure via [seclog.LogLoginFailure] and returns resp
 // unchanged. It is a convenience wrapper so that each error return path in
 // loginUser can log with a single call.
-func apiLoginError(resp *apiError, snapdUser seclog.SnapdUser, code string) *apiError {
-	seclog.LogLoginFailure(snapdUser, seclog.Reason{
-		Code:    code,
-		Message: resp.Message,
-	})
+func apiLoginError(resp *apiError, snapdUser seclog.SnapdUser) *apiError {
+	seclog.LogLoginFailure(snapdUser, resp.reason())
 	return resp
 }
 
@@ -105,8 +102,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&loginData); err != nil {
-		return apiLoginError(BadRequest("cannot decode login data from request body: %v", err),
-			seclog.SnapdUser{}, seclog.ReasonInvalidAuthData)
+		return apiLoginError(BadRequest("cannot decode login data from request body: %v", err), seclog.SnapdUser{})
 	}
 
 	if loginData.Email == "" && isEmailish(loginData.Username) {
@@ -129,7 +125,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		}, seclog.SnapdUser{
 			StoreUserName:  loginData.Username,
 			StoreUserEmail: loginData.Email,
-		}, seclog.ReasonInvalidAuthData)
+		})
 	}
 
 	// Build the user identity for security audit logging. At this point we know
@@ -150,13 +146,13 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorRequired,
-		}, snapdUser, seclog.ReasonTwoFactorRequired)
+		}, snapdUser)
 	case store.Err2faFailed:
 		return apiLoginError(&apiError{
 			Status:  401,
 			Message: err.Error(),
 			Kind:    client.ErrorKindTwoFactorFailed,
-		}, snapdUser, seclog.ReasonTwoFactorFailed)
+		}, snapdUser)
 	default:
 		switch err := err.(type) {
 		case store.InvalidAuthDataError:
@@ -165,20 +161,16 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 				Message: err.Error(),
 				Kind:    client.ErrorKindInvalidAuthData,
 				Value:   err,
-			}, snapdUser, seclog.ReasonInvalidAuthData)
+			}, snapdUser)
 		case store.PasswordPolicyError:
 			return apiLoginError(&apiError{
 				Status:  401,
 				Message: err.Error(),
 				Kind:    client.ErrorKindPasswordPolicy,
 				Value:   err,
-			}, snapdUser, seclog.ReasonPasswordPolicy)
+			}, snapdUser)
 		}
-		reason := seclog.ReasonInternal
-		if err == store.ErrInvalidCredentials {
-			reason = seclog.ReasonInvalidCredentials
-		}
-		return apiLoginError(Unauthorized(err.Error()), snapdUser, reason)
+		return apiLoginError(Unauthorized(err.Error()), snapdUser)
 	case nil:
 		// continue
 	}
@@ -200,7 +192,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	st.Unlock()
 	if err != nil {
-		return apiLoginError(InternalError("cannot persist authentication details: %v", err), snapdUser, seclog.ReasonInternal)
+		return apiLoginError(InternalError("cannot persist authentication details: %v", err), snapdUser)
 	}
 
 	snapdUser.ID = int64(user.ID)

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -409,7 +409,6 @@ func (s *userSuite) TestLoginUserBadRequest(c *check.C) {
 	c.Check(rspe.Message, check.Not(check.Equals), "")
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
 }
 
 func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
@@ -425,7 +424,7 @@ func (s *userSuite) TestLoginUserNotEmailish(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "notemail")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindInvalidAuthData))
 }
 
 func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
@@ -442,7 +441,7 @@ func (s *userSuite) TestLoginUserDeveloperAPIError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInternal)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindLoginRequired))
 }
 
 func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
@@ -459,7 +458,7 @@ func (s *userSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonTwoFactorRequired)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindTwoFactorRequired))
 }
 
 func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
@@ -476,7 +475,7 @@ func (s *userSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonTwoFactorFailed)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindTwoFactorFailed))
 }
 
 func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
@@ -493,7 +492,7 @@ func (s *userSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidCredentials)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindLoginRequired))
 }
 
 func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
@@ -511,7 +510,7 @@ func (s *userSuite) TestLoginUserInvalidAuthDataError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInvalidAuthData)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindInvalidAuthData))
 }
 
 func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
@@ -529,7 +528,7 @@ func (s *userSuite) TestLoginUserPasswordPolicyError(c *check.C) {
 
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonPasswordPolicy)
+	c.Check(s.seclogBuf.String(), testutil.Contains, string(client.ErrorKindPasswordPolicy))
 }
 
 func (s *userSuite) TestLoginUserPersistError(c *check.C) {
@@ -551,7 +550,7 @@ func (s *userSuite) TestLoginUserPersistError(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "email@.com")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "username")
-	c.Check(s.seclogBuf.String(), testutil.Contains, seclog.ReasonInternal)
+	c.Check(s.seclogBuf.String(), testutil.Contains, "cannot persist authentication details")
 }
 
 func (s *userSuite) TestPostCreateUser(c *check.C) {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -47,8 +47,8 @@ type apiError struct {
 	Value errorValue
 }
 
-// reason returns a [seclog.Reason] derived from the API error fields.
-func (ae *apiError) reason() seclog.Reason {
+// seclogReason returns a [seclog.Reason] derived from the API error fields.
+func (ae *apiError) seclogReason() seclog.Reason {
 	return seclog.Reason{
 		Code:    ae.Status,
 		Kind:    string(ae.Kind),

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
@@ -44,6 +45,15 @@ type apiError struct {
 	// Kind is the error kind. See client/errors.go
 	Kind  client.ErrorKind
 	Value errorValue
+}
+
+// reason returns a [seclog.Reason] derived from the API error fields.
+func (ae *apiError) reason() seclog.Reason {
+	return seclog.Reason{
+		Code:    ae.Status,
+		Kind:    string(ae.Kind),
+		Message: ae.Message,
+	}
 }
 
 func (ae *apiError) Error() string {

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -79,28 +79,28 @@ type UserState struct {
 func (u *UserState) changedFields(other *UserState) []string {
 	var changed []string
 	if u.ID != other.ID {
-		changed = append(changed, "snapd-user-id")
+		changed = append(changed, "snapd_user_id")
 	}
 	if u.Username != other.Username {
-		changed = append(changed, "store-user-name")
+		changed = append(changed, "store_user_name")
 	}
 	if u.Email != other.Email {
-		changed = append(changed, "store-user-email")
+		changed = append(changed, "store_user_email")
 	}
 	if !u.Expiration.UTC().Equal(other.Expiration.UTC()) {
 		changed = append(changed, "expiration")
 	}
 	if u.Macaroon != other.Macaroon {
-		changed = append(changed, "local-macaroon")
+		changed = append(changed, "local_macaroon")
 	}
 	if !stringMultisetsEqual(u.Discharges, other.Discharges) {
-		changed = append(changed, "local-discharges")
+		changed = append(changed, "local_discharges")
 	}
 	if u.StoreMacaroon != other.StoreMacaroon {
-		changed = append(changed, "store-macaroon")
+		changed = append(changed, "store_macaroon")
 	}
 	if !stringMultisetsEqual(u.StoreDischarges, other.StoreDischarges) {
-		changed = append(changed, "store-discharges")
+		changed = append(changed, "store_discharges")
 	}
 	sort.Strings(changed)
 	return changed

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -610,10 +610,10 @@ func (as *authSuite) TestChangedFieldsFieldMapping(c *C) {
 	}
 	c.Check(prev.ChangedFields(cur), DeepEquals, []string{
 		"expiration",
-		"local-discharges", "local-macaroon",
-		"snapd-user-id",
-		"store-discharges", "store-macaroon",
-		"store-user-email", "store-user-name",
+		"local_discharges", "local_macaroon",
+		"snapd_user_id",
+		"store_discharges", "store_macaroon",
+		"store_user_email", "store_user_name",
 	})
 }
 
@@ -650,7 +650,7 @@ func (as *authSuite) TestChangedFieldsSingleField(c *C) {
 		ID: 1, Email: "new@test.com",
 		StoreMacaroon: "sm1",
 	}
-	c.Check(a.ChangedFields(b), DeepEquals, []string{"store-user-email"})
+	c.Check(a.ChangedFields(b), DeepEquals, []string{"store_user_email"})
 }
 
 func (as *authSuite) TestChangedFieldsExpirationLocationIndependent(c *C) {
@@ -710,8 +710,8 @@ func (as *authSuite) TestUpdateUserLogsUpdated(c *C) {
 	c.Check(as.seclogBuf.String(), testutil.Contains, "user_updated")
 	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe")
 	c.Check(as.seclogBuf.String(), testutil.Contains, "new@test.com")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "store-user-email")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "store-macaroon")
+	c.Check(as.seclogBuf.String(), testutil.Contains, "store_user_email")
+	c.Check(as.seclogBuf.String(), testutil.Contains, "store_macaroon")
 }
 
 func (as *authSuite) TestUpdateUserNoChangeSkipsLog(c *C) {

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -19,7 +19,7 @@
 
 // This file contains the Go types that represent the data carried by security
 // audit events, across all event categories. It is intentionally separate
-// from seclog.go, which owns the emission machinery (SecurityLogger, Setup,
+// from seclog.go, which owns the emission machinery ([SecurityLogger], [Setup],
 // LogEvent wrappers).
 //
 // Design goals:
@@ -30,7 +30,7 @@
 //  2. No imports from other snapd packages: seclog is imported by
 //     packages such as overlord/auth, so it cannot import them back.
 //     Types here must be self-contained. The translation from an
-//     internal type (e.g. auth.UserState) to an audit event type is
+//     internal type (e.g. [auth.UserState]) to an audit event type is
 //     the responsibility of the caller.
 //
 // When adding a new event category, define its types here.
@@ -45,30 +45,24 @@ import (
 // unknown is the placeholder for empty fields in descriptions.
 const unknown = "<unknown>"
 
-// Reason codes are stable identifiers for security audit events.
-const (
-	ReasonInvalidCredentials = "invalid-credentials"
-	ReasonTwoFactorRequired  = "two-factor-required"
-	ReasonTwoFactorFailed    = "two-factor-failed"
-	ReasonInvalidAuthData    = "invalid-auth-data"
-	ReasonPasswordPolicy     = "password-policy"
-	ReasonInternal           = "internal"
-)
+// none indicates an endpoint has no action (e.g. non-POST requests).
+const none = "<none>"
 
 // Reason describes why a security event happened. The JSON tags match
 // the security audit specification field names.
 type Reason struct {
-	Code    string `json:"code"`
+	Code    int    `json:"code"`
+	Kind    string `json:"kind"`
 	Message string `json:"message"`
 }
 
 // String returns a colon-separated representation in the form
-// "<Code>:<Message>". Fields that are unset use "<unknown>" as a
+// "<Code>:<Message>". Fields that are unset use [unknown] as a
 // placeholder.
 func (r Reason) String() string {
 	code := unknown
-	if r.Code != "" {
-		code = r.Code
+	if r.Code != 0 {
+		code = fmt.Sprintf("%d", r.Code)
 	}
 
 	message := unknown
@@ -81,15 +75,129 @@ func (r Reason) String() string {
 
 // SnapdUser represents the identity of a user for security log events.
 type SnapdUser struct {
-	ID             int64     `json:"snapd-user-id"`
-	StoreUserName  string    `json:"store-user-name"`
-	StoreUserEmail string    `json:"store-user-email"`
+	ID             int64     `json:"snapd_user_id"`
+	StoreUserName  string    `json:"store_user_name"`
+	StoreUserEmail string    `json:"store_user_email"`
 	Expiration     time.Time `json:"expiration"`
+}
+
+// Peer describes the Unix-domain peer of an API request (Socket, UID, PID).
+//
+// Callers may signal "unknown" by setting UID to [peerNobody] and/or PID to
+// [peerNoProcess]. These mirror the daemon ucrednetNobody and ucrednetNoProcess
+// sentinels (see daemon/ucrednet.go).
+type Peer struct {
+	Socket string `json:"socket"`
+	UID    uint32 `json:"uid"`
+	PID    int32  `json:"pid"`
+}
+
+// [peerNobody] and [peerNoProcess] mirror the daemon ucrednetNobody and
+// ucrednetNoProcess sentinels. They are duplicated here to keep seclog
+// free of snapd package imports.
+const (
+	peerNobody    = ^uint32(0)
+	peerNoProcess = int32(0)
+)
+
+// String returns a colon-separated representation in the form
+// "<Socket>:<UID>:<PID>". Fields that are unset, or set to a documented
+// "unknown" sentinel ([peerNobody], [peerNoProcess]), use [unknown] as a
+// placeholder.
+func (p Peer) String() string {
+	socket := unknown
+	if p.Socket != "" {
+		socket = p.Socket
+	}
+
+	uid := unknown
+	// 0 is a valid UID (root); only [peerNobody] is unknown.
+	if p.UID != peerNobody {
+		uid = fmt.Sprintf("%d", p.UID)
+	}
+
+	pid := unknown
+	if p.PID != peerNoProcess {
+		pid = fmt.Sprintf("%d", p.PID)
+	}
+
+	return socket + ":" + uid + ":" + pid
+}
+
+// Endpoint describes an API endpoint involved in an authorization event.
+type Endpoint struct {
+	Method        string `json:"method"`
+	Path          string `json:"path"`
+	Action        string `json:"action"`
+	AccessChecker string `json:"access_checker"`
+	AccessLevel   string `json:"access_level"`
+}
+
+// String returns a colon-separated representation in the form
+// "<Method>:<Path>:<Action>". Unset method and path use [unknown]; an empty
+// action is rendered as "<none>".
+func (e Endpoint) String() string {
+	method := unknown
+	if e.Method != "" {
+		method = e.Method
+	}
+
+	path := unknown
+	if e.Path != "" {
+		path = e.Path
+	}
+
+	action := none
+	if e.Action != "" {
+		action = e.Action
+	}
+
+	return method + ":" + path + ":" + action
+}
+
+// AuthzCheck represents the outcome of a single authorization check.
+type AuthzCheck string
+
+// AuthzCheck outcome values for a single authorization stage.
+// The default for a new [AuthzChecks] is [AuthzNotApplicable].
+const (
+	AuthzNotApplicable AuthzCheck = "not-applicable" // stage not used for this request
+	AuthzNotReached    AuthzCheck = "not-reached"    // applicable but not evaluated yet
+	AuthzFail          AuthzCheck = "fail"
+	AuthzPass          AuthzCheck = "pass"
+)
+
+// AuthzChecks captures the outcome of each authorization stage evaluated
+// during an access check. Each field records whether that stage passed,
+// failed, or was not applicable to the request.
+type AuthzChecks struct {
+	AccessOptions AuthzCheck `json:"access_options"`
+	PeerCreds     AuthzCheck `json:"peer_credentials"`
+	Socket        AuthzCheck `json:"socket"`
+	Interface     AuthzCheck `json:"interface_requirements"`
+	OpenAccess    AuthzCheck `json:"open_access"`
+	UserAuth      AuthzCheck `json:"user_authentication"`
+	Root          AuthzCheck `json:"root"`
+	Polkit        AuthzCheck `json:"polkit"`
+}
+
+// NewAuthzChecks returns an [AuthzChecks] with all fields set to [AuthzNotApplicable].
+func NewAuthzChecks() AuthzChecks {
+	return AuthzChecks{
+		AccessOptions: AuthzNotApplicable,
+		PeerCreds:     AuthzNotApplicable,
+		Socket:        AuthzNotApplicable,
+		Interface:     AuthzNotApplicable,
+		OpenAccess:    AuthzNotApplicable,
+		UserAuth:      AuthzNotApplicable,
+		Root:          AuthzNotApplicable,
+		Polkit:        AuthzNotApplicable,
+	}
 }
 
 // String returns a colon-separated description of the user in the form
 // "<ID>:<StoreUserEmail>:<StoreUserName>". Fields that are unset use
-// "<unknown>" as a placeholder; a zero ID is considered unset.
+// [unknown] as a placeholder; a zero ID is considered unset.
 func (u SnapdUser) String() string {
 	id := unknown
 	if u.ID != 0 {

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -51,8 +51,14 @@ const none = "<none>"
 // Reason describes why a security event happened. The JSON tags match
 // the security audit specification field names.
 type Reason struct {
-	Code    int    `json:"code"`
-	Kind    string `json:"kind"`
+	// Code is a numeric error code defined by its originating domain:
+	// an HTTP response code (e.g. 401, 500), a standard-library code,
+	// or a custom code. Zero means unset.
+	Code int `json:"code"`
+	// Kind is an existing error-kind identifier from that domain (e.g.
+	// "invalid-credentials"), for programmatic matching, not display.
+	Kind string `json:"kind"`
+	// Message is the human-readable explanation, suitable for logs.
 	Message string `json:"message"`
 }
 

--- a/seclog/eventdata_test.go
+++ b/seclog/eventdata_test.go
@@ -26,16 +26,16 @@ import (
 )
 
 func (s *SecLogSuite) TestReasonString(c *C) {
-	// Both fields set.
+	// Code and message set.
 	c.Check(seclog.Reason{
-		Code: seclog.ReasonInvalidCredentials, Message: "bad password",
-	}.String(), Equals, "invalid-credentials:bad password")
+		Code: 401, Kind: "invalid-credentials", Message: "bad password",
+	}.String(), Equals, "401:bad password")
 
-	// Both fields empty — all "<unknown>".
+	// All fields empty — all "<unknown>".
 	c.Check(seclog.Reason{}.String(), Equals, "<unknown>:<unknown>")
 
 	// Only code set.
-	c.Check(seclog.Reason{Code: seclog.ReasonInternal}.String(), Equals, "internal:<unknown>")
+	c.Check(seclog.Reason{Code: 500, Kind: "internal"}.String(), Equals, "500:<unknown>")
 
 	// Only message set.
 	c.Check(seclog.Reason{Message: "something broke"}.String(), Equals, "<unknown>:something broke")
@@ -58,4 +58,42 @@ func (s *SecLogSuite) TestSnapdUserString(c *C) {
 
 	// Only username set.
 	c.Check(seclog.SnapdUser{StoreUserName: "root"}.String(), Equals, "<unknown>:<unknown>:root")
+}
+
+func (s *SecLogSuite) TestEndpointString(c *C) {
+	c.Check(seclog.Endpoint{
+		Method: "POST", Path: "/v2/snaps", Action: "install",
+	}.String(), Equals, "POST:/v2/snaps:install")
+
+	c.Check(seclog.Endpoint{Method: "DELETE", Path: "/v2/snaps/core"}.String(),
+		Equals, "DELETE:/v2/snaps/core:<none>")
+
+	c.Check(seclog.Endpoint{}.String(), Equals, "<unknown>:<unknown>:<none>")
+
+	c.Check(seclog.Endpoint{Method: "GET"}.String(), Equals, "GET:<unknown>:<none>")
+}
+
+func (s *SecLogSuite) TestPeerString(c *C) {
+	c.Check(seclog.Peer{
+		Socket: "/run/snapd.socket", UID: 0, PID: 4242,
+	}.String(), Equals, "/run/snapd.socket:0:4242")
+
+	// Zero UID is root; only the nobody sentinel is unknown.
+	c.Check(seclog.Peer{}.String(), Equals, "<unknown>:0:<unknown>")
+
+	c.Check(seclog.Peer{Socket: "/run/snapd.socket"}.String(), Equals, "/run/snapd.socket:0:<unknown>")
+
+	c.Check(seclog.Peer{UID: ^uint32(0)}.String(), Equals, "<unknown>:<unknown>:<unknown>")
+}
+
+func (s *SecLogSuite) TestNewAuthzChecks(c *C) {
+	checks := seclog.NewAuthzChecks()
+	c.Check(checks.AccessOptions, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.PeerCreds, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.Socket, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.Interface, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.OpenAccess, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.UserAuth, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.Root, Equals, seclog.AuthzNotApplicable)
+	c.Check(checks.Polkit, Equals, seclog.AuthzNotApplicable)
 }

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -189,3 +189,40 @@ func LogUserRemoved(user SnapdUser) {
 		Attr{Key: "user", Value: user},
 	)
 }
+
+// LogAdminActivity logs an administrative API access event using the
+// global security logger. It is emitted when authorization succeeds (the
+// access gate passed), not when the API operation or handler succeeds.
+func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "AUTHZ", Name: "authz_admin", Level: LevelInfo},
+		fmt.Sprintf("User %s from %s accessed %s", user.String(), peer.String(), endpoint.String()),
+		Attr{Key: "user", Value: user},
+		Attr{Key: "peer", Value: peer},
+		Attr{Key: "endpoint", Value: endpoint},
+		Attr{Key: "authz_checks", Value: checks},
+	)
+}
+
+// LogUnauthorizedAccess logs an unauthorized access attempt using the
+// global security logger. It is emitted when authorization fails (the
+// access gate denied the request), not when the API operation or handler
+// fails after access was granted.
+func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks, reason Reason) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "AUTHZ", Name: "authz_fail", Level: LevelCritical},
+		fmt.Sprintf("User %s from %s attempted to access %s without authorization: %s",
+			user.String(), peer.String(), endpoint.String(), reason.String()),
+		Attr{Key: "user", Value: user},
+		Attr{Key: "peer", Value: peer},
+		Attr{Key: "endpoint", Value: endpoint},
+		Attr{Key: "authz_checks", Value: checks},
+		Attr{Key: "error", Value: reason},
+	)
+}

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -122,11 +122,11 @@ func (s *SecLogSuite) TestLogLoginFailure(c *C) {
 		StoreUserEmail: "user@example.com",
 		StoreUserName:  "jdoe",
 	}
-	seclog.LogLoginFailure(user, seclog.Reason{Code: seclog.ReasonInvalidCredentials, Message: "invalid credentials"})
+	seclog.LogLoginFailure(user, seclog.Reason{Code: 401, Kind: "invalid-credentials", Message: "invalid credentials"})
 
 	c.Check(s.buf.String(), testutil.Contains, "authn_login_failure")
 	c.Check(s.buf.String(), testutil.Contains, "user@example.com")
-	c.Check(s.buf.String(), testutil.Contains, seclog.ReasonInvalidCredentials)
+	c.Check(s.buf.String(), testutil.Contains, "invalid-credentials")
 }
 
 func (s *SecLogSuite) TestLogLoggerEnabledLogsEvent(c *C) {
@@ -217,4 +217,52 @@ func (s *SecLogSuite) TestLogUserRemoved(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "user_removed")
 	c.Check(s.buf.String(), testutil.Contains, "jdoe")
 	c.Check(s.buf.String(), testutil.Contains, "jdoe@test.com")
+}
+
+// TestLogAdminActivity verifies that LogAdminActivity emits the expected event and attributes.
+func (s *SecLogSuite) TestLogAdminActivity(c *C) {
+	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}
+	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 0, PID: 4242}
+	endpoint := seclog.Endpoint{
+		Method:        "POST",
+		Path:          "/v2/snaps",
+		Action:        "install",
+		AccessChecker: "authenticated",
+		AccessLevel:   "authenticated",
+	}
+	checks := seclog.NewAuthzChecks()
+
+	seclog.LogAdminActivity(user, peer, endpoint, checks)
+
+	c.Check(s.buf.String(), testutil.Contains, "authz_admin")
+	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
+	c.Check(s.buf.String(), testutil.Contains, "accessed POST:/v2/snaps:install")
+	c.Check(s.buf.String(), testutil.Contains, "admin@example.com")
+	c.Check(s.buf.String(), testutil.Contains, "/run/snapd.socket")
+	c.Check(s.buf.String(), testutil.Contains, "4242")
+	c.Check(s.buf.String(), testutil.Contains, "[peer=")
+	c.Check(s.buf.String(), testutil.Contains, "[endpoint=")
+	c.Check(s.buf.String(), testutil.Contains, "[authz_checks=")
+	c.Check(s.buf.String(), testutil.Contains, "[user=")
+}
+
+// TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event, peer, and reason.
+func (s *SecLogSuite) TestLogUnauthorizedAccess(c *C) {
+	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "hacker@example.com", StoreUserName: "hacker"}
+	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 1000, PID: 12345}
+	endpoint := seclog.Endpoint{Method: "DELETE", Path: "/v2/snaps/core"}
+	checks := seclog.NewAuthzChecks()
+	reason := seclog.Reason{Code: 401, Kind: "invalid-credentials", Message: "no permission"}
+
+	seclog.LogUnauthorizedAccess(user, peer, endpoint, checks, reason)
+
+	c.Check(s.buf.String(), testutil.Contains, "authz_fail")
+	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
+	c.Check(s.buf.String(), testutil.Contains, "without authorization:")
+	c.Check(s.buf.String(), testutil.Contains, "without authorization: 401:no permission")
+	c.Check(s.buf.String(), testutil.Contains, "hacker@example.com")
+	c.Check(s.buf.String(), testutil.Contains, "DELETE:/v2/snaps/core:<none>")
+	c.Check(s.buf.String(), testutil.Contains, "12345")
+	c.Check(s.buf.String(), testutil.Contains, "[error=")
+	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -163,16 +163,17 @@ func (h *errorAwareHandler) WithGroup(name string) slog.Handler {
 	return &errorAwareHandler{inner: h.inner.WithGroup(name)}
 }
 
-// LogValue implements [slog.LogValuer], allowing Reason to be
+// LogValue implements [slog.LogValuer], allowing [Reason] to be
 // used directly as a structured log attribute value.
 func (r Reason) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("code", r.Code),
+		slog.Int("code", r.Code),
+		slog.String("kind", r.Kind),
 		slog.String("message", r.Message),
 	)
 }
 
-// LogValue implements [slog.LogValuer], allowing SnapdUser to be
+// LogValue implements [slog.LogValuer], allowing [SnapdUser] to be
 // used directly as a structured log attribute value.
 func (u SnapdUser) LogValue() slog.Value {
 	expiration := "never"
@@ -180,9 +181,46 @@ func (u SnapdUser) LogValue() slog.Value {
 		expiration = u.Expiration.UTC().Format(time.RFC3339Nano)
 	}
 	return slog.GroupValue(
-		slog.Int64("snapd-user-id", u.ID),
-		slog.String("store-user-name", u.StoreUserName),
-		slog.String("store-user-email", u.StoreUserEmail),
+		slog.Int64("snapd_user_id", u.ID),
+		slog.String("store_user_name", u.StoreUserName),
+		slog.String("store_user_email", u.StoreUserEmail),
 		slog.String("expiration", expiration),
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing [Endpoint] to be
+// used directly as a structured log attribute value.
+func (e Endpoint) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("method", e.Method),
+		slog.String("path", e.Path),
+		slog.String("action", e.Action),
+		slog.String("access_checker", e.AccessChecker),
+		slog.String("access_level", e.AccessLevel),
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing [Peer] to be used
+// directly as a structured log attribute value.
+func (p Peer) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("socket", p.Socket),
+		slog.Int64("uid", int64(p.UID)),
+		slog.Int64("pid", int64(p.PID)),
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing [AuthzChecks] to be
+// used directly as a structured log attribute value.
+func (a AuthzChecks) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("access_options", string(a.AccessOptions)),
+		slog.String("peer_credentials", string(a.PeerCreds)),
+		slog.String("socket", string(a.Socket)),
+		slog.String("interface_requirements", string(a.Interface)),
+		slog.String("open_access", string(a.OpenAccess)),
+		slog.String("user_authentication", string(a.UserAuth)),
+		slog.String("root", string(a.Root)),
+		slog.String("polkit", string(a.Polkit)),
 	)
 }

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -18,6 +18,17 @@
  *
  */
 
+// slog.go coverage (all tests in this file):
+//   NewSlogLogger, LogEvent envelope  → TestNewSlogLogger, TestLogEventEnvelope
+//   Key order                           → TestLogEventKeyOrder
+//   Level filtering                     → TestLevelFiltering
+//   Write failure handling              → TestWriteFailure*
+//   SnapdUser.LogValue                  → TestSnapdUserLogValue
+//   Reason.LogValue                     → TestReasonLogValue
+//   Peer.LogValue                       → TestPeerLogValue
+//   Endpoint.LogValue                   → TestEndpointLogValue
+//   AuthzChecks.LogValue                → TestAuthzChecksLogValue
+
 package seclog_test
 
 import (
@@ -57,6 +68,12 @@ func (s *SlogSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
+func (s *SlogSuite) newLogger(c *C) seclog.SecurityLogger {
+	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
+	c.Assert(logger, NotNil)
+	return logger
+}
+
 func (s *SlogSuite) TestNewSlogLogger(c *C) {
 	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
 	c.Check(logger, NotNil)
@@ -71,6 +88,12 @@ type baseAttrs struct {
 	AppID       string    `json:"app_id"`
 	Type        string    `json:"type"`
 	Category    string    `json:"category"`
+}
+
+// envelopeRecord is used for envelope-only log event tests.
+type envelopeRecord struct {
+	baseAttrs
+	Event string `json:"event"`
 }
 
 // orderedKeys extracts the top-level JSON object keys in order.
@@ -104,21 +127,15 @@ func orderedKeys(data []byte) ([]string, error) {
 	return keys, nil
 }
 
-func (s *SlogSuite) TestLogEvent(c *C) {
-	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
-	c.Assert(logger, NotNil)
-
-	type record struct {
-		baseAttrs
-		Event string `json:"event"`
-	}
+func (s *SlogSuite) TestLogEventEnvelope(c *C) {
+	logger := s.newLogger(c)
 
 	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"Something happened",
 	)
 
-	var obtained record
+	var obtained envelopeRecord
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
 	c.Check(time.Since(obtained.Datetime) < time.Second, Equals, true)
@@ -128,102 +145,256 @@ func (s *SlogSuite) TestLogEvent(c *C) {
 	c.Check(obtained.Type, Equals, "security")
 	c.Check(obtained.Category, Equals, "TEST")
 	c.Check(obtained.Event, Equals, "test_event")
-
-	// verify key order for human readability
-	keys, err := orderedKeys(s.buf.Bytes())
-	c.Assert(err, IsNil)
-	c.Check(keys, DeepEquals, []string{
-		"datetime", "level", "description",
-		"app_id", "type", "category", "event",
-	})
 }
 
-func (s *SlogSuite) TestLogEventWithAttrs(c *C) {
-	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
-	c.Assert(logger, NotNil)
+func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
+	cases := []struct {
+		attrs    []seclog.Attr
+		wantKeys []string
+	}{
+		{
+			attrs: nil,
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "user", Value: seclog.SnapdUser{ID: 1}},
+				{Key: "error", Value: seclog.Reason{Code: 401, Message: "nope"}},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "user", "error",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
+				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
+				{Key: "authz_checks", Value: seclog.NewAuthzChecks()},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "peer", "endpoint", "authz_checks",
+			},
+		},
+	}
 
-	type record struct {
-		baseAttrs
-		Event string `json:"event"`
-		User  struct {
-			ID             int64  `json:"snapd-user-id"`
-			StoreUserName  string `json:"store-user-name"`
-			StoreUserEmail string `json:"store-user-email"`
+	for _, tc := range cases {
+		s.buf.Reset()
+		logger := s.newLogger(c)
+		logger.LogEvent(
+			seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+			"test",
+			tc.attrs...,
+		)
+
+		keys, err := orderedKeys(s.buf.Bytes())
+		c.Assert(err, IsNil)
+		c.Check(keys, DeepEquals, tc.wantKeys)
+	}
+}
+
+func (s *SlogSuite) TestSnapdUserLogValue(c *C) {
+	type userRecord struct {
+		User struct {
+			ID             int64  `json:"snapd_user_id"`
+			StoreUserName  string `json:"store_user_name"`
+			StoreUserEmail string `json:"store_user_email"`
 			Expiration     string `json:"expiration"`
 		} `json:"user"`
+	}
+
+	cases := []struct {
+		user     seclog.SnapdUser
+		wantExp  string
+		wantID   int64
+		wantName string
+		wantMail string
+	}{
+		{
+			user: seclog.SnapdUser{
+				ID:             42,
+				StoreUserEmail: "user@gmail.com",
+				StoreUserName:  "jdoe",
+			},
+			wantExp:  "never",
+			wantID:   42,
+			wantName: "jdoe",
+			wantMail: "user@gmail.com",
+		},
+		{
+			user: seclog.SnapdUser{
+				ID:         42,
+				Expiration: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+			},
+			wantExp: "2026-06-15T12:00:00Z",
+			wantID:  42,
+		},
+	}
+
+	for _, tc := range cases {
+		s.buf.Reset()
+		logger := s.newLogger(c)
+		logger.LogEvent(
+			seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+			"test",
+			seclog.Attr{Key: "user", Value: tc.user},
+		)
+
+		var obtained userRecord
+		err := json.Unmarshal(s.buf.Bytes(), &obtained)
+		c.Assert(err, IsNil)
+		c.Check(obtained.User.ID, Equals, tc.wantID)
+		c.Check(obtained.User.StoreUserName, Equals, tc.wantName)
+		c.Check(obtained.User.StoreUserEmail, Equals, tc.wantMail)
+		c.Check(obtained.User.Expiration, Equals, tc.wantExp)
+	}
+}
+
+func (s *SlogSuite) TestReasonLogValue(c *C) {
+	type errorRecord struct {
 		Error struct {
-			Code    string `json:"code"`
+			Code    int    `json:"code"`
+			Kind    string `json:"kind"`
 			Message string `json:"message"`
 		} `json:"error"`
 	}
 
-	user := seclog.SnapdUser{
-		ID:             42,
-		StoreUserEmail: "user@gmail.com",
-		StoreUserName:  "jdoe",
+	cases := []struct {
+		reason      seclog.Reason
+		wantCode    int
+		wantKind    string
+		wantMessage string
+	}{
+		{
+			reason:      seclog.Reason{Code: 401, Kind: "invalid-credentials", Message: "invalid credentials"},
+			wantCode:    401,
+			wantKind:    "invalid-credentials",
+			wantMessage: "invalid credentials",
+		},
+		{
+			reason:      seclog.Reason{Code: 500, Message: "internal error"},
+			wantCode:    500,
+			wantMessage: "internal error",
+		},
 	}
-	reason := seclog.Reason{Code: seclog.ReasonInvalidCredentials, Message: "invalid credentials"}
-	logger.LogEvent(
-		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelWarn},
-		fmt.Sprintf("User %s caused an issue: %s", user.String(), reason.String()),
-		seclog.Attr{Key: "user", Value: user},
-		seclog.Attr{Key: "error", Value: reason},
-	)
 
-	var obtained record
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(time.Since(obtained.Datetime) < time.Second, Equals, true)
-	c.Check(obtained.Level, Equals, "WARN")
-	c.Check(obtained.Description, Equals,
-		"User 42:user@gmail.com:jdoe caused an issue: invalid-credentials:invalid credentials")
-	c.Check(obtained.AppID, Equals, s.appID)
-	c.Check(obtained.Type, Equals, "security")
-	c.Check(obtained.Category, Equals, "TEST")
-	c.Check(obtained.Event, Equals, "test_event")
-	// SnapdUser is a LogValuer — verify structured output
-	c.Check(obtained.User.ID, Equals, int64(42))
-	c.Check(obtained.User.StoreUserEmail, Equals, "user@gmail.com")
-	c.Check(obtained.User.StoreUserName, Equals, "jdoe")
-	c.Check(obtained.User.Expiration, Equals, "never")
-	// Reason is a plain struct — verify JSON marshaling via slog.Any
-	c.Check(obtained.Error.Code, Equals, seclog.ReasonInvalidCredentials)
-	c.Check(obtained.Error.Message, Equals, "invalid credentials")
+	for _, tc := range cases {
+		s.buf.Reset()
+		logger := s.newLogger(c)
+		logger.LogEvent(
+			seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+			"test",
+			seclog.Attr{Key: "error", Value: tc.reason},
+		)
 
-	// verify key order for human readability
-	keys, err := orderedKeys(s.buf.Bytes())
-	c.Assert(err, IsNil)
-	c.Check(keys, DeepEquals, []string{
-		"datetime", "level", "description",
-		"app_id", "type", "category", "event", "user", "error",
-	})
+		var obtained errorRecord
+		err := json.Unmarshal(s.buf.Bytes(), &obtained)
+		c.Assert(err, IsNil)
+		c.Check(obtained.Error.Code, Equals, tc.wantCode)
+		c.Check(obtained.Error.Kind, Equals, tc.wantKind)
+		c.Check(obtained.Error.Message, Equals, tc.wantMessage)
+	}
 }
 
-func (s *SlogSuite) TestLogEventWithLogValuer(c *C) {
-	logger := seclog.NewSlogLogger(s.buf, s.appID, seclog.LevelInfo)
-	c.Assert(logger, NotNil)
-
-	type record struct {
-		User struct {
-			Expiration string `json:"expiration"`
-		} `json:"user"`
+func (s *SlogSuite) TestPeerLogValue(c *C) {
+	type peerRecord struct {
+		Peer struct {
+			Socket string `json:"socket"`
+			UID    int64  `json:"uid"`
+			PID    int64  `json:"pid"`
+		} `json:"peer"`
 	}
 
-	expiry := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	user := seclog.SnapdUser{
-		ID:         42,
-		Expiration: expiry,
-	}
+	logger := s.newLogger(c)
 	logger.LogEvent(
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"test",
-		seclog.Attr{Key: "user", Value: user},
+		seclog.Attr{Key: "peer", Value: seclog.Peer{
+			Socket: "/run/snapd.socket", UID: 0, PID: 4242,
+		}},
 	)
 
-	var obtained record
+	var obtained peerRecord
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
-	c.Check(obtained.User.Expiration, Equals, "2026-06-15T12:00:00Z")
+	c.Check(obtained.Peer.Socket, Equals, "/run/snapd.socket")
+	c.Check(obtained.Peer.UID, Equals, int64(0))
+	c.Check(obtained.Peer.PID, Equals, int64(4242))
+}
+
+func (s *SlogSuite) TestEndpointLogValue(c *C) {
+	type endpointRecord struct {
+		Endpoint struct {
+			Method        string `json:"method"`
+			Path          string `json:"path"`
+			Action        string `json:"action"`
+			AccessChecker string `json:"access_checker"`
+			AccessLevel   string `json:"access_level"`
+		} `json:"endpoint"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "endpoint", Value: seclog.Endpoint{
+			Method:        "POST",
+			Path:          "/v2/snaps",
+			Action:        "install",
+			AccessChecker: "authenticated",
+			AccessLevel:   "authenticated",
+		}},
+	)
+
+	var obtained endpointRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.Endpoint.Method, Equals, "POST")
+	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
+	c.Check(obtained.Endpoint.Action, Equals, "install")
+	c.Check(obtained.Endpoint.AccessChecker, Equals, "authenticated")
+	c.Check(obtained.Endpoint.AccessLevel, Equals, "authenticated")
+}
+
+func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {
+	type authzChecksRecord struct {
+		AuthzChecks struct {
+			AccessOptions string `json:"access_options"`
+			PeerCreds     string `json:"peer_credentials"`
+			Socket        string `json:"socket"`
+			Interface     string `json:"interface_requirements"`
+			OpenAccess    string `json:"open_access"`
+			UserAuth      string `json:"user_authentication"`
+			Root          string `json:"root"`
+			Polkit        string `json:"polkit"`
+		} `json:"authz_checks"`
+	}
+
+	checks := seclog.NewAuthzChecks()
+	checks.PeerCreds = seclog.AuthzPass
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "authz_checks", Value: checks},
+	)
+
+	var obtained authzChecksRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.AuthzChecks.AccessOptions, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.PeerCreds, Equals, string(seclog.AuthzPass))
+	c.Check(obtained.AuthzChecks.Socket, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.Interface, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.OpenAccess, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.UserAuth, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.Root, Equals, string(seclog.AuthzNotApplicable))
+	c.Check(obtained.AuthzChecks.Polkit, Equals, string(seclog.AuthzNotApplicable))
 }
 
 func (s *SlogSuite) TestLevelFiltering(c *C) {

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -98,7 +98,7 @@ execute: |
 
     # WARN level is not being picked up by auditd, but it should be present in the journal when auditd is not active, so only check for the presence of the event when auditd is not active.
     if [ "$AUDITD_ACTIVE" -eq 0 ]; then
-        journal_match '"level":"WARN","description":"User <unknown>:someemail@testing.com:<unknown> login failure: invalid-credentials:invalid credentials","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_failure","user":{"snapd-user-id":0,"store-user-name":"","store-user-email":"someemail@testing.com","expiration":"never"},"error":{"code":"invalid-credentials","message":"invalid credentials"}'
+    	journal_match '"level":"WARN","description":"User <unknown>:someemail@testing.com:<unknown> login failure: 401:invalid credentials","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_failure","user":\{"snapd_user_id":0,"store_user_name":"","store_user_email":"someemail@testing.com","expiration":"never"\},"error":\{"code":401,"kind":"login-required","message":"invalid credentials"\}'
     fi
 
     # SPREAD_STORE_USER and SPREAD_STORE_PASSWORD are only available when running off master
@@ -108,10 +108,10 @@ execute: |
         journal_pin
         expect -d -f "$TESTSLIB"/successful_login.exp
 
-        journal_match '"level":"INFO","description":"User [^ ]* login success","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_success","user":\{"snapd-user-id":[0-9]+,"store-user-name":"[^"]*","store-user-email":"[^"]*","expiration":"[^"]*"\}'
+        journal_match '"level":"INFO","description":"User [^ ]* login success","app_id":"canonical.snapd.snapd","type":"security","category":"AUTHN","event":"authn_login_success","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\}'
 
         echo "Checking that user creation produces an audit event"
-        journal_match '"category":"USER","event":"user_created","user":\{"snapd-user-id":[0-9]+,"store-user-name":"[^"]*","store-user-email":"[^"]*","expiration":"[^"]*"\}'
+        journal_match '"category":"USER","event":"user_created","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\}'
 
         echo "Checking that a second login produces a user_updated audit event"
         # A second login refreshes the store macaroon and discharges, so the
@@ -121,11 +121,11 @@ execute: |
         journal_pin
         expect -d -f "$TESTSLIB"/successful_login.exp
 
-        journal_match '"category":"USER","event":"user_updated","user":\{"snapd-user-id":[0-9]+,"store-user-name":"[^"]*","store-user-email":"[^"]*","expiration":"[^"]*"\},"changed_fields":\[.*\]'
+        journal_match '"category":"USER","event":"user_updated","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\},"changed_fields":\[.*\]'
 
         echo "Checking that logout produces a user_removed audit event"
         journal_pin
         snap logout
 
-        journal_match '"category":"USER","event":"user_removed","user":\{"snapd-user-id":[0-9]+,"store-user-name":"[^"]*","store-user-email":"[^"]*","expiration":"[^"]*"\}'
+        journal_match '"category":"USER","event":"user_removed","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\}'
     fi


### PR DESCRIPTION
Add seclog API for administrative actions.

  1. Add a seclog authorization audit API — types Peer, Endpoint, and AuthzChecks/AuthzCheck (with NewAuthzChecks() defaulting every stage to not-applicable), plus emitters LogAdminActivity (authz_admin, INFO) and LogUnauthorizedAccess (authz_fail, CRITICAL). Type used in descriptions implements String() and all implement their slog.LogValuer as the format source of truth.

  3. Do not wire the new authz logging into daemon access checks yet — the API is staged for the next part; only login-failure logging is wired in this PR.

  5. Refactor Reason from a string code to {code int, kind string, message string}, derive it from the daemon apiError via a new apiError.reason(), simplify apiLoginError to a single call, and drop the bespoke Reason* constants. String() renders code:message; LogValue emits all three fields unconditionally.

  7. Standardize all audit JSON keys on snake_case (snapd_user_id, store_user_name, access_checker, access_options, peer_credentials, ...), including the auth.UserState changedFields audit labels; UserState persistence tags are intentionally left untouched.

  9. Add <unknown>/<none> sentinel handling consistently across all String() methods (root UID 0 is shown; peer/PID sentinels and empty endpoint action render as placeholders).

  11. Reorganize seclog tests to mirror their source files (one Test*LogValue per LogValuer, table-driven TestLogEventKeyOrder, source→test coverage-index comment) and update the security-logging spread test to the new snake_case keys and Reason shape.

[Spec SD236](https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0#heading=h.etzql0edger)
 
---

Part 5 adds security logging for administrative actions: [Full reference implementation](https://github.com/canonical/snapd/pull/17044).
- Part 5.1: Add seclog API                                                                           <==== THIS
- Part 5.2: Add daemon/access implementation & spread test

---

[Done] Part [4](https://github.com/canonical/snapd/pull/17043) adds security logging for adding, updating and removing a snapd user.

[Done] Part [1](https://github.com/canonical/snapd/pull/16987), [2](https://github.com/canonical/snapd/pull/16988), & [3](https://github.com/canonical/snapd/pull/16990)  provides the logger implementation.