### PR TITLE
asserts: add validation-sets confdb-schema builtin

### DIFF
--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -56,6 +56,16 @@ views:
                 storage: revision
               -
                 storage: presence
+              -
+                storage: components
+                content:
+                  -
+                    storage: {component}
+                    content:
+                      -
+                        storage: presence
+                      -
+                        storage: revision
           -
             storage: mode
           -
@@ -122,6 +132,18 @@ views:
       "set-name": {
         "type": "string",
         "pattern": "^[a-z0-9](?:-?[a-z0-9])*$"
+      },
+      "natural-number": {
+        "type": "int",
+        "min": 1
+      },
+      "presence": {
+        "type": "string",
+        "choices": [
+          "required",
+          "optional",
+          "invalid"
+        ]
       }
     },
     "schema": {
@@ -141,18 +163,9 @@ views:
                   "enforce"
                 ]
               },
-              "pinned-sequence": {
-                "type": "int",
-                "min": 0
-              },
-              "revision": {
-                "type": "int",
-                "min": 0
-              },
-              "sequence": {
-                "type": "int",
-                "min": 1
-              },
+              "pinned-sequence": "${natural-number}",
+              "revision": "${natural-number}",
+              "sequence": "${natural-number}",
               "snaps": {
                 "type": "array",
                 "unique": true,
@@ -160,17 +173,15 @@ views:
                   "schema": {
                     "id": "string",
                     "name": "string",
-                    "presence": {
-                      "type": "string",
-                      "choices": [
-                        "required",
-                        "optional",
-                        "invalid"
-                      ]
-                    },
-                    "revision": {
-                      "type": "int",
-                      "min": 1
+                    "presence": "${presence}",
+                    "revision": "${natural-number}",
+                    "components": {
+                      "values": {
+                        "schema": {
+                          "presence": "${presence}",
+                          "revision": "${natural-number}"
+                        }
+                      }
                     }
                   }
                 }

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -242,7 +242,11 @@ func (ar *ConfdbSchema) Schema() *confdb.Schema {
 func assembleConfdbSchema(assert assertionBase) (Assertion, error) {
 	authorityID := assert.AuthorityID()
 	accountID := assert.HeaderString("account-id")
-	if accountID != "system" && accountID != authorityID {
+	if accountID == "system" {
+		if authorityID != "canonical" {
+			return nil, fmt.Errorf(`"system" confdb-schemas must be signed by "canonical" got %q`, authorityID)
+		}
+	} else if accountID != authorityID {
 		return nil, fmt.Errorf("authority-id and account-id must match, confdb assertions are expected to be signed by the issuer account: %q != %q", authorityID, accountID)
 	}
 

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -28,6 +28,191 @@ import (
 	"github.com/snapcore/snapd/confdb"
 )
 
+var (
+	rawConfdbBuiltins = map[string]map[string][]byte{
+		"validation-sets": {
+			"headers": []byte(`type: confdb-schema
+account-id: system
+authority-id: canonical
+name: validation-sets
+summary: Manage the validation sets installed on a device
+views:
+  state:
+    summary: Read the validation sets state
+    rules:
+      -
+        request: {account}.{validation-set}
+        storage: v1.{account}.{validation-set}
+        access: read
+        content:
+          -
+            storage: snaps[{n}]
+            content:
+              -
+                storage: name
+              -
+                storage: id
+              -
+                storage: revision
+              -
+                storage: presence
+          -
+            storage: mode
+          -
+            storage: status
+          -
+            storage: sequence
+          -
+            storage: revision
+          -
+            storage: pinned-sequence
+  admin:
+    summary: Control validation sets
+    rules:
+      -
+        request: {account}.{set-name}
+        storage: v1.{account}.{set-name}
+        access: write
+        content:
+          -
+            storage: pinned-sequence
+          -
+            storage: mode
+      -
+        request: {account}.{set-name}
+        storage: v1.{account}.{set-name}
+        access: read
+        content:
+          -
+            storage: snaps[{n}]
+            content:
+              -
+                storage: name
+              -
+                storage: id
+              -
+                storage: revision
+              -
+                storage: presence
+          -
+            storage: status
+          -
+            storage: sequence
+          -
+            storage: revision
+          -
+            storage: pinned-sequence
+          -
+            storage: mode
+  pinning-admin:
+    summary: Control pinning of validation sets
+    rules:
+      -
+        request: {account}.{set-name}.pinned-sequence
+        storage: v1.{account}.{set-name}.pinned-sequence
+        access: read-write
+`),
+			"body": []byte(`{
+  "storage": {
+    "aliases": {
+      "account-id": {
+        "type": "string",
+        "pattern": "^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28})$"
+      },
+      "set-name": {
+        "type": "string",
+        "pattern": "^[a-z0-9](?:-?[a-z0-9])*$"
+      }
+    },
+    "schema": {
+      "v1": {
+        "keys": "${account-id}",
+        "values": {
+          "keys": "${set-name}",
+          "values": {
+            "required": [
+              "mode"
+            ],
+            "schema": {
+              "mode": {
+                "type": "string",
+                "choices": [
+                  "monitor",
+                  "enforce"
+                ]
+              },
+              "pinned-sequence": {
+                "type": "int",
+                "min": 0
+              },
+              "revision": {
+                "type": "int",
+                "min": 0
+              },
+              "sequence": {
+                "type": "int",
+                "min": 1
+              },
+              "snaps": {
+                "type": "array",
+                "unique": true,
+                "values": {
+                  "schema": {
+                    "id": "string",
+                    "name": "string",
+                    "presence": {
+                      "type": "string",
+                      "choices": [
+                        "required",
+                        "optional",
+                        "invalid"
+                      ]
+                    },
+                    "revision": {
+                      "type": "int",
+                      "min": 1
+                    }
+                  }
+                }
+              },
+              "status": {
+                "type": "string",
+                "choices": [
+                  "valid",
+                  "invalid"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`),
+		},
+	}
+
+	confdbSchemaCheckOrder      = []string{"type", "account-id", "authority-id"}
+	confdbSchemaExpectedHeaders = map[string]any{
+		"type":         "confdb-schema",
+		"account-id":   "system",
+		"authority-id": "canonical",
+	}
+)
+
+func init() {
+	for name, builtin := range rawConfdbBuiltins {
+		a, err := assembleBuiltinAssertion(ConfdbSchemaType, builtin["headers"], builtin["body"], builtinCheckParams{
+			order:           confdbSchemaCheckOrder,
+			expectedHeaders: confdbSchemaExpectedHeaders,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("cannot create builtin %q confdb-schema: %v", name, err))
+		}
+		builtinAssertions = append(builtinAssertions, a)
+	}
+}
+
 // ConfdbSchema holds a confdb-schema assertion, which is a definition by an
 // account of access views and a storage schema for a set of related
 // configuration options under the purview of the account.
@@ -57,7 +242,7 @@ func (ar *ConfdbSchema) Schema() *confdb.Schema {
 func assembleConfdbSchema(assert assertionBase) (Assertion, error) {
 	authorityID := assert.AuthorityID()
 	accountID := assert.HeaderString("account-id")
-	if accountID != authorityID {
+	if accountID != "system" && accountID != authorityID {
 		return nil, fmt.Errorf("authority-id and account-id must match, confdb assertions are expected to be signed by the issuer account: %q != %q", authorityID, accountID)
 	}
 

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -89,19 +89,86 @@ const schema = `{
 }`
 
 func (s *confdbSuite) TestDecodeOK(c *C) {
-	encoded := strings.Replace(confdbExample, "TSLINE", s.tsLine, 1)
+	tests := []struct {
+		original    string
+		replacement string
+		authorityID string
+		accountID   string
+	}{
+		{
+			authorityID: "brand-id1",
+			accountID:   "brand-id1",
+		},
+		{
+			original:    "account-id: brand-id1\n",
+			replacement: "account-id: system\n",
+			authorityID: "brand-id1",
+			accountID:   "system",
+		},
+	}
 
-	a, err := asserts.Decode([]byte(encoded))
-	c.Assert(err, IsNil)
-	c.Check(a, NotNil)
-	c.Check(a.Type(), Equals, asserts.ConfdbSchemaType)
-	ar := a.(*asserts.ConfdbSchema)
-	c.Check(ar.AuthorityID(), Equals, "brand-id1")
-	c.Check(ar.AccountID(), Equals, "brand-id1")
-	c.Check(ar.Name(), Equals, "my-network")
-	schema := ar.Schema()
-	c.Assert(schema, NotNil)
-	c.Check(schema.View("wifi-setup"), NotNil)
+	for i, t := range tests {
+		cmt := Commentf("testcase %d/%d", i+1, len(tests))
+		encoded := strings.Replace(confdbExample, "TSLINE", s.tsLine, 1)
+		if t.original != "" {
+			encoded = strings.Replace(encoded, t.original, t.replacement, 1)
+		}
+
+		a, err := asserts.Decode([]byte(encoded))
+		c.Assert(err, IsNil, cmt)
+		c.Check(a.Type(), Equals, asserts.ConfdbSchemaType, cmt)
+		ar := a.(*asserts.ConfdbSchema)
+		c.Check(ar.AuthorityID(), Equals, t.authorityID, cmt)
+		c.Check(ar.AccountID(), Equals, t.accountID, cmt)
+		c.Check(ar.Name(), Equals, "my-network", cmt)
+
+		schema := ar.Schema()
+		c.Assert(schema, NotNil, cmt)
+		c.Check(schema.View("wifi-setup"), NotNil, cmt)
+	}
+}
+
+func (s *confdbSuite) TestBuiltinConfdbSchemas(c *C) {
+	tests := []struct {
+		name  string
+		views []string
+	}{
+		{
+			name:  "validation-sets",
+			views: []string{"state", "admin", "pinning-admin"},
+		},
+	}
+
+	builtins := make(map[string]*asserts.ConfdbSchema)
+	for _, a := range asserts.Builtin() {
+		if cs, ok := a.(*asserts.ConfdbSchema); ok {
+			if _, ok := builtins[cs.Name()]; ok {
+				c.Fatalf("expected one %q confdb-schema: got two", cs.Name())
+			}
+			builtins[cs.Name()] = cs
+		}
+	}
+	// we should have one test per builtin
+	c.Assert(builtins, HasLen, len(tests))
+
+	for _, t := range tests {
+		cmt := Commentf("testcase %q", t.name)
+		cs, ok := builtins[t.name]
+		c.Assert(ok, Equals, true, cmt)
+
+		c.Check(cs.AccountID(), Equals, "system", cmt)
+		c.Check(cs.AuthorityID(), Equals, "canonical", cmt)
+		c.Check(cs.Name(), Equals, t.name, cmt)
+
+		schema := cs.Schema()
+		for _, view := range t.views {
+			c.Check(schema.View(view), NotNil, cmt)
+		}
+
+		// carries a "$builtin" signature
+		_, sign := cs.Signature()
+		c.Assert(string(sign), Equals, "$builtin", cmt)
+	}
 }
 
 func (s *confdbSuite) TestDecodeInvalid(c *C) {

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -90,19 +90,21 @@ const schema = `{
 
 func (s *confdbSuite) TestDecodeOK(c *C) {
 	tests := []struct {
-		original    string
-		replacement string
-		authorityID string
-		accountID   string
+		original     string
+		replacements [][2]string
+		authorityID  string
+		accountID    string
 	}{
 		{
 			authorityID: "brand-id1",
 			accountID:   "brand-id1",
 		},
 		{
-			original:    "account-id: brand-id1\n",
-			replacement: "account-id: system\n",
-			authorityID: "brand-id1",
+			replacements: [][2]string{
+				{"account-id: brand-id1\n", "account-id: system\n"},
+				{"authority-id: brand-id1\n", "authority-id: canonical\n"},
+			},
+			authorityID: "canonical",
 			accountID:   "system",
 		},
 	}
@@ -110,8 +112,8 @@ func (s *confdbSuite) TestDecodeOK(c *C) {
 	for i, t := range tests {
 		cmt := Commentf("testcase %d/%d", i+1, len(tests))
 		encoded := strings.Replace(confdbExample, "TSLINE", s.tsLine, 1)
-		if t.original != "" {
-			encoded = strings.Replace(encoded, t.original, t.replacement, 1)
+		for _, replace := range t.replacements {
+			encoded = strings.Replace(encoded, replace[0], replace[1], 1)
 		}
 
 		a, err := asserts.Decode([]byte(encoded))
@@ -183,6 +185,7 @@ func (s *confdbSuite) TestDecodeInvalid(c *C) {
 		{"account-id: brand-id1\n", "", `"account-id" header is mandatory`},
 		{"account-id: brand-id1\n", "account-id: \n", `"account-id" header should not be empty`},
 		{"account-id: brand-id1\n", "account-id: random\n", `authority-id and account-id must match, confdb assertions are expected to be signed by the issuer account: "brand-id1" != "random"`},
+		{"account-id: brand-id1\n", "account-id: system\n", `"system" confdb-schemas must be signed by "canonical" got "brand-id1"`},
 		{"name: my-network\n", "", `"name" header is mandatory`},
 		{"name: my-network\n", "name: \n", `"name" header should not be empty`},
 		{"name: my-network\n", "name: my/network\n", `"name" primary key header cannot contain '/'`},


### PR DESCRIPTION
Adds a builtin confdb-schema for configuring the validation sets on the device. Note that `snap known` doesn't automatically work with builtin assertions because we can't decode assertions with a signature and key hash (added a JIRA ticket to support that).


https://warthogs.atlassian.net/browse/SNAPDENG-36958