### PR TITLE
github, tests: add time and feature based coverage calculator for feature tagging

### DIFF
--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -203,6 +203,12 @@ jobs:
         with:
           name: all-features
 
+      - name: Get spread results
+        uses: actions/download-artifact@v8
+        with:
+          path: spread-results-artifacts
+          pattern: spread-results-*
+
       - name: Create feature tags
         run: |
           WORK_DIR=. ./tests/utils/features/process-features.sh

--- a/tests/utils/features/README.md
+++ b/tests/utils/features/README.md
@@ -51,13 +51,13 @@ Find tests that contain the snap command `snap abort` in all systems at timestam
 ```
 $ ./query_features.py feat find -f ~/features.json -t "2025-07-08T11:59:16.460000" --feat '{"cmd":"abort"}'
 ```
-List all possible features at timestamp `2025-07-08T11:59:16.460000` using local data found in the directory `~/Desktop/features`.
+List all possible features at timestamp `2025-07-08` using local data found in the directory `~/Desktop/features`.
 ```
-$ ./query_features.py feat all -d ~/Desktop/features -t "2025-07-08T11:59:16.460000"
+$ ./query_features.py feat all -d ~/Desktop/features -t "2025-07-08"
 ```
-List features found in system `ubuntu 25.04` at timestamp `2025-07-08T11:59:16.460000` using local data found in the directory `~/Desktop/features`.
+List features found in system `ubuntu 25.04` at timestamp `2025-07-08` using local data found in the directory `~/Desktop/features`.
 ```
-$ ./query_features.py feat sys -d ~/Desktop/features/ -t "2025-07-08T11:59:16.460000" -s "google:ubuntu-25.04-64"
+$ ./query_features.py feat sys -d ~/Desktop/features/ -t "2025-07-08" -s "google:ubuntu-25.04-64"
 ```
 
 #### Calculate difference in features
@@ -66,16 +66,16 @@ Using data from mongodb, calculate the difference in features between system `go
 $ ./query_features.py diff systems -f ~/features.json -t1 "2025-07-08T11:59:16.460000" -t2 "2025-07-08T11:59:16.460000" -s1 'google:ubuntu-20.04-64' -s2 'google:ubuntu-22.04-64'
 ```
 
-Using local data in folder `~/Desktop/features`, at timestamp `2025-07-08T11:59:16.460000`, calculate the difference between all possible features and the features for system `google:ubuntu-22.04-64`.
+Using local data in folder `~/Desktop/features`, at timestamp `2025-07-08`, calculate the difference between all possible features and the features for system `google:ubuntu-22.04-64`.
 ```
-$ ./query_features.py diff all-features -d ~/Desktop/features -t "2025-07-08T11:59:16.460000" -s "google:ubuntu-22.04-64"
+$ ./query_features.py diff all-features -d ~/Desktop/features -t "2025-07-08" -s "google:ubuntu-22.04-64"
 ```
 
 #### Calculate duplicate features
 
-Using local data in folder `~/Desktop/features` at timestamp `2025-07-08T11:59:16.460000`, calculate the tests whose features are copmletely covered by the set of all other tests (excluding variants of the same test) for system `google-distro-2:arch-linux-64`.
+Using local data in folder `~/Desktop/features` at timestamp `2025-07-08`, calculate the tests whose features are copmletely covered by the set of all other tests (excluding variants of the same test) for system `google-distro-2:arch-linux-64`.
 ```
-$ ./query_features.py dup -d ~/Desktop/features -t "2025-07-08T11:59:16.460000" -s 'google-distro-2:arch-linux-64'
+$ ./query_features.py dup -d ~/Desktop/features -t "2025-07-08" -s 'google-distro-2:arch-linux-64'
 ```
 
 #### Calculate feature coverage

--- a/tests/utils/features/README.md
+++ b/tests/utils/features/README.md
@@ -77,3 +77,16 @@ Using local data in folder `~/Desktop/features` at timestamp `2025-07-08T11:59:1
 ```
 $ ./query_features.py dup -d ~/Desktop/features -t "2025-07-08T11:59:16.460000" -s 'google-distro-2:arch-linux-64'
 ```
+
+#### Calculate feature coverage
+
+Using local data in folder `~/Desktop/features` at timestamp `2026-06-06`, calculate complete feature coverage including matching snap types.
+
+```
+$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06 --match-snap-types
+```
+
+Using local data in folder `~/Desktop/features` at timestamp `2026-06-06`, calculate feature coverage with a total runtime for each system at or under 15 minutes, but force include any features with "refresh" or "install" keywords. Also remove features "cmds" and "interfaces" from consideration.
+```
+$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06 --max-minutes 15 --force-matches refresh install --match-snap-types --remove cmds interfaces
+```

--- a/tests/utils/features/README.md
+++ b/tests/utils/features/README.md
@@ -80,13 +80,13 @@ $ ./query_features.py dup -d ~/Desktop/features -t "2025-07-08" -s 'google-distr
 
 #### Calculate feature coverage
 
-Using local data in folder `~/Desktop/features` at timestamp `2026-06-06`, calculate complete feature coverage including matching snap types.
+Using local data in folder `~/Desktop/features` at timestamp `2026-06-06`, calculate complete feature coverage
 
 ```
-$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06 --match-snap-types
+$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06
 ```
 
 Using local data in folder `~/Desktop/features` at timestamp `2026-06-06`, calculate feature coverage with a total runtime for each system at or under 15 minutes, but force include any features with "refresh" or "install" keywords. Also remove features "cmds" and "interfaces" from consideration.
 ```
