### PR TITLE
tests/main/interfaces-xdg-portal-permission-store: tweaks and smart skip on openSUSE

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -860,6 +860,7 @@ pkg_dependencies_opensuse(){
         clang
         curl
         dbus-1-python3
+        dbus-1-tools
         evolution-data-server
         expect
         fish

--- a/tests/main/interfaces-xdg-portal-permission-store/task.yaml
+++ b/tests/main/interfaces-xdg-portal-permission-store/task.yaml
@@ -34,6 +34,9 @@ prepare: |
     echo "Install the PermissionStore test client snap"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-xdg-portal-permission-store
 
+    cp -v fake-permission-store.py /tmp
+    tests.cleanup defer rm -f /tmp/fake-permission-store.py
+
     echo "Start the fake PermissionStore service on the session bus"
     tests.session -u test exec systemd-run --user \
         --unit test-snapd-permission-store.service \
@@ -41,7 +44,7 @@ prepare: |
             DBUS_BUS_NAME="$DBUS_BUS_NAME" \
             DBUS_OBJECT_PATH="$DBUS_OBJECT_PATH" \
             DBUS_IFACE_NAME="$DBUS_IFACE_NAME" \
-        python3 "$(pwd)/fake-permission-store.py"
+        python3 "/tmp/fake-permission-store.py"
 
     echo "Wait for the fake service to become available"
 

--- a/tests/main/interfaces-xdg-portal-permission-store/task.yaml
+++ b/tests/main/interfaces-xdg-portal-permission-store/task.yaml
@@ -10,9 +10,11 @@ details: |
 
 # This test starts a user transient unit via `systemd-run --user`, and
 # Ubuntu 14.04 has special version of systemd which doesn't have StartTransientUnit API.
-# TODO: There seems to be an AppArmor mismatch between the one we have and the
-# one in Arch. Disable for now.
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -arch-linux-*]
+# Arch: no DBus mediation support at all
+systems:
+    - -ubuntu-core-*
+    - -ubuntu-14.04-*
+    - -arch-linux-*
 
 environment:
     DBUS_BUS_NAME: org.freedesktop.impl.portal.PermissionStore
@@ -27,6 +29,13 @@ skip:
     - reason: System does not support AppArmor D-Bus mediation
       if: |
         ! snap debug sandbox-features --required apparmor:kernel:dbus
+
+    - reason: Session D-Bus broker does not enforce AppArmor D-Bus mediation
+      # On OpenSUSE, the user session dbus-broker is started without --audit,
+      # which means AppArmor D-Bus mediation is not enforced.
+      if: |
+        os.query is-opensuse &&
+        ! systemctl cat --user dbus-broker.service 2>/dev/null | grep -q -- '--audit'
 
 prepare: |
     tests.session -u test prepare


### PR DESCRIPTION
Skip the test on openSUSE as long as user session DBus broke runs without auditing.

While tweaking, make sure that dbus-send is available on openSUSE, like it is on the other distros.