### PR TITLE
cmd/snap, tests: add commands for debugging or accessing snap mount namespaces

### DIFF
--- a/cmd/snap/cmd_debug_mount_namespace.go
+++ b/cmd/snap/cmd_debug_mount_namespace.go
@@ -1,0 +1,128 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snapdtool"
+)
+
+var (
+	osGetuid = os.Getuid
+)
+
+type cmdDebugMountNamespace struct{}
+
+func init() {
+	cmd := addDebugCommand("mount-namespace",
+		"Debugging of snap mount namespaces",
+		"Commands to aid debugging of snap mount namespaces.",
+		func() flags.Commander { return &cmdDebugMountNamespace{} },
+		nil,
+		nil,
+	)
+	cmd.extra = func(c *flags.Command) {
+		c.AddCommand("discard", "Discard a snap mount namespace",
+			"Discard the mount namespace of the given snap by invoking snap-discard-ns.",
+			&cmdDebugMountNsDiscard{})
+		c.AddCommand("shell", "Start a shell or run a command in a snap mount namespace",
+			`Run a command inside the mount namespace of the given snap using nsenter.
+If no command is specified, an interactive shell (/bin/bash) is started.`,
+			&cmdDebugMountNsShell{})
+	}
+}
+
+func (x *cmdDebugMountNamespace) Execute(args []string) error {
+	return flag.ErrHelp
+}
+
+type cmdDebugMountNsDiscard struct {
+	Positionals struct {
+		SnapName string `required:"yes" positional-arg-name:"<snap-name>"`
+	} `positional-args:"true"`
+}
+
+func (x *cmdDebugMountNsDiscard) Execute(args []string) error {
+	if osGetuid() != 0 {
+		return fmt.Errorf("this command requires root privileges")
+	}
+
+	toolPath, err := snapdtool.InternalToolPath("snap-discard-ns")
+	if err != nil {
+		return fmt.Errorf("cannot find snap-discard-ns: %v", err)
+	}
+
+	cmd := exec.Command(toolPath, x.Positionals.SnapName)
+	cmd.Stdout = Stdout
+	cmd.Stderr = Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cannot discard mount namespace of snap %q: %v",
+			x.Positionals.SnapName, err)
+	}
+	return nil
+}
+
+type cmdDebugMountNsShell struct {
+	Positionals struct {
+		SnapName string `required:"yes" positional-arg-name:"<snap-name>"`
+	} `positional-args:"true"`
+}
+
+func (x *cmdDebugMountNsShell) Execute(args []string) error {
+	if osGetuid() != 0 {
+		return fmt.Errorf("this command requires root privileges")
+	}
+
+	mntPath := filepath.Join(dirs.SnapRunNsDir, x.Positionals.SnapName+".mnt")
+	if _, err := os.Stat(mntPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("cannot enter mount namespace of snap %q: "+
+				"the mount namespace is not bound to a file (%s does not exist)",
+				x.Positionals.SnapName, mntPath)
+		}
+		return fmt.Errorf("cannot stat mount namespace file: %w", err)
+	}
+
+	nsenterPath, err := exec.LookPath("nsenter")
+	if err != nil {
+		return fmt.Errorf("cannot find nsenter: %v", err)
+	}
+
+	argv := []string{"nsenter", "-m" + mntPath}
+	if len(args) > 0 {
+		argv = append(argv, args...)
+	} else {
+		// We know that /bin/bash is in the core* snaps. If a given uses
+		// bare, then the user can always invoke '/bin/busybox sh'.
+		argv = append(argv, "/bin/bash")
+	}
+
+	// Override the environment and set a safe PATH.
+	env := []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"}
+	return syscallExec(nsenterPath, argv, env)
+}

