### PR TITLE
o/confdbstate: fix data loss when writing to a new schema or account

### DIFF
--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -196,10 +196,11 @@ var writeDatabag = func(st *state.State, databag confdb.JSONDatabag, account, db
 	err := st.Get("confdb-databags", &databags)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
-	} else if errors.Is(err, &state.NoStateError{}) || databags[account] == nil || databags[account][dbSchemaName] == nil {
-		databags = map[string]map[string]confdb.JSONDatabag{
-			account: {dbSchemaName: confdb.NewJSONDatabag()},
-		}
+	} else if errors.Is(err, &state.NoStateError{}) {
+		databags = map[string]map[string]confdb.JSONDatabag{}
+	}
+	if databags[account] == nil {
+		databags[account] = map[string]confdb.JSONDatabag{}
 	}
 
 	databags[account][dbSchemaName] = databag

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -312,6 +312,73 @@ func (s *confdbTestSuite) TestSetView(c *C) {
 	c.Assert(val, DeepEquals, "foo")
 }
 
+func (s *confdbTestSuite) TestSetViewDoesNotEraseOtherSchemaUnderSameAccount(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupConfdbScenario(c, map[string]confdbHooks{"custodian-snap": noHooks}, nil)
+
+	// Write a value into the first schema.
+	view, err := confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
+	c.Assert(err, IsNil)
+
+	chgID, err := confdbstate.WriteConfdb(context.Background(), s.state, view, map[string]any{"ssid": "preserved-value"})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	s.o.Settle(5 * time.Second)
+	s.state.Lock()
+
+	c.Assert(s.state.Change(chgID).Status(), Equals, state.DoneStatus)
+
+	// Write a value into a second schema under the same account.
+	view, err = confdbstate.GetView(s.state, s.devAccID, "other", "other")
+	c.Assert(err, IsNil)
+
+	chgID, err = confdbstate.WriteConfdb(context.Background(), s.state, view, map[string]any{"foo": "bar"})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	s.o.Settle(5 * time.Second)
+	s.state.Lock()
+
+	c.Assert(s.state.Change(chgID).Status(), Equals, state.DoneStatus)
+
+	// The first schema's data must still be present.
+	bag, err := confdbstate.ReadDatabag(s.state, s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	val, err := bag.Get(parsePath(c, "wifi.ssid"), nil)
+	c.Assert(err, IsNil)
+	c.Assert(val, DeepEquals, "preserved-value")
+}
+
+func (s *confdbTestSuite) TestWriteDatabagDoesNotEraseOtherAccounts(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Seed data for a different account directly.
+	otherAccID := "other-account-id"
+	otherBag := confdb.NewJSONDatabag()
+	err := otherBag.Set(parsePath(c, "foo"), "preserved-value")
+	c.Assert(err, IsNil)
+	s.state.Set("confdb-databags", map[string]map[string]confdb.JSONDatabag{
+		otherAccID: {"some-schema": otherBag},
+	})
+
+	// Write to our account for the first time.
+	err = confdbstate.WriteDatabag(s.state, confdb.NewJSONDatabag(), s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	// The other account's data must still be present.
+	bag, err := confdbstate.ReadDatabag(s.state, otherAccID, "some-schema")
+	c.Assert(err, IsNil)
+
+	val, err := bag.Get(parsePath(c, "foo"), nil)
+	c.Assert(err, IsNil)
+	c.Assert(val, DeepEquals, "preserved-value")
+}
+
 func (s *confdbTestSuite) TestSetNotFound(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
`writeDatabag` replaced the entire databags map with a fresh single-entry map whenever the account being written to was absent, silently discarding data stored under other accounts. The same bug existed for the schema-level case: if the schema key was absent under an existing account, the whole map was replaced, discarding all other schemas under that account. The fix initializes only the missing entry rather than replacing the map.

Minimal reproduction: https://github.com/st3v3nmw/multi-schema-confdb-data-loss

Extra details on the support case can be found [here](https://chat.canonical.com/canonical/pl/hbd5ub3eqffwtrcq8q65yinxwa).

----

Copying in a comment I left elsewhere:

This is my understanding of the new flow :sweat_smile:, say we're trying to write new data to `acct-b/schema-x`:

```
Get("confdb-databags") -> databags // from snapd state
  Real error  => Return early.
  ErrNoState  => No confdb data has ever been written on this device. Initialize
                 an empty outer map: databags = {}
  Ok          => databags is populated from disk (snapd state):
                 databags = {"acct-a": {"schema-1": {...}, "schema-2": {...}}, ...}

databags[account] == nil?
  Yes => This account has never been written to (or was emptied). Initialize an empty inner map
         so the outer map is preserved:
         databags = {"acct-a": {"schema-1": {...}, ...}, "acct-b": {}}
  No  => Account already has data, use as-is.

databags[account][dbSchemaName] = incoming databag
  Always safe at this point. If the schema key (dbSchemaName) was absent
  it is simply created, if it existed it is overwritten:
  databags = {"acct-a": {"schema-1": {...}, ...}, "acct-b": {"schema-x": {new data}}}
```

I dropped `databags[account][dbSchemaName] == nil` because by the time we're assigning `databags["acct-b"]["schema-x"] = databag`, we've already constructed `acct-b`'s inner map or retrieved it from disk so we can safely assign directly.

And just for comparison, this is the old flow:

```
Get("confdb-databags") -> databags // from snapd state
  Real error  => Return early.
  ErrNoState  => Initialize a new map with only this account and schema:
                 databags = {"acct-b": {"schema-x": {}}}
  Ok          => databags is populated from disk (snapd state):
                 {"acct-a": {"schema-1": {...}, "schema-2": {...}}, ...}

databags[account] == nil || databags[account][dbSchemaName] == nil?
  Yes (account missing) => Replace the entire map.
                           All other accounts are lost (from Ok case above):
                           databags = {"acct-b": {"schema-x": {}}}
  Yes (schema missing)  => Replace the entire map.
                           All other accounts and all other schemas under
                           this account are lost (from Ok case above):
                           databags = {"acct-b": {"schema-x": {}}}
  No                    => Use as-is.

databags[account][dbSchemaName] = databag
  databags = {"acct-b": {"schema-x": {new data}}}
```