### PR TITLE
asserts: introduce NewExternalKeypairManagerWithBackend

### DIFF
--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -38,98 +38,19 @@ type ExternalKeyInfo struct {
 // ExternalKeypairManager is key pair manager implemented via an external program interface.
 // TODO: points to interface docs
 type ExternalKeypairManager struct {
-	keyMgrPath string
-	impl       *extKeypairMgrImpl
+	impl *extKeypairMgrImpl
 }
 
 // NewExternalKeypairManager creates a new ExternalKeypairManager using the program at keyMgrPath.
 func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, error) {
-	em := &ExternalKeypairManager{keyMgrPath: keyMgrPath}
-	impl, err := newExtKeypairMgrImpl(&externalKeypairMgrBackend{manager: em}, extKeypairMgrConfig{
+	impl, err := newExtKeypairMgrImpl(&externalCmdKeypairMgrBackend{keyMgrPath: keyMgrPath}, extKeypairMgrConfig{
 		signingWith: fmt.Sprintf("external keypair manager %q", keyMgrPath),
 		keyStore:    "external keypair manager",
 	})
 	if err != nil {
 		return nil, err
 	}
-	em.impl = impl
-	return em, nil
-}
-
-func (em *ExternalKeypairManager) keyMgr(op string, args []string, in []byte, out any) error {
-	args = append([]string{op}, args...)
-	cmd := exec.Command(em.keyMgrPath, args...)
-	var outBuf bytes.Buffer
-	var errBuf bytes.Buffer
-
-	if len(in) != 0 {
-		cmd.Stdin = bytes.NewBuffer(in)
-	}
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("external keypair manager %q %v failed: %v (%q)", em.keyMgrPath, args, err, errBuf.Bytes())
-
-	}
-	switch o := out.(type) {
-	case *[]byte:
-		*o = outBuf.Bytes()
-	default:
-		if err := json.Unmarshal(outBuf.Bytes(), out); err != nil {
-			return fmt.Errorf("cannot decode external keypair manager %q %v output: %v", em.keyMgrPath, args, err)
-		}
-	}
-	return nil
-}
-
-func (em *ExternalKeypairManager) checkFeatures() (extKeypairMgrSigning, error) {
-	var feats struct {
-		Signing    []string `json:"signing"`
-		PublicKeys []string `json:"public-keys"`
-	}
-	if err := em.keyMgr("features", nil, nil, &feats); err != nil {
-		return "", err
-	}
-	var signing extKeypairMgrSigning
-	if strutil.ListContains(feats.Signing, "RSA-PKCS") {
-		signing = extKeypairMgrSigningRSAPKCS
-	} else if strutil.ListContains(feats.Signing, "OPENPGP") {
-		signing = extKeypairMgrSigningOpenPGP
-	} else {
-		return "", fmt.Errorf("external keypair manager %q missing support for RSA-PKCS or OPENPGP signing", em.keyMgrPath)
-	}
-	if !strutil.ListContains(feats.PublicKeys, "DER") {
-		return "", fmt.Errorf("external keypair manager %q missing support for public key DER output format", em.keyMgrPath)
-	}
-	return signing, nil
-}
-
-func (em *ExternalKeypairManager) keyNames() ([]string, error) {
-	var knames struct {
-		Names []string `json:"key-names"`
-	}
-	if err := em.keyMgr("key-names", nil, nil, &knames); err != nil {
-		return nil, fmt.Errorf("cannot get all external keypair manager key names: %v", err)
-	}
-	return knames.Names, nil
-}
-
-func (em *ExternalKeypairManager) findByName(name string) (PublicKey, error) {
-	var k []byte
-	err := em.keyMgr("get-public-key", []string{"-f", "DER", "-k", name}, nil, &k)
-	if err != nil {
-		return nil, &keyNotFoundError{msg: fmt.Sprintf("cannot find external key pair: %v", err)}
-	}
-	pubk, err := x509.ParsePKIXPublicKey(k)
-	if err != nil {
-		return nil, fmt.Errorf("cannot decode external key %q: %v", name, err)
-	}
-	rsaPub, ok := pubk.(*rsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("expected RSA public key, got instead: %T", pubk)
-	}
-	return RSAPublicKey(rsaPub), nil
+	return &ExternalKeypairManager{impl: impl}, nil
 }
 
 func (em *ExternalKeypairManager) Export(keyName string) ([]byte, error) {
@@ -174,26 +95,97 @@ func (em *ExternalKeypairManager) List() ([]ExternalKeyInfo, error) {
 	return em.impl.List()
 }
 
-// externalKeypairMgrBackend implements extKeypairMgrBackend and
-// extKeypairMgrByNameLookupBackend as a thin wrapper around
-// ExternalKeypairManager, allowing it to be used as the backend for an
-// extKeypairMgrImpl.
-type externalKeypairMgrBackend struct {
-	manager *ExternalKeypairManager
+// externalCmdKeypairMgrBackend implements extKeypairMgrBackend and
+// extKeypairMgrByNameLookupBackend by invoking the configured external
+// keypair manager command.
+type externalCmdKeypairMgrBackend struct {
+	keyMgrPath string
 }
 
 // expected interfaces are implemented
 var (
-	_ extKeypairMgrBackend             = (*externalKeypairMgrBackend)(nil)
-	_ extKeypairMgrByNameLookupBackend = (*externalKeypairMgrBackend)(nil)
+	_ extKeypairMgrBackend             = (*externalCmdKeypairMgrBackend)(nil)
+	_ extKeypairMgrByNameLookupBackend = (*externalCmdKeypairMgrBackend)(nil)
 )
 
-func (s *externalKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
-	return s.manager.checkFeatures()
+func (s *externalCmdKeypairMgrBackend) keyMgr(op string, args []string, in []byte, out any) error {
+	args = append([]string{op}, args...)
+	cmd := exec.Command(s.keyMgrPath, args...)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+
+	if len(in) != 0 {
+		cmd.Stdin = bytes.NewBuffer(in)
+	}
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("external keypair manager %q %v failed: %v (%q)", s.keyMgrPath, args, err, errBuf.Bytes())
+
+	}
+	switch o := out.(type) {
+	case *[]byte:
+		*o = outBuf.Bytes()
+	default:
+		if err := json.Unmarshal(outBuf.Bytes(), out); err != nil {
+			return fmt.Errorf("cannot decode external keypair manager %q %v output: %v", s.keyMgrPath, args, err)
+		}
+	}
+	return nil
 }
 
-func (s *externalKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
-	pubKey, err := s.manager.findByName(name)
+func (s *externalCmdKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
+	var feats struct {
+		Signing    []string `json:"signing"`
+		PublicKeys []string `json:"public-keys"`
+	}
+	if err := s.keyMgr("features", nil, nil, &feats); err != nil {
+		return "", err
+	}
+	var signing extKeypairMgrSigning
+	if strutil.ListContains(feats.Signing, "RSA-PKCS") {
+		signing = extKeypairMgrSigningRSAPKCS
+	} else if strutil.ListContains(feats.Signing, "OPENPGP") {
+		signing = extKeypairMgrSigningOpenPGP
+	} else {
+		return "", fmt.Errorf("external keypair manager %q missing support for RSA-PKCS or OPENPGP signing", s.keyMgrPath)
+	}
+	if !strutil.ListContains(feats.PublicKeys, "DER") {
+		return "", fmt.Errorf("external keypair manager %q missing support for public key DER output format", s.keyMgrPath)
+	}
+	return signing, nil
+}
+
+func (s *externalCmdKeypairMgrBackend) keyNames() ([]string, error) {
+	var knames struct {
+		Names []string `json:"key-names"`
+	}
+	if err := s.keyMgr("key-names", nil, nil, &knames); err != nil {
+		return nil, fmt.Errorf("cannot get all external keypair manager key names: %v", err)
+	}
+	return knames.Names, nil
+}
+
+func (s *externalCmdKeypairMgrBackend) findByName(name string) (PublicKey, error) {
+	var k []byte
+	err := s.keyMgr("get-public-key", []string{"-f", "DER", "-k", name}, nil, &k)
+	if err != nil {
+		return nil, &keyNotFoundError{msg: fmt.Sprintf("cannot find external key pair: %v", err)}
+	}
+	pubk, err := x509.ParsePKIXPublicKey(k)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode external key %q: %v", name, err)
+	}
+	rsaPub, ok := pubk.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("expected RSA public key, got instead: %T", pubk)
+	}
+	return RSAPublicKey(rsaPub), nil
+}
+
+func (s *externalCmdKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
+	pubKey, err := s.findByName(name)
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +196,8 @@ func (s *externalKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoade
 	}, nil
 }
 
-func (s *externalKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
-	names, err := s.manager.keyNames()
+func (s *externalCmdKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+	names, err := s.keyNames()
 	if err != nil {
 		return err
 	}
@@ -221,18 +213,18 @@ func (s *externalKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoa
 	return nil
 }
 
-func (s *externalKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+func (s *externalCmdKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
 	var signature []byte
-	err := s.manager.keyMgr("sign", []string{"-m", "RSA-PKCS", "-k", keyHandle}, prepared, &signature)
+	err := s.keyMgr("sign", []string{"-m", "RSA-PKCS", "-k", keyHandle}, prepared, &signature)
 	if err != nil {
 		return nil, err
 	}
 	return signature, nil
 }
 
-func (s *externalKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
+func (s *externalCmdKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
 	var signature []byte
-	err := s.manager.keyMgr("sign", []string{"-m", "OPENPGP", "-k", keyHandle}, content, &signature)
+	err := s.keyMgr("sign", []string{"-m", "OPENPGP", "-k", keyHandle}, content, &signature)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -43,10 +43,19 @@ type ExternalKeypairManager struct {
 
 // NewExternalKeypairManager creates a new ExternalKeypairManager using the program at keyMgrPath.
 func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, error) {
-	impl, err := newExtKeypairMgrImpl(&externalCmdKeypairMgrBackend{keyMgrPath: keyMgrPath}, extKeypairMgrConfig{
-		signingWith: fmt.Sprintf("external keypair manager %q", keyMgrPath),
-		keyStore:    "external keypair manager",
+	impl, err := newExtKeypairMgrImpl(&externalCmdKeypairMgrBackend{keyMgrPath: keyMgrPath}, ExtKeypairMgrConfig{
+		SigningWith: fmt.Sprintf("external keypair manager %q", keyMgrPath),
+		KeyStore:    "external keypair manager",
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &ExternalKeypairManager{impl: impl}, nil
+}
+
+// NewExternalKeypairManagerWithBackend creates a new ExternalKeypairManager using backend.
+func NewExternalKeypairManagerWithBackend(backend ExtKeypairMgrBackend, config ExtKeypairMgrConfig) (*ExternalKeypairManager, error) {
+	impl, err := newExtKeypairMgrImpl(backend, config)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +113,8 @@ type externalCmdKeypairMgrBackend struct {
 
 // expected interfaces are implemented
 var (
-	_ extKeypairMgrBackend             = (*externalCmdKeypairMgrBackend)(nil)
-	_ extKeypairMgrByNameLookupBackend = (*externalCmdKeypairMgrBackend)(nil)
+	_ ExtKeypairMgrBackend             = (*externalCmdKeypairMgrBackend)(nil)
+	_ ExtKeypairMgrByNameLookupBackend = (*externalCmdKeypairMgrBackend)(nil)
 )
 
 func (s *externalCmdKeypairMgrBackend) keyMgr(op string, args []string, in []byte, out any) error {
@@ -135,7 +144,7 @@ func (s *externalCmdKeypairMgrBackend) keyMgr(op string, args []string, in []byt
 	return nil
 }
 
-func (s *externalCmdKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
+func (s *externalCmdKeypairMgrBackend) CheckFeatures() (ExtKeypairMgrSigning, error) {
 	var feats struct {
 		Signing    []string `json:"signing"`
 		PublicKeys []string `json:"public-keys"`
@@ -143,11 +152,11 @@ func (s *externalCmdKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, er
 	if err := s.keyMgr("features", nil, nil, &feats); err != nil {
 		return "", err
 	}
-	var signing extKeypairMgrSigning
+	var signing ExtKeypairMgrSigning
 	if strutil.ListContains(feats.Signing, "RSA-PKCS") {
-		signing = extKeypairMgrSigningRSAPKCS
+		signing = ExtKeypairMgrSigningRSAPKCS
 	} else if strutil.ListContains(feats.Signing, "OPENPGP") {
-		signing = extKeypairMgrSigningOpenPGP
+		signing = ExtKeypairMgrSigningOpenPGP
 	} else {
 		return "", fmt.Errorf("external keypair manager %q missing support for RSA-PKCS or OPENPGP signing", s.keyMgrPath)
 	}
@@ -184,19 +193,19 @@ func (s *externalCmdKeypairMgrBackend) findByName(name string) (PublicKey, error
 	return RSAPublicKey(rsaPub), nil
 }
 
-func (s *externalCmdKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
+func (s *externalCmdKeypairMgrBackend) LoadByName(name string) (*ExtKeypairMgrLoadedKey, error) {
 	pubKey, err := s.findByName(name)
 	if err != nil {
 		return nil, err
 	}
-	return &extKeypairMgrLoadedKey{
-		name:      name,
-		keyHandle: name,
-		pubKey:    pubKey,
+	return &ExtKeypairMgrLoadedKey{
+		Name:      name,
+		KeyHandle: name,
+		PublicKey: pubKey,
 	}, nil
 }
 
-func (s *externalCmdKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+func (s *externalCmdKeypairMgrBackend) Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error {
 	names, err := s.keyNames()
 	if err != nil {
 		return err

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -46,6 +47,36 @@ type extKeypairMgrSuite struct {
 }
 
 var _ = Suite(&extKeypairMgrSuite{})
+
+type fakePublicExtKeypairMgrBackend struct {
+	loaded *asserts.ExtKeypairMgrLoadedKey
+}
+
+func (b *fakePublicExtKeypairMgrBackend) CheckFeatures() (asserts.ExtKeypairMgrSigning, error) {
+	return asserts.ExtKeypairMgrSigningRSAPKCS, nil
+}
+
+func (b *fakePublicExtKeypairMgrBackend) LoadByName(name string) (*asserts.ExtKeypairMgrLoadedKey, error) {
+	if b.loaded == nil || b.loaded.Name != name {
+		return nil, errors.New("missing key")
+	}
+	return b.loaded, nil
+}
+
+func (b *fakePublicExtKeypairMgrBackend) Visit(consider func(loaded *asserts.ExtKeypairMgrLoadedKey) error) error {
+	if b.loaded == nil {
+		return nil
+	}
+	return consider(b.loaded)
+}
+
+func (b *fakePublicExtKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+	return nil, errors.New("unexpected sign call")
+}
+
+func (b *fakePublicExtKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
+	return nil, errors.New("unexpected sign call")
+}
 
 func (s *extKeypairMgrSuite) SetUpSuite(c *C) {
 	tmpdir := c.MkDir()
@@ -130,6 +161,31 @@ esac
 
 func (s *extKeypairMgrSuite) TearDownSuite(c *C) {
 	s.pgm.Restore()
+}
+
+func (s *extKeypairMgrSuite) TestNewExternalKeypairManagerWithBackend(c *C) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	c.Assert(err, IsNil)
+	rsaPub := asserts.RSAPublicKey(&priv.PublicKey)
+	backend := &fakePublicExtKeypairMgrBackend{
+		loaded: &asserts.ExtKeypairMgrLoadedKey{
+			Name:      "default",
+			KeyHandle: "backend-default",
+			PublicKey: rsaPub,
+		},
+	}
+
+	kmgr, err := asserts.NewExternalKeypairManagerWithBackend(backend, asserts.ExtKeypairMgrConfig{
+		SigningWith: "fake backend",
+		KeyStore:    "fake store",
+	})
+	c.Assert(err, IsNil)
+
+	exported, err := kmgr.Export("default")
+	c.Assert(err, IsNil)
+	expected, err := asserts.EncodePublicKey(rsaPub)
+	c.Assert(err, IsNil)
+	c.Check(exported, DeepEquals, expected)
 }
 
 func (s *extKeypairMgrSuite) TestFeatures(c *C) {

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -36,30 +36,44 @@ const (
 	extKeypairMgrSigningOpenPGP extKeypairMgrSigning = "OpenPGP"
 )
 
-// extKeypairMgrBackend defines the backend contract for the shared external
-// keypair manager implementation. keyHandle is the preferred backend-native
-// identifier and Visit is the discovery path used for enumeration and fallback
-// lookup by name when by-name lookup is not available.
-type extKeypairMgrBackend interface {
+// ExtKeypairMgrSigning describes the signing mode supported by an external keypair manager backend.
+type ExtKeypairMgrSigning string
+
+const (
+	// ExtKeypairMgrSigningRSAPKCS signs caller-prepared RSA-PKCS input.
+	ExtKeypairMgrSigningRSAPKCS ExtKeypairMgrSigning = "RSA-PKCS"
+	// ExtKeypairMgrSigningOpenPGP signs content and returns a detached OpenPGP signature packet.
+	ExtKeypairMgrSigningOpenPGP ExtKeypairMgrSigning = "OpenPGP"
+)
+
+// ExtKeypairMgrBackend defines the backend contract used by ExternalKeypairManager.
+// KeyHandle is the backend-native identifier and Visit is used for enumeration
+// and fallback lookup when direct by-name lookup is not available.
+type ExtKeypairMgrBackend interface {
 	// CheckFeatures validates backend support and returns the supported signing method.
-	CheckFeatures() (extKeypairMgrSigning, error)
+	CheckFeatures() (ExtKeypairMgrSigning, error)
 	// Visit discovers keys and may be used for both enumeration and fallback search.
-	Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error
+	Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error
 	// RSAPKCSSign signs the caller-prepared RSA-PKCS input using keyHandle.
 	RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error)
 	// Sign signs content directly and returns a detached OpenPGP signature packet.
 	Sign(keyHandle string, content []byte) ([]byte, error)
 }
 
-type extKeypairMgrByNameLookupBackend interface {
+// ExtKeypairMgrByNameLookupBackend adds optional direct lookup by user-visible key name.
+type ExtKeypairMgrByNameLookupBackend interface {
 	// LoadByName resolves a user-visible name directly when the backend supports by-name lookup.
-	LoadByName(name string) (*extKeypairMgrLoadedKey, error)
+	LoadByName(name string) (*ExtKeypairMgrLoadedKey, error)
 }
 
-type extKeypairMgrLoadedKey struct {
-	name      string
-	keyHandle string
-	pubKey    PublicKey
+// ExtKeypairMgrLoadedKey carries the key information loaded by a backend.
+type ExtKeypairMgrLoadedKey struct {
+	// Name is the user-visible key name.
+	Name string
+	// KeyHandle is the backend-native identifier used for signing.
+	KeyHandle string
+	// PublicKey is the key material exposed through the asserts package.
+	PublicKey PublicKey
 }
 
 type extKeypairMgrCachedKey struct {
@@ -69,17 +83,16 @@ type extKeypairMgrCachedKey struct {
 	privKey   PrivateKey
 }
 
-// extKeypairMgrConfig carries configuration for the shared external
-// keypair manager implementation.
-type extKeypairMgrConfig struct {
+// ExtKeypairMgrConfig carries diagnostic strings for ExternalKeypairManager.
+type ExtKeypairMgrConfig struct {
 	// signingWith identifies the signing backend for diagnostics and error messages.
-	signingWith string
+	SigningWith string
 	// keyStore names the backing key store for diagnostics, in particular key not found errors.
-	keyStore string
+	KeyStore string
 }
 
 type extKeypairMgrImpl struct {
-	backend       extKeypairMgrBackend
+	backend       ExtKeypairMgrBackend
 	signingMethod extKeypairMgrSigning
 	signingWith   string
 	keyStore      string
@@ -88,16 +101,16 @@ type extKeypairMgrImpl struct {
 	cache map[string]*extKeypairMgrCachedKey
 }
 
-func newExtKeypairMgrImpl(backend extKeypairMgrBackend, config extKeypairMgrConfig) (*extKeypairMgrImpl, error) {
+func newExtKeypairMgrImpl(backend ExtKeypairMgrBackend, config ExtKeypairMgrConfig) (*extKeypairMgrImpl, error) {
 	signingMethod, err := backend.CheckFeatures()
 	if err != nil {
 		return nil, err
 	}
 	return &extKeypairMgrImpl{
 		backend:       backend,
-		signingMethod: signingMethod,
-		signingWith:   config.signingWith,
-		keyStore:      config.keyStore,
+		signingMethod: extKeypairMgrSigning(signingMethod),
+		signingWith:   config.SigningWith,
+		keyStore:      config.KeyStore,
 		nameToID:      make(map[string]string),
 		cache:         make(map[string]*extKeypairMgrCachedKey),
 	}, nil
@@ -107,37 +120,37 @@ func (m *extKeypairMgrImpl) keyNotFoundError() error {
 	return &keyNotFoundError{msg: fmt.Sprintf("cannot find key pair in %s", m.keyStore)}
 }
 
-func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *extKeypairMgrLoadedKey) (*extKeypairMgrCachedKey, error) {
+func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *ExtKeypairMgrLoadedKey) (*extKeypairMgrCachedKey, error) {
 	if loaded == nil {
 		return nil, fmt.Errorf("internal error: missing loaded key")
 	}
-	if loaded.name == "" {
+	if loaded.Name == "" {
 		return nil, fmt.Errorf("internal error: loaded key is missing a name")
 	}
-	if loaded.keyHandle == "" {
-		return nil, fmt.Errorf("internal error: loaded key %q is missing a key handle", loaded.name)
+	if loaded.KeyHandle == "" {
+		return nil, fmt.Errorf("internal error: loaded key %q is missing a key handle", loaded.Name)
 	}
-	if loaded.pubKey == nil {
-		return nil, fmt.Errorf("internal error: loaded key %q is missing a public key", loaded.name)
+	if loaded.PublicKey == nil {
+		return nil, fmt.Errorf("internal error: loaded key %q is missing a public key", loaded.Name)
 	}
-	if _, err := cryptoRSAPublicKey(loaded.pubKey); err != nil {
-		return nil, fmt.Errorf("loaded key %q has invalid public key: %v", loaded.name, err)
+	if _, err := cryptoRSAPublicKey(loaded.PublicKey); err != nil {
+		return nil, fmt.Errorf("loaded key %q has invalid public key: %v", loaded.Name, err)
 	}
 
-	keyID := loaded.pubKey.ID()
+	keyID := loaded.PublicKey.ID()
 	entry := m.cache[keyID]
 	if entry == nil {
 		entry = &extKeypairMgrCachedKey{
-			name:      loaded.name,
-			keyHandle: loaded.keyHandle,
-			pubKey:    loaded.pubKey,
+			name:      loaded.Name,
+			keyHandle: loaded.KeyHandle,
+			pubKey:    loaded.PublicKey,
 		}
 		m.cache[keyID] = entry
-		m.nameToID[loaded.name] = keyID
+		m.nameToID[loaded.Name] = keyID
 	} else {
 		// we expect and assume that for the same key ID (which represents the key content) the name and keyHandle will not change
-		if entry.keyHandle != loaded.keyHandle || entry.name != loaded.name {
-			return nil, fmt.Errorf("inconsistent external loaded key %q: cached name %q, cached handle %q, loaded name %q, loaded handle %q", keyID, entry.name, entry.keyHandle, loaded.name, loaded.keyHandle)
+		if entry.keyHandle != loaded.KeyHandle || entry.name != loaded.Name {
+			return nil, fmt.Errorf("inconsistent external loaded key %q: cached name %q, cached handle %q, loaded name %q, loaded handle %q", keyID, entry.name, entry.keyHandle, loaded.Name, loaded.KeyHandle)
 		}
 	}
 	return entry, nil
@@ -156,7 +169,7 @@ func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, er
 			return entry, nil
 		}
 	}
-	if byNameLookupBackend, ok := m.backend.(extKeypairMgrByNameLookupBackend); ok {
+	if byNameLookupBackend, ok := m.backend.(ExtKeypairMgrByNameLookupBackend); ok {
 		loaded, err := byNameLookupBackend.LoadByName(name)
 		if err != nil {
 			return nil, err
@@ -166,8 +179,8 @@ func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, er
 
 	stop := errors.New("stop marker")
 	var hit *extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
-		if loaded.name != name {
+	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
+		if loaded.Name != name {
 			return nil
 		}
 		entry, err := m.cacheLoadedKey(loaded)
@@ -193,7 +206,7 @@ func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, err
 
 	stop := errors.New("stop marker")
 	var hit *extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
+	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
 		entry, err := m.cacheLoadedKey(loaded)
 		if err != nil {
 			return err
@@ -215,7 +228,7 @@ func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, err
 
 func (m *extKeypairMgrImpl) visitAll() ([]*extKeypairMgrCachedKey, error) {
 	var entries []*extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *extKeypairMgrLoadedKey) error {
+	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
 		entry, err := m.cacheLoadedKey(loaded)
 		if err != nil {
 			return err

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -35,12 +35,12 @@ type extKeypairMgrImplSuite struct{}
 
 var _ = check.Suite(&extKeypairMgrImplSuite{})
 
-var fakeExtKeypairMgrConfig = extKeypairMgrConfig{signingWith: "fake", keyStore: "fake"}
+var fakeExtKeypairMgrConfig = ExtKeypairMgrConfig{SigningWith: "fake", KeyStore: "fake"}
 
 type fakeExtKeypairMgrBackendBase struct {
-	signingMethod   extKeypairMgrSigning
-	loadByName      map[string]*extKeypairMgrLoadedKey
-	visitKeys       []*extKeypairMgrLoadedKey
+	signingMethod   ExtKeypairMgrSigning
+	loadByName      map[string]*ExtKeypairMgrLoadedKey
+	visitKeys       []*ExtKeypairMgrLoadedKey
 	loadCalls       []string
 	visitCalls      int
 	visitConsidered [][]string
@@ -50,15 +50,15 @@ type fakeExtKeypairMgrBackendBase struct {
 	privByHandle    map[string]*rsa.PrivateKey
 }
 
-func (s *fakeExtKeypairMgrBackendBase) CheckFeatures() (extKeypairMgrSigning, error) {
+func (s *fakeExtKeypairMgrBackendBase) CheckFeatures() (ExtKeypairMgrSigning, error) {
 	return s.signingMethod, nil
 }
 
-func (s *fakeExtKeypairMgrBackendBase) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+func (s *fakeExtKeypairMgrBackendBase) Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error {
 	s.visitCalls++
 	considered := make([]string, 0, len(s.visitKeys))
 	for _, loaded := range s.visitKeys {
-		considered = append(considered, loaded.name)
+		considered = append(considered, loaded.Name)
 		if err := consider(loaded); err != nil {
 			s.visitConsidered = append(s.visitConsidered, considered)
 			return err
@@ -94,7 +94,7 @@ type fakeExtKeypairMgrBackend struct {
 	fakeExtKeypairMgrBackendBase
 }
 
-func (s *fakeExtKeypairMgrBackend) LoadByName(name string) (*extKeypairMgrLoadedKey, error) {
+func (s *fakeExtKeypairMgrBackend) LoadByName(name string) (*ExtKeypairMgrLoadedKey, error) {
 	s.loadCalls = append(s.loadCalls, name)
 	loaded := s.loadByName[name]
 	if loaded == nil {
@@ -107,21 +107,21 @@ type fakeExtKeypairMgrBackendWithoutByNameLookup struct {
 	fakeExtKeypairMgrBackendBase
 }
 
-func (s *extKeypairMgrImplSuite) newLoadedKeyBits(c *check.C, name string, keyHandle string, bits int) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+func (s *extKeypairMgrImplSuite) newLoadedKeyBits(c *check.C, name string, keyHandle string, bits int) (*rsa.PrivateKey, *ExtKeypairMgrLoadedKey) {
 	privKey, err := rsa.GenerateKey(rand.Reader, bits)
 	c.Assert(err, check.IsNil)
-	return privKey, &extKeypairMgrLoadedKey{
-		name:      name,
-		keyHandle: keyHandle,
-		pubKey:    RSAPublicKey(&privKey.PublicKey),
+	return privKey, &ExtKeypairMgrLoadedKey{
+		Name:      name,
+		KeyHandle: keyHandle,
+		PublicKey: RSAPublicKey(&privKey.PublicKey),
 	}
 }
 
-func (s *extKeypairMgrImplSuite) newLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+func (s *extKeypairMgrImplSuite) newLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *ExtKeypairMgrLoadedKey) {
 	return s.newLoadedKeyBits(c, name, keyHandle, 1024)
 }
 
-func (s *extKeypairMgrImplSuite) newSigningLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *extKeypairMgrLoadedKey) {
+func (s *extKeypairMgrImplSuite) newSigningLoadedKey(c *check.C, name string, keyHandle string) (*rsa.PrivateKey, *ExtKeypairMgrLoadedKey) {
 	return s.newLoadedKeyBits(c, name, keyHandle, 4096)
 }
 
@@ -129,8 +129,8 @@ func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *chec
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName: map[string]*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
 			},
 			privByHandle: map[string]*rsa.PrivateKey{
@@ -148,7 +148,7 @@ func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *chec
 	c.Assert(err, check.IsNil)
 	exported, err := impl.Export("default")
 	c.Assert(err, check.IsNil)
-	expectedExport, err := EncodePublicKey(loaded.pubKey)
+	expectedExport, err := EncodePublicKey(loaded.PublicKey)
 	c.Assert(err, check.IsNil)
 
 	c.Check(key1, check.Equals, key2)
@@ -162,9 +162,9 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAfterFirstMatchingVisitedKey(c *che
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
-			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
+			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
 		},
 	}
@@ -172,13 +172,13 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAfterFirstMatchingVisitedKey(c *che
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
-	key1, err := impl.Get(loaded1.pubKey.ID())
+	key1, err := impl.Get(loaded1.PublicKey.ID())
 	c.Assert(err, check.IsNil)
 
-	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.pubKey.ID())
+	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.PublicKey.ID())
 	c.Check(backend.visitCalls, check.Equals, 1)
 	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default"}})
-	_, found := impl.cache[loaded2.pubKey.ID()]
+	_, found := impl.cache[loaded2.PublicKey.ID()]
 	c.Check(found, check.Equals, false)
 }
 
@@ -187,9 +187,9 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAtMatchingVisitedKeyAndCachesVisite
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
-			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
+			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
 		},
 	}
@@ -197,23 +197,23 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAtMatchingVisitedKeyAndCachesVisite
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
-	key2, err := impl.Get(loaded2.pubKey.ID())
+	key2, err := impl.Get(loaded2.PublicKey.ID())
 	c.Assert(err, check.IsNil)
-	key1, err := impl.Get(loaded1.pubKey.ID())
+	key1, err := impl.Get(loaded1.PublicKey.ID())
 	c.Assert(err, check.IsNil)
 
-	c.Check(key2.PublicKey().ID(), check.Equals, loaded2.pubKey.ID())
-	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.pubKey.ID())
+	c.Check(key2.PublicKey().ID(), check.Equals, loaded2.PublicKey.ID())
+	c.Check(key1.PublicKey().ID(), check.Equals, loaded1.PublicKey.ID())
 	c.Check(backend.visitCalls, check.Equals, 1)
 	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default", "models"}})
-	c.Check(impl.cache[loaded1.pubKey.ID()], check.NotNil)
-	c.Check(impl.cache[loaded2.pubKey.ID()], check.NotNil)
+	c.Check(impl.cache[loaded1.PublicKey.ID()], check.NotNil)
+	c.Check(impl.cache[loaded2.PublicKey.ID()], check.NotNil)
 
 	list, err := impl.List()
 	c.Assert(err, check.IsNil)
 	c.Check(backend.visitCalls, check.Equals, 2)
 	c.Check(backend.visitConsidered, check.DeepEquals, [][]string{{"default", "models"}, {"default", "models"}})
-	c.Check(list, check.DeepEquals, []ExternalKeyInfo{{Name: "default", ID: loaded1.pubKey.ID()}, {Name: "models", ID: loaded2.pubKey.ID()}})
+	c.Check(list, check.DeepEquals, []ExternalKeyInfo{{Name: "default", ID: loaded1.PublicKey.ID()}, {Name: "models", ID: loaded2.PublicKey.ID()}})
 }
 
 func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPrefix(c *check.C) {
@@ -221,9 +221,9 @@ func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPr
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
-			visitKeys:     []*extKeypairMgrLoadedKey{loaded1, loaded2},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
+			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
 		},
 	}
@@ -231,9 +231,9 @@ func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPr
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
-	_, err = impl.Get(loaded1.pubKey.ID())
+	_, err = impl.Get(loaded1.PublicKey.ID())
 	c.Assert(err, check.IsNil)
-	_, err = impl.Get(loaded2.pubKey.ID())
+	_, err = impl.Get(loaded2.PublicKey.ID())
 	c.Assert(err, check.IsNil)
 
 	c.Check(backend.visitCalls, check.Equals, 2)
@@ -244,11 +244,11 @@ func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName: map[string]*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
 			},
-			visitKeys: []*extKeypairMgrLoadedKey{loaded},
+			visitKeys: []*ExtKeypairMgrLoadedKey{loaded},
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
@@ -268,8 +268,8 @@ func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.
 func (s *extKeypairMgrImplSuite) TestGetByNamePropagatesNotFoundWithByNameLookup(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 		},
 	}
 
@@ -287,8 +287,8 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallsBackToVisitWithoutByNameLooku
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			visitKeys:     []*extKeypairMgrLoadedKey{loaded},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded},
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
@@ -300,7 +300,7 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallsBackToVisitWithoutByNameLooku
 
 	priv, err := impl.GetByName("default")
 	c.Assert(err, check.IsNil)
-	c.Check(priv.PublicKey().ID(), check.Equals, loaded.pubKey.ID())
+	c.Check(priv.PublicKey().ID(), check.Equals, loaded.PublicKey.ID())
 	c.Check(backend.visitCalls, check.Equals, 1)
 }
 
@@ -308,8 +308,8 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *chec
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			visitKeys:     []*extKeypairMgrLoadedKey{loaded},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded},
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
@@ -325,7 +325,7 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *chec
 	c.Assert(err, check.IsNil)
 	key2, err := impl.GetByName("default")
 	c.Assert(err, check.IsNil)
-	expectedExport, err := EncodePublicKey(loaded.pubKey)
+	expectedExport, err := EncodePublicKey(loaded.PublicKey)
 	c.Assert(err, check.IsNil)
 
 	c.Check(key1, check.Equals, key2)
@@ -336,7 +336,7 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *chec
 func (s *extKeypairMgrImplSuite) TestGetByNameFallbackUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 		},
 	}
 
@@ -352,8 +352,8 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackUsesKeyStoreError(c *check
 func (s *extKeypairMgrImplSuite) TestExportPropagatesNotFoundWithByNameLookup(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 		},
 	}
 
@@ -370,7 +370,7 @@ func (s *extKeypairMgrImplSuite) TestExportPropagatesNotFoundWithByNameLookup(c 
 func (s *extKeypairMgrImplSuite) TestExportFallbackUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 		},
 	}
 
@@ -395,15 +395,15 @@ func (pk *fakeNonRSAPublicKey) keyEncode(w io.Writer) error                     
 func (s *extKeypairMgrImplSuite) TestCacheLoadedKeyInvalidPublicKeyErrorIsNotRepetitive(c *check.C) {
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 		},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
-	_, err = impl.cacheLoadedKey(&extKeypairMgrLoadedKey{
-		name:      "default",
-		keyHandle: "handle-default",
-		pubKey:    &fakeNonRSAPublicKey{id: "ZmFrZQ"},
+	_, err = impl.cacheLoadedKey(&ExtKeypairMgrLoadedKey{
+		Name:      "default",
+		KeyHandle: "handle-default",
+		PublicKey: &fakeNonRSAPublicKey{id: "ZmFrZQ"},
 	})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Matches, `loaded key "default" has invalid public key: internal error: expected RSA public key, got instead: .*`)
@@ -414,13 +414,13 @@ func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			visitKeys: []*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			visitKeys: []*ExtKeypairMgrLoadedKey{
 				loaded,
 				{
-					name:      "renamed",
-					keyHandle: loaded.keyHandle,
-					pubKey:    loaded.pubKey,
+					Name:      "renamed",
+					KeyHandle: loaded.KeyHandle,
+					PublicKey: loaded.PublicKey,
 				},
 			},
 		},
@@ -432,14 +432,14 @@ func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.
 	_, err = impl.List()
 	c.Assert(err, check.ErrorMatches, `inconsistent external loaded key ".*": cached name "default", cached handle "handle-default", loaded name "renamed", loaded handle "handle-default"`)
 	c.Check(backend.visitCalls, check.Equals, 1)
-	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.pubKey.ID()})
+	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.PublicKey.ID()})
 }
 
 func (s *extKeypairMgrImplSuite) TestDropCachedKeyRemovesCachedAndNamedEntries(c *check.C) {
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 		},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
@@ -447,7 +447,7 @@ func (s *extKeypairMgrImplSuite) TestDropCachedKeyRemovesCachedAndNamedEntries(c
 	_, err = impl.cacheLoadedKey(loaded)
 	c.Assert(err, check.IsNil)
 
-	impl.dropCachedKey(loaded.pubKey.ID())
+	impl.dropCachedKey(loaded.PublicKey.ID())
 
 	c.Check(impl.cache, check.DeepEquals, map[string]*extKeypairMgrCachedKey{})
 	c.Check(impl.nameToID, check.DeepEquals, map[string]string{})
@@ -457,7 +457,7 @@ func (s *extKeypairMgrImplSuite) TestDropCachedKeyMissingKeyLeavesCacheUntouched
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 		},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
@@ -467,15 +467,15 @@ func (s *extKeypairMgrImplSuite) TestDropCachedKeyMissingKeyLeavesCacheUntouched
 
 	impl.dropCachedKey("missing-id")
 
-	c.Check(impl.cache, check.DeepEquals, map[string]*extKeypairMgrCachedKey{loaded.pubKey.ID(): entry})
-	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.pubKey.ID()})
+	c.Check(impl.cache, check.DeepEquals, map[string]*extKeypairMgrCachedKey{loaded.PublicKey.ID(): entry})
+	c.Check(impl.nameToID, check.DeepEquals, map[string]string{"default": loaded.PublicKey.ID()})
 }
 
 func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*extKeypairMgrLoadedKey{},
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 			privByHandle:  map[string]*rsa.PrivateKey{},
 		},
 	}
@@ -493,8 +493,8 @@ func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
 	privKey, loaded := s.newSigningLoadedKey(c, "default", "rsa-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningRSAPKCS,
-			loadByName: map[string]*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
 			},
 			privByHandle: map[string]*rsa.PrivateKey{
@@ -519,8 +519,8 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
 	privKey, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningOpenPGP,
-			loadByName: map[string]*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningOpenPGP,
+			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
 			},
 			privByHandle: map[string]*rsa.PrivateKey{
@@ -545,8 +545,8 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithI
 	_, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
 		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: extKeypairMgrSigningOpenPGP,
-			loadByName: map[string]*extKeypairMgrLoadedKey{
+			signingMethod: ExtKeypairMgrSigningOpenPGP,
+			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
 			},
 			pgpSignResult: map[string][]byte{

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -136,9 +136,9 @@ func (gkm *GPGKeypairManager) gpg(input []byte, args ...string) ([]byte, error) 
 // Main purpose is allowing signing using keys from a GPG setup.
 func NewGPGKeypairManager() *GPGKeypairManager {
 	gkm := &GPGKeypairManager{}
-	impl, err := newExtKeypairMgrImpl(&gpgKeypairMgrBackend{manager: gkm}, extKeypairMgrConfig{
-		signingWith: "GPG",
-		keyStore:    "GPG keyring",
+	impl, err := newExtKeypairMgrImpl(&gpgKeypairMgrBackend{manager: gkm}, ExtKeypairMgrConfig{
+		SigningWith: "GPG",
+		KeyStore:    "GPG keyring",
 	})
 	if err != nil {
 		panic(fmt.Sprintf("internal error: cannot setup keypair manager: %v", err))
@@ -147,7 +147,7 @@ func NewGPGKeypairManager() *GPGKeypairManager {
 	return gkm
 }
 
-func (gkm *GPGKeypairManager) retrieveLoadedKey(fpr string, uid string) (*extKeypairMgrLoadedKey, error) {
+func (gkm *GPGKeypairManager) retrieveLoadedKey(fpr string, uid string) (*ExtKeypairMgrLoadedKey, error) {
 	out, err := gkm.gpg(nil, "--batch", "--export", "--export-options", "export-minimal,export-clean,no-export-attributes", "0x"+fpr)
 	if err != nil {
 		return nil, err
@@ -163,10 +163,10 @@ func (gkm *GPGKeypairManager) retrieveLoadedKey(fpr string, uid string) (*extKey
 	if gotFingerprint != fpr {
 		return nil, fmt.Errorf("got wrong public key from GPG, expected fingerprint %q: %s", fpr, gotFingerprint)
 	}
-	return &extKeypairMgrLoadedKey{
-		name:      uid,
-		keyHandle: fpr,
-		pubKey:    pubKey,
+	return &ExtKeypairMgrLoadedKey{
+		Name:      uid,
+		KeyHandle: fpr,
+		PublicKey: pubKey,
 	}, nil
 }
 
@@ -338,13 +338,13 @@ type gpgKeypairMgrBackend struct {
 }
 
 // expected interface is implemented
-var _ extKeypairMgrBackend = (*gpgKeypairMgrBackend)(nil)
+var _ ExtKeypairMgrBackend = (*gpgKeypairMgrBackend)(nil)
 
-func (s *gpgKeypairMgrBackend) CheckFeatures() (extKeypairMgrSigning, error) {
-	return extKeypairMgrSigningOpenPGP, nil
+func (s *gpgKeypairMgrBackend) CheckFeatures() (ExtKeypairMgrSigning, error) {
+	return ExtKeypairMgrSigningOpenPGP, nil
 }
 
-func (s *gpgKeypairMgrBackend) Visit(consider func(loaded *extKeypairMgrLoadedKey) error) error {
+func (s *gpgKeypairMgrBackend) Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error {
 	return s.manager.walkSecretKeys(func(fpr string, uid string) error {
 		loaded, err := s.manager.retrieveLoadedKey(fpr, uid)
 		if err != nil {


### PR DESCRIPTION
Now instead of just supporting external commands to implement keypair manager logic,
this can be done in code via backend implementations (interface ExtKeypairMgrBackend).

It might be better to review the commits separately, the first makes the ExtKeyparManager a thin wrapper around the implementation.
