### PR TITLE
tests/nested/manual/cmdline-option: use nesting instead of dot notation

### DIFF
--- a/tests/nested/manual/cmdline-option/defaults.yaml
+++ b/tests/nested/manual/cmdline-option/defaults.yaml
@@ -5,4 +5,5 @@ defaults:
     journal:
       persistent: true
     system:
-      kernel.cmdline-append: foo=1 foo=2
+      kernel:
+        cmdline-append: foo=1 foo=2


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