-$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06 --max-minutes 15 --force-matches refresh install --match-snap-types --remove cmds interfaces
+$ ./query_features.py feat cover -d ~/Desktop/features/ -t 2026-06-06 --max-minutes 15 --force-match-keywords refresh install --exclude cmds interfaces
 ```

--- a/tests/utils/features/features.py
+++ b/tests/utils/features/features.py
@@ -4,7 +4,7 @@ Dictionaries to specify structure of feature logs
 '''
 
 from enum import Enum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class Cmd(TypedDict):
@@ -60,6 +60,7 @@ class TaskFeatures(TypedDict):
     tasks: list[Task]
     changes: list[Change]
     ensures: list[Ensure]
+    runtime: NotRequired[float | None]
 
 
 class SystemFeatures(TypedDict):

--- a/tests/utils/features/features.py
+++ b/tests/utils/features/features.py
@@ -4,7 +4,7 @@ Dictionaries to specify structure of feature logs
 '''
 
 from enum import Enum
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 
 
 class Cmd(TypedDict):
@@ -60,7 +60,7 @@ class TaskFeatures(TypedDict):
     tasks: list[Task]
     changes: list[Change]
     ensures: list[Ensure]
-    runtime: NotRequired[float | None]
+    runtime: float
 
 
 class SystemFeatures(TypedDict):

--- a/tests/utils/features/process-features.sh
+++ b/tests/utils/features/process-features.sh
@@ -26,7 +26,13 @@ if ! [ -f "$work_dir/all-features.json" ]; then
     mv "$work_dir/all-features/all-features.json" "$work_dir/all-features.json"
     rm -r "$work_dir/all-features"
 fi
-          
+if ! [ -d "$work_dir/spread-results-artifacts" ]; then
+    if [ -z "$run_id" ]; then
+        echo "RUN_ID is not set. Please set it to the ID of the GitHub Actions run to download artifacts from."
+        exit 1
+    fi
+    gh run download "$run_id" --pattern "spread-results-*" --dir "$work_dir/spread-results-artifacts"
+fi
 composedir="$work_dir/composed-tags"
 mkdir -p "$composedir"
 IFS=',' read -ra features <<< "$features"
@@ -70,5 +76,9 @@ done
     --dir "$composedir" \
     --output "$work_dir/final-feature-tags" \
     --replace-old-runs
+
+./tests/utils/features/runtimeadder.py \
+    --results-dir "$work_dir/spread-results-artifacts" \
+    --features-dir "$work_dir/final-feature-tags"
 
 ./tests/utils/features/feattranslator.py -f "$work_dir/all-features.json" -o "$work_dir/final-feature-tags/all-features.json"

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -17,12 +17,10 @@ from typing import Any, Iterable
 
 from features import SystemFeatures, Cmd, Endpoint, Status, Task, Change, Interface
 
-
-KNOWN_FEATURES = ['cmds', 'endpoints',
-                  'ensures', 'tasks', 'changes', 'interfaces']
+KNOWN_FEATURES = ["cmds", "endpoints", "ensures", "tasks", "changes", "interfaces"]
 
 # file name for the complete list of all features
-ALL_FEATURES_FILE = 'all-features.json'
+ALL_FEATURES_FILE = "all-features.json"
 
 
 class TaskId:
@@ -76,29 +74,29 @@ class DateTimeEncoder(json.JSONEncoder):
 
 
 class Retriever(ABC):
-    '''
+    """
     Retrieves features tags from a data source.
-    '''
+    """
 
     def __init__(self):
         self.cache = {}
 
     @abstractmethod
     def get_sorted_timestamps_and_systems(self) -> list[dict[str, Any]]:
-        '''
+        """
         Gets the complete list of all timestamps and the systems run under each timestamp.
         Format: [{"timestamp":<timestamp>,"systems":[<system1>,...,<systemN>]}]
-        '''
+        """
 
     def get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
-        '''
+        """
         Given the timestamp and system, gets a single dictionary entry.
 
         :raises RuntimeError: when there is not exactly one entry for the system at the timestamp
-        '''
-        if timestamp in self.cache and 'systems' in self.cache[timestamp]:
-            for s in self.cache[timestamp]['systems']:
-                if s['system'] == system:
+        """
+        if timestamp in self.cache and "systems" in self.cache[timestamp]:
+            for s in self.cache[timestamp]["systems"]:
+                if s["system"] == system:
                     return s
         return self._get_single_json(timestamp, system)
 
@@ -107,17 +105,17 @@ class Retriever(ABC):
         pass
 
     def get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:
-        '''
-        Retrieves dictionary entries for all indicated systems at 
-        the given timestamp. If systems is None, then it retrieves 
+        """
+        Retrieves dictionary entries for all indicated systems at
+        the given timestamp. If systems is None, then it retrieves
         all dictionary entries for all systems at the given timestamp.
-        '''
-        if timestamp in self.cache and 'systems' in self.cache[timestamp]:
+        """
+        if timestamp in self.cache and "systems" in self.cache[timestamp]:
             if not systems:
-                return self.cache[timestamp]['systems']
+                return self.cache[timestamp]["systems"]
             else:
-                return [sys for sys in self.cache[timestamp]['systems'] if sys['system'] in systems]
-            
+                return [sys for sys in self.cache[timestamp]["systems"] if sys["system"] in systems]
+
         if systems:
             # Do not cache if only a subset of systems is specified
             # otherwise the cached list won't be complete
@@ -125,26 +123,25 @@ class Retriever(ABC):
         else:
             if timestamp not in self.cache:
                 self.cache[timestamp] = {}
-            self.cache[timestamp]['systems'] = list(self._get_systems(timestamp, systems))
-            return self.cache[timestamp]['systems']
-        
+            self.cache[timestamp]["systems"] = list(self._get_systems(timestamp, systems))
+            return self.cache[timestamp]["systems"]
 
     @abstractmethod
     def _get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:
         pass
 
     def get_all_features(self, timestamp: str) -> dict[str, list[Any]]:
-        '''
+        """
         Retrives a dictionary of all feature data at the given timestmap.
         It contains only feature keys (e.g. cmds, endpoints) and the list
         of all possible feature data at the indicated moment in time.
-        '''
-        if timestamp in self.cache and 'all-features' in self.cache[timestamp]:
-            return self.cache[timestamp]['all-features']
+        """
+        if timestamp in self.cache and "all-features" in self.cache[timestamp]:
+            return self.cache[timestamp]["all-features"]
         if timestamp not in self.cache:
             self.cache[timestamp] = {}
         all_feat = self._get_all_features(timestamp)
-        self.cache[timestamp]['all-features'] = all_feat
+        self.cache[timestamp]["all-features"] = all_feat
         return all_feat
 
     @abstractmethod
@@ -157,65 +154,70 @@ class Retriever(ABC):
 
 
 class MongoRetriever(Retriever):
-    '''
-    Retrieves feature data from a mongodb instance at snapd.features. 
-    The mongodb entries should all be SystemFeatures documents with a 
-    timestamp added. Use of this retriever, requires a credentials 
+    """
+    Retrieves feature data from a mongodb instance at snapd.features.
+    The mongodb entries should all be SystemFeatures documents with a
+    timestamp added. Use of this retriever, requires a credentials
     json file with host, port, user, and password defined.
-    '''
+    """
 
     def __init__(self, creds_file):
         super().__init__()
         config = json.load(creds_file)
         self.client = pymongo.MongoClient(
-            host=config['host'], port=config['port'], username=config['user'], password=config['password'])
+            host=config["host"], port=config["port"], username=config["user"], password=config["password"]
+        )
         self.collection = self.client.snapd.features
 
     def close(self):
         self.client.close()
 
     def get_sorted_timestamps_and_systems(self) -> list[dict[str, Any]]:
-        results = self.collection.find({}, {'timestamp': 1, 'system': 1, 'all_features': 1})
+        results = self.collection.find({}, {"timestamp": 1, "system": 1, "all_features": 1})
         dictionary = defaultdict(list)
         for result in results:
-            if 'all_features' in result and result['all_features'] == True:
+            if "all_features" in result and result["all_features"] == True:
                 continue
-            dictionary[result['timestamp'].isoformat()].append(
-                result['system'])
+            dictionary[result["timestamp"].isoformat()].append(result["system"])
         return [{"timestamp": entry[0], "systems": entry[1]} for entry in sorted(dictionary.items(), reverse=True)]
 
     def _get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:
         if systems:
             for system in systems:
                 system_jsons = self.collection.find(
-                    {'timestamp': datetime.datetime.fromisoformat(timestamp), 'system': system})
+                    {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system}
+                )
                 for system_json in system_jsons:
                     yield system_json
         else:
-            for result in self.collection.find({'timestamp': datetime.datetime.fromisoformat(timestamp)}):
-                if 'all_features' not in result or not result['all_features']:
+            for result in self.collection.find({"timestamp": datetime.datetime.fromisoformat(timestamp)}):
+                if "all_features" not in result or not result["all_features"]:
                     yield result
 
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
         json_result = self.collection.find(
-            {'timestamp': datetime.datetime.fromisoformat(timestamp), 'system': system}).to_list()
+            {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system}
+        ).to_list()
         if len(json_result) != 1:
-            raise RuntimeError(f'{len(json_result)} entries of system {system} found in collection {timestamp}')
+            raise RuntimeError(f"{len(json_result)} entries of system {system} found in collection {timestamp}")
         return json_result[0]
-    
+
     def _get_all_features(self, timestamp) -> dict[str, list[Any]]:
         json_result = self.collection.find(
-            {'timestamp': datetime.datetime.fromisoformat(timestamp), 'all_features': True}).to_list()
+            {"timestamp": datetime.datetime.fromisoformat(timestamp), "all_features": True}
+        ).to_list()
         if len(json_result) != 1:
-            raise RuntimeError(f'{len(json_result)} entries of feature coverage information found in collection {timestamp}')
+            raise RuntimeError(
+                f"{len(json_result)} entries of feature coverage information found in collection {timestamp}"
+            )
         res = json_result[0]
-        del res['timestamp']
-        del res['all_features']
+        del res["timestamp"]
+        del res["all_features"]
         return res
 
 
 class DirRetriever(Retriever):
-    '''
+    """
     Retrieves features tagging data from the filesystem.
     It assumes data is saved in the following structure:
      <dir>/<timestamp>/<system>.json.
@@ -224,17 +226,17 @@ class DirRetriever(Retriever):
     ./query_features.py export -f /mongo/creds.json -o /write/dir -t <timestamp1> .. <timestampN> -s <system1> .. <systemN>
 
     Then one can use /write/dir as a data source with this retriever
-    '''
+    """
 
     def __init__(self, dir: str):
         super().__init__()
         if not os.path.exists(dir):
-            raise RuntimeError(f'directory {dir} does not exist')
+            raise RuntimeError(f"directory {dir} does not exist")
         self.dir = dir
 
     @staticmethod
     def __get_filename_without_last_ext(filename):
-        return filename.rsplit('.', 1)[0]
+        return filename.rsplit(".", 1)[0]
 
     def close(self):
         pass
@@ -246,7 +248,7 @@ class DirRetriever(Retriever):
             if not os.path.isdir(timestamp_path):
                 continue
             for filename in os.listdir(timestamp_path):
-                if filename.endswith('.json') and not filename == ALL_FEATURES_FILE:
+                if filename.endswith(".json") and not filename == ALL_FEATURES_FILE:
                     system = self.__get_filename_without_last_ext(filename)
                     dictionary[timestamp].append(system)
         return [{"timestamp": entry[0], "systems": entry[1]} for entry in sorted(dictionary.items(), reverse=True)]
@@ -254,37 +256,40 @@ class DirRetriever(Retriever):
     def _get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:
         timestamp_dir = os.path.join(self.dir, timestamp)
         if not os.path.isdir(timestamp_dir):
-            raise RuntimeError(
-                f'timestamp {timestamp} not present in dir {self.dir}')
+            raise RuntimeError(f"timestamp {timestamp} not present in dir {self.dir}")
         for filename in os.listdir(timestamp_dir):
             if filename == ALL_FEATURES_FILE:
                 continue
-            if filename.endswith('.json') and (not systems or self.__get_filename_without_last_ext(filename) in systems):
-                with open(os.path.join(timestamp_dir, filename), 'r', encoding='utf-8') as f:
+            if filename.endswith(".json") and (
+                not systems or self.__get_filename_without_last_ext(filename) in systems
+            ):
+                with open(os.path.join(timestamp_dir, filename), "r", encoding="utf-8") as f:
                     yield json.load(f)
 
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
-        sys_path = os.path.join(self.dir, timestamp, system+'.json')
+        sys_path = os.path.join(self.dir, timestamp, system + ".json")
         if not os.path.exists(sys_path):
-            raise RuntimeError(f'system file not found {sys_path}')
-        with open(sys_path, 'r', encoding='utf-8') as f:
+            raise RuntimeError(f"system file not found {sys_path}")
+        with open(sys_path, "r", encoding="utf-8") as f:
             return json.load(f)
-        
+
     def _get_all_features(self, timestamp) -> dict[str, list[Any]]:
         sys_path = os.path.join(self.dir, timestamp, ALL_FEATURES_FILE)
         if not os.path.exists(sys_path):
-            raise RuntimeError(f'{ALL_FEATURES_FILE} not found')
-        with open(sys_path, 'r', encoding='utf-8') as f:
+            raise RuntimeError(f"{ALL_FEATURES_FILE} not found")
+        with open(sys_path, "r", encoding="utf-8") as f:
             all = json.load(f)
-            if 'timestamp' in all:
-                del all['timestamp']
-            if 'all_features' in all:
-                del all['all_features']
+            if "timestamp" in all:
+                del all["timestamp"]
+            if "all_features" in all:
+                del all["all_features"]
             return all
 
 
-def consolidate_system_features(system_json: SystemFeatures, include_tasks: Iterable[TaskId] = None, exclude_tasks: Iterable[TaskId] = None) -> dict[str, list[dict[str, Any]]]:
-    '''
+def consolidate_system_features(
+    system_json: SystemFeatures, include_tasks: Iterable[TaskId] = None, exclude_tasks: Iterable[TaskId] = None
+) -> dict[str, list[dict[str, Any]]]:
+    """
     Given a dictionary of system feature data, consolidates features across
     all tests into one feature data dictionary.
 
@@ -292,12 +297,18 @@ def consolidate_system_features(system_json: SystemFeatures, include_tasks: Iter
     :param include_tasks: if not None, will only consolidate tasks present in this list
     :param exclude_tasks: if not None, will not consolidate tasks present in this list
     :returns: a dictionary with only feature data
-    '''
+    """
     features = defaultdict(list)
-    for test in system_json['tests']:
-        if include_tasks is not None and TaskIdVariant(test['suite'], test['task_name'], test['variant']) not in include_tasks:
+    for test in system_json["tests"]:
+        if (
+            include_tasks is not None
+            and TaskIdVariant(test["suite"], test["task_name"], test["variant"]) not in include_tasks
+        ):
             continue
-        if exclude_tasks is not None and TaskIdVariant(test['suite'], test['task_name'], test['variant']) in exclude_tasks:
+        if (
+            exclude_tasks is not None
+            and TaskIdVariant(test["suite"], test["task_name"], test["variant"]) in exclude_tasks
+        ):
             continue
 
         for feature_name in test.keys():
@@ -310,15 +321,15 @@ def consolidate_system_features(system_json: SystemFeatures, include_tasks: Iter
 
 
 def minus(first: dict[str, list], second: dict[str, list]) -> dict:
-    '''
+    """
     Creates a new dictionary of first - second calculated on values.
 
-    Ex: 
+    Ex:
     >>> first = {'a':['b','c'],'d':['e']}
     >>> second = {'a':['c'], 'q':[]}
     >>> minus(first, second)
     {'a': ['b'], 'd': ['e']}
-    '''
+    """
     minus = {}
     for feature, feature_list in first.items():
         if feature not in second:
@@ -331,15 +342,15 @@ def minus(first: dict[str, list], second: dict[str, list]) -> dict:
 
 
 def union(first: dict[str, list], second: dict[str, list]) -> dict[str, list]:
-    '''
+    """
     Creates a new dictionary of first U second calculated on values.
 
-    Ex: 
+    Ex:
     >>> first = {'a':['b','c'],'d':['e']}
     >>> second = {'a':['c'], 'd':['f'], 'q':[]}
     >>> union(first, second)
     {'a': ['b', 'c], 'd': ['e','f'], 'q':[]}
-    '''
+    """
     union = copy.deepcopy(first)
     for feature, feature_list in second.items():
         if feature not in union:
@@ -354,45 +365,54 @@ def union(first: dict[str, list], second: dict[str, list]) -> dict[str, list]:
 def subtract_features(first: dict[str, list], second: dict[str, list], match_snap_types: bool) -> dict:
     if match_snap_types:
         return minus(first, second)
-    
-    diff = minus({'cmds': first['cmds'], 'ensures': first['ensures'], 'endpoints': first['endpoints']}, second)
-    tasks = [af for af in first['tasks'] 
-            if not any(af['kind'] == sf['kind'] and af['last_status'] == sf['last_status'] for sf in second['tasks'])]
-    changes = [af for af in first['changes'] 
-            if not any(af['kind'] == sf['kind'] for sf in second['changes'])]
-    interfaces = [af for af in first['interfaces'] 
-                if not any(af['name'] == sf['name'] for sf in second['interfaces'])]
+
+    diff = minus({"cmds": first["cmds"], "ensures": first["ensures"], "endpoints": first["endpoints"]}, second)
+    tasks = [
+        af
+        for af in first["tasks"]
+        if not any(af["kind"] == sf["kind"] and af["last_status"] == sf["last_status"] for sf in second["tasks"])
+    ]
+    changes = [af for af in first["changes"] if not any(af["kind"] == sf["kind"] for sf in second["changes"])]
+    interfaces = [af for af in first["interfaces"] if not any(af["name"] == sf["name"] for sf in second["interfaces"])]
     if tasks:
-        diff['tasks'] = tasks
+        diff["tasks"] = tasks
     if changes:
-        diff['changes'] = changes
+        diff["changes"] = changes
     if interfaces:
-        diff['interfaces'] = interfaces
+        diff["interfaces"] = interfaces
     return diff
 
 
 def list_tasks(system_json: SystemFeatures, remove_failed: bool) -> set[TaskIdVariant]:
-    '''
+    """
     Lists all tasks present in the SystemFeatures dictionary
 
     :param remove_failed: if true, will only include those tasks where success == True
-    '''
+    """
     tasks = set()
-    for test in system_json['tests']:
-        if not remove_failed or test['success']:
-            tasks.add(
-                TaskIdVariant(test['suite'], test['task_name'], test['variant']))
+    for test in system_json["tests"]:
+        if not remove_failed or test["success"]:
+            tasks.add(TaskIdVariant(test["suite"], test["task_name"], test["variant"]))
     return tasks
 
 
-def diff(retriever: Retriever, timestamp1: str, system1: str, timestamp2: str, system2: str, remove_failed: bool, only_same: bool, match_snap_types: bool = True) -> dict:
-    '''
+def diff(
+    retriever: Retriever,
+    timestamp1: str,
+    system1: str,
+    timestamp2: str,
+    system2: str,
+    remove_failed: bool,
+    only_same: bool,
+    match_snap_types: bool = True,
+) -> dict:
+    """
     Calculates set(system1_features) - set(system2_features), each at their
-    respective timestamps. 
+    respective timestamps.
 
     :param remove_failed: if true, will remove all instances of tests where success == False
     :param only_same: if true, will only calculate difference between tests run on both systems
-    '''
+    """
     system_json1 = retriever.get_single_json(timestamp1, system1)
     system_json2 = retriever.get_single_json(timestamp2, system2)
 
@@ -402,30 +422,47 @@ def diff(retriever: Retriever, timestamp1: str, system1: str, timestamp2: str, s
         include_tasks1 = list_tasks(system_json1, remove_failed)
         include_tasks2 = list_tasks(system_json2, remove_failed)
         if only_same:
-            include_tasks2 = include_tasks1 = include_tasks1.intersection(
-                include_tasks2)
+            include_tasks2 = include_tasks1 = include_tasks1.intersection(include_tasks2)
 
-    features1 = consolidate_system_features(
-        system_json1, include_tasks=include_tasks1)
-    features2 = consolidate_system_features(
-        system_json2, include_tasks=include_tasks2)
-    
+    features1 = consolidate_system_features(system_json1, include_tasks=include_tasks1)
+    features2 = consolidate_system_features(system_json2, include_tasks=include_tasks2)
+
     return subtract_features(features1, features2, match_snap_types)
 
 
-def diff_group_by_test(retriever: Retriever, timestamp1: str, system1: str, timestamp2: str, system2: str, remove_failed: bool, only_same: bool, match_snap_types: bool = True) -> dict:
+def diff_group_by_test(
+    retriever: Retriever,
+    timestamp1: str,
+    system1: str,
+    timestamp2: str,
+    system2: str,
+    remove_failed: bool,
+    only_same: bool,
+    match_snap_types: bool = True,
+) -> dict:
     differences = diff(retriever, timestamp1, system1, timestamp2, system2, remove_failed, only_same, match_snap_types)
 
     test_dict = {}
     for feature, feat_list in differences.items():
         for feat in feat_list:
-            results = find_feat(retriever, timestamp1, feat, remove_failed=remove_failed, system=system1, match_snap_types=match_snap_types)
+            results = find_feat(
+                retriever,
+                timestamp1,
+                feat,
+                remove_failed=remove_failed,
+                system=system1,
+                match_snap_types=match_snap_types,
+            )
             if len(results) == 0:
-                raise RuntimeError(f"Something weird happened. The feature {feat} doesn't exist in {system1} at timestamp {timestamp1}")
+                raise RuntimeError(
+                    f"Something weird happened. The feature {feat} doesn't exist in {system1} at timestamp {timestamp1}"
+                )
             if len(results) != 1:
-                raise RuntimeError(f'There should only be one system returned in searching for feature')
+                raise RuntimeError(f"There should only be one system returned in searching for feature")
             if len(results[system1]) == 0:
-                raise RuntimeError(f"A test was not found that contained feature {feat} for {system1}. This is impossible.")
+                raise RuntimeError(
+                    f"A test was not found that contained feature {feat} for {system1}. This is impossible."
+                )
             for test in results[system1]:
                 test = str(TaskId(test.suite, test.task_name))
                 if test not in test_dict:
@@ -443,96 +480,135 @@ def dict_to_string(d):
         stringed = stringed + "-" + str(value)
     return stringed[1:]
 
-def diff_group_by_test_csv(retriever: Retriever, timestamp1: str, system1: str, timestamp2: str, system2: str, remove_failed: bool, only_same: bool, match_snap_types: bool = True) -> str:
+
+def diff_group_by_test_csv(
+    retriever: Retriever,
+    timestamp1: str,
+    system1: str,
+    timestamp2: str,
+    system2: str,
+    remove_failed: bool,
+    only_same: bool,
+    match_snap_types: bool = True,
+) -> str:
     differences = diff(retriever, timestamp1, system1, timestamp2, system2, remove_failed, only_same, match_snap_types)
 
     test_dict = {}
     for feature, feat_list in differences.items():
         for feat in feat_list:
-            results = find_feat(retriever, timestamp1, feat, remove_failed=remove_failed, system=system1, match_snap_types=match_snap_types)
+            results = find_feat(
+                retriever,
+                timestamp1,
+                feat,
+                remove_failed=remove_failed,
+                system=system1,
+                match_snap_types=match_snap_types,
+            )
             if len(results) == 0:
-                raise RuntimeError(f"Something weird happened. The feature {feat} doesn't exist in {system1} at timestamp {timestamp1}")
+                raise RuntimeError(
+                    f"Something weird happened. The feature {feat} doesn't exist in {system1} at timestamp {timestamp1}"
+                )
             if len(results) != 1:
-                raise RuntimeError(f'There should only be one system returned in searching for feature')
+                raise RuntimeError(f"There should only be one system returned in searching for feature")
             if len(results[system1]) == 0:
-                raise RuntimeError(f"A test was not found that contained feature {feat} for {system1}. This is impossible.")
+                raise RuntimeError(
+                    f"A test was not found that contained feature {feat} for {system1}. This is impossible."
+                )
             for test in results[system1]:
                 test = str(TaskId(test.suite, test.task_name))
                 if test not in test_dict:
                     test_dict[test] = []
                 test_dict[test].append(dict_to_string(feat))
 
-    csv=""
+    csv = ""
     for test, features in test_dict.items():
         csv = f"{csv}\n{test}"
         for feature in features:
             csv = f"{csv},{feature}"
     return csv
-            
 
 
 def diff_all_features(retriever: Retriever, timestamp: str, system: str, remove_failed: bool) -> dict:
-    '''
+    """
     Calculates set(coverage_features) - set(system_features), at the indicated timestamp. The difference
     in features for cmds, ensures, and endpoints is calculated on the complete feature. The difference
     for tasks is computed on kind and last_status. The difference for changes are computed on kind.
     The difference for interfaces is computed on name.
 
     :param remove_failed: if true, will remove all instances of tests where success == False
-    '''
+    """
     sys_features = feat_sys(retriever, timestamp, system, remove_failed)
     all_features = retriever.get_all_features(timestamp)
     return subtract_features(all_features, sys_features, False)
 
 
-def feat_sys(retriever: Retriever, timestamp: str, system: str, remove_failed: bool, suite: str = None, task: str = None, variant: str = None) -> dict:
-    '''
-    Calculates set(system_features), at the indicated timestamp. 
+def feat_sys(
+    retriever: Retriever,
+    timestamp: str,
+    system: str,
+    remove_failed: bool,
+    suite: str = None,
+    task: str = None,
+    variant: str = None,
+) -> dict:
+    """
+    Calculates set(system_features), at the indicated timestamp.
 
     :param remove_failed: if true, will remove all instances of tests where success == False
-    '''
+    """
     system_json = retriever.get_single_json(timestamp, system)
 
     if suite or task or variant:
-        tests = system_json['tests']
-        system_json = SystemFeatures(schema_version=system_json['schema_version'] if 'schema_version' in system_json else '', 
-                                     system=system_json['system'] if 'system' in system_json else '', 
-                                     scenarios=system_json['scenarios'] if 'scenarios' in system_json else '',
-                                     env_variables=system_json['env_variables'] if 'env_variables' in system_json else '')
-        system_json['tests'] = [test for test in tests 
-                                if (not suite or test['suite'] == suite) and 
-                                (not task or test['task_name'] == task) and 
-                                (not variant or test['variant'] == variant)]
+        tests = system_json["tests"]
+        system_json = SystemFeatures(
+            schema_version=system_json["schema_version"] if "schema_version" in system_json else "",
+            system=system_json["system"] if "system" in system_json else "",
+            scenarios=system_json["scenarios"] if "scenarios" in system_json else "",
+            env_variables=system_json["env_variables"] if "env_variables" in system_json else "",
+        )
+        system_json["tests"] = [
+            test
+            for test in tests
+            if (not suite or test["suite"] == suite)
+            and (not task or test["task_name"] == task)
+            and (not variant or test["variant"] == variant)
+        ]
 
     include_tasks = None
     if remove_failed:
         include_tasks = list_tasks(system_json, remove_failed)
 
-    return consolidate_system_features(
-        system_json, include_tasks=include_tasks)
+    return consolidate_system_features(system_json, include_tasks=include_tasks)
 
 
 def get_feature_name_from_feature(feat: dict) -> str:
-    if 'cmd' in feat and len(feat) == 1:
-        return 'cmds'
-    elif 'method' in feat and 'path' in feat and (len(feat) == 2 or len(feat) == 3):
-        return 'endpoints'
-    elif 'manager' in feat and 'function' in feat and len(feat) == 2:
-        return 'ensures'
-    elif 'kind' in feat and 'last_status' in feat:
-        return 'tasks'
-    elif 'name' in feat:
-        return 'interfaces'
-    elif 'kind' in feat:
-        return 'changes'
-    return ''
+    if "cmd" in feat and len(feat) == 1:
+        return "cmds"
+    elif "method" in feat and "path" in feat and (len(feat) == 2 or len(feat) == 3):
+        return "endpoints"
+    elif "manager" in feat and "function" in feat and len(feat) == 2:
+        return "ensures"
+    elif "kind" in feat and "last_status" in feat:
+        return "tasks"
+    elif "name" in feat:
+        return "interfaces"
+    elif "kind" in feat:
+        return "changes"
+    return ""
 
 
-def find_feat(retriever: Retriever, timestamp: str, feat: dict, remove_failed: bool, system: str = None, match_snap_types: bool = False) -> dict[str, TaskIdVariant]:
-    '''
+def find_feat(
+    retriever: Retriever,
+    timestamp: str,
+    feat: dict,
+    remove_failed: bool,
+    system: str = None,
+    match_snap_types: bool = False,
+) -> dict[str, TaskIdVariant]:
+    """
     Given a timestamp, a feature, and optionally a system, finds
     all tests that contain the indicated feature. If no system
-    is specified, then returns all systems that contain the 
+    is specified, then returns all systems that contain the
     feature combined with tests.
 
     A feature match happens for cmds, endpoints, and ensures
@@ -548,20 +624,22 @@ def find_feat(retriever: Retriever, timestamp: str, feat: dict, remove_failed: b
     :param remove_failed: if true, will remove all instances of tests where success == False
     :param force_exact: if true, will match the entire feature when searching for tests
     :returns: dictionary where each key is a system and each value is a list of tests that contain the feature
-    '''
+    """
 
     feat_name = get_feature_name_from_feature(feat)
     if not feat_name:
-        raise RuntimeError(f'feature {feat} not a recognized feature')
+        raise RuntimeError(f"feature {feat} not a recognized feature")
 
-    feat_in_test=lambda test: feat_name in test and feat in test[feat_name]
+    feat_in_test = lambda test: feat_name in test and feat in test[feat_name]
     if not match_snap_types:
-        if feat_name == 'tasks':
-            feat_in_test = lambda test: feat_name in test and any(t['kind'] == feat['kind'] and t['last_status'] == feat['last_status'] for t in test['tasks'])
-        elif feat_name == 'changes':
-            feat_in_test = lambda test: feat_name in test and any(c['kind'] == feat['kind'] for c in test['changes'])
-        elif feat_name == 'interfaces':
-            feat_in_test = lambda test: feat_name in test and any(i['name'] == feat['name'] for i in test['interfaces'])
+        if feat_name == "tasks":
+            feat_in_test = lambda test: feat_name in test and any(
+                t["kind"] == feat["kind"] and t["last_status"] == feat["last_status"] for t in test["tasks"]
+            )
+        elif feat_name == "changes":
+            feat_in_test = lambda test: feat_name in test and any(c["kind"] == feat["kind"] for c in test["changes"])
+        elif feat_name == "interfaces":
+            feat_in_test = lambda test: feat_name in test and any(i["name"] == feat["name"] for i in test["interfaces"])
 
     system_list = None
     if system:
@@ -570,10 +648,13 @@ def find_feat(retriever: Retriever, timestamp: str, feat: dict, remove_failed: b
 
     ret = {}
     for system_json in system_jsons:
-        tests = [TaskIdVariant(suite=test['suite'], task_name=test['task_name'], variant=test['variant']) 
-                    for test in system_json['tests'] if feat_in_test(test) and (not remove_failed or test['success'])]
+        tests = [
+            TaskIdVariant(suite=test["suite"], task_name=test["task_name"], variant=test["variant"])
+            for test in system_json["tests"]
+            if feat_in_test(test) and (not remove_failed or test["success"])
+        ]
         if tests:
-            ret[system_json['system']] = tests
+            ret[system_json["system"]] = tests
     return ret
 
 
@@ -582,38 +663,36 @@ def check_duplicate(args):
     # Exclude all variants of the task from consolidation so that
     # it isn't flagged as a duplicate when variants of the same
     # task have identical features.
-    task_id = TaskId(suite=task['suite'], task_name=task['task_name'])
-    features = consolidate_system_features(
-        system_json, exclude_tasks=[task_id])
-    to_check = {key: value for key,
-                value in task.items() if key in KNOWN_FEATURES}
+    task_id = TaskId(suite=task["suite"], task_name=task["task_name"])
+    features = consolidate_system_features(system_json, exclude_tasks=[task_id])
+    to_check = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
     mns = minus(to_check, features)
     if to_check and not mns:
-        return TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
+        return TaskIdVariant(suite=task["suite"], task_name=task["task_name"], variant=task["variant"])
     return None
 
 
 def dup(retriever: Retriever, timestamp: str, system: str, remove_failed: bool) -> list[TaskIdVariant]:
-    '''
+    """
     Returns tests whose features are completely covered by other tests in that system.
 
     :param remove_failed: if true, will remove all instances of tests whose success == False
-    '''
+    """
     system_json = retriever.get_single_json(timestamp, system)
 
     if remove_failed:
-        tests = system_json['tests']
-        system_json = SystemFeatures(schema_version=system_json['schema_version'] if 'schema_version' in system_json else '', 
-                                     system=system_json['system'] if 'system' in system_json else '', 
-                                     scenarios=system_json['scenarios'] if 'scenarios' in system_json else '',
-                                     env_variables=system_json['env_variables'] if 'env_variables' in system_json else '')
-        system_json['tests'] = [
-            task for task in tests if task['success']]
+        tests = system_json["tests"]
+        system_json = SystemFeatures(
+            schema_version=system_json["schema_version"] if "schema_version" in system_json else "",
+            system=system_json["system"] if "system" in system_json else "",
+            scenarios=system_json["scenarios"] if "scenarios" in system_json else "",
+            env_variables=system_json["env_variables"] if "env_variables" in system_json else "",
+        )
+        system_json["tests"] = [task for task in tests if task["success"]]
 
     duplicates = []
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        results = executor.map(
-            check_duplicate, [(task, system_json) for task in system_json['tests']])
+        results = executor.map(check_duplicate, [(task, system_json) for task in system_json["tests"]])
         for result in results:
             if result is not None:
                 duplicates.append(result)
@@ -622,72 +701,76 @@ def dup(retriever: Retriever, timestamp: str, system: str, remove_failed: bool) 
 
 
 def export(retriever: Retriever, output: str, timestamps: list[str], systems: list[str] = None):
-    '''
+    """
     Writes the feature data to the output directory in format <dir>/<timestamp>/<system>.json.
     It creates one directory for each supplied timestamp, and will write one json file for each system
     in that timestamp and present in the systems list. If the systems list is None, then it will write
     all systems at each supplied timestamp.
-    '''
+    """
     for timestamp in timestamps:
         os.makedirs(os.path.join(output, timestamp), exist_ok=True)
         for system_json in retriever.get_systems(timestamp, systems):
-            with open(os.path.join(output, timestamp, system_json['system'] + ".json"), 'w', encoding='utf-8') as f:
+            with open(os.path.join(output, timestamp, system_json["system"] + ".json"), "w", encoding="utf-8") as f:
                 json.dump(system_json, f, cls=DateTimeEncoder)
         try:
             all_features = retriever.get_all_features(timestamp)
-            with open(os.path.join(output, timestamp, ALL_FEATURES_FILE), 'w', encoding='utf-8') as f:
+            with open(os.path.join(output, timestamp, ALL_FEATURES_FILE), "w", encoding="utf-8") as f:
                 json.dump(all_features, f, cls=DateTimeEncoder)
         except Exception as e:
-            print(f'could not find all features at timestamp {timestamp}', file=sys.stderr)
+            print(f"could not find all features at timestamp {timestamp}", file=sys.stderr)
 
 
 def task_list(retriever: Retriever, timestamp: str) -> set[TaskIdVariant]:
-    '''
+    """
     Given a timestamp, gets the complete set of tasks (suite, task, and variant names)
-    '''
+    """
     all_data = retriever.get_systems(timestamp)
     tasks = set()
     for data in all_data:
-        if 'tests' not in data:
+        if "tests" not in data:
             continue
         tasks.update(
-            {TaskIdVariant(suite=d['suite'], task_name=d['task_name'], variant=d['variant']) for d in data['tests']}
+            {TaskIdVariant(suite=d["suite"], task_name=d["task_name"], variant=d["variant"]) for d in data["tests"]}
         )
     return tasks
 
 
 def filter_snap_types(snap_types: list[str]) -> list[str]:
-    return [t for t in snap_types if 'NOT FOUND' not in t]
+    return [t for t in snap_types if "NOT FOUND" not in t]
 
 
 def clean_dictionary(features: SystemFeatures, exclude: list[str], remove_snap_types: bool = False) -> None:
-    '''
+    """
     Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
 
     :param features: features dictionary to clean
     :param exclude: removes all features of the specified type
     :param remove_snap_types: if true, removes snap types from all features in the dictionary.
-    '''
+    """
+
     def clean_snap_types(lst: list):
         if not lst:
             return
         for entry in lst:
-            if 'snap_types' in entry:
+            if "snap_types" in entry:
                 if remove_snap_types:
-                    del entry['snap_types']
+                    del entry["snap_types"]
                 else:
-                    entry['snap_types'] = filter_snap_types(entry['snap_types'])
-                
-    for test in features['tests']:
+                    entry["snap_types"] = filter_snap_types(entry["snap_types"])
+
+    for test in features["tests"]:
         for exclude_feature in exclude:
             test.pop(exclude_feature, None)
-        clean_snap_types(test.get('tasks'))
-        clean_snap_types(test.get('changes'))
+        clean_snap_types(test.get("tasks"))
+        clean_snap_types(test.get("changes"))
 
 
-def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]) -> tuple[dict, list[TaskIdVariant], int]:
+def get_force_matched_features(
+    sorted_tasks: list[dict], force_matches: list[str]
+) -> tuple[dict, list[TaskIdVariant], int]:
     force_matches = [fm.lower() for fm in force_matches]
+
     def contains_force_matches(feature: dict[str, Any]) -> bool:
         def has_terms(value: Any) -> bool:
             if isinstance(value, str):
@@ -697,6 +780,7 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
             if isinstance(value, (list, tuple, set)):
                 return any(has_terms(v) for v in value)
             return False
+
         return has_terms(feature)
 
     total_time = 0
@@ -707,19 +791,29 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
         task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
         for name, features in task_features.items():
             matching = [
-                feature for feature in features
+                feature
+                for feature in features
                 if feature not in covered_features.get(name, []) and contains_force_matches(feature)
             ]
             if matching:
                 covered_features = union(covered_features, task_features)
-                minimal_tasks.add(TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant']))
-                total_time += task['runtime']
+                minimal_tasks.add(
+                    TaskIdVariant(suite=task["suite"], task_name=task["task_name"], variant=task["variant"])
+                )
+                total_time += task["runtime"]
                 break
     return covered_features, minimal_tasks, total_time
 
 
-def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_match_keywords: list[str], exclude: list[str]) -> dict[str, list[TaskIdVariant]]:
-    '''
+def minimal_coverage(
+    retriever: Retriever,
+    timestamp: str,
+    system: str,
+    max_minutes: int,
+    force_match_keywords: list[str],
+    exclude: list[str],
+) -> dict[str, list[TaskIdVariant]]:
+    """
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
 
     :param max_minutes: if greater than 0, then the total runtime for each system will be less than max_minutes.
@@ -728,9 +822,9 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
     :param exclude: for each name of feature included (i.e. cmds, endpoints, ensures, interfaces, tasks, changes), in this list, will remove it before calculating coverage.
     :param match_snap_types: if true, will include matching snap types in coverage calculation.
     :returns: dictionary where each system is a key and the value is a list of tests for coverage.
-    '''
+    """
     if max_minutes == 0 and force_match_keywords:
-        raise RuntimeError('force match keywords should only be used in conjunction with max minutes')
+        raise RuntimeError("force match keywords should only be used in conjunction with max minutes")
     if system:
         sys_jsons = [retriever.get_single_json(timestamp, system)]
     else:
@@ -739,37 +833,39 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
     for sys_json in sys_jsons:
         time_left = max_minutes if max_minutes > 0 else math.inf
         clean_dictionary(sys_json, exclude)
-        tasks = sys_json['tests']
+        tasks = sys_json["tests"]
         # All tasks that were successful appear before those that failed
-        tasks = sorted(tasks, key=lambda x: (not x['success'], x['runtime']))
+        tasks = sorted(tasks, key=lambda x: (not x["success"], x["runtime"]))
         covered_features = {}
         minimal_tasks = set()
         if force_match_keywords:
             covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_match_keywords)
             time_left -= total_seconds / 60
         for task in tasks:
-            task_id = TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
-            # Since we have failed tasks at the end of the task list, 
+            task_id = TaskIdVariant(suite=task["suite"], task_name=task["task_name"], variant=task["variant"])
+            # Since we have failed tasks at the end of the task list,
             # we can have tasks with lower runtime after those with higher
-            if task_id in minimal_tasks or time_left - task['runtime'] / 60 < 0:
+            if task_id in minimal_tasks or time_left - task["runtime"] / 60 < 0:
                 continue
             task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
             new_covered = minus(task_features, covered_features)
             if new_covered:
                 minimal_tasks.add(task_id)
                 covered_features = union(covered_features, task_features)
-                time_left -= task['runtime'] / 60
-        coverage[sys_json['system']] = list(minimal_tasks)
+                time_left -= task["runtime"] / 60
+        coverage[sys_json["system"]] = list(minimal_tasks)
     return coverage
 
 
 def add_data_source_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('-f', '--file', help='json file containing creds for mongodb', type=argparse.FileType('r', encoding='utf-8'))
-    parser.add_argument('-d', '--dir', help='folder containing feature data', type=str)
+    parser.add_argument(
+        "-f", "--file", help="json file containing creds for mongodb", type=argparse.FileType("r", encoding="utf-8")
+    )
+    parser.add_argument("-d", "--dir", help="folder containing feature data", type=str)
 
 
 def add_diff_parser(subparsers: argparse._SubParsersAction) -> str:
-    diff_description = '''
+    diff_description = """
         Calculates feature diff between two systems: set(features_1) - set(features_2).
         You can specify either a json file with credentials for mongodb or a directory with features output.
         If using a directory, the directory format must be <dir>/<timestamp1>/<system1>.json and 
@@ -780,23 +876,27 @@ def add_diff_parser(subparsers: argparse._SubParsersAction) -> str:
         comparison to only tasks that executed on both systems, use the --only-same flag.
 
         If you wish to create a directory from mongo data, use the export command instead of diff first.
-    '''
-    cmd = 'diff'
-    diff: argparse.ArgumentParser = subparsers.add_parser(cmd, help='calculate diff between system features',
-                                 description=diff_description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    """
+    cmd = "diff"
+    diff: argparse.ArgumentParser = subparsers.add_parser(
+        cmd,
+        help="calculate diff between system features",
+        description=diff_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     add_data_source_args(diff)
-    diff.add_argument('-t1', '--timestamp1', help='timestamp of first execution', type=str, required=True)
-    diff.add_argument('-s1', '--system1', help='system of first execution', type=str, required=True)
-    diff.add_argument('-t2', '--timestamp2', help='timestamp of second execution', type=str, required=True)
-    diff.add_argument('-s2', '--system2', help='system of second execution', type=str, required=True)
-    diff.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
-    diff.add_argument('--only-same', help='only compare tasks that were executed on both systems', action='store_true')
+    diff.add_argument("-t1", "--timestamp1", help="timestamp of first execution", type=str, required=True)
+    diff.add_argument("-s1", "--system1", help="system of first execution", type=str, required=True)
+    diff.add_argument("-t2", "--timestamp2", help="timestamp of second execution", type=str, required=True)
+    diff.add_argument("-s2", "--system2", help="system of second execution", type=str, required=True)
+    diff.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    diff.add_argument("--only-same", help="only compare tasks that were executed on both systems", action="store_true")
     return cmd
 
 
 def add_diff_parsers(subparsers: argparse._SubParsersAction) -> tuple[str, str, str]:
 
-    sys_description = '''
+    sys_description = """
         Calculates feature diff between two systems: set(features_1) - set(features_2).
         You can specify either a json file with credentials for mongodb or a directory with features output.
         If using a directory, the directory format must be <dir>/<timestamp1>/<system1>.json and 
@@ -807,8 +907,8 @@ def add_diff_parsers(subparsers: argparse._SubParsersAction) -> tuple[str, str, 
         comparison to only tasks that executed on both systems, use the --only-same flag.
 
         If you wish to create a directory from mongo data, use the export command instead of diff first.
-    '''
-    all_description = '''
+    """
+    all_description = """
         Calculates feature diff between all possible features a system's: set(all_features) - set(system_features).
         You can specify either a json file with credentials for mongodb or a directory with features output.
         If using a directory, the directory format must be <dir>/<timestamp1>/<system1>.json and 
@@ -818,37 +918,48 @@ def add_diff_parsers(subparsers: argparse._SubParsersAction) -> tuple[str, str, 
         to only tasks that were successful, use the --remove-failed flag.
 
         If you wish to create a directory from mongo data, use the export command instead of diff first.
-    '''
-    cmd = 'diff'
-    cmd_sys = 'systems'
-    cmd_all = 'all-features'
-    diff: argparse.ArgumentParser = subparsers.add_parser(cmd, help='calculate diff between features',
-                                 description='Calculates feature diff either between two systems or between a system and all possible features.')
-    diff_subparsers = diff.add_subparsers(dest='diff_cmd')
-    sys = diff_subparsers.add_parser(cmd_sys, help='calculate diff between two systems\' features',
-                               description=sys_description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    """
+    cmd = "diff"
+    cmd_sys = "systems"
+    cmd_all = "all-features"
+    diff: argparse.ArgumentParser = subparsers.add_parser(
+        cmd,
+        help="calculate diff between features",
+        description="Calculates feature diff either between two systems or between a system and all possible features.",
+    )
+    diff_subparsers = diff.add_subparsers(dest="diff_cmd")
+    sys = diff_subparsers.add_parser(
+        cmd_sys,
+        help="calculate diff between two systems' features",
+        description=sys_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     add_data_source_args(sys)
-    sys.add_argument('-t1', '--timestamp1', help='timestamp of first execution', type=str, required=True)
-    sys.add_argument('-s1', '--system1', help='system of first execution', type=str, required=True)
-    sys.add_argument('-t2', '--timestamp2', help='timestamp of second execution', type=str, required=True)
-    sys.add_argument('-s2', '--system2', help='system of second execution', type=str, required=True)
-    sys.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
-    sys.add_argument('--only-same', help='only compare tasks that were executed on both systems', action='store_true')
-    sys.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
-    sys.add_argument('--sort-by-test', help='group features by the tests they are found in', action='store_true')
-    sys.add_argument('--csv', help='output the diff in csv format rather than json', action='store_true')
+    sys.add_argument("-t1", "--timestamp1", help="timestamp of first execution", type=str, required=True)
+    sys.add_argument("-s1", "--system1", help="system of first execution", type=str, required=True)
+    sys.add_argument("-t2", "--timestamp2", help="timestamp of second execution", type=str, required=True)
+    sys.add_argument("-s2", "--system2", help="system of second execution", type=str, required=True)
+    sys.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    sys.add_argument("--only-same", help="only compare tasks that were executed on both systems", action="store_true")
+    sys.add_argument("--match-snap-types", help="match the entire feature, including snap types", action="store_true")
+    sys.add_argument("--sort-by-test", help="group features by the tests they are found in", action="store_true")
+    sys.add_argument("--csv", help="output the diff in csv format rather than json", action="store_true")
 
-    all = diff_subparsers.add_parser(cmd_all, help='calculate diff between system features and all features',
-                                     description=all_description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    all = diff_subparsers.add_parser(
+        cmd_all,
+        help="calculate diff between system features and all features",
+        description=all_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     add_data_source_args(all)
-    all.add_argument('-t', '--timestamp', help='timestamp of instance to search', required=True, type=str)
-    all.add_argument('-s', '--system', help='system whose features should be searched', required=True, type=str)
-    all.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
+    all.add_argument("-t", "--timestamp", help="timestamp of instance to search", required=True, type=str)
+    all.add_argument("-s", "--system", help="system whose features should be searched", required=True, type=str)
+    all.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
     return cmd, cmd_sys, cmd_all
 
 
 def add_dup_parser(subparsers: argparse._SubParsersAction) -> str:
-    dup_description = '''
+    dup_description = """
         For each task present in the indicated system under the indicated timestamp,
         calculates the difference between that task's features and the system's 
         without the task: set(task_features) - set(system_features without task).
@@ -856,73 +967,93 @@ def add_dup_parser(subparsers: argparse._SubParsersAction) -> str:
         a duplicate feature.
 
         To remove all failed tasks from consideration, add the --remove-failed flag.
-    '''
-    cmd = 'dup'
-    duplicate: argparse.ArgumentParser = subparsers.add_parser(cmd,
-                                      help='show tasks whose features are completely covered by the rest',
-                                      description=dup_description,
-                                      formatter_class=argparse.RawDescriptionHelpFormatter)
+    """
+    cmd = "dup"
+    duplicate: argparse.ArgumentParser = subparsers.add_parser(
+        cmd,
+        help="show tasks whose features are completely covered by the rest",
+        description=dup_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     add_data_source_args(duplicate)
-    duplicate.add_argument('-t', '--timestamp', help='timestamp of instance to search', required=True, type=str)
-    duplicate.add_argument('-s', '--system', help='system whose features should be searched', required=True, type=str)
-    duplicate.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
+    duplicate.add_argument("-t", "--timestamp", help="timestamp of instance to search", required=True, type=str)
+    duplicate.add_argument("-s", "--system", help="system whose features should be searched", required=True, type=str)
+    duplicate.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
     return cmd
 
 
 def add_export_parser(subparsers: argparse._SubParsersAction) -> str:
-    cmd = 'export'
-    export: argparse.ArgumentParser = subparsers.add_parser(cmd, help='export data to output local directory',
-                                   description='Grabs system json files by timestamps and systems and saves them to the folder indicated in the output arguement.')
+    cmd = "export"
+    export: argparse.ArgumentParser = subparsers.add_parser(
+        cmd,
+        help="export data to output local directory",
+        description="Grabs system json files by timestamps and systems and saves them to the folder indicated in the output arguement.",
+    )
     add_data_source_args(export)
-    export.add_argument('-t', '--timestamps', help='space-separated list of identifying timestamps', required=True, nargs='+')
-    export.add_argument('-s', '--systems', help='space-separated list of systems', nargs='*')
-    export.add_argument('-o', '--output', help='folder to save feature data', required=True, type=str)
+    export.add_argument(
+        "-t", "--timestamps", help="space-separated list of identifying timestamps", required=True, nargs="+"
+    )
+    export.add_argument("-s", "--systems", help="space-separated list of systems", nargs="*")
+    export.add_argument("-o", "--output", help="folder to save feature data", required=True, type=str)
     return cmd
 
 
 def add_list_parser(subparsers: argparse._SubParsersAction) -> str:
-    cmd = 'list'
-    lst: argparse.ArgumentParser = subparsers.add_parser(cmd, help='lists all timestamps with systems present in data source',
-                                description='Lists all timestamps with systems present in data source.')
+    cmd = "list"
+    lst: argparse.ArgumentParser = subparsers.add_parser(
+        cmd,
+        help="lists all timestamps with systems present in data source",
+        description="Lists all timestamps with systems present in data source.",
+    )
     add_data_source_args(lst)
     return cmd
 
 
 def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str, str, str, str]:
-    cmd = 'feat'
-    cmd_all = 'all'
-    cmd_sys = 'sys'
-    cmd_find = 'find'
-    cmd_cover = 'cover'
-    feat: argparse.ArgumentParser = subparsers.add_parser(cmd, help='', description='')
-    feat_subparsers = feat.add_subparsers(dest='features_cmd')
-    all = feat_subparsers.add_parser(cmd_all, help='lists all features at a given timestamp',
-                                     description='Lists all features for a given timestamp present in data source.')
+    cmd = "feat"
+    cmd_all = "all"
+    cmd_sys = "sys"
+    cmd_find = "find"
+    cmd_cover = "cover"
+    feat: argparse.ArgumentParser = subparsers.add_parser(cmd, help="", description="")
+    feat_subparsers = feat.add_subparsers(dest="features_cmd")
+    all = feat_subparsers.add_parser(
+        cmd_all,
+        help="lists all features at a given timestamp",
+        description="Lists all features for a given timestamp present in data source.",
+    )
     add_data_source_args(all)
-    all.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
+    all.add_argument("-t", "--timestamp", help="timestamp for feature data", required=True, type=str)
 
-    sys = feat_subparsers.add_parser(cmd_sys, help='lists all features for a given system and timestamp',
-                                     description='Lists all features for a given system and timestamp present in data source.')
+    sys = feat_subparsers.add_parser(
+        cmd_sys,
+        help="lists all features for a given system and timestamp",
+        description="Lists all features for a given system and timestamp present in data source.",
+    )
     add_data_source_args(sys)
-    sys.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
-    sys.add_argument('-s', '--system', help='system for feature data', required=True, type=str)
-    sys.add_argument('--suite', help='if provided, only grab features from this suite', default=None, type=str)
-    sys.add_argument('--task', help='if provided, only grab features of this task', default=None, type=str)
-    sys.add_argument('--variant', help='if provided, only grab features with this variant', default=None, type=str)
-    sys.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
+    sys.add_argument("-t", "--timestamp", help="timestamp for feature data", required=True, type=str)
+    sys.add_argument("-s", "--system", help="system for feature data", required=True, type=str)
+    sys.add_argument("--suite", help="if provided, only grab features from this suite", default=None, type=str)
+    sys.add_argument("--task", help="if provided, only grab features of this task", default=None, type=str)
+    sys.add_argument("--variant", help="if provided, only grab features with this variant", default=None, type=str)
+    sys.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
 
-
-    find = feat_subparsers.add_parser(cmd_find, help='given a feature, finds which tests contain it',
-                                     description='Lists tests that contain the feature')
+    find = feat_subparsers.add_parser(
+        cmd_find,
+        help="given a feature, finds which tests contain it",
+        description="Lists tests that contain the feature",
+    )
     add_data_source_args(find)
-    find.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
-    find.add_argument('-s', '--system', help='(optional) system to search for feature in', default=None, type=str)
-    find.add_argument('--feat', help='feature to search for (json format)', required=True, type=str)
-    find.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
-    find.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
+    find.add_argument("-t", "--timestamp", help="timestamp for feature data", required=True, type=str)
+    find.add_argument("-s", "--system", help="(optional) system to search for feature in", default=None, type=str)
+    find.add_argument("--feat", help="feature to search for (json format)", required=True, type=str)
+    find.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    find.add_argument("--match-snap-types", help="match the entire feature, including snap types", action="store_true")
 
-    cover = feat_subparsers.add_parser(cmd_cover, help='find the minimal set of tests that cover features of a system',
-                                     description='''
+    cover = feat_subparsers.add_parser(
+        cmd_cover,
+        help="find the minimal set of tests that cover features of a system",
+        description="""
                                      Lists minimal set of tests that cover features of a system. It calculates coverage
                                      using a greedy approach based on runtime and will attempt to include tests with 
                                      smaller runtimes first. To impose a time constraint (and therefore reduce the result
@@ -932,20 +1063,26 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
                                      use the flag --force-match-keywords followed by keywords to include. To instead exclude
                                      certain features from the coverage set calculating, use --exclude followed by the names
                                      of the features to exclude (one of: cmds, endpoints, ensures, tasks, changes, interfaces).
-                                     ''')
-    add_data_source_args(cover)      
-    cover.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
-    cover.add_argument('-s', '--system', help='system to search for feature in', default=None, type=str)
-    cover.add_argument('--max-minutes', help='Maximum amount of runtime minutes allowed in minimal set of tests', default=0, type=int)
-    cover.add_argument('--force-match-keywords', help='when combined with max-minutes, ensures that features that contain one of the following strings are included (even if longer than max minutes)', nargs='+')
-    cover.add_argument('--exclude', help='exclude the list of features from coverage considerations', nargs='+')
+                                     """,
+    )
+    add_data_source_args(cover)
+    cover.add_argument("-t", "--timestamp", help="timestamp for feature data", required=True, type=str)
+    cover.add_argument("-s", "--system", help="system to search for feature in", default=None, type=str)
+    cover.add_argument(
+        "--max-minutes", help="Maximum amount of runtime minutes allowed in minimal set of tests", default=0, type=int
+    )
+    cover.add_argument(
+        "--force-match-keywords",
+        help="when combined with max-minutes, ensures that features that contain one of the following strings are included (even if longer than max minutes)",
+        nargs="+",
+    )
+    cover.add_argument("--exclude", help="exclude the list of features from coverage considerations", nargs="+")
     return cmd, cmd_all, cmd_sys, cmd_find, cmd_cover
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='cli to query data source containing feature data')
-    subparsers = parser.add_subparsers(dest='command')
+    parser = argparse.ArgumentParser(description="cli to query data source containing feature data")
+    subparsers = parser.add_subparsers(dest="command")
     subparsers.required = True
     diff_cmd, diff_sys_cmd, diff_all_cmd = add_diff_parsers(subparsers)
     dup_cmd = add_dup_parser(subparsers)
@@ -957,36 +1094,66 @@ def main():
 
     retriever_creator = None
     if args.dir:
-        def retriever_creator(): return DirRetriever(args.dir)
+
+        def retriever_creator():
+            return DirRetriever(args.dir)
+
     elif args.file:
-        def retriever_creator(): return MongoRetriever(args.file)
+
+        def retriever_creator():
+            return MongoRetriever(args.file)
+
     else:
         raise RuntimeError(
-            'you must specify either a mongodb credential file (-f) or a directory with feature tagging results (-d)')
+            "you must specify either a mongodb credential file (-f) or a directory with feature tagging results (-d)"
+        )
 
     with closing(retriever_creator()) as retriever:
         if args.command == diff_cmd:
             if args.diff_cmd == diff_sys_cmd:
                 if args.sort_by_test:
                     if args.csv:
-                        result = diff_group_by_test_csv(retriever, args.timestamp1, args.system1,
-                            args.timestamp2, args.system2, args.remove_failed, args.only_same, args.match_snap_types)    
+                        result = diff_group_by_test_csv(
+                            retriever,
+                            args.timestamp1,
+                            args.system1,
+                            args.timestamp2,
+                            args.system2,
+                            args.remove_failed,
+                            args.only_same,
+                            args.match_snap_types,
+                        )
                         print(result)
                         exit(0)
-                    result = diff_group_by_test(retriever, args.timestamp1, args.system1,
-                            args.timestamp2, args.system2, args.remove_failed, args.only_same, args.match_snap_types)
+                    result = diff_group_by_test(
+                        retriever,
+                        args.timestamp1,
+                        args.system1,
+                        args.timestamp2,
+                        args.system2,
+                        args.remove_failed,
+                        args.only_same,
+                        args.match_snap_types,
+                    )
                 else:
-                    result = diff(retriever, args.timestamp1, args.system1,
-                            args.timestamp2, args.system2, args.remove_failed, args.only_same, args.match_snap_types)
+                    result = diff(
+                        retriever,
+                        args.timestamp1,
+                        args.system1,
+                        args.timestamp2,
+                        args.system2,
+                        args.remove_failed,
+                        args.only_same,
+                        args.match_snap_types,
+                    )
             elif args.diff_cmd == diff_all_cmd:
                 result = diff_all_features(retriever, args.timestamp, args.system, args.remove_failed)
             else:
-                raise RuntimeError(f'diff command not recognized: {args.diff_cmd}')
+                raise RuntimeError(f"diff command not recognized: {args.diff_cmd}")
             json.dump(result, sys.stdout, cls=DateTimeEncoder)
             print()
         elif args.command == dup_cmd:
-            results = dup(retriever, args.timestamp,
-                          args.system, args.remove_failed)
+            results = dup(retriever, args.timestamp, args.system, args.remove_failed)
             if results:
                 json.dump(results, sys.stdout, default=lambda x: str(x))
                 print()
@@ -1001,25 +1168,30 @@ def main():
                 result = retriever.get_all_features(args.timestamp)
                 json.dump(result, sys.stdout, cls=DateTimeEncoder)
             elif args.features_cmd == feat_sys_cmd:
-                result = feat_sys(retriever, args.timestamp, args.system, args.remove_failed, args.suite, args.task, args.variant)
+                result = feat_sys(
+                    retriever, args.timestamp, args.system, args.remove_failed, args.suite, args.task, args.variant
+                )
                 json.dump(result, sys.stdout, cls=DateTimeEncoder)
             elif args.features_cmd == feat_find_cmd:
                 try:
                     feat = json.loads(args.feat)
-                    result = find_feat(retriever, args.timestamp, feat, args.remove_failed, args.system, args.match_snap_types)
+                    result = find_feat(
+                        retriever, args.timestamp, feat, args.remove_failed, args.system, args.match_snap_types
+                    )
                     json.dump(result, sys.stdout, default=lambda x: str(x))
                 except Exception as e:
-                    raise RuntimeError(f'Error parsing feature {args.feat}: {e}')
+                    raise RuntimeError(f"Error parsing feature {args.feat}: {e}")
             elif args.features_cmd == feat_cover_cmd:
-                result = minimal_coverage(retriever, args.timestamp, args.system, args.max_minutes, args.force_match_keywords, 
-                                          args.exclude)
+                result = minimal_coverage(
+                    retriever, args.timestamp, args.system, args.max_minutes, args.force_match_keywords, args.exclude
+                )
                 json.dump(result, sys.stdout, default=lambda x: str(x))
             else:
-                raise RuntimeError(f'unrecognized feature command {args.features_cmd}')
+                raise RuntimeError(f"unrecognized feature command {args.features_cmd}")
             print()
         else:
-            raise RuntimeError(f'command not recognized: {args.command}')
+            raise RuntimeError(f"command not recognized: {args.command}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -656,58 +656,42 @@ def task_list(retriever: Retriever, timestamp: str) -> set[TaskIdVariant]:
     return tasks
 
 
-def filter_snap_types(snap_types):
+def filter_snap_types(snap_types: list[str]) -> list[str]:
     return [t for t in snap_types if 'NOT FOUND' not in t]
 
-def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_cmds: bool, remove_interfaces: bool) -> None:
+
+def clean_dictionary(features: SystemFeatures, exclude: list[str], remove_snap_types: bool = False) -> None:
     '''
     Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
 
+    :param features: features dictionary to clean
+    :param exclude: removes all features of the specified type
     :param remove_snap_types: if true, removes snap types from all features in the dictionary.
-    :param remove_cmds: if true, removes all commands features from the dictionary.
-    :param remove_interfaces: if true, removes all interface features from the dictionary.
     '''
+    def clean_snap_types(lst: list):
+        if not lst:
+            return
+        for entry in lst:
+            if 'snap_types' in entry:
+                if remove_snap_types:
+                    del entry['snap_types']
+                else:
+                    entry['snap_types'] = filter_snap_types(entry['snap_types'])
+                
     for test in features['tests']:
-        if 'tasks' in test:
-            for task in test['tasks']:
-                if remove_snap_types and 'snap_types' in task:
-                    del task['snap_types']
-                elif 'snap_types' in task:
-                    task['snap_types'] = filter_snap_types(task['snap_types'])
-                if 'last_status' in task and task['last_status'] != 'Done' and task['last_status'] != 'Undone' and task['last_status'] != 'Error':
-                    task['last_status'] = ''
-        if remove_snap_types and 'changes' in test:
-            for change in test['changes']:
-                if 'snap_types' in change:
-                    del change['snap_types']
-        elif 'changes'in test:
-            for change in test['changes']:
-                if 'snap_types' in change:
-                    change['snap_types'] = filter_snap_types(change['snap_types'])
-        if remove_cmds and 'cmds' in test:
-            del test['cmds']
-        if remove_interfaces and 'interfaces' in test:
-            del test['interfaces']
-        if remove_snap_types and 'interfaces' in test:
-            for interface in test['interfaces']:                            
-                if 'plug_snap_type' in interface:
-                    del interface['plug_snap_type']
-                if 'slot_snap_type' in interface:
-                    del interface['slot_snap_type']
-        elif 'interfaces' in test:
-            for interface in test['interfaces']:                            
-                if 'plug_snap_type' in interface:
-                    interface['plug_snap_type'] = interface['plug_snap_type'] if 'NOT FOUND' not in interface['plug_snap_type'] else ''
-                if 'slot_snap_type' in interface:
-                    interface['slot_snap_type'] = interface['slot_snap_type'] if 'NOT FOUND' not in interface['slot_snap_type'] else ''
+        for exclude_feature in exclude:
+            test.pop(exclude_feature, None)
+        clean_snap_types(test.get('tasks'))
+        clean_snap_types(test.get('changes'))
 
 
-def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]):
+def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]) -> tuple[dict, list[TaskIdVariant], int]:
+    force_matches = [fm.lower() for fm in force_matches]
     def contains_force_matches(feature: dict[str, Any]) -> bool:
         def has_terms(value: Any) -> bool:
             if isinstance(value, str):
-                return any(term in value for term in force_matches)
+                return any(term in value.lower() for term in force_matches)
             if isinstance(value, dict):
                 return any(has_terms(v) for v in value.values())
             if isinstance(value, (list, tuple, set)):
@@ -729,22 +713,24 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
             if matching:
                 covered_features = union(covered_features, task_features)
                 minimal_tasks.add(TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant']))
-                total_time += task.get('runtime', 0) or 0
+                total_time += task['runtime']
                 break
     return covered_features, minimal_tasks, total_time
 
 
-def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_matches: list[str], remove: list[str], match_snap_types: bool) -> dict[str, list[TaskIdVariant]]:
+def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_match_keywords: list[str], exclude: list[str]) -> dict[str, list[TaskIdVariant]]:
     '''
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
 
     :param max_minutes: if greater than 0, then the total runtime for each system will be less than max_minutes.
-    :param force_matches: if len > 0, then coverage will include all features that include the specified strings. If the set of
+    :param force_match_keywords: if len > 0, then coverage will include all features that include the specified strings. If the set of
     such coverage has a greater runtime than max_minutes, then it will still be included.
-    :param remove: for each name of feature included (i.e. cmds, endpoints, ensures, interfaces, tasks, changes), in this list, will remove it before calculating coverage.
+    :param exclude: for each name of feature included (i.e. cmds, endpoints, ensures, interfaces, tasks, changes), in this list, will remove it before calculating coverage.
     :param match_snap_types: if true, will include matching snap types in coverage calculation.
     :returns: dictionary where each system is a key and the value is a list of tests for coverage.
     '''
+    if max_minutes == 0 and force_match_keywords:
+        raise RuntimeError('force match keywords should only be used in conjunction with max minutes')
     if system:
         sys_jsons = [retriever.get_single_json(timestamp, system)]
     else:
@@ -752,26 +738,27 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
     coverage = {}
     for sys_json in sys_jsons:
         time_left = max_minutes if max_minutes > 0 else math.inf
-        clean_dictionary(sys_json, not match_snap_types, remove and 'cmds' in remove, remove and 'interfaces' in remove)
+        clean_dictionary(sys_json, exclude)
         tasks = sys_json['tests']
-        tasks = sorted(tasks, key=lambda x: x.get('runtime', 0) or 0)
+        # All tasks that were successful appear before those that failed
+        tasks = sorted(tasks, key=lambda x: (not x['success'], x['runtime']))
         covered_features = {}
         minimal_tasks = set()
-        if force_matches:
-            covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_matches)
+        if force_match_keywords:
+            covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_match_keywords)
             time_left -= total_seconds / 60
         for task in tasks:
-            if time_left - (task.get('runtime', 0) or 0) / 60 < 0:
-                break
             task_id = TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
-            if task_id in minimal_tasks:
+            # Since we have failed tasks at the end of the task list, 
+            # we can have tasks with lower runtime after those with higher
+            if task_id in minimal_tasks or time_left - task['runtime'] / 60 < 0:
                 continue
             task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
             new_covered = minus(task_features, covered_features)
             if new_covered:
                 minimal_tasks.add(task_id)
                 covered_features = union(covered_features, task_features)
-                time_left -= (task.get('runtime', 0) or 0) / 60
+                time_left -= task['runtime'] / 60
         coverage[sys_json['system']] = list(minimal_tasks)
     return coverage
 
@@ -935,14 +922,23 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     find.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
 
     cover = feat_subparsers.add_parser(cmd_cover, help='find the minimal set of tests that cover features of a system',
-                                     description='Lists minimal set of tests that cover features of a system')
-    add_data_source_args(cover)
+                                     description='''
+                                     Lists minimal set of tests that cover features of a system. It calculates coverage
+                                     using a greedy approach based on runtime and will attempt to include tests with 
+                                     smaller runtimes first. To impose a time constraint (and therefore reduce the result
+                                     to a subset of total coverage), specify the constraint with --max-minutes. In 
+                                     conjunction with a time constraint specified with --max-minutes, to force the inclusion
+                                     of features that contain certain keywords to ensure they are included in the subset, 
+                                     use the flag --force-match-keywords followed by keywords to include. To instead exclude
+                                     certain features from the coverage set calculating, use --exclude followed by the names
+                                     of the features to exclude (one of: cmds, endpoints, ensures, tasks, changes, interfaces).
+                                     ''')
+    add_data_source_args(cover)      
     cover.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
     cover.add_argument('-s', '--system', help='system to search for feature in', default=None, type=str)
     cover.add_argument('--max-minutes', help='Maximum amount of runtime minutes allowed in minimal set of tests', default=0, type=int)
-    cover.add_argument('--force-matches', help='Require including all features that contain one of the following strings', nargs='+')
-    cover.add_argument('--remove', help='remove the list of features from coverage considerations', nargs='+')
-    cover.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
+    cover.add_argument('--force-match-keywords', help='when combined with max-minutes, ensures that features that contain one of the following strings are included (even if longer than max minutes)', nargs='+')
+    cover.add_argument('--exclude', help='exclude the list of features from coverage considerations', nargs='+')
     return cmd, cmd_all, cmd_sys, cmd_find, cmd_cover
 
 
@@ -1015,8 +1011,8 @@ def main():
                 except Exception as e:
                     raise RuntimeError(f'Error parsing feature {args.feat}: {e}')
             elif args.features_cmd == feat_cover_cmd:
-                result = minimal_coverage(retriever, args.timestamp, args.system, args.max_minutes, args.force_matches, 
-                                          args.remove, args.match_snap_types)
+                result = minimal_coverage(retriever, args.timestamp, args.system, args.max_minutes, args.force_match_keywords, 
+                                          args.exclude)
                 json.dump(result, sys.stdout, default=lambda x: str(x))
             else:
                 raise RuntimeError(f'unrecognized feature command {args.features_cmd}')

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -746,7 +746,6 @@ def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]]) -> 
 
     :param features: features dictionary to clean
     :param exclude: removes all features of the specified type
-    :param remove_snap_types: if true, removes snap types from all features in the dictionary.
     """
 
     def clean_snap_types(lst: list):

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -13,7 +13,7 @@ import os
 import pymongo
 import pymongo.collection
 import sys
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 from features import SystemFeatures, Cmd, Endpoint, Status, Task, Change, Interface
 
@@ -739,7 +739,7 @@ def filter_snap_types(snap_types: list[str]) -> list[str]:
     return [t for t in snap_types if "NOT FOUND" not in t]
 
 
-def clean_dictionary(features: SystemFeatures, exclude: list[str], remove_snap_types: bool = False) -> None:
+def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]], remove_snap_types: bool = False) -> None:
     """
     Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
@@ -760,8 +760,9 @@ def clean_dictionary(features: SystemFeatures, exclude: list[str], remove_snap_t
                     entry["snap_types"] = filter_snap_types(entry["snap_types"])
 
     for test in features["tests"]:
-        for exclude_feature in exclude:
-            test.pop(exclude_feature, None)
+        if exclude:
+            for exclude_feature in exclude:
+                test.pop(exclude_feature, None)
         clean_snap_types(test.get("tasks"))
         clean_snap_types(test.get("changes"))
 
@@ -810,8 +811,8 @@ def minimal_coverage(
     timestamp: str,
     system: str,
     max_minutes: int,
-    force_match_keywords: list[str],
-    exclude: list[str],
+    force_match_keywords: Optional[list[str]],
+    exclude: Optional[list[str]],
 ) -> dict[str, list[TaskIdVariant]]:
     """
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -8,6 +8,7 @@ from contextlib import closing
 import copy
 import datetime
 import json
+import math
 import os
 import pymongo
 import pymongo.collection
@@ -64,8 +65,8 @@ class TaskIdVariant(TaskId):
 
     def __str__(self) -> str:
         if self.variant:
-            return self.suite + ":" + self.task_name + ":" + self.variant
-        return self.suite + ":" + self.task_name
+            return self.suite + "/" + self.task_name + ":" + self.variant
+        return self.suite + "/" + self.task_name
 
 
 class DateTimeEncoder(json.JSONEncoder):
@@ -655,6 +656,123 @@ def task_list(retriever: Retriever, timestamp: str) -> set[TaskIdVariant]:
     return tasks
 
 
+def filter_snap_types(snap_types):
+    return [t for t in snap_types if t.startswith('NOT_FOUND')]
+
+def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_cmds: bool, remove_interfaces: bool) -> None:
+    '''
+    Removes all status entires entries other than Done, Undone, Error.
+    Filters out NOT_FOUND snap types.
+    if remove_snap_types, removes snap types from all features in the dictionary.
+    if remove_cmds: removes all commands features from the dictionary.
+    if remove_interfaces: removes all interface features from the dictionary.
+    '''
+    for test in features['tests']:
+        if 'tasks' in test:
+            for task in test['tasks']:
+                if remove_snap_types and 'snap_types' in task:
+                    del task['snap_types']
+                elif 'snap_types' in task:
+                    task['snap_types'] = filter_snap_types(task['snap_types'])
+                if 'last_status' in task and task['last_status'] != 'Done' and task['last_status'] != 'Undone' and task['last_status'] != 'Error':
+                    task['last_status'] = ''
+        if remove_snap_types and 'changes' in test:
+            for change in test['changes']:
+                if 'snap_types' in change:
+                    del change['snap_types']
+        elif 'changes'in test:
+            for change in test['changes']:
+                if 'snap_types' in change:
+                    change['snap_types'] = filter_snap_types(change['snap_types'])
+        if remove_cmds and 'cmds' in test:
+            del test['cmds']
+        if remove_interfaces and 'interfaces' in test:
+            del test['interfaces']
+        if remove_snap_types and 'interfaces' in test:
+            for interface in test['interfaces']:                            
+                if 'plug_snap_type' in interface:
+                    del interface['plug_snap_type']
+                if 'slot_snap_type' in interface:
+                    del interface['slot_snap_type']
+        elif 'interfaces' in test:
+            for interface in test['interfaces']:                            
+                if 'plug_snap_type' in interface:
+                    interface['plug_snap_type'] = filter_snap_types(interface['plug_snap_type'])
+                if 'slot_snap_type' in interface:
+                    interface['slot_snap_type'] = filter_snap_types(interface['slot_snap_type'])
+
+
+def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]):
+    def contains_install_or_refresh(feature: dict[str, Any]) -> bool:
+        def has_terms(value: Any) -> bool:
+            if isinstance(value, str):
+                return any(term in value for term in force_matches)
+            if isinstance(value, dict):
+                return any(has_terms(v) for v in value.values())
+            if isinstance(value, (list, tuple, set)):
+                return any(has_terms(v) for v in value)
+            return False
+        return has_terms(feature)
+
+    total_time = 0
+    covered_features = {}
+    minimal_tasks = set()
+
+    for task in sorted_tasks:
+        task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
+        for name, features in task_features.items():
+            matching = [
+                feature for feature in features
+                if feature not in covered_features.get(name, []) and contains_install_or_refresh(feature)
+            ]
+            if matching:
+                covered_features = union(covered_features, task_features)
+                minimal_tasks.add(TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant']))
+                total_time += task['runtime']
+                break
+    return covered_features, minimal_tasks, total_time
+
+
+def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_matches: list[str], remove: list[str], match_snap_types: bool) -> list[TaskIdVariant]:
+    '''
+    Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
+    If max_minutes is greater than 0, then the total runtime for each system will be less than max_minutes.
+    If force_matches is provided, then coverage will include all features that include the specified strings. If the set of
+    such coverage has a greater runtime than max_minutes, then it will still be included.
+    remove will remove the specified list of features before calculating coverage.
+    match_snap_types will include matching snap types in coverage calculation.
+    '''
+    if system:
+        sys_jsons = [retriever.get_single_json(timestamp, system)]
+    else:
+        sys_jsons = retriever.get_systems(timestamp)
+    coverage = {}
+    for sys_json in sys_jsons:
+        time_left = max_minutes if max_minutes > 0 else math.inf
+        clean_dictionary(sys_json, not match_snap_types, remove and 'cmds' in remove, remove and 'interfaces' in remove)
+        tasks = sys_json['tests']
+        tasks = sorted(tasks, key=lambda x: x['runtime'])
+        covered_features = {}
+        minimal_tasks = set()
+        if force_matches:
+            covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_matches)
+            time_left -= total_seconds / 60
+        for task in tasks:
+            if time_left - task['runtime'] / 60 < 0:
+                break
+            task_id = TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
+            if task_id in minimal_tasks:
+                continue
+            task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
+            new_covered = minus(task_features, covered_features)
+            if new_covered:
+                minimal_tasks.add(task_id)
+                covered_features = union(covered_features, task_features)
+                time_left -= task['runtime'] / 60
+        coverage[sys_json['system']] = list(minimal_tasks)
+    return coverage
+
+
 def add_data_source_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-f', '--file', help='json file containing creds for mongodb', type=argparse.FileType('r', encoding='utf-8'))
     parser.add_argument('-d', '--dir', help='folder containing feature data', type=str)
@@ -785,6 +903,7 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     cmd_all = 'all'
     cmd_sys = 'sys'
     cmd_find = 'find'
+    cmd_cover = 'cover'
     feat: argparse.ArgumentParser = subparsers.add_parser(cmd, help='', description='')
     feat_subparsers = feat.add_subparsers(dest='features_cmd')
     all = feat_subparsers.add_parser(cmd_all, help='lists all features at a given timestamp',
@@ -811,7 +930,17 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     find.add_argument('--feat', help='feature to search for (json format)', required=True, type=str)
     find.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
     find.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
-    return cmd, cmd_all, cmd_sys, cmd_find
+
+    cover = feat_subparsers.add_parser(cmd_cover, help='find the minimal set of tests that cover all features of a system',
+                                     description='Lists minimal set of tests that cover all features of a system')
+    add_data_source_args(cover)
+    cover.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
+    cover.add_argument('-s', '--system', help='system to search for feature in', default=None, type=str)
+    cover.add_argument('--max-minutes', help='Maximum amount of runtime minutes allowed in minimal set of tests', default=0, type=int)
+    cover.add_argument('--force-matches', help='Require including all features that contain one of the following strings', nargs='+')
+    cover.add_argument('--remove', help='remove the list of features from coverage considerations', nargs='+')
+    cover.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
+    return cmd, cmd_all, cmd_sys, cmd_find, cmd_cover
 
 
 def main():
@@ -823,7 +952,7 @@ def main():
     dup_cmd = add_dup_parser(subparsers)
     export_cmd = add_export_parser(subparsers)
     list_cmd = add_list_parser(subparsers)
-    feat_cmd, feat_all_cmd, feat_sys_cmd, feat_find_cmd = add_all_features_parser(subparsers)
+    feat_cmd, feat_all_cmd, feat_sys_cmd, feat_find_cmd, feat_cover_cmd = add_all_features_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -882,6 +1011,10 @@ def main():
                     json.dump(result, sys.stdout, default=lambda x: str(x))
                 except Exception as e:
                     raise RuntimeError(f'Error parsing feature {args.feat}: {e}')
+            elif args.features_cmd == feat_cover_cmd:
+                result = minimal_coverage(retriever, args.timestamp, args.system, args.max_minutes, args.force_matches, 
+                                          args.remove, args.match_snap_types)
+                json.dump(result, sys.stdout, default=lambda x: str(x))
             else:
                 raise RuntimeError(f'unrecognized feature command {args.features_cmd}')
             print()

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -704,7 +704,7 @@ def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_c
 
 
 def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]):
-    def contains_install_or_refresh(feature: dict[str, Any]) -> bool:
+    def contains_force_matches(feature: dict[str, Any]) -> bool:
         def has_terms(value: Any) -> bool:
             if isinstance(value, str):
                 return any(term in value for term in force_matches)
@@ -724,7 +724,7 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
         for name, features in task_features.items():
             matching = [
                 feature for feature in features
-                if feature not in covered_features.get(name, []) and contains_install_or_refresh(feature)
+                if feature not in covered_features.get(name, []) and contains_force_matches(feature)
             ]
             if matching:
                 covered_features = union(covered_features, task_features)

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -739,7 +739,7 @@ def filter_snap_types(snap_types: list[str]) -> list[str]:
     return [t for t in snap_types if "NOT FOUND" not in t]
 
 
-def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]], remove_snap_types: bool = False) -> None:
+def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]]) -> None:
     """
     Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
@@ -750,26 +750,21 @@ def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]], rem
     """
 
     def clean_snap_types(lst: list):
-        if not lst:
-            return
         for entry in lst:
             if "snap_types" in entry:
-                if remove_snap_types:
-                    del entry["snap_types"]
-                else:
-                    entry["snap_types"] = filter_snap_types(entry["snap_types"])
+                entry["snap_types"] = filter_snap_types(entry["snap_types"])
 
     for test in features["tests"]:
         if exclude:
             for exclude_feature in exclude:
                 test.pop(exclude_feature, None)
-        clean_snap_types(test.get("tasks"))
-        clean_snap_types(test.get("changes"))
+        clean_snap_types(test.get("tasks", []))
+        clean_snap_types(test.get("changes", []))
 
 
 def get_force_matched_features(
     sorted_tasks: list[dict], force_matches: list[str]
-) -> tuple[dict, list[TaskIdVariant], int]:
+) -> tuple[dict, set[TaskIdVariant], int]:
     force_matches = [fm.lower() for fm in force_matches]
 
     def contains_force_matches(feature: dict[str, Any]) -> bool:
@@ -791,11 +786,8 @@ def get_force_matched_features(
     for task in sorted_tasks:
         task_features = {key: value for key, value in task.items() if key in KNOWN_FEATURES}
         for name, features in task_features.items():
-            matching = [
-                feature
-                for feature in features
-                if feature not in covered_features.get(name, []) and contains_force_matches(feature)
-            ]
+            matching = any(feature not in covered_features.get(name, []) and contains_force_matches(feature) 
+                           for feature in features)
             if matching:
                 covered_features = union(covered_features, task_features)
                 minimal_tasks.add(
@@ -809,7 +801,7 @@ def get_force_matched_features(
 def minimal_coverage(
     retriever: Retriever,
     timestamp: str,
-    system: str,
+    system: Optional[str],
     max_minutes: int,
     force_match_keywords: Optional[list[str]],
     exclude: Optional[list[str]],
@@ -821,7 +813,6 @@ def minimal_coverage(
     :param force_match_keywords: if len > 0, then coverage will include all features that include the specified strings. If the set of
     such coverage has a greater runtime than max_minutes, then it will still be included.
     :param exclude: for each name of feature included (i.e. cmds, endpoints, ensures, interfaces, tasks, changes), in this list, will remove it before calculating coverage.
-    :param match_snap_types: if true, will include matching snap types in coverage calculation.
     :returns: dictionary where each system is a key and the value is a list of tests for coverage.
     """
     if max_minutes == 0 and force_match_keywords:

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -657,7 +657,7 @@ def task_list(retriever: Retriever, timestamp: str) -> set[TaskIdVariant]:
 
 
 def filter_snap_types(snap_types):
-    return [t for t in snap_types if t.startswith('NOT_FOUND')]
+    return [t for t in snap_types if 'NOT FOUND' not in t]
 
 def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_cmds: bool, remove_interfaces: bool) -> None:
     '''
@@ -697,9 +697,9 @@ def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_c
         elif 'interfaces' in test:
             for interface in test['interfaces']:                            
                 if 'plug_snap_type' in interface:
-                    interface['plug_snap_type'] = filter_snap_types(interface['plug_snap_type'])
+                    interface['plug_snap_type'] = interface['plug_snap_type'] if 'NOT FOUND' not in interface['plug_snap_type'] else ''
                 if 'slot_snap_type' in interface:
-                    interface['slot_snap_type'] = filter_snap_types(interface['slot_snap_type'])
+                    interface['slot_snap_type'] = interface['slot_snap_type'] if 'NOT FOUND' not in interface['slot_snap_type'] else ''
 
 
 def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str]):
@@ -728,12 +728,12 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
             if matching:
                 covered_features = union(covered_features, task_features)
                 minimal_tasks.add(TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant']))
-                total_time += task['runtime']
+                total_time += task.get('runtime', 0)
                 break
     return covered_features, minimal_tasks, total_time
 
 
-def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_matches: list[str], remove: list[str], match_snap_types: bool) -> list[TaskIdVariant]:
+def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_matches: list[str], remove: list[str], match_snap_types: bool) -> dict[str, list[TaskIdVariant]]:
     '''
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
     If max_minutes is greater than 0, then the total runtime for each system will be less than max_minutes.
@@ -751,14 +751,14 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
         time_left = max_minutes if max_minutes > 0 else math.inf
         clean_dictionary(sys_json, not match_snap_types, remove and 'cmds' in remove, remove and 'interfaces' in remove)
         tasks = sys_json['tests']
-        tasks = sorted(tasks, key=lambda x: x['runtime'])
+        tasks = sorted(tasks, key=lambda x: x.get('runtime', 0))
         covered_features = {}
         minimal_tasks = set()
         if force_matches:
             covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_matches)
             time_left -= total_seconds / 60
         for task in tasks:
-            if time_left - task['runtime'] / 60 < 0:
+            if time_left - task.get('runtime', 0) / 60 < 0:
                 break
             task_id = TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
             if task_id in minimal_tasks:
@@ -768,7 +768,7 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
             if new_covered:
                 minimal_tasks.add(task_id)
                 covered_features = union(covered_features, task_features)
-                time_left -= task['runtime'] / 60
+                time_left -= task.get('runtime', 0) / 60
         coverage[sys_json['system']] = list(minimal_tasks)
     return coverage
 

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -661,11 +661,12 @@ def filter_snap_types(snap_types):
 
 def clean_dictionary(features: SystemFeatures, remove_snap_types: bool, remove_cmds: bool, remove_interfaces: bool) -> None:
     '''
-    Removes all status entires entries other than Done, Undone, Error.
+    Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
-    if remove_snap_types, removes snap types from all features in the dictionary.
-    if remove_cmds: removes all commands features from the dictionary.
-    if remove_interfaces: removes all interface features from the dictionary.
+
+    :param remove_snap_types: if true, removes snap types from all features in the dictionary.
+    :param remove_cmds: if true, removes all commands features from the dictionary.
+    :param remove_interfaces: if true, removes all interface features from the dictionary.
     '''
     for test in features['tests']:
         if 'tasks' in test:
@@ -728,7 +729,7 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
             if matching:
                 covered_features = union(covered_features, task_features)
                 minimal_tasks.add(TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant']))
-                total_time += task.get('runtime', 0)
+                total_time += task.get('runtime', 0) or 0
                 break
     return covered_features, minimal_tasks, total_time
 
@@ -736,11 +737,13 @@ def get_force_matched_features(sorted_tasks: list[dict], force_matches: list[str
 def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minutes: int, force_matches: list[str], remove: list[str], match_snap_types: bool) -> dict[str, list[TaskIdVariant]]:
     '''
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
-    If max_minutes is greater than 0, then the total runtime for each system will be less than max_minutes.
-    If force_matches is provided, then coverage will include all features that include the specified strings. If the set of
+
+    :param max_minutes: if greater than 0, then the total runtime for each system will be less than max_minutes.
+    :param force_matches: if len > 0, then coverage will include all features that include the specified strings. If the set of
     such coverage has a greater runtime than max_minutes, then it will still be included.
-    remove will remove the specified list of features before calculating coverage.
-    match_snap_types will include matching snap types in coverage calculation.
+    :param remove: for each name of feature included (i.e. cmds, endpoints, ensures, interfaces, tasks, changes), in this list, will remove it before calculating coverage.
+    :param match_snap_types: if true, will include matching snap types in coverage calculation.
+    :returns: dictionary where each system is a key and the value is a list of tests for coverage.
     '''
     if system:
         sys_jsons = [retriever.get_single_json(timestamp, system)]
@@ -751,14 +754,14 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
         time_left = max_minutes if max_minutes > 0 else math.inf
         clean_dictionary(sys_json, not match_snap_types, remove and 'cmds' in remove, remove and 'interfaces' in remove)
         tasks = sys_json['tests']
-        tasks = sorted(tasks, key=lambda x: x.get('runtime', 0))
+        tasks = sorted(tasks, key=lambda x: x.get('runtime', 0) or 0)
         covered_features = {}
         minimal_tasks = set()
         if force_matches:
             covered_features, minimal_tasks, total_seconds = get_force_matched_features(tasks, force_matches)
             time_left -= total_seconds / 60
         for task in tasks:
-            if time_left - task.get('runtime', 0) / 60 < 0:
+            if time_left - (task.get('runtime', 0) or 0) / 60 < 0:
                 break
             task_id = TaskIdVariant(suite=task['suite'], task_name=task['task_name'], variant=task['variant'])
             if task_id in minimal_tasks:
@@ -768,7 +771,7 @@ def minimal_coverage(retriever: Retriever, timestamp: str, system: str, max_minu
             if new_covered:
                 minimal_tasks.add(task_id)
                 covered_features = union(covered_features, task_features)
-                time_left -= task.get('runtime', 0) / 60
+                time_left -= (task.get('runtime', 0) or 0) / 60
         coverage[sys_json['system']] = list(minimal_tasks)
     return coverage
 
@@ -931,8 +934,8 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     find.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
     find.add_argument('--match-snap-types', help='match the entire feature, including snap types', action='store_true')
 
-    cover = feat_subparsers.add_parser(cmd_cover, help='find the minimal set of tests that cover all features of a system',
-                                     description='Lists minimal set of tests that cover all features of a system')
+    cover = feat_subparsers.add_parser(cmd_cover, help='find the minimal set of tests that cover features of a system',
+                                     description='Lists minimal set of tests that cover features of a system')
     add_data_source_args(cover)
     cover.add_argument('-t', '--timestamp', help='timestamp for feature data', required=True, type=str)
     cover.add_argument('-s', '--system', help='system to search for feature in', default=None, type=str)

--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -9,7 +9,7 @@ for each executed task.
 
 For each test in the final composed feature files, this script finds the
 runtime from the most recent attempt that ran that test and adds it as a
-"runtime" field (in seconds, or null if not found). Runtime is the sum of
+"runtime" field in seconds. Runtime is the sum of
 task-level preparing + executing + restoring durations.
 '''
 
@@ -83,7 +83,7 @@ def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
             if item.get('level') != 'task' or item.get('verb') not in phases:
                 continue
             try:
-                system = '{}:{}'.format(item['backend'], item['system'])
+                system = f'{item['backend']}:{item['system']}'
                 name = item['name']
                 variant = item.get('variant') or ''
                 runtime = _parse_runtime_seconds(item['start'], item['end'])
@@ -104,7 +104,6 @@ def add_runtime_to_features(features_dir: str, runtime_lookup: dict[tuple, float
     '''
     Reads each system feature JSON file in features_dir, adds a "runtime"
     field (in seconds) to each test from the lookup, and writes the file back.
-    Tests with no matching entry in the lookup get runtime set to null.
 
     :param features_dir: directory containing composed feature JSON files
     :param runtime_lookup: dict from build_runtime_lookup
@@ -121,9 +120,9 @@ def add_runtime_to_features(features_dir: str, runtime_lookup: dict[tuple, float
             suite = test.get('suite', '')
             task_name = test.get('task_name', '')
             variant = test.get('variant') or ''
-            full_name = '{}/{}'.format(suite, task_name) if suite else task_name
+            full_name = f'{suite}/{task_name}' if suite else task_name
             key = (system, full_name, variant)
-            test['runtime'] = runtime_lookup.get(key)
+            test['runtime'] = runtime_lookup[key]
 
         with open(filepath, 'w', encoding='utf-8') as f:
             json.dump(system_data, f)

--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 from datetime import datetime
+from typing import Optional
 
 
 def _parse_runtime_seconds(start: str, end: str) -> float:
@@ -33,7 +34,7 @@ def _parse_runtime_seconds(start: str, end: str) -> float:
     return (fmt_end - fmt_start).total_seconds()
 
 
-def _parse_attempt_from_dirname(dirname: str) -> int | None:
+def _parse_attempt_from_dirname(dirname: str) -> Optional[int]:
     '''
     Parse the attempt number from a directory name of the form:
       spread-results-<run_id>-<attempt>-<group>

--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-'''
+"""
 Adds runtime data from spread-results artifacts to composed feature files.
 
 The spread-results artifacts are named:
@@ -11,7 +11,7 @@ For each test in the final composed feature files, this script finds the
 runtime from the most recent attempt that ran that test and adds it as a
 "runtime" field in seconds. Runtime is the sum of
 task-level preparing + executing + restoring durations.
-'''
+"""
 
 import argparse
 import json
@@ -22,35 +22,35 @@ from typing import Optional
 
 
 def _parse_runtime_seconds(start: str, end: str) -> float:
-    '''
+    """
     Calculate runtime in seconds from ISO8601 start/end strings.
 
     :param start: ISO8601 start timestamp string
     :param end: ISO8601 end timestamp string
     :returns: Duration in seconds as a float
-    '''
-    fmt_start = datetime.fromisoformat(start.replace('Z', '+00:00'))
-    fmt_end = datetime.fromisoformat(end.replace('Z', '+00:00'))
+    """
+    fmt_start = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    fmt_end = datetime.fromisoformat(end.replace("Z", "+00:00"))
     return (fmt_end - fmt_start).total_seconds()
 
 
 def _parse_attempt_from_dirname(dirname: str) -> Optional[int]:
-    '''
+    """
     Parse the attempt number from a directory name of the form:
       spread-results-<run_id>-<attempt>-<group>
     where run_id and attempt are a sequence of digits
 
     :param dirname: the directory name to parse
     :returns: attempt number as an int, or None if the name does not match
-    '''
-    m = re.match(r'^spread-results-\d+-(\d+)-', dirname)
+    """
+    m = re.match(r"^spread-results-\d+-(\d+)-", dirname)
     if m:
         return int(m.group(1))
     return None
 
 
 def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
-    '''
+    """
     Walks results_dir, reads each results.json in subdirectories named like
     spread-results-<run_id>-<attempt>-<group>, and builds a lookup:
       (system, full_test_name, variant) -> runtime_seconds
@@ -60,10 +60,10 @@ def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
 
     :param results_dir: directory containing spread-results artifact subdirectories
     :returns: dict mapping (system, test_name, variant) to runtime in seconds
-    '''
+    """
     # key -> (attempt, runtime_seconds)
     best: dict[tuple, tuple[int, float]] = {}
-    phases = {'preparing', 'executing', 'restoring'}
+    phases = {"preparing", "executing", "restoring"}
 
     for entry in os.scandir(results_dir):
         if not entry.is_dir():
@@ -71,22 +71,22 @@ def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
         attempt = _parse_attempt_from_dirname(entry.name)
         if attempt is None:
             continue
-        results_file = os.path.join(entry.path, 'results.json')
+        results_file = os.path.join(entry.path, "results.json")
         if not os.path.isfile(results_file):
             continue
 
-        with open(results_file, 'r', encoding='utf-8') as f:
+        with open(results_file, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         per_attempt_totals: dict[tuple, float] = {}
-        for item in data.get('items', []):
-            if item.get('level') != 'task' or item.get('verb') not in phases:
+        for item in data.get("items", []):
+            if item.get("level") != "task" or item.get("verb") not in phases:
                 continue
             try:
-                system = f'{item['backend']}:{item['system']}'
-                name = item['name']
-                variant = item.get('variant') or ''
-                runtime = _parse_runtime_seconds(item['start'], item['end'])
+                system = f"{item['backend']}:{item['system']}"
+                name = item["name"]
+                variant = item.get("variant") or ""
+                runtime = _parse_runtime_seconds(item["start"], item["end"])
             except (KeyError, ValueError):
                 continue
 
@@ -101,50 +101,53 @@ def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
 
 
 def add_runtime_to_features(features_dir: str, runtime_lookup: dict[tuple, float]) -> None:
-    '''
+    """
     Reads each system feature JSON file in features_dir, adds a "runtime"
     field (in seconds) to each test from the lookup, and writes the file back.
 
     :param features_dir: directory containing composed feature JSON files
     :param runtime_lookup: dict from build_runtime_lookup
-    '''
+    """
     for filename in os.listdir(features_dir):
-        if not filename.endswith('.json'):
+        if not filename.endswith(".json"):
             continue
         filepath = os.path.join(features_dir, filename)
-        with open(filepath, 'r', encoding='utf-8') as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             system_data = json.load(f)
 
-        system = system_data.get('system', '')
-        for test in system_data.get('tests', []):
-            suite = test.get('suite', '')
-            task_name = test.get('task_name', '')
-            variant = test.get('variant') or ''
-            full_name = f'{suite}/{task_name}' if suite else task_name
+        system = system_data.get("system", "")
+        for test in system_data.get("tests", []):
+            suite = test.get("suite", "")
+            task_name = test.get("task_name", "")
+            variant = test.get("variant") or ""
+            full_name = f"{suite}/{task_name}" if suite else task_name
             key = (system, full_name, variant)
-            test['runtime'] = runtime_lookup[key]
+            test["runtime"] = runtime_lookup[key]
 
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             json.dump(system_data, f)
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='''Adds runtime data from spread-results artifacts to composed feature files.
+        description="""Adds runtime data from spread-results artifacts to composed feature files.
         
         Reads spread-results artifact directories (named spread-results-<run_id>-<attempt>-<group>)
         from results-dir and uses them to populate the "runtime" field on each test entry in the
         composed feature JSON files in features-dir. The most recent attempt wins when a test
-        appears in multiple attempts.''')
-    parser.add_argument('--results-dir', required=True,
-                        help='Directory containing spread-results artifact subdirectories')
-    parser.add_argument('--features-dir', required=True,
-                        help='Directory containing composed feature JSON files to update')
+        appears in multiple attempts."""
+    )
+    parser.add_argument(
+        "--results-dir", required=True, help="Directory containing spread-results artifact subdirectories"
+    )
+    parser.add_argument(
+        "--features-dir", required=True, help="Directory containing composed feature JSON files to update"
+    )
     args = parser.parse_args()
 
     runtime_lookup = build_runtime_lookup(args.results_dir)
     add_runtime_to_features(args.features_dir, runtime_lookup)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+'''
+Adds runtime data from spread-results artifacts to composed feature files.
+
+The spread-results artifacts are named:
+  spread-results-<run_id>-<attempt>-<group>
+and each contains a results.json with items having start/end timestamps
+for each executed task.
+
+For each test in the final composed feature files, this script finds the
+runtime from the most recent attempt that ran that test and adds it as a
+"runtime" field (in seconds, or null if not found). Runtime is the sum of
+task-level preparing + executing + restoring durations.
+'''
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime
+
+
+def _parse_runtime_seconds(start: str, end: str) -> float:
+    '''
+    Calculate runtime in seconds from ISO8601 start/end strings.
+
+    :param start: ISO8601 start timestamp string
+    :param end: ISO8601 end timestamp string
+    :returns: Duration in seconds as a float
+    '''
+    fmt_start = datetime.fromisoformat(start.replace('Z', '+00:00'))
+    fmt_end = datetime.fromisoformat(end.replace('Z', '+00:00'))
+    return (fmt_end - fmt_start).total_seconds()
+
+
+def _parse_attempt_from_dirname(dirname: str) -> int | None:
+    '''
+    Parse the attempt number from a directory name of the form:
+      spread-results-<run_id>-<attempt>-<group>
+    where run_id is a sequence of digits and attempt is a single digit.
+
+    :param dirname: the directory name to parse
+    :returns: attempt number as an int, or None if the name does not match
+    '''
+    m = re.match(r'^spread-results-\d+-(\d+)-', dirname)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
+    '''
+    Walks results_dir, reads each results.json in subdirectories named like
+    spread-results-<run_id>-<attempt>-<group>, and builds a lookup:
+      (system, full_test_name, variant) -> runtime_seconds
+
+    When the same test appears in multiple attempts, only the latest attempt
+    is kept.
+
+    :param results_dir: directory containing spread-results artifact subdirectories
+    :returns: dict mapping (system, test_name, variant) to runtime in seconds
+    '''
+    # key -> (attempt, runtime_seconds)
+    best: dict[tuple, tuple[int, float]] = {}
+    phases = {'preparing', 'executing', 'restoring'}
+
+    for entry in os.scandir(results_dir):
+        if not entry.is_dir():
+            continue
+        attempt = _parse_attempt_from_dirname(entry.name)
+        if attempt is None:
+            continue
+        results_file = os.path.join(entry.path, 'results.json')
+        if not os.path.isfile(results_file):
+            continue
+
+        with open(results_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        per_attempt_totals: dict[tuple, float] = {}
+        for item in data.get('items', []):
+            if item.get('level') != 'task' or item.get('verb') not in phases:
+                continue
+            try:
+                system = '{}:{}'.format(item['backend'], item['system'])
+                name = item['name']
+                variant = item.get('variant') or ''
+                runtime = _parse_runtime_seconds(item['start'], item['end'])
+            except (KeyError, ValueError):
+                continue
+
+            key = (system, name, variant)
+            per_attempt_totals[key] = per_attempt_totals.get(key, 0.0) + runtime
+
+        for key, runtime in per_attempt_totals.items():
+            if key not in best or attempt > best[key][0]:
+                best[key] = (attempt, runtime)
+
+    return {k: v[1] for k, v in best.items()}
+
+
+def add_runtime_to_features(features_dir: str, runtime_lookup: dict[tuple, float]) -> None:
+    '''
+    Reads each system feature JSON file in features_dir, adds a "runtime"
+    field (in seconds) to each test from the lookup, and writes the file back.
+    Tests with no matching entry in the lookup get runtime set to null.
+
+    :param features_dir: directory containing composed feature JSON files
+    :param runtime_lookup: dict from build_runtime_lookup
+    '''
+    for filename in os.listdir(features_dir):
+        if not filename.endswith('.json'):
+            continue
+        filepath = os.path.join(features_dir, filename)
+        with open(filepath, 'r', encoding='utf-8') as f:
+            system_data = json.load(f)
+
+        system = system_data.get('system', '')
+        for test in system_data.get('tests', []):
+            suite = test.get('suite', '')
+            task_name = test.get('task_name', '')
+            variant = test.get('variant') or ''
+            full_name = '{}/{}'.format(suite, task_name) if suite else task_name
+            key = (system, full_name, variant)
+            test['runtime'] = runtime_lookup.get(key)
+
+        with open(filepath, 'w', encoding='utf-8') as f:
+            json.dump(system_data, f)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='''Adds runtime data from spread-results artifacts to composed feature files.
+        
+        Reads spread-results artifact directories (named spread-results-<run_id>-<attempt>-<group>)
+        from results-dir and uses them to populate the "runtime" field on each test entry in the
+        composed feature JSON files in features-dir. The most recent attempt wins when a test
+        appears in multiple attempts.''')
+    parser.add_argument('--results-dir', required=True,
+                        help='Directory containing spread-results artifact subdirectories')
+    parser.add_argument('--features-dir', required=True,
+                        help='Directory containing composed feature JSON files to update')
+    args = parser.parse_args()
+
+    runtime_lookup = build_runtime_lookup(args.results_dir)
+    add_runtime_to_features(args.features_dir, runtime_lookup)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -38,7 +38,7 @@ def _parse_attempt_from_dirname(dirname: str) -> Optional[int]:
     '''
     Parse the attempt number from a directory name of the form:
       spread-results-<run_id>-<attempt>-<group>
-    where run_id is a sequence of digits and attempt is a single digit.
+    where run_id and attempt are a sequence of digits
 
     :param dirname: the directory name to parse
     :returns: attempt number as an int, or None if the name does not match

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -854,6 +854,34 @@ class TestQueryFeatures:
         assert TaskIdVariant(suite='suite1', task_name='task2', variant='') in coverage['system1']
 
 
+    def test_minimal_coverage_failed_task_at_end(self):
+        data = {'timestamp1': {'system1': {'system': 'system1', 'tests': [
+            TaskFeatures(suite='suite1', task_name='task1', success=True, variant='', runtime=150,
+                         cmds=[Cmd(cmd='snap list')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite1', task_name='task2', success=False, variant='', runtime=120,
+                         cmds=[Cmd(cmd='snap info')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite2', task_name='task3', success=True, variant='v1', runtime=60,
+                         changes=[Change(kind='install-snap', snap_types=['app'])]),
+        ]}}}
+        retriever = DictRetriever(data)
+
+        coverage = query_features.minimal_coverage(
+            retriever,
+            timestamp='timestamp1',
+            system='system1',
+            max_minutes=4,
+            force_match_keywords=None,
+            exclude=None
+        )
+
+        assert 'system1' in coverage and len(coverage['system1']) == 2
+        # force_matches includes install-snap even if it consumes most of max_minutes budget
+        assert TaskIdVariant(suite='suite2', task_name='task3', variant='v1') in coverage['system1']
+        assert TaskIdVariant(suite='suite1', task_name='task1', variant='') in coverage['system1']
+
+
     def test_sys_caching(self):
         data = {'timestamp1': {
                 'system1': {'system':'system1', 'tests': [

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -798,6 +798,64 @@ class TestQueryFeatures:
         assert TaskIdVariant(suite='suite2',task_name='task1',variant='v1') in tasks
 
 
+    def test_minimal_coverage_force_matches(self):
+        data = {'timestamp1': {'system1': {'system': 'system1', 'tests': [
+            TaskFeatures(suite='suite1', task_name='task1', success=True, variant='', runtime=30,
+                         cmds=[Cmd(cmd='snap list')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite1', task_name='task2', success=True, variant='', runtime=20,
+                         cmds=[Cmd(cmd='snap info')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite2', task_name='task3', success=True, variant='v1', runtime=50,
+                         changes=[Change(kind='install-snap', snap_types=['app'])]),
+        ]}}}
+        retriever = DictRetriever(data)
+
+        coverage = query_features.minimal_coverage(
+            retriever,
+            timestamp='timestamp1',
+            system='system1',
+            max_minutes=1,
+            force_matches=['install'],
+            remove=[],
+            match_snap_types=True,
+        )
+
+        assert 'system1' in coverage
+        # force_matches includes install-snap even if it consumes most of max_minutes budget
+        expected = {TaskIdVariant(suite='suite2', task_name='task3', variant='v1')}
+        assert expected == set(coverage['system1'])
+
+
+    def test_minimal_coverage_force_matches(self):
+        data = {'timestamp1': {'system1': {'system': 'system1', 'tests': [
+            TaskFeatures(suite='suite1', task_name='task1', success=True, variant='', runtime=150,
+                         cmds=[Cmd(cmd='snap list')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite1', task_name='task2', success=True, variant='', runtime=120,
+                         cmds=[Cmd(cmd='snap info')],
+                         endpoints=[Endpoint(method='GET', path='/v2/snaps')]),
+            TaskFeatures(suite='suite2', task_name='task3', success=True, variant='v1', runtime=60,
+                         changes=[Change(kind='install-snap', snap_types=['app'])]),
+        ]}}}
+        retriever = DictRetriever(data)
+
+        coverage = query_features.minimal_coverage(
+            retriever,
+            timestamp='timestamp1',
+            system='system1',
+            max_minutes=4,
+            force_matches=['install'],
+            remove=[],
+            match_snap_types=True,
+        )
+
+        assert 'system1' in coverage and len(coverage['system1']) == 2
+        # force_matches includes install-snap even if it consumes most of max_minutes budget
+        assert TaskIdVariant(suite='suite2', task_name='task3', variant='v1') in coverage['system1']
+        assert TaskIdVariant(suite='suite1', task_name='task2', variant='') in coverage['system1']
+
+
     def test_sys_caching(self):
         data = {'timestamp1': {
                 'system1': {'system':'system1', 'tests': [
@@ -1028,8 +1086,8 @@ class TestQueryFeatures:
             query_features.main()
             actual = json.loads(mocker.get_stdout())
             assert 2 == len(actual)
-            assert 'suite2:task3' in actual
-            assert 'suite1:task4:v1' in actual
+            assert str(TaskIdVariant(suite='suite2', task_name='task3', variant='')) in actual
+            assert str(TaskIdVariant(suite='suite1', task_name='task4', variant='v1')) in actual
 
 
     @pytest.mark.parametrize("mocker_class", ["MongoMocker","DirMocker"])
@@ -1208,3 +1266,38 @@ class TestQueryFeatures:
             expected = {'system1':[str(TaskIdVariant(suite='suite1',task_name='task2',variant=''))],
                         'system2':[str(TaskIdVariant(suite='suite1',task_name='task1',variant=''))]}
             assert expected == output
+
+
+    @pytest.mark.parametrize("mocker_class", ["MongoMocker","DirMocker"])
+    @patch('argparse.ArgumentParser.parse_args')
+    def test_retriever_feat_cover(self, parse_args_mock: Mock, mocker_class: str):
+        data = [
+            {'timestamp': '2025-05-04', 'system': 'system1', 'tests': [
+                TaskFeatures(success=True, task_name='task1', suite='suite1', variant='', runtime=180,
+                             cmds=[{'cmd': 'snap list'}], endpoints=[{'path': '/v2/validate', 'method': 'GET'}]),
+                TaskFeatures(success=True, task_name='task2', suite='suite1', variant='', runtime=120,
+                             cmds=[{'cmd': 'snap info'}], endpoints=[{'path': '/v2/snaps', 'method': 'GET'}]),
+                TaskFeatures(success=True, task_name='task3', suite='suite2', variant='v1', runtime=300,
+                             changes=[{'kind': 'install-snap', 'snap_types': ['app']}]),
+            ]},
+        ]
+        Mocker = globals()[mocker_class]
+        with Mocker(data, do_patch_stdout=True) as mocker:
+            parse_args_mock.return_value = argparse.Namespace(
+                command='feat',
+                features_cmd='cover',
+                file=StringIO('') if mocker_class == "MongoMocker" else None,
+                dir=mocker.get_dir() if mocker_class == "DirMocker" else None,
+                timestamp='2025-05-04',
+                system='system1',
+                max_minutes=8,
+                force_matches=['install'],
+                remove=[],
+                match_snap_types=True,
+            )
+            query_features.main()
+
+            output = json.loads(mocker.get_stdout())
+            assert 'system1' in output and len(output['system1']) == 2
+            assert 'system1' in output and str(TaskIdVariant(suite='suite2', task_name='task3', variant='v1')) in output['system1']
+            assert 'system1' in output and str(TaskIdVariant(suite='suite1', task_name='task2', variant='')) in output['system1']

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -816,9 +816,8 @@ class TestQueryFeatures:
             timestamp='timestamp1',
             system='system1',
             max_minutes=1,
-            force_matches=['install'],
-            remove=[],
-            match_snap_types=True,
+            force_match_keywords=['install'],
+            exclude=[]
         )
 
         assert 'system1' in coverage
@@ -845,9 +844,8 @@ class TestQueryFeatures:
             timestamp='timestamp1',
             system='system1',
             max_minutes=4,
-            force_matches=['install'],
-            remove=[],
-            match_snap_types=True,
+            force_match_keywords=['install'],
+            exclude=[]
         )
 
         assert 'system1' in coverage and len(coverage['system1']) == 2
@@ -1291,9 +1289,8 @@ class TestQueryFeatures:
                 timestamp='2025-05-04',
                 system='system1',
                 max_minutes=8,
-                force_matches=['install'],
-                remove=[],
-                match_snap_types=True,
+                force_match_keywords=['install'],
+                exclude=[]
             )
             query_features.main()
 

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -827,7 +827,7 @@ class TestQueryFeatures:
         assert expected == set(coverage['system1'])
 
 
-    def test_minimal_coverage_force_matches(self):
+    def test_minimal_coverage_force_matches_and_one_task(self):
         data = {'timestamp1': {'system1': {'system': 'system1', 'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='', runtime=150,
                          cmds=[Cmd(cmd='snap list')],

--- a/tests/utils/features/test_runtimeadder.py
+++ b/tests/utils/features/test_runtimeadder.py
@@ -1,0 +1,222 @@
+import json
+import os
+import tempfile
+import unittest
+
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import runtimeadder
+
+
+def _make_results_json(items: list) -> dict:
+    return {'items': items}
+
+
+def _make_task_item(backend: str, system: str, name: str, variant: str,
+                    start: str, end: str, verb: str = 'executing') -> dict:
+    return {
+        'level': 'task',
+        'verb': verb,
+        'backend': backend,
+        'system': system,
+        'name': name,
+        'variant': variant,
+        'start': start,
+        'end': end,
+        'success': True,
+    }
+
+
+class TestParseAttemptFromDirname(unittest.TestCase):
+
+    def test_valid_name(self):
+        self.assertEqual(1, runtimeadder._parse_attempt_from_dirname(
+            'spread-results-26594493301-1-ubuntu-focal'))
+
+    def test_valid_name_higher_attempt(self):
+        self.assertEqual(3, runtimeadder._parse_attempt_from_dirname(
+            'spread-results-26594493301-3-ubuntu-core-24'))
+
+    def test_invalid_name(self):
+        self.assertIsNone(runtimeadder._parse_attempt_from_dirname(
+            'spread-artifacts-26594493301-1-ubuntu-focal'))
+
+    def test_no_match(self):
+        self.assertIsNone(runtimeadder._parse_attempt_from_dirname('something-else'))
+
+
+class TestParseRuntimeSeconds(unittest.TestCase):
+
+    def test_basic(self):
+        runtime = runtimeadder._parse_runtime_seconds(
+            '2026-01-01T00:00:00Z', '2026-01-01T00:01:30Z')
+        self.assertAlmostEqual(90.0, runtime)
+
+    def test_sub_second(self):
+        runtime = runtimeadder._parse_runtime_seconds(
+            '2026-01-01T00:00:00.500Z', '2026-01-01T00:00:01.000Z')
+        self.assertAlmostEqual(0.5, runtime, places=2)
+
+
+class TestBuildRuntimeLookup(unittest.TestCase):
+
+    def test_single_attempt(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_dir = os.path.join(tmpdir, 'spread-results-12345-1-focal')
+            os.makedirs(artifact_dir)
+            items = [
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:00:00Z', '2026-01-01T00:00:30Z', 'preparing'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:00:30Z', '2026-01-01T00:01:00Z', 'executing'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:01:00Z', '2026-01-01T00:01:10Z', 'restoring'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/remove', 'v1',
+                                '2026-01-01T00:01:10Z', '2026-01-01T00:01:20Z', 'preparing'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/remove', 'v1',
+                                '2026-01-01T00:01:20Z', '2026-01-01T00:01:30Z', 'executing'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/remove', 'v1',
+                                '2026-01-01T00:01:30Z', '2026-01-01T00:01:45Z', 'restoring'),
+                # Non-target verbs should be ignored.
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:00:00Z', '2026-01-01T00:10:00Z', 'checking'),
+            ]
+            with open(os.path.join(artifact_dir, 'results.json'), 'w') as f:
+                json.dump(_make_results_json(items), f)
+
+            lookup = runtimeadder.build_runtime_lookup(tmpdir)
+
+            self.assertAlmostEqual(70.0, lookup[('google:ubuntu-24.04-64', 'tests/smoke/install', '')])
+            self.assertAlmostEqual(35.0, lookup[('google:ubuntu-24.04-64', 'tests/smoke/remove', 'v1')])
+            self.assertEqual(2, len(lookup))
+
+    def test_latest_attempt_wins(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for attempt, phase_end in [
+                (1, ('00:00:30Z', '00:01:30Z', '00:02:00Z')),
+                (2, ('00:01:00Z', '00:02:30Z', '00:03:00Z')),
+            ]:
+                artifact_dir = os.path.join(
+                    tmpdir, f'spread-results-12345-{attempt}-focal')
+                os.makedirs(artifact_dir)
+                items = [
+                    _make_task_item('google', 'ubuntu-24.04-64',
+                                    'tests/smoke/install', '',
+                                    '2026-01-01T00:00:00Z',
+                                    f'2026-01-01T{phase_end[0]}', 'preparing'),
+                    _make_task_item('google', 'ubuntu-24.04-64',
+                                    'tests/smoke/install', '',
+                                    f'2026-01-01T{phase_end[0]}',
+                                    f'2026-01-01T{phase_end[1]}', 'executing'),
+                    _make_task_item('google', 'ubuntu-24.04-64',
+                                    'tests/smoke/install', '',
+                                    f'2026-01-01T{phase_end[1]}',
+                                    f'2026-01-01T{phase_end[2]}', 'restoring'),
+                ]
+                with open(os.path.join(artifact_dir, 'results.json'), 'w') as f:
+                    json.dump(_make_results_json(items), f)
+
+            lookup = runtimeadder.build_runtime_lookup(tmpdir)
+            # Attempt 1 total = 120s, attempt 2 total = 180s.
+            self.assertAlmostEqual(180.0, lookup[('google:ubuntu-24.04-64', 'tests/smoke/install', '')])
+
+    def test_ignores_non_matching_dirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # a dir that doesn't match the naming pattern
+            other_dir = os.path.join(tmpdir, 'spread-artifacts-12345-1-focal')
+            os.makedirs(other_dir)
+            items = [_make_task_item('google', 'ubuntu-24.04-64',
+                                     'tests/smoke/install', '',
+                                     '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z')]
+            with open(os.path.join(other_dir, 'results.json'), 'w') as f:
+                json.dump(_make_results_json(items), f)
+
+            lookup = runtimeadder.build_runtime_lookup(tmpdir)
+            self.assertEqual(0, len(lookup))
+
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertEqual({}, runtimeadder.build_runtime_lookup(tmpdir))
+
+    def test_partial_phases_are_summed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_dir = os.path.join(tmpdir, 'spread-results-12345-1-focal')
+            os.makedirs(artifact_dir)
+            items = [
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:00:00Z', '2026-01-01T00:00:20Z', 'preparing'),
+                _make_task_item('google', 'ubuntu-24.04-64', 'tests/smoke/install', '',
+                                '2026-01-01T00:00:20Z', '2026-01-01T00:01:00Z', 'executing'),
+            ]
+            with open(os.path.join(artifact_dir, 'results.json'), 'w') as f:
+                json.dump(_make_results_json(items), f)
+
+            lookup = runtimeadder.build_runtime_lookup(tmpdir)
+
+            self.assertAlmostEqual(60.0, lookup[('google:ubuntu-24.04-64', 'tests/smoke/install', '')])
+            self.assertEqual(1, len(lookup))
+
+
+class TestAddRuntimeToFeatures(unittest.TestCase):
+
+    def _make_system_features(self, system: str, tests: list) -> dict:
+        return {
+            'schema_version': '0.0.0',
+            'system': system,
+            'scenarios': [],
+            'env_variables': [],
+            'tests': tests,
+        }
+
+    def test_adds_runtime(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system = 'google:ubuntu-24.04-64'
+            features = self._make_system_features(system, [
+                {'suite': 'tests/smoke', 'task_name': 'install', 'variant': '',
+                 'success': True, 'cmds': []},
+                {'suite': 'tests/smoke', 'task_name': 'remove', 'variant': 'v1',
+                 'success': True, 'cmds': []},
+            ])
+            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json'), 'w') as f:
+                json.dump(features, f)
+
+            lookup = {
+                ('google:ubuntu-24.04-64', 'tests/smoke/install', ''): 60.0,
+                ('google:ubuntu-24.04-64', 'tests/smoke/remove', 'v1'): 30.0,
+            }
+            runtimeadder.add_runtime_to_features(tmpdir, lookup)
+
+            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json')) as f:
+                result = json.load(f)
+
+            tests = {t['task_name']: t for t in result['tests']}
+            self.assertAlmostEqual(60.0, tests['install']['runtime'])
+            self.assertAlmostEqual(30.0, tests['remove']['runtime'])
+
+    def test_runtime_null_when_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system = 'google:ubuntu-24.04-64'
+            features = self._make_system_features(system, [
+                {'suite': 'tests/smoke', 'task_name': 'missing', 'variant': '',
+                 'success': True, 'cmds': []},
+            ])
+            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json'), 'w') as f:
+                json.dump(features, f)
+
+            runtimeadder.add_runtime_to_features(tmpdir, {})
+
+            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json')) as f:
+                result = json.load(f)
+            self.assertIsNone(result['tests'][0]['runtime'])
+
+    def test_skips_non_json_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, 'not-a-feature.txt'), 'w') as f:
+                f.write('hello')
+            # Should not raise
+            runtimeadder.add_runtime_to_features(tmpdir, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/features/test_runtimeadder.py
+++ b/tests/utils/features/test_runtimeadder.py
@@ -194,22 +194,6 @@ class TestAddRuntimeToFeatures(unittest.TestCase):
             self.assertAlmostEqual(60.0, tests['install']['runtime'])
             self.assertAlmostEqual(30.0, tests['remove']['runtime'])
 
-    def test_runtime_null_when_not_found(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            system = 'google:ubuntu-24.04-64'
-            features = self._make_system_features(system, [
-                {'suite': 'tests/smoke', 'task_name': 'missing', 'variant': '',
-                 'success': True, 'cmds': []},
-            ])
-            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json'), 'w') as f:
-                json.dump(features, f)
-
-            runtimeadder.add_runtime_to_features(tmpdir, {})
-
-            with open(os.path.join(tmpdir, 'google:ubuntu-24.04-64.json')) as f:
-                result = json.load(f)
-            self.assertIsNone(result['tests'][0]['runtime'])
-
     def test_skips_non_json_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, 'not-a-feature.txt'), 'w') as f:


### PR DESCRIPTION
This adds coverage based on test execution times (including prepare, execute, and restore phases of a single task). Note that project/suite prepare/restore times are not considered.

For example, on the data from June 6:
- the sets of tests must be under a total maximum of 15 minutes of execution time
- all features that include the strings "refresh" and "install" must be included in the set (even if their total runtime is more than the maximum specified of 15 minutes)
- feature coverage considerations include snap types

```
$ tests/utils/features/query_features.py feat cover -d ~/Documents/features/ -t 2026-06-06 --max-minutes 15 --force-matches refresh install --match-snap-types --remove cmds interfaces | jq -r 'to_entries[] | "\(.value | length)\t\(.key)"'
4       garden:ubuntu-22.04-64
7       openstack-ext:ubuntu-24.04-64
3       garden:fedora-44-64
56      openstack:ubuntu-25.10-64
1       google-nested-arm:ubuntu-24.04-arm-64
4       garden:ubuntu-20.04-64
56      openstack-arm:ubuntu-core-24-arm-64
3       garden:ubuntu-25.10-64
67      openstack:ubuntu-18.04-64
76      openstack:ubuntu-core-18-64
5       openstack-ext:ubuntu-20.04-64
7       openstack-ext:ubuntu-26.04-64
76      openstack:centos-9-64
71      openstack:opensuse-16.0-64
45      openstack-arm:ubuntu-24.04-arm-64
72      openstack:ubuntu-16.04-64
60      openstack:ubuntu-22.04-64
59      openstack:amazon-linux-2023-64
66      openstack:arch-linux-64
4       openstack-ext:ubuntu-18.04-64
61      openstack:ubuntu-20.04-64
60      openstack:debian-sid-64
58      openstack:ubuntu-core-24-64
6       google-pro:ubuntu-fips-22.04-64
65      openstack:fedora-44-64
62      openstack:ubuntu-core-20-64
68      openstack:opensuse-tumbleweed-selinux-64
62      openstack:debian-12-64
67      openstack:opensuse-tumbleweed-64
6       google-pro:ubuntu-fips-24.04-64
61      openstack:ubuntu-core-22-64
4       garden:ubuntu-core-18-64
56      openstack:ubuntu-26.04-64
2       garden:ubuntu-core-24-64
6       openstack-ext:ubuntu-22.04-64
62      openstack:ubuntu-core-26-64
76      openstack:amazon-linux-2-64
4       google:ubuntu-secboot-20.04-64
51      openstack:ubuntu-24.04-64
```

https://warthogs.atlassian.net/browse/SNAPDENG-36925