### PR TITLE
many: fix broken links and outdated docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -515,7 +515,7 @@ by `./configure` with your desired flags. See `./configure --help` for available
 
 After building the code locally as explained in the previous section, you can run the 
 test suite available for snap-confine (among other low-level tools) by running the 
-`make check` target available in [./cmd]((./cmd/)).
+`make check` target available in [./cmd](./cmd/).
 
 ## Submitting patches
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Alongside its various service and management functions, snapd:
 
 For general details, including
 [installation](https://snapcraft.io/docs/installing-snapd) and [Getting
-started](https://snapcraft.io/docs/getting-started) guides, head over to our
+started](https://snapcraft.io/docs/tutorials/get-started/#tutorials-get-started) guides, head over to our
 [Snap documentation](https://snapcraft.io/docs). If you're looking for
 something to install, such as [Spotify](https://snapcraft.io/spotify) or
 [Visual Studio Code](https://snapcraft.io/code), take a look at the [Snap
 Store](https://snapcraft.io/store). And if you want to build your own snaps,
-start with our [Creating a snap](https://snapcraft.io/docs/creating-a-snap)
+start with our [Creating a snap](https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/)
 documentation.
 
 ## Get involved

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,7 +111,7 @@ The release process produces the following:
 - GitHub release https://github.com/canonical/snapd/releases
 - Cross-distro artifacts https://snapcraft.io/docs/reference/administration/distribution-support/
 
-*Note: documentation is produced separately from the [snap-docs repository](github.com/canonical/snap-docs)*
+*Note: documentation is produced separately from the [snap-docs repository](https://github.com/canonical/snap-docs)*
 
 ### Prerequisites
 

--- a/docs/api/CONTRIBUTING.md
+++ b/docs/api/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This document provides a set of guidelines for contributing to our OpenAPI speci
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+This project and everyone participating in it is governed by our [Code of Conduct](../../CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior.
 
 ---
@@ -38,7 +38,7 @@ There are many ways to contribute to the project.
 ### **Reporting Bugs**
 
 If you find a bug in the API specification (e.g., an incorrect data type, a missing field, or a confusing description),
-please **[open a new issue](https://github.com/canonical/snapd-rest-openapi/issues)** in our issue tracker.
+please **[open a new issue](https://bugs.launchpad.net/snapd/)** in our issue tracker.
 
 Please include:
 * A clear and descriptive title.
@@ -49,7 +49,7 @@ Please include:
 ### **Suggesting Enhancements**
 
 If you have an idea for a new feature or an improvement to an existing one,
-please **[open a new issue](https://github.com/rnfudge02/canonical/issues)** to discuss it.
+please **[open a new issue](https://bugs.launchpad.net/snapd/)** to discuss it.
 This allows us to coordinate our efforts and prevent duplication of work.
 
 ### **Your First Code Contribution**
@@ -64,15 +64,4 @@ These are typically smaller changes that are a great way to get familiar with th
 Contributions are submitted through a **pull request** (PR) created from a fork of this repository.
 Before making a PR, ensure that the specification is valid using the Makefile.
 
-### **1. Setup Your Environment**
-
-Fork the repository, clone it to your local machine, and create a new branch with a descriptive name.
-
-```bash
-# Clone your fork
-git clone [https://github.com/YOUR_USERNAME/snapd-rest-openapi.git](https://github.com/rnfudge02/snapd-rest-openapi.git)
-cd snapd-rest-openapi
-
-# Create a new branch
-git checkout -b feature/some-change
-```
+For more information on contributing to snapd, see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/osutil/udev/README.md
+++ b/osutil/udev/README.md
@@ -1,4 +1,4 @@
-# go-udev [![Go Report Card](https://goreportcard.com/badge/github.com/pilebones/go-udev)](https://goreportcard.com/report/github.com/pilebones/go-udev) [![GoDoc](https://godoc.org/github.com/pilebones/go-udev?status.svg)](https://godoc.org/github.com/pilebones/go-udev) [![Build Status](https://travis-ci.org/pilebones/go-udev.svg?branch=master)](https://travis-ci.org/pilebones/go-udev)
+# go-udev [![Go Report Card](https://goreportcard.com/badge/github.com/pilebones/go-udev)](https://goreportcard.com/report/github.com/pilebones/go-udev) [![GoDoc](https://godoc.org/github.com/pilebones/go-udev?status.svg)](https://godoc.org/github.com/pilebones/go-udev) [![Build Status](https://github.com/pilebones/go-udev/workflows/CI/badge.svg)](https://github.com/pilebones/go-udev/actions)
 
 Simple udev implementation in Golang developed from scratch.
 This library allow to listen and manage Linux-kernel (since version 2.6.10) Netlink messages to user space (ie: NETLINK_KOBJECT_UEVENT).


### PR DESCRIPTION
Fixes broken links in various markdown files. Replaces some outdated parts of the openapi contributing guides.