### PR TITLE
daemon: account for provided channel/revision in install command when checking if already installed

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -926,6 +926,21 @@ func (inst *snapInstruction) dispatchForMany() (op snapManyActionFunc) {
 	return op
 }
 
+func targetAlreadyInstalled(snapst *snapstate.SnapState, ropts *snapRevisionOptions) bool {
+	if !ropts.Revision.Unset() {
+		return snapst.Current == ropts.Revision
+	}
+
+	if ropts.Channel != "" {
+		// if the channel is provided, it is already validated
+		targetChannel, _ := channel.Parse(ropts.Channel, "")
+		curChannel, _ := channel.Parse(snapst.TrackingChannel, "")
+		return targetChannel == curChannel
+	}
+
+	return true
+}
+
 func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstruction) ([]string, map[string][]string, []*state.TaskSet, error) {
 	expectOneSnap := len(inst.Snaps) == 1
 	opts := snapstate.Options{
@@ -974,6 +989,8 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 			if len(comps) > 0 {
 				installedComponents[name] = comps
 			}
+		} else if !targetAlreadyInstalled(&snapst, &inst.snapRevisionOptions) && len(comps) == 0 {
+			continue
 		} else if len(comps) > 0 {
 			info, err := snapst.CurrentInfo()
 			if err != nil {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -926,7 +926,7 @@ func (inst *snapInstruction) dispatchForMany() (op snapManyActionFunc) {
 	return op
 }
 
-func targetAlreadyInstalled(snapst *snapstate.SnapState, ropts *snapRevisionOptions) bool {
+func targetAlreadyInstalled(snapst *snapstate.SnapState, ropts snapstate.RevisionOptions) bool {
 	if !ropts.Revision.Unset() {
 		return snapst.Current == ropts.Revision
 	}
@@ -989,7 +989,7 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 			if len(comps) > 0 {
 				installedComponents[name] = comps
 			}
-		} else if !targetAlreadyInstalled(&snapst, &inst.snapRevisionOptions) && len(comps) == 0 {
+		} else if !targetAlreadyInstalled(&snapst, revOpts) {
 			continue
 		} else if len(comps) > 0 {
 			info, err := snapst.CurrentInfo()

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2674,6 +2674,122 @@ func (s *snapsSuite) TestInstallManySomeSnapsAndComponentsAlreadyInstalled(c *ch
 
 }
 
+func (s *snapsSuite) TestInstallSameChannelAndRevision(c *check.C) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
+		return nil, nil, errors.New("should not be called")
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{
+		Action: "install",
+		Snaps:  []string{"some-snap"},
+	}
+	inst.Channel = "edge"
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "edge",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
+
+	snapstate.Set(st, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(si, nil)},
+		),
+		Current:         snap.R(1),
+		TrackingChannel: "edge",
+	})
+
+	_, err := inst.Dispatch()(context.Background(), inst, st)
+	c.Check(err, testutil.ErrorIs, *snap.NewAlreadyInstalledSnapsError([]string{"some-snap"}))
+
+	inst.Channel = ""
+	inst.Revision = snap.R(1)
+
+	_, err = inst.Dispatch()(context.Background(), inst, st)
+	c.Check(err, testutil.ErrorIs, *snap.NewAlreadyInstalledSnapsError([]string{"some-snap"}))
+}
+
+func (s *snapsSuite) TestInstallDifferentChannel(c *check.C) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
+		return nil, nil, errors.New("should not be called")
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{
+		Action: "install",
+		Snaps:  []string{"some-snap"},
+	}
+	// install from a different channel
+	inst.Channel = "stable"
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "edge",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
+
+	snapstate.Set(st, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(si, nil)},
+		),
+		Current:         snap.R(1),
+		TrackingChannel: "edge",
+	})
+
+	_, err := inst.Dispatch()(context.Background(), inst, st)
+	c.Check(err, testutil.ErrorIs, *snap.NewAlreadyInstalledSnapsError([]string{"some-snap"}))
+}
+
+func (s *snapsSuite) TestInstallDifferentRevision(c *check.C) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
+		return nil, nil, errors.New("should not be called")
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{
+		Action: "install",
+		Snaps:  []string{"some-snap"},
+	}
+	// install a different revision
+	inst.Revision = snap.R(2)
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "edge",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
+
+	snapstate.Set(st, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(si, nil)},
+		),
+		Current:         snap.R(1),
+		TrackingChannel: "edge",
+	})
+
+	_, err := inst.Dispatch()(context.Background(), inst, st)
+	c.Check(err, testutil.ErrorIs, *snap.NewAlreadyInstalledSnapsError([]string{"some-snap"}))
+}
+
 func (s *snapsSuite) TestInstallOnNonDevModeDistro(c *check.C) {
 	s.testInstall(c, false, snapstate.Flags{}, snap.R(0))
 }


### PR DESCRIPTION
`snap install --channel=latest/edge <snap>` exits with 0 even if the installed snap is tracking another channel. Same for revision. This PR accounts for provided channel and revision options in the install command when checking if the requested snap is already installed. 

Tracking with: [SNAPDENG-37033](https://warthogs.atlassian.net/browse/SNAPDENG-37033?atlOrigin=eyJpIjoiMTk4NzY2ZThkYjUwNDMxY2FlNWExM2FmMWFmYzFmNGQiLCJwIjoiaiJ9_


[SNAPDENG-37033]: https://warthogs.atlassian.net/browse/SNAPDENG-37033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