### PR TITLE
boot/makebootable.go: allow reprovision without factory reset

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -351,11 +351,13 @@ func MakeRecoverySystemBootable(model *asserts.Model, rootdir string, relativeRe
 }
 
 type makeRunnableOptions struct {
-	Standalone     bool
-	AfterDataReset bool
-	SeedDir        string
-	StateUnlocker  Unlocker
-	UseTokens      bool
+	Standalone    bool
+	SeedDir       string
+	StateUnlocker Unlocker
+
+	LegacyFactoryResetKeyPath bool
+	Reprovision               bool
+	UseTokens                 bool
 }
 
 func copyBootSnap(orig string, filename string, dstSnapBlobDir string) error {
@@ -674,11 +676,12 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets 
 		}
 
 		flags := sealKeyToModeenvFlags{
-			HookKeyProtectorFactory: protector,
-			FactoryReset:            makeOpts.AfterDataReset,
-			SeedDir:                 makeOpts.SeedDir,
-			StateUnlocker:           makeOpts.StateUnlocker,
-			UseTokens:               tokens,
+			HookKeyProtectorFactory:   protector,
+			LegacyFactoryResetKeyPath: makeOpts.LegacyFactoryResetKeyPath,
+			Reprovision:               makeOpts.Reprovision,
+			SeedDir:                   makeOpts.SeedDir,
+			StateUnlocker:             makeOpts.StateUnlocker,
+			UseTokens:                 tokens,
 		}
 		if makeOpts.Standalone {
 			flags.SnapsDir = snapBlobDir
@@ -801,7 +804,18 @@ func MakeRunnableStandaloneSystemFromInitrd(model *asserts.Model, bootWith *Boot
 // back to the new run system.
 func MakeRunnableSystemAfterDataReset(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
 	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
-		AfterDataReset: true,
-		SeedDir:        dirs.SnapSeedDir,
+		LegacyFactoryResetKeyPath: true,
+		Reprovision:               true,
+		SeedDir:                   dirs.SnapSeedDir,
+	})
+}
+
+// MakeRunnableSystemReprovision make the systems currently running bootable again.
+// This is intended to repair the boot of a system that was booted for example
+// with a recovery key.
+func MakeRunnableSystemReprovision(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
+	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
+		Reprovision: true,
+		SeedDir:     dirs.SnapSeedDir,
 	})
 }

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -580,6 +580,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnableSealWithHookKeyProtector(c *
 type testMakeSystemRunnable20Opts struct {
 	standalone           bool
 	factoryReset         bool
+	reprovision          bool
 	classic              bool
 	fromInitrd           bool
 	withKComps           bool
@@ -821,7 +822,8 @@ version: 5.0
 		c.Assert(recoveryGrub.Hashes, HasLen, 1)
 		c.Check(recoveryGrub.Hashes[0], Equals, "aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5")
 
-		c.Check(params.FactoryReset, Equals, opts.factoryReset)
+		c.Check(params.Reprovision, Equals, opts.reprovision || opts.factoryReset)
+		c.Check(params.LegacyFactoryResetKeyPath, Equals, opts.factoryReset)
 		if opts.classic {
 			c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data"))
 		} else {
@@ -868,6 +870,8 @@ version: 5.0
 		c.Check(u.unlocked, Equals, 1)
 	case opts.factoryReset && !opts.fromInitrd:
 		err = boot.MakeRunnableSystemAfterDataReset(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
+	case opts.reprovision && !opts.fromInitrd:
+		err = boot.MakeRunnableSystemReprovision(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	default:
 		err = boot.MakeRunnableSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	}
@@ -991,18 +995,16 @@ current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20Install(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   false,
-		factoryReset: false,
-		classic:      false,
-		fromInitrd:   false,
-		withKComps:   false,
+		standalone: false,
+		classic:    false,
+		fromInitrd: false,
+		withKComps: false,
 	})
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20InstallWithKernelArgs(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
 		standalone:           false,
-		factoryReset:         false,
 		classic:              false,
 		fromInitrd:           false,
 		withKComps:           false,
@@ -1012,21 +1014,19 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20InstallWithKernelArgs(c *C
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20InstallWithKComps(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   false,
-		factoryReset: false,
-		classic:      false,
-		fromInitrd:   false,
-		withKComps:   true,
+		standalone: false,
+		classic:    false,
+		fromInitrd: false,
+		withKComps: true,
 	})
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20InstallOnClassic(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   false,
-		factoryReset: false,
-		classic:      true,
-		fromInitrd:   false,
-		withKComps:   true,
+		standalone: false,
+		classic:    true,
+		fromInitrd: false,
+		withKComps: true,
 	})
 }
 
@@ -1050,13 +1050,22 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20FactoryResetOnClassic(c *C
 	})
 }
 
