### PR TITLE
daemon/access: account for snapd FIPS build

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -501,11 +501,18 @@ func isRequestFromSnapCmd(r *http.Request) (bool, error) {
 	}
 
 	// Check if re-exec in snapd
-	path := filepath.Join(dirs.SnapMountDir, "snapd/*/usr/bin/snap")
+	path := filepath.Join(dirs.SnapMountDir, "snapd/*/usr/bin/*")
 	if matched, err := filepath.Match(path, exe); err != nil {
 		return false, err
 	} else if matched {
-		return true, nil
+		base := filepath.Base(exe)
+		// Depending on the build variant of the snapd snap, the command could
+		// either be $SNAPD_MOUNT/usr/bin/snap or $SNAPD_MOUNT/usr/bin/snap-fips
+		if base == "snap" || base == "snap-fips" {
+			return true, nil
+		}
+
+		return false, nil
 	}
 
 	// Check if re-exec in core

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -970,6 +970,10 @@ func (s *noticesSuite) TestAddNoticesSnapCmdReexecSnapd(c *C) {
 	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "snapd/11/usr/bin/snap"), false)
 }
 
+func (s *noticesSuite) TestAddNoticesSnapCmdReexecSnapdFIPS(c *C) {
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "snapd/11/usr/bin/snap-fips"), false)
+}
+
 func (s *noticesSuite) TestAddNoticesSnapCmdReexecCore(c *C) {
 	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "core/12/usr/bin/snap"), false)
 }


### PR DESCRIPTION
Account for differences in names of tbe binaries in the snapd FIPS build. The actual snap binary is at <snapd-mount>/usr/bin/snap-fips.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