--- a/cmd/snap/cmd_debug_mount_namespace_test.go
+++ b/cmd/snap/cmd_debug_mount_namespace_test.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func (s *SnapSuite) TestDebugMountNamespaceDiscardRequiresRoot(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 1000 })
+	defer restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
+	c.Assert(err, ErrorMatches, "this command requires root privileges")
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellRequiresRoot(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 1000 })
+	defer restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
+	c.Assert(err, ErrorMatches, "this command requires root privileges")
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellFailsIfMntFileNotExist(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
+	c.Assert(err, ErrorMatches, `cannot enter mount namespace of snap "test-snap": the mount namespace is not bound to a file \(.*/run/snapd/ns/test-snap.mnt does not exist\)`)
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	rootDir := c.MkDir()
+	dirs.SetRootDir(rootDir)
+	defer dirs.SetRootDir("/")
+
+	// Create the .mnt file so the existence check passes
+	nsDir := filepath.Join(rootDir, "/run/snapd/ns")
+	err := os.MkdirAll(nsDir, 0755)
+	c.Assert(err, IsNil)
+	mntFile := filepath.Join(nsDir, "test-snap.mnt")
+	err = os.WriteFile(mntFile, nil, 0600)
+	c.Assert(err, IsNil)
+
+	// Mock nsenter so exec.LookPath resolves without host dependency
+	nsenterCmd := testutil.MockCommand(c, "nsenter", "")
+	defer nsenterCmd.Restore()
+
+	var execCalled bool
+	var execPath string
+	var execArgv []string
+	var execEnv []string
+	restoreExec := snap.MockSyscallExec(func(path string, argv []string, env []string) error {
+		execCalled = true
+		execPath = path
+		execArgv = argv
+		execEnv = env
+		return nil
+	})
+	defer restoreExec()
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
+	c.Assert(err, IsNil)
+	c.Assert(execCalled, Equals, true)
+	c.Assert(execPath, Equals, nsenterCmd.Exe())
+	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/bin/bash"})
+	c.Assert(execEnv, DeepEquals, []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"})
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellWithCommand(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	rootDir := c.MkDir()
+	dirs.SetRootDir(rootDir)
+	defer dirs.SetRootDir("/")
+
+	// Create the .mnt file so the existence check passes
+	nsDir := filepath.Join(rootDir, "/run/snapd/ns")
+	err := os.MkdirAll(nsDir, 0755)
+	c.Assert(err, IsNil)
+	mntFile := filepath.Join(nsDir, "test-snap.mnt")
+	err = os.WriteFile(mntFile, nil, 0600)
+	c.Assert(err, IsNil)
+
+	// Mock nsenter so exec.LookPath resolves without host dependency
+	nsenterCmd := testutil.MockCommand(c, "nsenter", "")
+	defer nsenterCmd.Restore()
+
+	var execArgv []string
+	var execEnv []string
+	restoreExec := snap.MockSyscallExec(func(path string, argv []string, env []string) error {
+		execArgv = argv
+		execEnv = env
+		return nil
+	})
+	defer restoreExec()
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap", "--", "/usr/bin/findmnt", "-l"})
+	c.Assert(err, IsNil)
+	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/usr/bin/findmnt", "-l"})
+	c.Assert(execEnv, DeepEquals, []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"})
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellWithCommandNoDash(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	rootDir := c.MkDir()
+	dirs.SetRootDir(rootDir)
+	defer dirs.SetRootDir("/")
+
+	// Create the .mnt file so the existence check passes
+	nsDir := filepath.Join(rootDir, "/run/snapd/ns")
+	err := os.MkdirAll(nsDir, 0755)
+	c.Assert(err, IsNil)
+	mntFile := filepath.Join(nsDir, "test-snap.mnt")
+	err = os.WriteFile(mntFile, nil, 0600)
+	c.Assert(err, IsNil)
+
+	// Mock nsenter so exec.LookPath resolves without host dependency
+	nsenterCmd := testutil.MockCommand(c, "nsenter", "")
+	defer nsenterCmd.Restore()
+
+	var execArgv []string
+	restoreExec := snap.MockSyscallExec(func(path string, argv []string, env []string) error {
+		execArgv = argv
+		return nil
+	})
+	defer restoreExec()
+
+	// Without --, positional arguments that don't look like flags work fine
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap", "/usr/bin/findmnt"})
+	c.Assert(err, IsNil)
+	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/usr/bin/findmnt"})
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceDiscardRunsTool(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
+	dirs.DistroLibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Calls(), DeepEquals, [][]string{
+		{"snap-discard-ns", "test-snap"},
+	})
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceDiscardReportsError(c *C) {
+	restore := snap.MockOsGetuid(func() int { return 0 })
+	defer restore()
+
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "echo 'namespace error'; exit 1")
+	dirs.DistroLibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
+	c.Assert(err, ErrorMatches, `cannot discard mount namespace of snap "test-snap": .*`)
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -504,3 +504,7 @@ func MockSquashfsGenerateDelta(f func(context.Context, string, string, string, s
 func MockSquashfsApplyDelta(f func(context.Context, string, string, string) error) (restore func()) {
 	return testutil.Mock(&squashfsApplyDelta, f)
 }
+
+func MockOsGetuid(f func() int) (restore func()) {
+	return testutil.Mock(&osGetuid, f)
+}

--- a/tests/main/interfaces-fuse-support/task.yaml
+++ b/tests/main/interfaces-fuse-support/task.yaml
@@ -40,10 +40,10 @@ prepare: |
 
 restore: |
     # remove the mount point
-    mounts=$(nsenter "--mount=/run/snapd/ns/$NAME.mnt" cat /proc/mounts | \
+    mounts=$(snap debug mount-namespace shell "$NAME" -- cat /proc/mounts | \
              grep "$(basename "$MOUNT_POINT") fuse" | cut -f2 -d' ')
     for m in $mounts; do
-        nsenter "--mount=/run/snapd/ns/$NAME.mnt" umount "$m"
+        snap debug mount-namespace shell "$NAME" -- umount "$m"
     done
     rm -rf "$MOUNT_POINT_OUTSIDE"
 
@@ -103,6 +103,6 @@ execute: |
     wait $createpid || test "$?" = "159"
 
     # verify that the mount_point was not removed from mount namespace of the snap
-    mountpath=$(nsenter "--mount=/run/snapd/ns/$NAME.mnt" cat /proc/mounts | \
+    mountpath=$(snap debug mount-namespace shell "$NAME" -- cat /proc/mounts | \
                 grep "$(basename "$MOUNT_POINT") fuse" | cut -f2 -d' ')
     test -n "$mountpath"

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -27,17 +27,17 @@ execute: |
     snap connect app:runtime runtime:runtime
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per the layout, there is a symlink
-    nsenter -m/run/snapd/ns/app.mnt /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
 
     echo "The application is refreshed with another layout"
     snap install --dangerous ./app_2_all.snap
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per new layout, there is a bind mount
-    nsenter -m/run/snapd/ns/app.mnt /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
+    snap debug mount-namespace shell app -- /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
 
     echo "The application is reverted"
     snap revert app 2>&1 | MATCH 'app reverted to 1'
     # Back to symlink
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # And we still have a bind mount
-    nsenter -m/run/snapd/ns/app.mnt /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'

--- a/tests/main/ld-cache-from-base/task.yaml
+++ b/tests/main/ld-cache-from-base/task.yaml
@@ -16,7 +16,7 @@ execute: |
   test-snapd-sh-core"$base".sh -c pwd
 
   # Check ld cache related paths are mounted from the base
-  nsenter --mount=/run/snapd/ns/"$test_snap".mnt mount > mounts.txt
+  snap debug mount-namespace shell "$test_snap" -- mount > mounts.txt
   SNAP_MOUNT_DIR=$(os.paths snap-mount-dir)
   currBaseRev=$(readlink "$SNAP_MOUNT_DIR"/core"$base"/current)
   basePath=/var/lib/snapd/snaps/core"$base"_"$currBaseRev".snap

--- a/tests/regression/lp-1884849/task.yaml
+++ b/tests/regression/lp-1884849/task.yaml
@@ -19,9 +19,9 @@ prepare: |
   sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.test-snapd-desktop.fstab
   # Having manually altered the mount namespace, so that fontconfig cache is not mounted
   touch /var/cache/fontconfig/.canary
-  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test -e /var/cache/fontconfig/.canary
-  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt umount /var/cache/fontconfig
-  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace shell test-snapd-desktop -- test -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace shell test-snapd-desktop -- umount /var/cache/fontconfig
+  snap debug mount-namespace shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
   # Having confirmed that snap-update-ns manifest assumes it still is.
   grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
 
@@ -35,4 +35,4 @@ execute: |
   MATCH 'DEBUG:?.*ignoring EINVAL from unmount, [\]?"/var/cache/fontconfig[\]?" is not mounted' <snap-update-ns.log
   # And confirm snap-update-ns fixed the situation
   not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
-  nsenter -m/run/snapd/ns/test-snapd-desktop.mnt test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary

--- a/tests/regression/lp-1898038/task.yaml
+++ b/tests/regression/lp-1898038/task.yaml
@@ -44,9 +44,9 @@ execute: |
     # now connect it and verify profile can be compiled
     test-snapd-docker-support-app.test-snapd-docker-support
     # check that within the snap mount namespace /etc/apparmor is mounted and comes from a snap
-    test "$(nsenter -m/run/snapd/ns/test-snapd-docker-support-app.mnt mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace shell test-snapd-docker-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 
     # and do the same for multipass-support
     test-snapd-multipass-support-app.test-snapd-multipass-support
-    test "$(nsenter -m/run/snapd/ns/test-snapd-multipass-support-app.mnt mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace shell test-snapd-multipass-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 


### PR DESCRIPTION
Add new commands for debugging snap mount namespaces:

- `snap debug mount-namespace shell <snap-name> [--] [command]` - enter the snap's mount namespace, similar to `unshare -m/run/snapd/ns/<snap-name>.mnt /bin/bash`, or run a specific command inside the mount namespace
- `snap debug mount-namespace discard <snap-name>` - discard snap's mount namespace, similar to invokind the snap-discard-ns <snap-name> command

Related: SNAPDENG-37024