+func (s *makeBootable20Suite) TestMakeSystemRunnable20Reprovision(c *C) {
+	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
+		standalone:  false,
+		reprovision: true,
+		classic:     false,
+		fromInitrd:  false,
+		withKComps:  true,
+	})
+}
+
 func (s *makeBootable20Suite) TestMakeSystemRunnable20InstallFromInitrd(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   true,
-		factoryReset: false,
-		classic:      false,
-		fromInitrd:   true,
-		withKComps:   true,
+		standalone: true,
+		classic:    false,
+		fromInitrd: true,
+		withKComps: true,
 	})
 }
 
@@ -1347,7 +1356,8 @@ version: 5.0
 		c.Assert(recoveryGrub.Hashes, HasLen, 1)
 		c.Check(recoveryGrub.Hashes[0], Equals, "aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5")
 
-		c.Check(params.FactoryReset, Equals, false)
+		c.Check(params.Reprovision, Equals, false)
+		c.Check(params.LegacyFactoryResetKeyPath, Equals, false)
 		c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data", "system-data"))
 
 		return fmt.Errorf("seal error")
@@ -1550,7 +1560,8 @@ version: 5.0
 		c.Assert(recoveryGrub.Hashes, HasLen, 1)
 		c.Check(recoveryGrub.Hashes[0], Equals, "aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5")
 
-		c.Check(params.FactoryReset, Equals, false)
+		c.Check(params.Reprovision, Equals, false)
+		c.Check(params.LegacyFactoryResetKeyPath, Equals, false)
 		c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data", "system-data"))
 
 		return nil
