### PR TITLE
sandbox/cgroup: add helpers for listing and iterating device mediation groups

### DIFF
--- a/sandbox/cgroup/devices.go
+++ b/sandbox/cgroup/devices.go
@@ -167,23 +167,23 @@ func collectDevicesV1(securityTag string) ([]DeviceEntry, error) {
 			majMin := parts[1]
 			access := parts[2]
 
-			majMinParts := strings.SplitN(majMin, ":", 2)
-			if l := len(majMinParts); l != 2 {
-				return fmt.Errorf("unexpected number of fields in major:minor: %v", l)
+			majPart, minPart, found := strings.Cut(majMin, ":")
+			if !found {
+				return fmt.Errorf("unexpected format of major:minor")
 			}
 
-			major, err := strconv.ParseUint(majMinParts[0], 10, 32)
+			major, err := strconv.ParseUint(majPart, 10, 32)
 			if err != nil {
-				if majMinParts[0] == "*" {
+				if majPart == "*" {
 					major = AccessAny
 				} else {
 					return fmt.Errorf("malformed major number: %w", err)
 				}
 			}
 
-			minor, err := strconv.ParseUint(majMinParts[1], 10, 32)
+			minor, err := strconv.ParseUint(minPart, 10, 32)
 			if err != nil {
-				if majMinParts[1] == "*" {
+				if minPart == "*" {
 					minor = AccessAny
 				} else {
 					return fmt.Errorf("malformed minor number: %w", err)

--- a/sandbox/cgroup/devices.go
+++ b/sandbox/cgroup/devices.go
@@ -1,0 +1,211 @@
+// -*- Mode: Go; indent-tabs-mode: t; tab-width: 4 -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/sandbox/ebpf"
+)
+
+// deviceMapAccessor abstracts iteration over device map entries.
+type deviceMapAccessor interface {
+	Iterate(fn func(ebpf.DeviceKey) error) error
+	Close() error
+}
+
+var (
+	loadDeviceMapFunc         = loadDeviceMapImpl
+	findDeviceMapsForSnapFunc = ebpf.FindActiveDeviceMapsForSnap
+)
+
+func loadDeviceMapImpl(securityTag string) (deviceMapAccessor, error) {
+	return ebpf.LoadDeviceMap(securityTag)
+}
+
+// FindActiveDeviceMediationForSnap finds all security tags for a given
+// snap name which have active device mediation.
+func FindActiveDeviceMediationForSnap(snapName string) (tags []string, err error) {
+	v, err := Version()
+	if err != nil {
+		return nil, err
+	}
+	if v == V2 {
+		return findDeviceMapsForSnapFunc(snapName)
+	}
+	return findSecurityTagsV1(snapName)
+}
+
+func findSecurityTagsV1(snapName string) ([]string, error) {
+	cgroupDevicesPath := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/devices")
+	prefix := fmt.Sprintf("snap.%s.", snapName)
+	entries, err := os.ReadDir(cgroupDevicesPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot read %s: %w", cgroupDevicesPath, err)
+	}
+	var tags []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), prefix) {
+			tags = append(tags, e.Name())
+		}
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+// AccessAny is the special value matching any major or minor value.
+const AccessAny = math.MaxUint32 // same value as ebpf.AccessAny
+
+// DeviceEntry represents a single device entry to which the snap's access is
+// mediated.
+type DeviceEntry struct {
+	DevType byte   // 'c' (character), 'b' (block), or 'a' (any)
+	Major   uint32 // major number
+	Minor   uint32 // minor number
+	Access  string // e.g. "rwm"
+}
+
+// ListMediatedDevicesForSecurityTag returns the list of mediated device access
+// for a given security tag.
+func ListMediatedDevicesForSecurityTag(tag string) ([]DeviceEntry, error) {
+	v, err := Version()
+	if err != nil {
+		return nil, err
+	}
+	if v == V2 {
+		return collectDevicesV2(tag)
+	}
+	return collectDevicesV1(tag)
+}
+
+func collectDevicesV2(securityTag string) ([]DeviceEntry, error) {
+	m, err := loadDeviceMapFunc(securityTag)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open device map: %w", err)
+	}
+	defer m.Close()
+
+	var entries []DeviceEntry
+
+	err = m.Iterate(func(key ebpf.DeviceKey) error {
+		entries = append(entries, DeviceEntry{
+			DevType: key.Type,
+			Major:   key.Major,
+			Minor:   key.Minor,
+			// The BPF device map only records whether access is
+			// allowed (value=1), not individual r/w/m permissions.
+			// Report "rwm" as presence in the map means full access.
+			Access: "rwm",
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot iterate device map: %w", err)
+	}
+
+	return entries, nil
+}
+
+func collectDevicesV1(securityTag string) ([]DeviceEntry, error) {
+	path := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/devices", securityTag, "devices.list")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var entries []DeviceEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// The data parsed here is coming directly from the kernel, limited
+		// validation and gracefully skip on errors.
+		err := func() error {
+			// Format: "c 1:3 rwm" or "a *:* rwm"
+			parts := strings.Fields(line)
+			if l := len(parts); l != 3 {
+				return fmt.Errorf("unexpected number of fields: %v", l)
+			}
+
+			devTypeStr := parts[0]
+			majMin := parts[1]
+			access := parts[2]
+
+			majMinParts := strings.SplitN(majMin, ":", 2)
+			if l := len(majMinParts); l != 2 {
+				return fmt.Errorf("unexpected number of fields in major:minor: %v", l)
+			}
+
+			major, err := strconv.ParseUint(majMinParts[0], 10, 32)
+			if err != nil {
+				if majMinParts[0] == "*" {
+					major = AccessAny
+				} else {
+					return fmt.Errorf("malformed major number: %w", err)
+				}
+			}
+
+			minor, err := strconv.ParseUint(majMinParts[1], 10, 32)
+			if err != nil {
+				if majMinParts[1] == "*" {
+					minor = AccessAny
+				} else {
+					return fmt.Errorf("malformed minor number: %w", err)
+				}
+			}
+
+			entries = append(entries, DeviceEntry{
+				DevType: devTypeStr[0],
+				Major:   uint32(major),
+				Minor:   uint32(minor),
+				Access:  access,
+			})
+
+			return nil
+		}()
+		if err != nil {
+			logger.Debugf("cannot parse entry: %q: %v", line, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cannot read devices.list: %w", err)
+	}
+
+	return entries, nil
+}

--- a/sandbox/cgroup/devices_test.go
+++ b/sandbox/cgroup/devices_test.go
@@ -1,0 +1,233 @@
+// -*- Mode: Go; indent-tabs-mode: t; tab-width: 4 -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cgroup_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/sandbox/ebpf"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type devicesSuite struct {
+	testutil.BaseTest
+	rootDir string
+	log     *bytes.Buffer
+}
+
+var _ = Suite(&devicesSuite{})
+
+func (s *devicesSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.rootDir = c.MkDir()
+	dirs.SetRootDir(s.rootDir)
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	l, r := logger.MockDebugLogger()
+	s.AddCleanup(r)
+	s.log = l
+}
+
+// V1 tests
+
+func (s *devicesSuite) TestFindSecurityTagsV1(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	cgroupDir := filepath.Join(s.rootDir, "/sys/fs/cgroup/devices")
+	c.Assert(os.MkdirAll(filepath.Join(cgroupDir, "snap.mysnap.app1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(cgroupDir, "snap.mysnap.app2"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(cgroupDir, "snap.other.thing"), 0755), IsNil)
+	// A regular file should be ignored
+	c.Assert(os.WriteFile(filepath.Join(cgroupDir, "snap.mysnap.ignored"), nil, 0644), IsNil)
+
+	tags, err := cgroup.FindSecurityTagsV1("mysnap")
+	c.Assert(err, IsNil)
+	c.Check(tags, DeepEquals, []string{"snap.mysnap.app1", "snap.mysnap.app2"})
+}
+
+func (s *devicesSuite) TestFindSecurityTagsV1NoDir(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	tags, err := cgroup.FindSecurityTagsV1("anything")
+	c.Assert(err, IsNil)
+	c.Check(tags, IsNil)
+}
+
+func (s *devicesSuite) TestCollectDevicesV1(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	tag := "snap.mysnap.app1"
+	devicesDir := filepath.Join(s.rootDir, "/sys/fs/cgroup/devices", tag)
+	c.Assert(os.MkdirAll(devicesDir, 0755), IsNil)
+
+	content := `c 1:3 rwm
+b 8:* rw
+a *:* rwm
+
+c 5:0 r
+
+# malformed
+z -1 m
+z 1:1a f
+z
+b 12:z rwm
+`
+	c.Assert(os.WriteFile(filepath.Join(devicesDir, "devices.list"), []byte(content), 0644), IsNil)
+
+	entries, err := cgroup.CollectDevicesV1(tag)
+	c.Assert(err, IsNil)
+	c.Assert(entries, HasLen, 4)
+	c.Check(entries[0], Equals, cgroup.DeviceEntry{DevType: 'c', Major: 1, Minor: 3, Access: "rwm"})
+	c.Check(entries[1], Equals, cgroup.DeviceEntry{DevType: 'b', Major: 8, Minor: cgroup.AccessAny, Access: "rw"})
+	c.Check(entries[2], Equals, cgroup.DeviceEntry{DevType: 'a', Major: cgroup.AccessAny, Minor: cgroup.AccessAny, Access: "rwm"})
+	c.Check(entries[3], Equals, cgroup.DeviceEntry{DevType: 'c', Major: 5, Minor: 0, Access: "r"})
+
+	l := s.log.String()
+	c.Check(l, testutil.Contains, "malformed minor number:")
+	c.Check(l, testutil.Contains, "unexpected number of fields: 2")
+	c.Check(l, testutil.Contains, "unexpected number of fields in major:minor: 1")
+}
+
+func (s *devicesSuite) TestCollectDevicesV1MissingFile(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	_, err := cgroup.CollectDevicesV1("snap.noexist.app")
+	c.Assert(err, ErrorMatches, "cannot open .*/devices.list:.*")
+}
+
+func (s *devicesSuite) TestListMediatedDevicesV1(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	tag := "snap.mysnap.app1"
+	devicesDir := filepath.Join(s.rootDir, "/sys/fs/cgroup/devices", tag)
+	c.Assert(os.MkdirAll(devicesDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(devicesDir, "devices.list"), []byte("c 1:3 rwm\n"), 0644), IsNil)
+
+	entries, err := cgroup.ListMediatedDevicesForSecurityTag(tag)
+	c.Assert(err, IsNil)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0], Equals, cgroup.DeviceEntry{DevType: 'c', Major: 1, Minor: 3, Access: "rwm"})
+}
+
+func (s *devicesSuite) TestFindActiveDeviceMediationV1(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	cgroupDir := filepath.Join(s.rootDir, "/sys/fs/cgroup/devices")
+	c.Assert(os.MkdirAll(filepath.Join(cgroupDir, "snap.mysnap.app1"), 0755), IsNil)
+
+	tags, err := cgroup.FindActiveDeviceMediationForSnap("mysnap")
+	c.Assert(err, IsNil)
+	c.Check(tags, DeepEquals, []string{"snap.mysnap.app1"})
+}
+
+// V2 tests (mocked)
+
+type fakeDeviceMapAccessor struct {
+	keys       []ebpf.DeviceKey
+	iterateErr error
+}
+
+func (f *fakeDeviceMapAccessor) Iterate(fn func(ebpf.DeviceKey) error) error {
+	if f.iterateErr != nil {
+		return f.iterateErr
+	}
+
+	for _, k := range f.keys {
+		if err := fn(k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeDeviceMapAccessor) Close() error {
+	return nil
+}
+
+func (s *devicesSuite) TestCollectDevicesV2(c *C) {
+	restore := cgroup.MockVersion(cgroup.V2, nil)
+	defer restore()
+
+	fakeMap := &fakeDeviceMapAccessor{
+		keys: []ebpf.DeviceKey{
+			{Type: 'c', Major: 1, Minor: 3},
+			{Type: 'b', Major: 8, Minor: 0},
+		},
+	}
+	restore = cgroup.MockLoadDeviceMap(func(tag string) (cgroup.DeviceMapAccessor, error) {
+		c.Check(tag, Equals, "snap.mysnap.app1")
+		return fakeMap, nil
+	})
+	defer restore()
+
+	entries, err := cgroup.ListMediatedDevicesForSecurityTag("snap.mysnap.app1")
+	c.Assert(err, IsNil)
+	c.Assert(entries, HasLen, 2)
+	c.Check(entries[0], Equals, cgroup.DeviceEntry{DevType: 'c', Major: 1, Minor: 3, Access: "rwm"})
+	c.Check(entries[1], Equals, cgroup.DeviceEntry{DevType: 'b', Major: 8, Minor: 0, Access: "rwm"})
+
+	// inject an error
+	fakeMap.iterateErr = fmt.Errorf("mock error")
+	entries, err = cgroup.ListMediatedDevicesForSecurityTag("snap.mysnap.app1")
+	c.Assert(err, ErrorMatches, "cannot iterate device map: mock error")
+	c.Assert(entries, IsNil)
+}
+
+func (s *devicesSuite) TestCollectDevicesV2Error(c *C) {
+	restore := cgroup.MockVersion(cgroup.V2, nil)
+	defer restore()
+
+	restoreLoad := cgroup.MockLoadDeviceMap(func(tag string) (cgroup.DeviceMapAccessor, error) {
+		return nil, fmt.Errorf("mock error")
+	})
+	defer restoreLoad()
+
+	_, err := cgroup.ListMediatedDevicesForSecurityTag("snap.mysnap.app1")
+	c.Assert(err, ErrorMatches, "cannot open device map: mock error")
+}
+
+func (s *devicesSuite) TestFindActiveDeviceMediationV2(c *C) {
+	restore := cgroup.MockVersion(cgroup.V2, nil)
+	defer restore()
+
+	restoreFind := cgroup.MockFindDeviceMapsForSnap(func(snapName string) ([]string, error) {
+		c.Check(snapName, Equals, "mysnap")
+		return []string{"snap.mysnap.app1", "snap.mysnap.app2"}, nil
+	})
+	defer restoreFind()
+
+	tags, err := cgroup.FindActiveDeviceMediationForSnap("mysnap")
+	c.Assert(err, IsNil)
+	c.Check(tags, DeepEquals, []string{"snap.mysnap.app1", "snap.mysnap.app2"})
+}

--- a/sandbox/cgroup/devices_test.go
+++ b/sandbox/cgroup/devices_test.go
@@ -113,7 +113,7 @@ b 12:z rwm
 	l := s.log.String()
 	c.Check(l, testutil.Contains, "malformed minor number:")
 	c.Check(l, testutil.Contains, "unexpected number of fields: 2")
-	c.Check(l, testutil.Contains, "unexpected number of fields in major:minor: 1")
+	c.Check(l, testutil.Contains, "unexpected format of major:minor")
 }
 
 func (s *devicesSuite) TestCollectDevicesV1MissingFile(c *C) {

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -42,7 +42,13 @@ var (
 	ApplyToSnap = applyToSnap
 
 	KillProcessesInCgroup = killProcessesInCgroup
+
+	CollectDevicesV1   = collectDevicesV1
+	FindSecurityTagsV1 = findSecurityTagsV1
 )
+
+// DeviceMapAccessor is exported for testing.
+type DeviceMapAccessor = deviceMapAccessor
 
 func MockFsTypeForPath(mock func(string) (int64, error)) (restore func()) {
 	old := fsTypeForPath
@@ -157,4 +163,12 @@ func MockMaxKillTimeout(t time.Duration) (restore func()) {
 
 func MockKillThawCooldown(t time.Duration) (restore func()) {
 	return testutil.Mock(&killThawCooldown, t)
+}
+
+func MockLoadDeviceMap(fn func(string) (DeviceMapAccessor, error)) (restore func()) {
+	return testutil.Mock(&loadDeviceMapFunc, fn)
+}
+
+func MockFindDeviceMapsForSnap(fn func(string) ([]string, error)) (restore func()) {
+	return testutil.Mock(&findDeviceMapsForSnapFunc, fn)
 }


### PR DESCRIPTION
Related: SNAPDENG-36949

Cherry picked from: https://github.com/canonical/snapd/pull/17141 builds on https://github.com/canonical/snapd/pull/17142

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
