### PR TITLE
data/selinux: use init_named_socket_activation() for allowing systemd to start snapd through socket activation

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -99,13 +99,8 @@ unconfined_domain(snappy_unconfined_snap_t)
 permissive snappy_t;
 
 # Allow transitions from init_t to snappy for sockets
-# init_named_socket_activation() is not supported by core policy in RHEL7
-gen_require(`
-	type init_t;
-	type var_run_t;
-')
-filetrans_pattern(init_t, var_run_t, snappy_var_run_t, sock_file, "snapd.socket")
-filetrans_pattern(init_t, var_run_t, snappy_var_run_t, sock_file, "snapd-snap.socket")
+init_named_socket_activation(snappy_t, snappy_var_run_t, "snapd.socket")
+init_named_socket_activation(snappy_t, snappy_var_run_t, "snapd-snap.socket")
 
 # Allow init_t to read snappy data
 allow init_t snappy_var_lib_t:dir read;


### PR DESCRIPTION
Since we've dropped RHEL7, we can update the policy to use init_named_socket_activation() macro rather than our workarounds.

CHERRY-PICK REQUIRED FOR `release/2.76` BRANCH