@@ -2463,21 +2474,19 @@ current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty
 
 func (s *makeBootable20Suite) TestMakeStandaloneSystemRunnable20Install(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   true,
-		factoryReset: false,
-		classic:      false,
-		fromInitrd:   false,
-		withKComps:   true,
+		standalone: true,
+		classic:    false,
+		fromInitrd: false,
+		withKComps: true,
 	})
 }
 
 func (s *makeBootable20Suite) TestMakeStandaloneSystemRunnable20InstallOnClassic(c *C) {
 	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:   true,
-		factoryReset: false,
-		classic:      true,
-		fromInitrd:   false,
-		withKComps:   true,
+		standalone: true,
+		classic:    true,
+		fromInitrd: false,
+		withKComps: true,
 	})
 }
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -88,9 +88,12 @@ type sealKeyToModeenvFlags struct {
 	// HookKeyProtectorFactory will be used to create a [secboot.KeyProtector].
 	// If nil, it is assumed that TPM sealing should be used.
 	HookKeyProtectorFactory secboot.KeyProtectorFactory
-	// FactoryReset indicates that the sealing is happening during factory
-	// reset.
-	FactoryReset bool
+	// LegacyFactoryResetKeyPath tells whether the path to legacy
+	// key file for save partition should use the name expected
+	// for factory reset.
+	LegacyFactoryResetKeyPath bool
+	// Reprovision affects how we provision the TPM if we do.
+	Reprovision bool
 	// SnapsDir is set to provide a non-default directory to find
 	// run mode snaps in.
 	SnapsDir string
@@ -161,8 +164,12 @@ type BootChains struct {
 
 type SealKeyForBootChainsParams struct {
 	BootChains
-	// FactoryReset...
-	FactoryReset bool
+	// LegacyFactoryResetKeyPath tells whether the path to legacy
+	// key file for save partition should use the name expected
+	// for factory reset.
+	LegacyFactoryResetKeyPath bool
+	// Reprovision affects how we provision the TPM if we do.
+	Reprovision bool
 	// UseTokens indicates that key data should be saved to the
 	// tokens of key slots. If not, they will be saved to key
 	// files.
@@ -200,11 +207,12 @@ func sealKeyToModeenvForMethod(
 	flags sealKeyToModeenvFlags,
 ) error {
 	params := &SealKeyForBootChainsParams{
-		FactoryReset:           flags.FactoryReset,
-		UseTokens:              flags.UseTokens,
-		InstallHostWritableDir: InstallHostWritableDir(model),
-		PrimaryKey:             primaryKey,
-		KeyProtectorFactory:    flags.HookKeyProtectorFactory,
+		LegacyFactoryResetKeyPath: flags.LegacyFactoryResetKeyPath,
+		Reprovision:               flags.Reprovision,
+		UseTokens:                 flags.UseTokens,
+		InstallHostWritableDir:    InstallHostWritableDir(model),
+		PrimaryKey:                primaryKey,
+		KeyProtectorFactory:       flags.HookKeyProtectorFactory,
 	}
 
 	var tbl bootloader.TrustedAssetsBootloader

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -82,6 +82,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		sealErr       error
 		provisionErr  error
 		factoryReset  bool
+		reprovision   bool
 		shimId        string
 		grubId        string
 		runGrubId     string
@@ -101,6 +102,10 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			expSealCalls: 1,
 		}, {
 			factoryReset: true,
+			reprovision:  true,
+			expSealCalls: 1,
+		}, {
+			reprovision:  true,
 			expSealCalls: 1,
 		}, {
 			sealErr: errors.New("seal error"), expErr: `seal error`,
@@ -231,7 +236,8 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			c.Assert(recoveryGrub.Hashes, HasLen, 1)
 			c.Check(recoveryGrub.Hashes[0], Equals, "grub-hash-1")
 
-			c.Check(params.FactoryReset, Equals, tc.factoryReset)
+			c.Check(params.Reprovision, Equals, tc.reprovision)
+			c.Check(params.LegacyFactoryResetKeyPath, Equals, tc.factoryReset)
 			c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data", "system-data"))
 			c.Check(params.UseTokens, Equals, !tc.disableTokens)
 
@@ -241,9 +247,10 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 
 		u := mockUnlocker{}
 		err = boot.SealKeyToModeenv(myKey, myKey2, nil, myVolumesAuth, myCheckResult, model, modeenv, boot.MockSealKeyToModeenvFlags{
-			FactoryReset:  tc.factoryReset,
-			StateUnlocker: u.unlocker,
-			UseTokens:     !tc.disableTokens,
+			LegacyFactoryResetKeyPath: tc.factoryReset,
+			Reprovision:               tc.reprovision,
+			StateUnlocker:             u.unlocker,
+			UseTokens:                 !tc.disableTokens,
 		})
 		c.Check(u.unlocked, Equals, 1)
 		c.Check(sealKeyForBootChainsCalled, Equals, tc.expSealCalls)
@@ -1634,7 +1641,8 @@ func (s *sealSuite) TestSealToModeenvWithSecbootProtectorHappy(c *C) {
 		c.Check(recoveryBootChain.Model, Equals, model.Model())
 		c.Check(recoveryBootChain.AssetChain, HasLen, 0)
 
-		c.Check(params.FactoryReset, Equals, false)
+		c.Check(params.Reprovision, Equals, false)
+		c.Check(params.LegacyFactoryResetKeyPath, Equals, false)
 		c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data", "system-data"))
 		c.Check(params.UseTokens, Equals, true)
 

--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -53,12 +53,12 @@ func runKeySealRequests(key secboot.BootstrappedContainer, useTokens bool) []sec
 	}
 }
 
-func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factoryReset bool, useTokens bool) []secboot.SealKeyRequest {
+func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factoryResetKeyPath bool, useTokens bool) []secboot.SealKeyRequest {
 	var dataFallbackKey, saveFallbackKey string
 	if !useTokens {
 		dataFallbackKey = device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
 
-		if factoryReset {
+		if factoryResetKeyPath {
 			// factory reset uses alternative sealed key location, such that
 			// until we boot into the run mode, both sealed keys are present
 			// on disk
@@ -145,7 +145,7 @@ func sealFallbackObjectKeys(
 	volumesAuth *device.VolumesAuthOptions,
 	checkResult *secboot.PreinstallCheckResult,
 	roleToBlName map[bootloader.Role]string,
-	factoryReset bool,
+	factoryResetKeyPath bool,
 	pcrHandle uint32,
 	useTokens bool,
 	keyRole string,
@@ -178,7 +178,7 @@ func sealFallbackObjectKeys(
 	// key files are stored on ubuntu-seed, separate from ubuntu-data so they
 	// can be used if ubuntu-data and ubuntu-boot are corrupted or unavailable.
 
-	if _, err := secbootSealKeys(fallbackKeySealRequests(key, saveKey, factoryReset, useTokens), sealKeyParams); err != nil {
+	if _, err := secbootSealKeys(fallbackKeySealRequests(key, saveKey, factoryResetKeyPath, useTokens), sealKeyParams); err != nil {
 		return fmt.Errorf("cannot seal the fallback encryption keys: %v", err)
 	}
 
@@ -203,7 +203,7 @@ func sealKeyForBootChainsHook(method device.SealingMethod, key, saveKey secboot.
 		break
 	}
 
-	skrs := append(runKeySealRequests(key, params.UseTokens), fallbackKeySealRequests(key, saveKey, params.FactoryReset, params.UseTokens)...)
+	skrs := append(runKeySealRequests(key, params.UseTokens), fallbackKeySealRequests(key, saveKey, params.LegacyFactoryResetKeyPath, params.UseTokens)...)
 	if err := secbootSealKeysWithProtector(params.KeyProtectorFactory, skrs, &sealingParams); err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func sealKeyForBootChainsBackend(
 	// we are preparing a new system, hence the TPM needs to be provisioned
 	lockoutAuthFile := device.TpmLockoutAuthUnder(boot.InstallHostFDESaveDir)
 	tpmProvisionMode := secboot.TPMProvisionFull
-	if params.FactoryReset {
+	if params.Reprovision {
 		tpmProvisionMode = secboot.TPMPartialReprovision
 	}
 	if err := secbootProvisionTPM(tpmProvisionMode, lockoutAuthFile); err != nil {
@@ -266,7 +266,7 @@ func sealKeyForBootChainsBackend(
 		return err
 	}
 
-	err = sealFallbackObjectKeys(key, saveKey, rpbc, primaryKey, volumesAuth, checkResult, params.RoleToBlName, params.FactoryReset,
+	err = sealFallbackObjectKeys(key, saveKey, rpbc, primaryKey, volumesAuth, checkResult, params.RoleToBlName, params.LegacyFactoryResetKeyPath,
 		handle, params.UseTokens, "recover")
 	if err != nil {
 		return err

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -89,6 +89,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 		sealErr           error
 		provisionErr      error
 		factoryReset      bool
+		reprovision       bool
 		shimId            string
 		grubId            string
 		runGrubId         string
@@ -117,23 +118,23 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 			sealErr: nil, expErr: "",
 			expProvisionCalls: 1, expSealCalls: 2, disableTokens: true, withVolumesAuth: true,
 		}, {
+			sealErr: nil, factoryReset: true,
+			expProvisionCalls: 1, expSealCalls: 2,
+		}, {
 			sealErr: nil,
 			// old boot assets
 			shimId: "bootx64.efi", grubId: "grubx64.efi",
 			expErr:            "",
 			expProvisionCalls: 1, expSealCalls: 2,
 		}, {
-			sealErr: nil, factoryReset: true,
+			sealErr: nil, reprovision: true,
 			expProvisionCalls: 1, expSealCalls: 2,
 		}, {
-			sealErr: nil, factoryReset: true,
+			sealErr: nil, reprovision: true,
 			expProvisionCalls: 1, expSealCalls: 2, withVolumesAuth: true, withCheckResult: true,
 		}, {
-			sealErr: nil, factoryReset: true,
+			sealErr: nil, factoryReset: true, reprovision: true,
 			expProvisionCalls: 1, expSealCalls: 2, disableTokens: true,
-		}, {
-			sealErr: nil, factoryReset: true,
-			expProvisionCalls: 1, expSealCalls: 2,
 		}, {
 			sealErr: errors.New("seal error"), expErr: "cannot seal the encryption keys: seal error",
 			expProvisionCalls: 1, expSealCalls: 1,
@@ -196,7 +197,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 		restore := fdeBackend.MockSecbootProvisionTPM(func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error {
 			provisionCalls++
 			c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
-			if tc.factoryReset {
+			if tc.reprovision {
 				c.Check(mode, Equals, secboot.TPMPartialReprovision)
 			} else {
 				c.Check(mode, Equals, secboot.TPMProvisionFull)
@@ -381,10 +382,11 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 			},
 		}
 		params := &boot.SealKeyForBootChainsParams{
-			BootChains:             bootChains,
-			FactoryReset:           tc.factoryReset,
-			InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
-			UseTokens:              !tc.disableTokens,
+			BootChains:                bootChains,
+			LegacyFactoryResetKeyPath: tc.factoryReset,
+			Reprovision:               tc.reprovision,
+			InstallHostWritableDir:    filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
+			UseTokens:                 !tc.disableTokens,
 		}
 		err := boot.SealKeyForBootChains(device.SealingMethodTPM, myKey, myKey2, nil, volumesAuth, checkResult, params)
 
@@ -584,7 +586,6 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 	}
 	params := &boot.SealKeyForBootChainsParams{
 		BootChains:             bootChains,
-		FactoryReset:           false,
 		InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
 		UseTokens:              useTokens,
 		PrimaryKey:             []byte{1, 2, 3, 4},
@@ -672,7 +673,6 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	}
 	params := &boot.SealKeyForBootChainsParams{
 		BootChains:             bootChains,
-		FactoryReset:           false,
 		InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
 	}
 	err := boot.SealKeyForBootChains(device.SealingMethodFDESetupHook, key, saveKey, nil, nil, nil, params)


### PR DESCRIPTION
FactoryReset flag was used for 2 things:
 * The path to some key files is different.
 * Whether TPM should be reprovisioned rather than fully provisioned.

With FDE reprovision, only the second one is needed. So we need to split the flag in two.