### PR TITLE
tests: migrate fips and secboot from google to openstack

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -102,16 +102,16 @@
       {
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-secboot",
-        "backend": "google",
+        "backend": "openstack",
         "alternative-backend": "google",
-        "systems": "ubuntu-secboot-20.04-64",
+        "systems": "ubuntu-secboot-24.04-64",
         "tasks": "tests/...",
         "rules": "main"
       },
       {
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-fips-snap",
-        "backend": "google-pro",
+        "backend": "openstack",
         "alternative-backend": "google-pro",
         "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
         "tasks": "tests/fips-snap/...",
@@ -120,7 +120,7 @@
       {
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-fips-deb",
-        "backend": "google-pro",
+        "backend": "openstack",
         "alternative-backend": "google-pro",
         "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
         "tasks": "tests/fips-deb/...",

--- a/spread.yaml
+++ b/spread.yaml
@@ -398,9 +398,18 @@ backends:
             - ubuntu-22.04-64:
                 image: snapd-spread/ubuntu-22.04-64
                 workers: 8
+            - ubuntu-fips-22.04-64:
+                image: snapd-spread/ubuntu-22.04-64-pro-fips
+            - ubuntu-22.04-64:
+                image: snapd-spread/ubuntu-22.04-64
+                workers: 8
             - ubuntu-24.04-64:
                 image: snapd-spread/ubuntu-24.04-64
                 workers: 8
+            - ubuntu-fips-24.04-64:
+                image: snapd-spread/ubuntu-24.04-64-pro-fips
+            - ubuntu-secboot-24.04-64:
+                image: snapd-spread/ubuntu-24.04-64-secboot
             - ubuntu-25.10-64:
                 image: snapd-spread/ubuntu-25.10-64
                 workers: 8
@@ -1295,12 +1304,6 @@ prepare: |
     if [[ "$SPREAD_SYSTEM" == ubuntu-fips-* ]]; then
         pro refresh
         pro status
-
-        if [[ "$SPREAD_REBOOT" = 0 ]]; then
-            echo "--- enabling FIPS"
-            pro enable fips-updates --assume-yes
-            REBOOT
-        fi
 
         if ! [ "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]; then
             echo "FIPS not enabled"

--- a/spread.yaml
+++ b/spread.yaml
@@ -1302,18 +1302,15 @@ prepare: |
     fi
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-fips-* ]]; then
-        pro refresh
-        pro status
-
         if ! [ "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]; then
             echo "FIPS not enabled"
             exit 1
         fi
 
-        # enable GO FIPS PPA
-        add-apt-repository --yes ppa:ubuntu-toolchain-r/golang-fips
-        # XXX pin priority?
-        apt update
+        if apt-cache policy | NOMATCH golang-fips; then
+            echo "golang-fips repo not found, the system is not properly configured for FIPS"
+            exit 1
+        fi
     fi
 
     # Enable EPEL see https://docs.fedoraproject.org/en-US/epel/

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -574,8 +574,7 @@ pkg_dependencies_ubuntu_classic(){
         fish
         fontconfig
         gnome-keyring
-        nfs-kernel-server
-        printer-driver-cups-pdf
+        nfs-kernel-server        
         python3-dbus
         python3-gi
         python3-yaml


### PR DESCRIPTION
This change is migrating the secboot and fips tests from google to openstack.

Also it is being removed a dependency because it is getting stuck to install it (configuring the service). It will be restored once the issue is solved.