### PR TITLE
many: support keyboard configuration at install-time for first-boot

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -67,7 +67,8 @@ type BootableSet struct {
 	KernelMods []BootableKModsComponents
 
 	// ExtraSnapdKernelCommandLineAppend holds extra snapd kernel command line
-	// arguments to append to the kernel command line.
+	// arguments to append to the kernel command line which is only applied to
+	// runnable systems.
 	ExtraSnapdKernelCommandLineAppend string
 }
 

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -65,6 +65,10 @@ type BootableSet struct {
 
 	// KernelMods contains kernel-modules components in the system.
 	KernelMods []BootableKModsComponents
+
+	// ExtraSnapdKernelCommandLineAppend holds extra snapd kernel command line
+	// arguments to append to the kernel command line.
+	ExtraSnapdKernelCommandLineAppend string
 }
 
 // BootableComponent represents kernel-modules components, which are
@@ -627,6 +631,9 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets 
 		if err != nil {
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
+
+		cmdlineAppend = strutil.JoinNonEmpty(
+			[]string{bootWith.ExtraSnapdKernelCommandLineAppend, cmdlineAppend}, " ")
 
 		modeenv.CurrentKernelCommandLines = bootCommandLines{
 			strutil.JoinNonEmpty([]string{cmdline, cmdlineAppend}, " ")}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1361,6 +1361,10 @@ version: 5.0
 }
 
 func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelArgs(c *C, whichFile, content, errMsg string, cmdlines map[string]string) {
+	s.testMakeSystemRunnable20WithCustomKernelAndSnapdArgs(c, whichFile, content, "", errMsg, cmdlines)
+}
+
+func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelAndSnapdArgs(c *C, whichFile, content, extraSnapdAppend, errMsg string, cmdlines map[string]string) {
 	if cmdlines == nil {
 		cmdlines = map[string]string{}
 	}
@@ -1420,7 +1424,9 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelArgs(c *C,
 		{"grubx64.efi", "grub content"},
 		{"meta/snap.yaml", gadgetSnapYaml},
 		{"meta/gadget.yaml", gadgetYaml},
-		{whichFile, content},
+	}
+	if whichFile != "" {
+		gadgetFiles = append(gadgetFiles, []string{whichFile, content})
 	}
 	snaptest.PopulateDir(unpackedGadgetDir, gadgetFiles)
 	restore := assets.MockInternal("grub-recovery.cfg", grubRecoveryCfgAsset)
@@ -1466,6 +1472,8 @@ version: 5.0
 		Kernel:              kernelInfo,
 		Recovery:            false,
 		UnpackedGadgetDir:   unpackedGadgetDir,
+
+		ExtraSnapdKernelCommandLineAppend: extraSnapdAppend,
 	}
 
 	// set up observer state
@@ -1589,17 +1597,28 @@ version: 5.0
 			defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 			c.Assert(err, IsNil)
 			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
-			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content}, " "))
+			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content, extraSnapdAppend}, " "))
 		} else {
-			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
+			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{content, extraSnapdAppend}, " "))
 			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
 		}
 	case "cmdline.full":
 		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
-		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, content)
+		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{content, extraSnapdAppend}, " "))
+	case "":
+		blopts := &bootloader.Options{
+			Role:        bootloader.RoleRunMode,
+			NoSlashBoot: true,
+		}
+		bl, err := bootloader.Find(boot.InitramfsUbuntuBootDir, blopts)
+		c.Assert(err, IsNil)
+		tbl := bl.(bootloader.TrustedAssetsBootloader)
+		candidate := false
+		defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
+		c.Assert(err, IsNil)
+		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, extraSnapdAppend}, " "))
 	}
-
-	// ensure modeenv looks correct
 	ubuntuDataModeEnvPath := filepath.Join(s.rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, fmt.Sprintf(`mode=run
 recovery_system=20191216
@@ -1640,6 +1659,30 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20WithCustomKernelFullArgs(c
 func (s *makeBootable20Suite) TestMakeSystemRunnable20WithCustomKernelInvalidArgs(c *C) {
 	errMsg := `cannot compose the candidate command line: cannot use kernel command line from gadget: invalid kernel command line in cmdline.extra: disallowed kernel argument "snapd=unhappy"`
 	s.testMakeSystemRunnable20WithCustomKernelArgs(c, "cmdline.extra", "foo bar snapd=unhappy", errMsg, nil)
+}
+
+func (s *makeBootable20Suite) TestMakeSystemRunnable20WithExtraSnapdKernelCommandLineAppend(c *C) {
+	extraSnapdAppend := "snapd.xkb=eg,pc105,,grp:alt_shift_toggle"
+	cmdlines := map[string]string{
+		"run": "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 " + extraSnapdAppend,
+	}
+	s.testMakeSystemRunnable20WithCustomKernelAndSnapdArgs(c, "", "", extraSnapdAppend, "", cmdlines)
+}
+
+func (s *makeBootable20Suite) TestMakeSystemRunnable20WithExtraSnapdKernelCommandLineAppendAndCustomKernelExtraArgs(c *C) {
+	extraSnapdAppend := "snapd.xkb=eg,pc105,,grp:alt_shift_toggle"
+	cmdlines := map[string]string{
+		"run": "snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 foo bar baz " + extraSnapdAppend,
+	}
+	s.testMakeSystemRunnable20WithCustomKernelAndSnapdArgs(c, "cmdline.extra", "foo bar baz", extraSnapdAppend, "", cmdlines)
+}
+
+func (s *makeBootable20Suite) TestMakeSystemRunnable20WithExtraSnapdKernelCommandLineAppendCustomKernelFullArgs(c *C) {
+	extraSnapdAppend := "snapd.xkb=eg,pc105,,grp:alt_shift_toggle"
+	cmdlines := map[string]string{
+		"run": "snapd_recovery_mode=run foo bar baz " + extraSnapdAppend,
+	}
+	s.testMakeSystemRunnable20WithCustomKernelAndSnapdArgs(c, "cmdline.full", "foo bar baz", extraSnapdAppend, "", cmdlines)
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20UnhappyMarkRecoveryCapable(c *C) {

--- a/client/systems.go
+++ b/client/systems.go
@@ -263,6 +263,7 @@ type KeyboardConfig struct {
 	Options []string `json:"options,omitempty"`
 }
 
+// XKBConfig converts the KeyboardConfig to simplified keyboard.XKBConfig struct.
 func (c *KeyboardConfig) XKBConfig() keyboard.XKBConfig {
 	xkb := keyboard.XKBConfig{
 		Model:   c.Model,
@@ -275,6 +276,12 @@ func (c *KeyboardConfig) XKBConfig() keyboard.XKBConfig {
 		xkb.Variants = []string{c.Variant}
 	}
 	return xkb
+}
+
+// Validate the keyboard configuration.
+func (c *KeyboardConfig) Validate() error {
+	xkb := c.XKBConfig()
+	return xkb.Validate()
 }
 
 type InstallSystemOptions struct {
@@ -295,7 +302,7 @@ type InstallSystemOptions struct {
 	// authentication). If VolumesAuth is nil, the default is to have no
 	// authentication.
 	VolumesAuth *device.VolumesAuthOptions `json:"volumes-auth,omitempty"`
-	// KeyboardConfig contains the keyboard layout selected at install-time.
+	// KeyboardConfig contains the selected keyboard layout.
 	KeyboardConfig *KeyboardConfig `json:"keyboard-config,omitempty"`
 
 	// TargetRoot is a path to the rootfs of a mounted target system for the

--- a/client/systems.go
+++ b/client/systems.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/osutil/keyboard"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 )
@@ -252,6 +253,30 @@ const (
 	InstallStepPreseed InstallStep = "preseed"
 )
 
+// KeyboardConfig carries the keyboard layout selected at install-time so it can
+// be propagated to the first-boot kernel command line (e.g. for plymouth to use
+// the correct keymap at the passphrase/PIN prompt).
+type KeyboardConfig struct {
+	Model   string   `json:"model,omitempty"`
+	Layout  string   `json:"layout,omitempty"`
+	Variant string   `json:"variant,omitempty"`
+	Options []string `json:"options,omitempty"`
+}
+
+func (c *KeyboardConfig) XKBConfig() keyboard.XKBConfig {
+	xkb := keyboard.XKBConfig{
+		Model:   c.Model,
+		Options: c.Options,
+	}
+	if c.Layout != "" {
+		xkb.Layouts = []string{c.Layout}
+	}
+	if c.Variant != "" {
+		xkb.Variants = []string{c.Variant}
+	}
+	return xkb
+}
+
 type InstallSystemOptions struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish", or "preseed".
@@ -270,6 +295,8 @@ type InstallSystemOptions struct {
 	// authentication). If VolumesAuth is nil, the default is to have no
 	// authentication.
 	VolumesAuth *device.VolumesAuthOptions `json:"volumes-auth,omitempty"`
+	// KeyboardConfig contains the keyboard layout selected at install-time.
+	KeyboardConfig *KeyboardConfig `json:"keyboard-config,omitempty"`
 
 	// TargetRoot is a path to the rootfs of a mounted target system for the
 	// "preseed" step.

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -493,3 +493,20 @@ func (s *clientSuite) TestKeyboardConfigXKBConfig(c *check.C) {
 		Options:  []string{"ctrl:nocaps"},
 	})
 }
+
+func (s *clientSuite) TestKeyboardConfigValidate(c *check.C) {
+	// Valid configuration
+	kb := client.KeyboardConfig{
+		Model:   "pc105",
+		Layout:  "us",
+		Variant: "dvorak",
+	}
+	c.Assert(kb.Validate(), check.IsNil)
+
+	kb = client.KeyboardConfig{
+		Model:   "pc105,",
+		Layout:  "us",
+		Variant: "dvorak",
+	}
+	c.Assert(kb.Validate(), check.ErrorMatches, `model cannot contain ',': found "pc105,"`)
+}

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/osutil/keyboard"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -475,4 +476,20 @@ func (cs *clientSuite) TestRequestGeneratePreInstallRecoveryKeyError(c *check.C)
 	c.Assert(err, check.ErrorMatches, `cannot generate recovery key for system "1234": boom!`)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/1234")
+}
+
+func (s *clientSuite) TestKeyboardConfigXKBConfig(c *check.C) {
+	kb := client.KeyboardConfig{
+		Model:   "pc105",
+		Layout:  "us",
+		Variant: "dvorak",
+		Options: []string{"ctrl:nocaps"},
+	}
+	xkb := kb.XKBConfig()
+	c.Check(xkb, check.DeepEquals, keyboard.XKBConfig{
+		Model:    "pc105",
+		Layouts:  []string{"us"},
+		Variants: []string{"dvorak"},
+		Options:  []string{"ctrl:nocaps"},
+	})
 }

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -376,12 +376,16 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 
 	switch req.Step {
 	case client.InstallStepSetupStorageEncryption:
+		// TODO: require volumes-auth if HWROT is ignored.
 		if req.VolumesAuth != nil {
 			if err := req.VolumesAuth.Validate(); err != nil {
 				return BadRequest("invalid volume authentication options: %v", err)
 			}
+			if req.KeyboardConfig == nil {
+				return BadRequest("keyboard configuration is required when volume authentication is set")
+			}
 		}
-		chg, err := devicestateInstallSetupStorageEncryption(st, systemLabel, req.OnVolumes, req.VolumesAuth)
+		chg, err := devicestateInstallSetupStorageEncryption(st, systemLabel, req.OnVolumes, req.VolumesAuth, req.KeyboardConfig)
 		if err != nil {
 			return BadRequest("cannot setup storage encryption for install from %q: %v", systemLabel, err)
 		}

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -385,6 +385,11 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 				return BadRequest("keyboard configuration is required when volume authentication is set")
 			}
 		}
+		if req.KeyboardConfig != nil {
+			if err := req.KeyboardConfig.Validate(); err != nil {
+				return BadRequest("invalid keyboard configuration: %v", err)
+			}
+		}
 		chg, err := devicestateInstallSetupStorageEncryption(st, systemLabel, req.OnVolumes, req.VolumesAuth, req.KeyboardConfig)
 		if err != nil {
 			return BadRequest("cannot setup storage encryption for install from %q: %v", systemLabel, err)

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -382,7 +382,7 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 				return BadRequest("invalid volume authentication options: %v", err)
 			}
 			if req.KeyboardConfig == nil {
-				return BadRequest("keyboard configuration is required when volume authentication is set")
+				return BadRequest("cannot use volumes authentication without a keyboard configuration")
 			}
 		}
 		if req.KeyboardConfig != nil {

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1427,7 +1427,7 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionMissingKeybo
 
 	rsp := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Message, check.Equals, "keyboard configuration is required when volume authentication is set")
+	c.Check(rsp.Message, check.Equals, "cannot use volumes authentication without a keyboard configuration")
 	c.Check(nCalls, check.Equals, 0)
 }
 

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1431,6 +1431,34 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionMissingKeybo
 	c.Check(nCalls, check.Equals, 0)
 }
 
+func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionKeyboardConfigError(c *check.C) {
+	s.daemon(c)
+
+	body := map[string]any{
+		"action": "install",
+		"step":   "setup-storage-encryption",
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
+				"bootloader": "grub",
+			},
+		},
+		"keyboard-config": map[string]any{
+			"model":   "pc105,",
+			"layout":  "eg",
+			"options": []string{"grp:alt_shift_toggle"},
+		},
+	}
+	b, err := json.Marshal(body)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(b)
+	req, err := http.NewRequest("POST", "/v2/systems/20191119", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Message, check.Equals, `invalid keyboard configuration: model cannot contain ',': found "pc105,"`)
+}
+
 func (s *systemsSuite) TestSystemInstallActionPreseedCallsDevicestate(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1331,10 +1331,12 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionCallsDevices
 	var gotOnVolumes map[string]*gadget.Volume
 	var gotLabel string
 	var gotVolumesAuth *device.VolumesAuthOptions
-	r := daemon.MockDevicestateInstallSetupStorageEncryption(func(st *state.State, label string, onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions) (*state.Change, error) {
+	var gotKeyboardConfig *client.KeyboardConfig
+	r := daemon.MockDevicestateInstallSetupStorageEncryption(func(st *state.State, label string, onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, keyboardConfig *client.KeyboardConfig) (*state.Change, error) {
 		gotLabel = label
 		gotOnVolumes = onVolumes
 		gotVolumesAuth = volumesAuth
+		gotKeyboardConfig = keyboardConfig
 		nCalls++
 		return st.NewChange("foo", "..."), nil
 	})
@@ -1352,6 +1354,11 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionCallsDevices
 			"mode":       "passphrase",
 			"passphrase": "1234",
 			"kdf-type":   "argon2id",
+		},
+		"keyboard-config": map[string]any{
+			"model":   "pc105",
+			"layout":  "eg",
+			"options": []string{"grp:alt_shift_toggle"},
 		},
 	}
 	b, err := json.Marshal(body)
@@ -1379,8 +1386,49 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionCallsDevices
 		Passphrase: "1234",
 		KDFType:    "argon2id",
 	})
+	c.Check(gotKeyboardConfig, check.DeepEquals, &client.KeyboardConfig{
+		Model:   "pc105",
+		Layout:  "eg",
+		Options: []string{"grp:alt_shift_toggle"},
+	})
 
 	c.Check(soon, check.Equals, 1)
+}
+
+func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionMissingKeyboardConfig(c *check.C) {
+	s.daemon(c)
+
+	nCalls := 0
+	r := daemon.MockDevicestateInstallSetupStorageEncryption(func(st *state.State, label string, onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, keyboardConfig *client.KeyboardConfig) (*state.Change, error) {
+		nCalls++
+		return st.NewChange("foo", "..."), nil
+	})
+	defer r()
+
+	body := map[string]any{
+		"action": "install",
+		"step":   "setup-storage-encryption",
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
+				"bootloader": "grub",
+			},
+		},
+		"volumes-auth": map[string]any{
+			"mode":       "passphrase",
+			"passphrase": "1234",
+			"kdf-type":   "argon2id",
+		},
+	}
+	b, err := json.Marshal(body)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(b)
+	req, err := http.NewRequest("POST", "/v2/systems/20191119", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Message, check.Equals, "keyboard configuration is required when volume authentication is set")
+	c.Check(nCalls, check.Equals, 0)
 }
 
 func (s *systemsSuite) TestSystemInstallActionPreseedCallsDevicestate(c *check.C) {

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -62,7 +63,7 @@ func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadge
 	return testutil.Mock(&devicestateInstallFinish, f)
 }
 
-func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*gadget.Volume, *device.VolumesAuthOptions) (*state.Change, error)) (restore func()) {
+func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*gadget.Volume, *device.VolumesAuthOptions, *client.KeyboardConfig) (*state.Change, error)) (restore func()) {
 	return testutil.Mock(&devicestateInstallSetupStorageEncryption, f)
 }
 

--- a/docs/api/v2/components/schemas/SystemActionInstall.yaml
+++ b/docs/api/v2/components/schemas/SystemActionInstall.yaml
@@ -40,21 +40,22 @@ oneOf:
         description: A map of volume labels to their authentication credentials (e.g., passphrase or PIN).
       keyboard-config:
         type: object
+        description: Keyboard configuration selected at install time, used to configure the keymap on first boot (e.g. plymouth passphrase/PIN prompt). Required when 'volumes-auth' is set.
         properties:
           layout:
             type: string
-            description: The keyboard layout to use during installation (e.g. 'us', 'uk', 'eg').
+            description: The keyboard layout to use (e.g. 'us', 'uk', 'eg').
           model:
             type: string
-            description: The keyboard model to use during installation (e.g. 'pc105').
+            description: The keyboard model to use (e.g. 'pc105').
           variant:
             type: string
-            description: The keyboard variant to use during installation (e.g. 'dvorak').
+            description: The keyboard variant to use (e.g. 'dvorak').
           options:
             type: array
             items:
               type: string
-            description: A list of additional keyboard options to use during installation (e.g. 'ctrl:nocaps').
+            description: A list of additional keyboard options to use (e.g. 'ctrl:nocaps').
   - type: object
     required:
       - step

--- a/docs/api/v2/components/schemas/SystemActionInstall.yaml
+++ b/docs/api/v2/components/schemas/SystemActionInstall.yaml
@@ -38,6 +38,23 @@ oneOf:
         additionalProperties:
           type: string
         description: A map of volume labels to their authentication credentials (e.g., passphrase or PIN).
+      keyboard-config:
+        type: object
+        properties:
+          layout:
+            type: string
+            description: The keyboard layout to use during installation (e.g. 'us', 'uk', 'eg').
+          model:
+            type: string
+            description: The keyboard model to use during installation (e.g. 'pc105').
+          variant:
+            type: string
+            description: The keyboard variant to use during installation (e.g. 'dvorak').
+          options:
+            type: array
+            items:
+              type: string
+            description: A list of additional keyboard options to use during installation (e.g. 'ctrl:nocaps').
   - type: object
     required:
       - step

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -688,12 +688,14 @@ func EncryptPartitions(
 	model *asserts.Model,
 	gadgetRoot,
 	kernelRoot string,
+	extraSnapdKernelCommandLineFragments map[string]string,
 	perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
 	setupData := &EncryptionSetupData{
-		parts:                  make(map[string]partEncryptionData),
-		volumesAuth:            volumesAuth,
-		preinstallCheckContext: checkContext,
+		parts:                                make(map[string]partEncryptionData),
+		volumesAuth:                          volumesAuth,
+		preinstallCheckContext:               checkContext,
+		extraSnapdKernelCommandLineFragments: extraSnapdKernelCommandLineFragments,
 	}
 	for volName, vol := range onVolumes {
 		onDiskVol, err := gadget.OnDiskVolumeFromGadgetVol(vol)

--- a/gadget/install/install_placeholder.go
+++ b/gadget/install/install_placeholder.go
@@ -58,6 +58,7 @@ func EncryptPartitions(
 	model *asserts.Model,
 	gadgetRoot,
 	kernelRoot string,
+	extraSnapdKernelCommandLineFragments map[string]string,
 	perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
 	return nil, fmt.Errorf("build without secboot support")

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1443,7 +1443,7 @@ func (s *installSuite) testWriteContent(c *C, opts writeContentOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData, nil, nil, nil)
+		esd = install.MockEncryptionSetupData(labelToEncData, nil, nil, nil, nil)
 	}
 	onDiskVols, err := install.WriteContent(ginfo.Volumes, allLaidOutVols, esd, nil, nil, timings.New(nil))
 	c.Assert(err, IsNil)
@@ -1490,8 +1490,9 @@ func (s *installSuite) TestInstallWriteContentDeviceNotFound(c *C) {
 }
 
 type encryptPartitionsOpts struct {
-	encryptType device.EncryptionType
-	volumesAuth *device.VolumesAuthOptions
+	encryptType                          device.EncryptionType
+	volumesAuth                          *device.VolumesAuthOptions
+	extraSnapdKernelCommandLineFragments map[string]string
 }
 
 func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
@@ -1534,11 +1535,15 @@ func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
 
 	checkContext := &secboot.PreinstallCheckContext{}
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, opts.volumesAuth, opts.encryptType, checkContext, model, gadgetRoot, "", timings.New(nil))
+	encryptSetup, err := install.EncryptPartitions(
+		ginfo.Volumes, opts.volumesAuth, opts.encryptType, checkContext, model,
+		gadgetRoot, "", opts.extraSnapdKernelCommandLineFragments, timings.New(nil),
+	)
 	c.Assert(err, IsNil)
 	c.Assert(encryptSetup, NotNil)
 	c.Assert(encryptSetup.VolumesAuth(), Equals, opts.volumesAuth)
 	c.Assert(encryptSetup.PreinstallCheckContext(), Equals, checkContext)
+	c.Assert(encryptSetup.ExtraSnapdKernelCommandLineFragments(), DeepEquals, opts.extraSnapdKernelCommandLineFragments)
 	err = install.CheckEncryptionSetupData(encryptSetup, map[string]string{
 		"ubuntu-save": "/dev/mapper/ubuntu-save",
 		"ubuntu-data": "/dev/mapper/ubuntu-data",
@@ -1556,6 +1561,9 @@ func (s *installSuite) TestInstallEncryptPartitions(c *C) {
 	s.testEncryptPartitions(c, encryptPartitionsOpts{
 		encryptType: device.EncryptionTypeLUKS,
 		volumesAuth: &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"},
+		extraSnapdKernelCommandLineFragments: map[string]string{
+			"xkb": `snapd.xkb="us,pc105,,grp:alt_shift_toggle"`,
+		},
 	})
 }
 
@@ -1572,7 +1580,7 @@ func (s *installSuite) TestInstallEncryptPartitionsNoDeviceSet(c *C) {
 	c.Assert(err, IsNil)
 	defer restore()
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, device.EncryptionTypeLUKS, nil, model, gadgetRoot, "", timings.New(nil))
+	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, device.EncryptionTypeLUKS, nil, model, gadgetRoot, "", nil, timings.New(nil))
 
 	c.Check(err.Error(), Equals, `volume "pc" has no device assigned`)
 	c.Check(encryptSetup, IsNil)
@@ -1679,7 +1687,7 @@ func (s *installSuite) testMountVolumes(c *C, opts mountVolumesOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData, nil, nil, nil)
+		esd = install.MockEncryptionSetupData(labelToEncData, nil, nil, nil, nil)
 	}
 
 	// 10 million mocks later ...

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -73,6 +73,11 @@ type EncryptionSetupData struct {
 	// reflects the outcome of the most recent check and contains information
 	// required for optimum PCR configuration and reseal post install
 	preinstallCheckContext *secboot.PreinstallCheckContext
+	// extraSnapdKernelCommandLineFragments holds extra snapd kernel command
+	// line fragments keyed by fragment ID (e.g. "xkb").
+	//
+	// TODO: use typed fragment IDs instead of string keys.
+	extraSnapdKernelCommandLineFragments map[string]string
 }
 
 // EncryptedDevices returns a map partition role -> LUKS mapper device.
@@ -87,6 +92,12 @@ func (esd *EncryptionSetupData) EncryptedDevices() map[string]string {
 // VolumesAuth returns attached volumes authentication options if any.
 func (esd *EncryptionSetupData) VolumesAuth() *device.VolumesAuthOptions {
 	return esd.volumesAuth
+}
+
+// ExtraSnapdKernelCommandLineFragments returns extra snapd kernel command line
+// fragments keyed by fragment ID.
+func (esd *EncryptionSetupData) ExtraSnapdKernelCommandLineFragments() map[string]string {
+	return esd.extraSnapdKernelCommandLineFragments
 }
 
 func (esd *EncryptionSetupData) SetRecoveryKey(rkey *keys.RecoveryKey) {
@@ -115,12 +126,14 @@ func MockEncryptionSetupData(
 	rkey *keys.RecoveryKey,
 	volumesAuth *device.VolumesAuthOptions,
 	checkContext *secboot.PreinstallCheckContext,
+	extraSnapdKernelCommandLineFragments map[string]string,
 ) *EncryptionSetupData {
 	esd := &EncryptionSetupData{
-		parts:                  map[string]partEncryptionData{},
-		volumesAuth:            volumesAuth,
-		rkey:                   rkey,
-		preinstallCheckContext: checkContext,
+		parts:                                map[string]partEncryptionData{},
+		volumesAuth:                          volumesAuth,
+		rkey:                                 rkey,
+		preinstallCheckContext:               checkContext,
+		extraSnapdKernelCommandLineFragments: extraSnapdKernelCommandLineFragments,
 	}
 	for label, encryptData := range labelToEncDevice {
 		//TODO:FDEM: we should use a mock for the bootstrap key. However,

--- a/osutil/inotify/inotify_others.go
+++ b/osutil/inotify/inotify_others.go
@@ -30,6 +30,7 @@ const (
 	InDeleteSelf uint32 = 0
 	InCreate     uint32 = 0
 	InCloseWrite uint32 = 0
+	InMovedTo    uint32 = 0
 )
 
 // NewWatcher creates and returns a new inotify instance using inotify_init(2)

--- a/osutil/keyboard/xkb.go
+++ b/osutil/keyboard/xkb.go
@@ -98,8 +98,8 @@ func (c *XKBConfig) KernelCommandLineFragment() string {
 	}
 	opts := strings.Join(c.Options, ",")
 
-	simplified := fmt.Sprintf("%s,%s,%s,%s", layout, c.Model, variant, opts)
-	return fmt.Sprintf("snapd.xkb=%q", simplified)
+	simplified := fmt.Sprintf(`"%s,%s,%s,%s"`, layout, c.Model, variant, opts)
+	return fmt.Sprintf("snapd.xkb=%s", simplified)
 }
 
 func CurrentXKBConfig() (*XKBConfig, error) {

--- a/osutil/keyboard/xkb.go
+++ b/osutil/keyboard/xkb.go
@@ -43,12 +43,22 @@ type XKBConfig struct {
 
 // Validates that this is a valid XKB config that can be parsed
 // by Plymouth.
-func (c *XKBConfig) validate() error {
+func (c *XKBConfig) Validate() error {
 	if strings.Contains(c.Model, ",") {
 		return fmt.Errorf("model cannot contain ',': found %q", c.Model)
 	}
 	if len(c.Variants) != 0 && len(c.Variants) != len(c.Layouts) {
 		return fmt.Errorf("layouts and variants do not have the same length")
+	}
+	for _, layout := range c.Layouts {
+		if strings.Contains(layout, ",") {
+			return fmt.Errorf("layout cannot contain ',': found %q", layout)
+		}
+	}
+	for _, variant := range c.Variants {
+		if strings.Contains(variant, ",") {
+			return fmt.Errorf("variant cannot contain ',': found %q", variant)
+		}
 	}
 	// XXX: Should we check that the model and layouts are always set?
 	return nil
@@ -131,7 +141,7 @@ func CurrentXKBConfig() (*XKBConfig, error) {
 	if vals["X11Options"] != "" {
 		config.Options = strings.Split(vals["X11Options"], ",")
 	}
-	if err := config.validate(); err != nil {
+	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("cannot parse XKB configuration: %v", err)
 	}
 

--- a/osutil/keyboard/xkb_test.go
+++ b/osutil/keyboard/xkb_test.go
@@ -206,6 +206,61 @@ func (s *xkbTestSuite) TestCurrentXKBConfigErrors(c *C) {
 	}
 }
 
+func (s *xkbTestSuite) TestXKBConfigValidate(c *C) {
+	type testcase struct {
+		config      keyboard.XKBConfig
+		expectedErr string
+	}
+
+	tcs := []testcase{
+		{
+			config: keyboard.XKBConfig{
+				Model:    "pc105",
+				Variants: []string{"", "bksl", ""},
+				Layouts:  []string{"us", "cz", "de"},
+				Options:  []string{"grp:alt_shift_toggle", "terminate:ctrl_alt_bksp"},
+			},
+		},
+		{
+			config: keyboard.XKBConfig{
+				Model:    "pc105,pc104",
+				Variants: []string{"", "bksl", ""},
+				Layouts:  []string{"us", "cz", "de"},
+				Options:  []string{"grp:alt_shift_toggle", "terminate:ctrl_alt_bksp"},
+			},
+			expectedErr: `model cannot contain ',': found "pc105,pc104"`,
+		},
+		{
+			config: keyboard.XKBConfig{
+				Model:    "pc105",
+				Variants: []string{},
+				Layouts:  []string{"us,cz,de"},
+				Options:  []string{"grp:alt_shift_toggle", "terminate:ctrl_alt_bksp"},
+			},
+			expectedErr: `layout cannot contain ',': found "us,cz,de"`,
+		},
+		{
+			config: keyboard.XKBConfig{
+				Model:    "pc105",
+				Variants: []string{",bksl"},
+				Layouts:  []string{"us"},
+				Options:  []string{"terminate:ctrl_alt_bksp"},
+			},
+			expectedErr: `variant cannot contain ',': found ",bksl"`,
+		},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("tc[%d] failed", i)
+		err := tc.config.Validate()
+		if tc.expectedErr != "" {
+			c.Check(err, ErrorMatches, tc.expectedErr, cmt)
+		} else {
+			c.Check(err, IsNil, cmt)
+		}
+	}
+}
+
 func (s *xkbTestSuite) TestXKBConfigListener(c *C) {
 	vconsoleConfPath := filepath.Join(s.rootDir, "/etc/vconsole.conf")
 	kbConfPath := filepath.Join(s.rootDir, "/etc/default/keyboard")

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -397,9 +397,14 @@ func (m *DeviceManager) StartUp() error {
 			}
 		}
 
+		// ensure install-time kernel cmdline fragments are seeded into state.
+		if err := initExtraSnapdFragmentsFromInstallTime(m.state); err != nil {
+			logger.Noticef("cannot initialize install-time kernel cmdline fragments: %v", err)
+		}
+
 		// ensure /var/lib/snapd/void permissions are ok
 		if err := ensureFileDirPermissions(); err != nil {
-			logger.Noticef("%v", fmt.Errorf("cannot ensure device file/dir permissions: %v", err))
+			logger.Noticef("cannot ensure device file/dir permissions: %v", err)
 		}
 
 		// TODO: setup proper timings measurements for this

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -2659,7 +2660,7 @@ func InstallFinish(st *state.State, label string, onVolumes map[string]*gadget.V
 // InstallSetupStorageEncryption creates a change that will setup the
 // storage encryption for the install of the given label and
 // volumes.
-func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions) (*state.Change, error) {
+func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, keyboardConfig *client.KeyboardConfig) (*state.Change, error) {
 	if label == "" {
 		return nil, fmt.Errorf("cannot setup storage encryption with an empty system label")
 	}
@@ -2667,6 +2668,9 @@ func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[
 		return nil, fmt.Errorf("cannot setup storage encryption without volumes data")
 	}
 	if volumesAuth != nil {
+		if volumesAuth.Mode != device.AuthModeNone && keyboardConfig == nil {
+			return nil, fmt.Errorf("cannot use authentication mode %q without a keyboard configuration", volumesAuth.Mode)
+		}
 		if err := volumesAuth.Validate(); err != nil {
 			return nil, err
 		}
@@ -2680,6 +2684,9 @@ func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[
 	setupStorageEncryptionTask.Set("on-volumes", onVolumes)
 	if volumesAuth != nil {
 		setupStorageEncryptionTask.Set("volumes-auth-required", true)
+	}
+	if keyboardConfig != nil {
+		setupStorageEncryptionTask.Set("keyboard-config", keyboardConfig)
 	}
 	chg.AddTask(setupStorageEncryptionTask)
 

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -2668,8 +2668,8 @@ func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[
 		return nil, fmt.Errorf("cannot setup storage encryption without volumes data")
 	}
 	if volumesAuth != nil {
-		if volumesAuth.Mode != device.AuthModeNone && keyboardConfig == nil {
-			return nil, fmt.Errorf("cannot use authentication mode %q without a keyboard configuration", volumesAuth.Mode)
+		if keyboardConfig == nil {
+			return nil, fmt.Errorf("cannot use volumes authentication without a keyboard configuration")
 		}
 		if err := volumesAuth.Validate(); err != nil {
 			return nil, err
@@ -2686,6 +2686,9 @@ func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[
 		setupStorageEncryptionTask.Set("volumes-auth-required", true)
 	}
 	if keyboardConfig != nil {
+		if err := keyboardConfig.Validate(); err != nil {
+			return nil, err
+		}
 		setupStorageEncryptionTask.Set("keyboard-config", keyboardConfig)
 	}
 	chg.AddTask(setupStorageEncryptionTask)

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -21,6 +21,7 @@
 package devicestate_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -34,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -86,14 +88,15 @@ func unpackSnap(snapBlob, targetDir string) error {
 }
 
 type finishStepOpts struct {
-	encrypted          bool
-	installClassic     bool
-	hasPartial         bool
-	hasSystemSeed      bool
-	hasKernelModsComps bool
-	hasRecoveryKey     bool
-	optionalContainers *seed.OptionalContainers
-	volumesAuth        *device.VolumesAuthOptions
+	encrypted              bool
+	installClassic         bool
+	hasPartial             bool
+	hasSystemSeed          bool
+	hasKernelModsComps     bool
+	hasRecoveryKey         bool
+	optionalContainers     *seed.OptionalContainers
+	volumesAuth            *device.VolumesAuthOptions
+	extraSnapdKCmdlineArgs map[string]string
 }
 
 func mockDiskVolume(opts finishStepOpts) *gadget.OnDiskVolume {
@@ -523,6 +526,11 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			// exact cmdline depends on arch, see
 			// bootloader/assets/grub.go:init()
 			c.Check(modeenv.CurrentKernelCommandLines[0], testutil.Contains, "snapd_recovery_mode=run")
+			// install-time extra snapd kernel command line fragments are
+			// rendered into the run mode command line
+			if rendered := devicestate.RenderExtraSnapdKernelCommandLineFragments(opts.extraSnapdKCmdlineArgs); rendered != "" {
+				c.Check(modeenv.CurrentKernelCommandLines[0], testutil.Contains, rendered)
+			}
 			// Check that volume authentication options where propagated
 			c.Check(volumesAuth, Equals, opts.volumesAuth)
 
@@ -566,7 +574,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			})
 			s.AddCleanup(restore)
 		}
-		restore = devicestate.MockEncryptionSetupDataInCache(s.state, label, rkey, opts.volumesAuth, checkContext)
+		restore = devicestate.MockEncryptionSetupDataInCache(s.state, label, rkey, opts.volumesAuth, checkContext, opts.extraSnapdKCmdlineArgs)
 		s.AddCleanup(restore)
 
 		// Write expected boot assets needed when creating bootchain
@@ -739,6 +747,20 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 		saveBootstrappedContainer := bootstrappedContainersForRole[gadget.SystemSave].(*secboot.MockBootstrappedContainer)
 		c.Check(saveBootstrappedContainer.Slots["default-recovery"], DeepEquals, []byte{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y', '-', '7', 0, 0, 0, 0, 0, 0})
 	}
+
+	// install-time extra snapd kernel command line fragments are persisted to
+	// the installed system's ubuntu-save device dir
+	fragmentsFile := filepath.Join(boot.InstallHostDeviceSaveDir, "kcmdline-extra-snapd-fragments.json")
+	if len(opts.extraSnapdKCmdlineArgs) > 0 {
+		c.Check(fragmentsFile, testutil.FilePresent)
+		var written map[string]string
+		data, err := os.ReadFile(fragmentsFile)
+		c.Assert(err, IsNil)
+		c.Assert(json.Unmarshal(data, &written), IsNil)
+		c.Check(written, DeepEquals, opts.extraSnapdKCmdlineArgs)
+	} else {
+		c.Check(fragmentsFile, testutil.FileAbsent)
+	}
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishNoEncryptionHappy(c *C) {
@@ -747,6 +769,16 @@ func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishNoEncryptionHappy(c *
 
 func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishEncryptionHappy(c *C) {
 	s.testInstallFinishStep(c, finishStepOpts{encrypted: true, installClassic: true})
+}
+
+func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishEncryptionWithExtraSnapdKernelCommandLineArgs(c *C) {
+	s.testInstallFinishStep(c, finishStepOpts{
+		encrypted:      true,
+		installClassic: true,
+		extraSnapdKCmdlineArgs: map[string]string{
+			"xkb": "snapd.xkb=eg,pc105,,grp:alt_shift_toggle",
+		},
+	})
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishNoEncryptionWithKModsHappy(c *C) {
@@ -777,6 +809,16 @@ func (s *deviceMgrInstallAPISuite) TestInstallCoreFinishNoEncryptionHappy(c *C) 
 
 func (s *deviceMgrInstallAPISuite) TestInstallCoreFinishEncryptionHappy(c *C) {
 	s.testInstallFinishStep(c, finishStepOpts{encrypted: true, installClassic: false})
+}
+
+func (s *deviceMgrInstallAPISuite) TestInstallCoreFinishEncryptionWithExtraSnapdKernelCommandLineArgs(c *C) {
+	s.testInstallFinishStep(c, finishStepOpts{
+		encrypted:      true,
+		installClassic: false,
+		extraSnapdKCmdlineArgs: map[string]string{
+			"xkb": "snapd.xkb=eg,pc105,,grp:alt_shift_toggle",
+		},
+	})
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallCoreFinishEncryptionWithPassphraseAuthHappy(c *C) {
@@ -833,7 +875,7 @@ func (s *deviceMgrInstallAPISuite) TestInstallFinishNoLabel(c *C) {
 - install API finish step \(cannot load assertions for label "classic": no seed assertions\)`)
 }
 
-func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, isSupportedHybrid, hasTPM bool, mockVolumesAuth *device.VolumesAuthOptions) {
+func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, isSupportedHybrid, hasTPM bool, mockVolumesAuth *device.VolumesAuthOptions, withKeyboardConfig bool) {
 	// Mock label
 	label := "classic"
 	isClassic := true
@@ -876,6 +918,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, isSup
 		model *asserts.Model,
 		gadgetRoot,
 		kernelRoot string,
+		extraSnapdKernelCommandLineFragments map[string]string,
 		perfTimings timings.Measurer,
 	) (*install.EncryptionSetupData, error) {
 		encrytpPartCalls++
@@ -898,6 +941,13 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, isSup
 		c.Check(volumesAuth, Equals, mockVolumesAuth)
 		c.Check(saveFound, Equals, true)
 		c.Check(dataFound, Equals, true)
+		if withKeyboardConfig {
+			c.Check(extraSnapdKernelCommandLineFragments, DeepEquals, map[string]string{
+				"xkb": `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
+			})
+		} else {
+			c.Check(extraSnapdKernelCommandLineFragments, HasLen, 0)
+		}
 		return &install.EncryptionSetupData{}, nil
 	})
 	s.AddCleanup(restore)
@@ -915,6 +965,15 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, isSup
 	if mockVolumesAuth != nil {
 		encryptTask.Set("volumes-auth-required", true)
 		s.state.Cache(devicestate.VolumesAuthOptionsKeyByLabel(label), mockVolumesAuth)
+	}
+	if withKeyboardConfig {
+		kbConfig := &client.KeyboardConfig{
+			Model:   "pc105",
+			Layout:  "eg",
+			Variant: "",
+			Options: []string{"grp:alt_shift_toggle"},
+		}
+		encryptTask.Set("keyboard-config", kbConfig)
 	}
 	chg.AddTask(encryptTask)
 
@@ -979,16 +1038,27 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHyb
 	// supported hybrid system uses specialized encryption availability check
 	const hasTPM = true
 	const isSupportedHybrid = true
+	const withKeyboardConfig = false
 	var volumesAuth *device.VolumesAuthOptions = nil
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNotSupportedHybridHappy(c *C) {
 	// unsupported hybrid system uses general encryption availability check
 	const hasTPM = true
 	const isSupportedHybrid = false
+	const withKeyboardConfig = false
 	var volumesAuth *device.VolumesAuthOptions = nil
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
+}
+
+func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHybridHappyWithKeyboardConfig(c *C) {
+	// supported hybrid system uses specialized encryption availability check
+	const hasTPM = true
+	const isSupportedHybrid = true
+	const withKeyboardConfig = true
+	var volumesAuth *device.VolumesAuthOptions = nil
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHybridHappyWithPassphrase(c *C) {
@@ -996,7 +1066,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHyb
 	const hasTPM = true
 	const isSupportedHybrid = true
 	volumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	const withKeyboardConfig = false
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHybridHappyWithPIN(c *C) {
@@ -1004,7 +1075,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHyb
 	const hasTPM = true
 	const isSupportedHybrid = true
 	volumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePIN, PIN: "1234"}
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	const withKeyboardConfig = false
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNotSupportedHybridHappyWithVolumesAuth(c *C) {
@@ -1012,7 +1084,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNotSupported
 	const hasTPM = true
 	const isSupportedHybrid = false
 	volumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	const withKeyboardConfig = false
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHybridNoCrypto(c *C) {
@@ -1020,7 +1093,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionSupportedHyb
 	const hasTPM = false
 	const isSupportedHybrid = true
 	var volumesAuth *device.VolumesAuthOptions = nil
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	const withKeyboardConfig = false
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNotSupportedHybridNoCrypto(c *C) {
@@ -1028,7 +1102,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNotSupported
 	const hasTPM = false
 	const isSupportedHybrid = false
 	var volumesAuth *device.VolumesAuthOptions = nil
-	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth)
+	const withKeyboardConfig = false
+	s.testInstallSetupStorageEncryption(c, isSupportedHybrid, hasTPM, volumesAuth, withKeyboardConfig)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNoLabel(c *C) {
@@ -1180,6 +1255,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryptionPassphraseAu
 		model *asserts.Model,
 		gadgetRoot,
 		kernelRoot string,
+		extraSnapdKernelCommandLineFragments map[string]string,
 		perfTimings timings.Measurer,
 	) (*install.EncryptionSetupData, error) {
 		return &install.EncryptionSetupData{}, nil

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -3517,7 +3518,7 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionEmptyLa
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "", mockOnVolumes, nil)
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "", mockOnVolumes, nil, nil)
 	c.Check(err, ErrorMatches, "cannot setup storage encryption with an empty system label")
 	c.Check(chg, IsNil)
 }
@@ -3526,7 +3527,7 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionNoVolum
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", nil, nil)
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", nil, nil, nil)
 	c.Check(err, ErrorMatches, "cannot setup storage encryption without volumes data")
 	c.Check(chg, IsNil)
 }
@@ -3536,8 +3537,19 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionVolumeA
 	defer s.state.Unlock()
 
 	volumeOpts := &device.VolumesAuthOptions{Mode: "bad-mode", Passphrase: "1234"}
-	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts)
+	keyboardConfig := &client.KeyboardConfig{Model: "pc105", Layout: "us"}
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts, keyboardConfig)
 	c.Check(err, ErrorMatches, `cannot use authentication mode "bad-mode", only "passphrase" and "pin" modes are supported`)
+	c.Check(chg, IsNil)
+}
+
+func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionMissingKeyboardConfigError(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	volumeOpts := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts, nil)
+	c.Check(err, ErrorMatches, `cannot use authentication mode "passphrase" without a keyboard configuration`)
 	c.Check(chg, IsNil)
 }
 
@@ -3546,11 +3558,14 @@ func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAn
 	defer s.state.Unlock()
 
 	var volumesAuth *device.VolumesAuthOptions
+	var keyboardConfig *client.KeyboardConfig
 	if withVolumesAuth {
 		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
+		// keyboard config is required when volumes-auth is passed
+		keyboardConfig = &client.KeyboardConfig{Model: "pc105", Layout: "us"}
 	}
 
-	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumesAuth)
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumesAuth, keyboardConfig)
 	c.Assert(err, IsNil)
 	c.Assert(chg, NotNil)
 	c.Check(chg.Summary(), Matches, `Setup storage encryption for installing system "1234"`)
@@ -3581,6 +3596,16 @@ func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAn
 		c.Assert(volumesAuthRequired, Equals, false)
 		c.Assert(cached, IsNil)
 	}
+
+	var tskKeyboardConfig *client.KeyboardConfig
+	err = tskInstallFinish.Get("keyboard-config", &tskKeyboardConfig)
+	if withVolumesAuth {
+		c.Assert(err, IsNil)
+		c.Assert(tskKeyboardConfig, DeepEquals, keyboardConfig)
+	} else {
+		c.Assert(errors.Is(err, state.ErrNoState), Equals, true)
+		c.Assert(tskKeyboardConfig, IsNil)
+	}
 }
 
 func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionTasksAndChange(c *C) {
@@ -3600,7 +3625,7 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionRunthro
 	defer st.Unlock()
 
 	s.state.Set("seeded", true)
-	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, nil)
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, nil, nil)
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -3614,7 +3639,7 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionRunthro
 }
 
 func (s *installStepSuite) TestGeneratePreInstallRecoveryKey(c *C) {
-	defer devicestate.MockEncryptionSetupDataInCache(s.state, "20250528", nil, nil, preinstallCheckContext)()
+	defer devicestate.MockEncryptionSetupDataInCache(s.state, "20250528", nil, nil, preinstallCheckContext, nil)()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -3543,13 +3543,23 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionVolumeA
 	c.Check(chg, IsNil)
 }
 
+func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionKeyboardConfigError(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	keyboardConfig := &client.KeyboardConfig{Model: "pc105,", Layout: "us"}
+	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, nil, keyboardConfig)
+	c.Check(err, ErrorMatches, `model cannot contain ',': found "pc105,"`)
+	c.Check(chg, IsNil)
+}
+
 func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionMissingKeyboardConfigError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	volumeOpts := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts, nil)
-	c.Check(err, ErrorMatches, `cannot use authentication mode "passphrase" without a keyboard configuration`)
+	c.Check(err, ErrorMatches, `cannot use volumes authentication without a keyboard configuration`)
 	c.Check(chg, IsNil)
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -21,6 +21,7 @@ package devicestate_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -1755,6 +1756,65 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20NoUbuntuSave(c *C) {
 
 	// known as available
 	c.Check(devicestate.SaveAvailable(mgr), Equals, true)
+}
+
+func setupInstallTimeExtraSnapdFragments(c *C, fragments map[string]string) {
+	data, err := json.Marshal(fragments)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(dirs.SnapDeviceSaveDir, 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json"), data, 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerStartupInitializesInstallTimeExtraSnapdFragments(c *C) {
+	setupInstallTimeExtraSnapdFragments(c, map[string]string{
+		"xkb":         `snapd.xkb="us,pc105"`,
+		"unsupported": "ignored-fragment",
+	})
+
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
+	c.Assert(err, IsNil)
+
+	err = mgr.StartUp()
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	checkExtraSnapdFragments(c, s.state, map[string]string{
+		"xkb": `snapd.xkb="us,pc105"`,
+	})
+
+	// File is kept as a record of the install-time choices.
+	c.Check(filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json"), testutil.FilePresent)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerStartupInitializesInstallTimeExtraSnapdFragmentsNoop(c *C) {
+	setupInstallTimeExtraSnapdFragments(c, map[string]string{
+		"xkb":         `snapd.xkb="us,pc105"`,
+		"unsupported": "ignored-fragment",
+	})
+
+	s.state.Lock()
+	s.state.Set("kcmdline-extra-snapd-fragments", map[string]string{
+		"xkb": `snapd.xkb="existing"`,
+	})
+	s.state.Unlock()
+
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
+	c.Assert(err, IsNil)
+
+	err = mgr.StartUp()
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	checkExtraSnapdFragments(c, s.state, map[string]string{
+		"xkb": `snapd.xkb="existing"`,
+	})
+
+	// File is kept as a record of the install-time choices.
+	c.Check(filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json"), testutil.FilePresent)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveErr(c *C) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -361,6 +361,9 @@ var (
 	CreateRecoverySystemTasks              = createRecoverySystemTasks
 
 	SetExtraSnapdKernelCommandLineFragment = setExtraSnapdKernelCommandLineFragment
+
+	RenderExtraSnapdKernelCommandLineFragments = renderExtraSnapdKernelCommandLineFragments
+	KernelCommandLineAppendArgsFromSnapd       = kernelCommandLineAppendArgsFromSnapd
 )
 
 func MockApplyPreseededData(f func(deviceSeed seed.PreseedCapable, writableDir string) error) (restore func()) {
@@ -469,6 +472,7 @@ func MockInstallEncryptPartitions(f func(
 	model *asserts.Model,
 	gadgetRoot,
 	kernelRoot string,
+	extraSnapdKernelCommandLineFragments map[string]string,
 	perfTimings timings.Measurer,
 ) (*install.EncryptionSetupData, error)) (restore func()) {
 	old := installEncryptPartitions
@@ -627,6 +631,7 @@ func MockEncryptionSetupDataInCache(
 	rkey *keys.RecoveryKey,
 	volumesAuth *device.VolumesAuthOptions,
 	checkContext *secboot.PreinstallCheckContext,
+	extraSnapdKernelCommandLineFragments map[string]string,
 ) (restore func()) {
 	st.Lock()
 	defer st.Unlock()
@@ -641,7 +646,7 @@ func MockEncryptionSetupDataInCache(
 			EncryptedDevice: "/dev/mapper/ubuntu-data",
 		},
 	}
-	esd = install.MockEncryptionSetupData(labelToEncData, rkey, volumesAuth, checkContext)
+	esd = install.MockEncryptionSetupData(labelToEncData, rkey, volumesAuth, checkContext, extraSnapdKernelCommandLineFragments)
 	st.Cache(encryptionSetupDataKey{label}, esd)
 	return func() { CleanUpEncryptionSetupDataInCache(st, label) }
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1208,6 +1208,21 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	// Carry any install-time extra snapd kernel command line fragments
+	// (e.g. keyboard configuration) into the boot configuration.
+	var extraSnapdKernelCommandLineFragments map[string]string
+	if encryptSetupData != nil {
+		extraSnapdKernelCommandLineFragments = encryptSetupData.ExtraSnapdKernelCommandLineFragments()
+	}
+	// Persist the install-time extra snapd kernel command line fragments to
+	// the installed system's ubuntu-save device dir so they can be lazily loaded
+	// into state at runtime and kept as a record of the install-time choices.
+	if len(extraSnapdKernelCommandLineFragments) > 0 {
+		if err := writeInstallTimeExtraSnapdFragments(boot.InstallHostDeviceSaveDir, extraSnapdKernelCommandLineFragments); err != nil {
+			return err
+		}
+	}
+
 	bootWith := &boot.BootableSet{
 		Base:              snapInfos[snap.TypeBase],
 		BasePath:          snapSeeds[snap.TypeBase].Path,
@@ -1219,15 +1234,9 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 		RecoverySystemLabel: systemLabel,
 		KernelMods:          kBootInfo.BootableKMods,
-	}
 
-	// Carry any install-time extra snapd kernel command line fragments
-	// (e.g. keyboard configuration) into the boot configuration.
-	var extraSnapdKernelCommandLineFragments map[string]string
-	if encryptSetupData != nil {
-		extraSnapdKernelCommandLineFragments = encryptSetupData.ExtraSnapdKernelCommandLineFragments()
+		ExtraSnapdKernelCommandLineAppend: renderExtraSnapdKernelCommandLineFragments(extraSnapdKernelCommandLineFragments),
 	}
-	bootWith.ExtraSnapdKernelCommandLineAppend = renderExtraSnapdKernelCommandLineFragments(extraSnapdKernelCommandLineFragments)
 
 	// installs in system-seed{,-null} partition: grub.cfg, grubenv
 	logger.Debugf("making the system-seed{,-null} partition bootable, mount dir is %q", seedMntDir)
@@ -1275,15 +1284,6 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		trustedInstallObserver.EncryptionSetup(),
 		st.Unlocker()); err != nil {
 		return err
-	}
-
-	// Persist the install-time extra snapd kernel command line fragments to
-	// the installed system's ubuntu-save device dir so they can be lazily loaded
-	// into state at runtime and kept as a record of the install-time choices.
-	if len(extraSnapdKernelCommandLineFragments) > 0 {
-		if err := writeInstallTimeExtraSnapdFragments(boot.InstallHostDeviceSaveDir, extraSnapdKernelCommandLineFragments); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -1220,6 +1221,14 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		KernelMods:          kBootInfo.BootableKMods,
 	}
 
+	// Carry any install-time extra snapd kernel command line fragments
+	// (e.g. keyboard configuration) into the boot configuration.
+	var extraSnapdKernelCommandLineFragments map[string]string
+	if encryptSetupData != nil {
+		extraSnapdKernelCommandLineFragments = encryptSetupData.ExtraSnapdKernelCommandLineFragments()
+	}
+	bootWith.ExtraSnapdKernelCommandLineAppend = renderExtraSnapdKernelCommandLineFragments(extraSnapdKernelCommandLineFragments)
+
 	// installs in system-seed{,-null} partition: grub.cfg, grubenv
 	logger.Debugf("making the system-seed{,-null} partition bootable, mount dir is %q", seedMntDir)
 	opts := &bootloader.Options{
@@ -1266,6 +1275,15 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		trustedInstallObserver.EncryptionSetup(),
 		st.Unlocker()); err != nil {
 		return err
+	}
+
+	// Persist the install-time extra snapd kernel command line fragments to
+	// the installed system's ubuntu-save device dir so they can be lazily loaded
+	// into state at runtime and kept as a record of the install-time choices.
+	if len(extraSnapdKernelCommandLineFragments) > 0 {
+		if err := writeInstallTimeExtraSnapdFragments(boot.InstallHostDeviceSaveDir, extraSnapdKernelCommandLineFragments); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1370,6 +1388,21 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		}
 	}
 
+	extraSnapdKernelCommandLineFragments := make(map[string]string)
+
+	// Convert the install-time keyboard configuration (if any) into extra
+	// snapd kernel command line fragments to be carried through encryption
+	// setup data.
+	var keyboardConfig *client.KeyboardConfig
+	if err := t.Get("keyboard-config", &keyboardConfig); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if keyboardConfig != nil {
+		xkbConfig := keyboardConfig.XKBConfig()
+		fragmentID := string(extraSnapdKernelCommandLineFragmentXKB)
+		extraSnapdKernelCommandLineFragments[fragmentID] = xkbConfig.KernelCommandLineFragment()
+	}
+
 	systemAndSeeds, mntPtForType, _, unmount, err := m.loadAndMountSystemLabelSnapsUnlock(
 		st, systemLabel, []snap.Type{snap.TypeSnapd, snap.TypeKernel, snap.TypeBase, snap.TypeGadget})
 	if err != nil {
@@ -1437,6 +1470,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		systemAndSeeds.Model,
 		mntPtForType[snap.TypeGadget],
 		mntPtForType[snap.TypeKernel],
+		extraSnapdKernelCommandLineFragments,
 		perfTimings,
 	)
 	if err != nil {

--- a/overlord/devicestate/kcmdline.go
+++ b/overlord/devicestate/kcmdline.go
@@ -174,13 +174,6 @@ func setExtraSnapdKernelCommandLineFragment(st *state.State, fragmentID extraSna
 		return fmt.Errorf("cannot set extra snapd kernel command line fragments until fully seeded")
 	}
 
-	// Ensure install-time fragments are seeded into state before comparing
-	// against the current value so runtime updates correctly override the
-	// install-time baseline.
-	if err := initExtraSnapdFragmentsFromInstallTime(st); err != nil {
-		return err
-	}
-
 	var currentFragments map[extraSnapdKernelCommandLineFragmentID]string
 	if err := st.Get(kcmdlineExtraSnapdFragmentsKey, &currentFragments); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
@@ -210,13 +203,6 @@ func setExtraSnapdKernelCommandLineFragment(st *state.State, fragmentID extraSna
 // kernelCommandLineAppendArgsFromSnapd returns extra arguments that snapd
 // might set internally using setExtraSnapdKernelCommandLineFragment.
 func kernelCommandLineAppendArgsFromSnapd(st *state.State) (string, error) {
-	// Lazily seed install-time fragments into state if not yet set so that
-	// the returned string includes any install-time choices that have not
-	// been overridden at runtime.
-	if err := initExtraSnapdFragmentsFromInstallTime(st); err != nil {
-		return "", err
-	}
-
 	var fragments map[extraSnapdKernelCommandLineFragmentID]string
 	if err := st.Get(kcmdlineExtraSnapdFragmentsKey, &fragments); err != nil && !errors.Is(err, state.ErrNoState) {
 		return "", err

--- a/overlord/devicestate/kcmdline.go
+++ b/overlord/devicestate/kcmdline.go
@@ -19,14 +19,19 @@
 package devicestate
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -38,6 +43,13 @@ type extraSnapdKernelCommandLineFragmentID string
 const (
 	extraSnapdKernelCommandLineFragmentXKB extraSnapdKernelCommandLineFragmentID = "xkb"
 )
+
+// expectedInstallTimeFragmentIDs lists the fragment IDs that may be initialized
+// from the install-time persistence file. Only these keys are copied into
+// state when lazily initializing from the file.
+var expectedInstallTimeFragmentIDs = []extraSnapdKernelCommandLineFragmentID{
+	extraSnapdKernelCommandLineFragmentXKB,
+}
 
 func (id extraSnapdKernelCommandLineFragmentID) validate(val string) error {
 	switch id {
@@ -59,6 +71,85 @@ const (
 	// and "update-gadget-cmdline".
 	kcmdlinePendingExtraSnapdFragmentsKey string = "kcmdline-pending-extra-snapd-fragments"
 )
+
+// kcmdlineExtraSnapdFragmentsFileName is the name of the JSON file written at
+// install time (to the ubuntu-save device dir) holding the extra snapd kernel
+// command line fragments map. It is read at runtime to lazily initialize
+// state with the install-time choices.
+const kcmdlineExtraSnapdFragmentsFileName = "kcmdline-extra-snapd-fragments.json"
+
+// renderExtraSnapdKernelCommandLineFragments renders a map of extra snapd
+// kernel command line fragments into sorted, space-joined args.
+func renderExtraSnapdKernelCommandLineFragments(fragments map[string]string) string {
+	if len(fragments) == 0 {
+		return ""
+	}
+
+	// XXX: Prune fragments that are no longer used?
+	sorted := make([]string, 0, len(fragments))
+	for _, fragment := range fragments {
+		sorted = append(sorted, fragment)
+	}
+	// Sorting is needed so that the same set of args would
+	// always have the same order so we don't accidentally
+	// trigger a kcmdline update when the args are unchanged.
+	sort.Strings(sorted)
+	return strings.Join(sorted, " ")
+}
+
+// initExtraSnapdFragmentsFromInstallTime initializes the extra snapd kernel command
+// line fragments state from the install-time persistence file when state has not
+// yet been set. If the state key is already set, it is a no-op.
+func initExtraSnapdFragmentsFromInstallTime(st *state.State) error {
+	var current map[extraSnapdKernelCommandLineFragmentID]string
+	if err := st.Get(kcmdlineExtraSnapdFragmentsKey, &current); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if current != nil {
+		// State already initialized, nothing to do.
+		return nil
+	}
+
+	path := filepath.Join(dirs.SnapDeviceSaveDir, kcmdlineExtraSnapdFragmentsFileName)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// No install-time file, nothing to do.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var fileFragments map[string]string
+	if err := json.Unmarshal(data, &fileFragments); err != nil {
+		return fmt.Errorf("cannot parse install-time kernel command line fragments file %q: %v", path, err)
+	}
+
+	fragments := make(map[extraSnapdKernelCommandLineFragmentID]string, len(expectedInstallTimeFragmentIDs))
+	for _, id := range expectedInstallTimeFragmentIDs {
+		if fragment, ok := fileFragments[string(id)]; ok && fragment != "" {
+			fragments[id] = fragment
+		}
+	}
+	st.Set(kcmdlineExtraSnapdFragmentsKey, fragments)
+	return nil
+}
+
+// writeInstallTimeExtraSnapdFragments writes the given extra snapd kernel
+// command line fragments map as a JSON file to the given device save
+// directory. It is written at install time so the fragments can be lazily
+// loaded into state at runtime.
+func writeInstallTimeExtraSnapdFragments(deviceSaveDir string, fragments map[string]string) error {
+	data, err := json.Marshal(fragments)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(deviceSaveDir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(deviceSaveDir, kcmdlineExtraSnapdFragmentsFileName)
+	return osutil.AtomicWriteFile(path, data, 0644, 0)
+}
 
 // setExtraSnapdKernelCommandLineFragment updates the specified extra snapd
 // named fragment that is appended to the kernel command line. An empty
@@ -82,6 +173,13 @@ func setExtraSnapdKernelCommandLineFragment(st *state.State, fragmentID extraSna
 	}
 	if !seeded {
 		return fmt.Errorf("cannot set extra snapd kernel command line fragments until fully seeded")
+	}
+
+	// Ensure install-time fragments are seeded into state before comparing
+	// against the current value so runtime updates correctly override the
+	// install-time baseline.
+	if err := initExtraSnapdFragmentsFromInstallTime(st); err != nil {
+		return err
 	}
 
 	var currentFragments map[extraSnapdKernelCommandLineFragmentID]string
@@ -113,6 +211,13 @@ func setExtraSnapdKernelCommandLineFragment(st *state.State, fragmentID extraSna
 // kernelCommandLineAppendArgsFromSnapd returns extra arguments that snapd
 // might set internally using setExtraSnapdKernelCommandLineFragment.
 func kernelCommandLineAppendArgsFromSnapd(st *state.State) (string, error) {
+	// Lazily seed install-time fragments into state if not yet set so that
+	// the returned string includes any install-time choices that have not
+	// been overridden at runtime.
+	if err := initExtraSnapdFragmentsFromInstallTime(st); err != nil {
+		return "", err
+	}
+
 	var fragments map[extraSnapdKernelCommandLineFragmentID]string
 	if err := st.Get(kcmdlineExtraSnapdFragmentsKey, &fragments); err != nil && !errors.Is(err, state.ErrNoState) {
 		return "", err
@@ -121,16 +226,11 @@ func kernelCommandLineAppendArgsFromSnapd(st *state.State) (string, error) {
 		return "", nil
 	}
 
-	// XXX: Prune fragments that are no longer used?
-	sorted := make([]string, 0, len(fragments))
-	for _, fragment := range fragments {
-		sorted = append(sorted, fragment)
+	rendered := make(map[string]string, len(fragments))
+	for id, fragment := range fragments {
+		rendered[string(id)] = fragment
 	}
-	// Sorting is needed so that the same set of args would
-	// always have the same order so we don't accidentally
-	// trigger a kcmdline update when the args are unchanged.
-	sort.Strings(sorted)
-	return strings.Join(sorted, " "), nil
+	return renderExtraSnapdKernelCommandLineFragments(rendered), nil
 }
 
 // kernelCommandLineAppendArgsFromConfig returns extra arguments that we

--- a/overlord/devicestate/kcmdline.go
+++ b/overlord/devicestate/kcmdline.go
@@ -51,7 +51,7 @@ var expectedInstallTimeFragmentIDs = []extraSnapdKernelCommandLineFragmentID{
 	extraSnapdKernelCommandLineFragmentXKB,
 }
 
-func (id extraSnapdKernelCommandLineFragmentID) validate(val string) error {
+func (id extraSnapdKernelCommandLineFragmentID) validate() error {
 	switch id {
 	case extraSnapdKernelCommandLineFragmentXKB:
 		// TODO:FDEM: add kind-specific validation?
@@ -162,7 +162,7 @@ func writeInstallTimeExtraSnapdFragments(deviceSaveDir string, fragments map[str
 // Note that this only updates the specified fragment in snapd state and
 // does not directly update the command line and key polices.
 func setExtraSnapdKernelCommandLineFragment(st *state.State, fragmentID extraSnapdKernelCommandLineFragmentID, fragment string) error {
-	if err := fragmentID.validate(fragment); err != nil {
+	if err := fragmentID.validate(); err != nil {
 		return err
 	}
 

--- a/overlord/devicestate/kcmdline.go
+++ b/overlord/devicestate/kcmdline.go
@@ -85,7 +85,6 @@ func renderExtraSnapdKernelCommandLineFragments(fragments map[string]string) str
 		return ""
 	}
 
-	// XXX: Prune fragments that are no longer used?
 	sorted := make([]string, 0, len(fragments))
 	for _, fragment := range fragments {
 		sorted = append(sorted, fragment)

--- a/overlord/devicestate/kcmdline_test.go
+++ b/overlord/devicestate/kcmdline_test.go
@@ -20,12 +20,17 @@
 package devicestate_test
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func checkExtraSnapdFragments(c *C, st *state.State, expected map[string]string) {
@@ -100,4 +105,108 @@ func (s *deviceMgrBootconfigSuite) TestSetExtraSnapdKernelCommandLineFragmentErr
 	fragmentID = devicestate.ExtraSnapdKernelCmdlineFragmentID("xkb")
 	err = devicestate.SetExtraSnapdKernelCommandLineFragment(s.state, fragmentID, "some-val")
 	c.Assert(err, ErrorMatches, "cannot set extra snapd kernel command line fragments until fully seeded")
+}
+
+func (s *deviceMgrBootconfigSuite) TestRenderExtraSnapdKernelCommandLineFragments(c *C) {
+	// Empty/nil returns empty string.
+	c.Check(devicestate.RenderExtraSnapdKernelCommandLineFragments(nil), Equals, "")
+	c.Check(devicestate.RenderExtraSnapdKernelCommandLineFragments(map[string]string{}), Equals, "")
+
+	// Single fragment.
+	c.Check(devicestate.RenderExtraSnapdKernelCommandLineFragments(map[string]string{
+		"xkb": `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
+	}), Equals, `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`)
+
+	// Multiple fragments are sorted by value to get a stable order.
+	c.Check(devicestate.RenderExtraSnapdKernelCommandLineFragments(map[string]string{
+		"b": "zzz",
+		"a": "aaa",
+		"c": "mmm",
+	}), Equals, "aaa mmm zzz")
+}
+
+func (s *deviceMgrBootconfigSuite) writeInstallTimeFragmentsFile(c *C, fragments map[string]string) {
+	c.Assert(os.MkdirAll(dirs.SnapDeviceSaveDir, 0755), IsNil)
+	data, err := json.Marshal(fragments)
+	c.Assert(err, IsNil)
+	path := filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json")
+	c.Assert(os.WriteFile(path, data, 0644), IsNil)
+}
+
+func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdNoFileNoState(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, "")
+	// State is not touched when there is no file.
+	checkExtraSnapdFragments(c, s.state, nil)
+}
+
+func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdLazyInitFromFile(c *C) {
+	// File holds an expected key (xkb) and an unexpected one which must be
+	// ignored when initializing state.
+	s.writeInstallTimeFragmentsFile(c, map[string]string{
+		"xkb":     `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
+		"unknown": "should-be-ignored",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
+	c.Assert(err, IsNil)
+	c.Check(args, Equals, `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`)
+
+	// Only the expected key was copied into state.
+	checkExtraSnapdFragments(c, s.state, map[string]string{
+		"xkb": `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
+	})
+
+	// File is kept as a record of the install-time choices.
+	c.Check(filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json"), testutil.FilePresent)
+}
+
+func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdAlreadySetNotReinitialized(c *C) {
+	// File has a different value from the one already in state.
+	s.writeInstallTimeFragmentsFile(c, map[string]string{
+		"xkb": `snapd.xkb="from-file"`,
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// State is already set, e.g. by a previous runtime detection.
+	s.state.Set("kcmdline-extra-snapd-fragments", map[string]string{
+		"xkb": `snapd.xkb="from-state"`,
+	})
+
+	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
+	c.Assert(err, IsNil)
+	// State value takes precedence, file is not consulted.
+	c.Check(args, Equals, `snapd.xkb="from-state"`)
+	checkExtraSnapdFragments(c, s.state, map[string]string{
+		"xkb": `snapd.xkb="from-state"`,
+	})
+}
+
+func (s *deviceMgrBootconfigSuite) TestSetExtraSnapdKernelCommandLineFragmentOverridesInstallTimeFile(c *C) {
+	s.writeInstallTimeFragmentsFile(c, map[string]string{
+		"xkb": `snapd.xkb="from-file"`,
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", true)
+
+	fragmentID := devicestate.ExtraSnapdKernelCmdlineFragmentID("xkb")
+	err := devicestate.SetExtraSnapdKernelCommandLineFragment(s.state, fragmentID, `snapd.xkb="runtime"`)
+	c.Assert(err, IsNil)
+	// Runtime value overrides the install-time file value.
+	checkExtraSnapdFragments(c, s.state, map[string]string{
+		"xkb": `snapd.xkb="runtime"`,
+	})
+	checkPendingExtraSnapdFragments(c, s.state, true)
 }

--- a/overlord/devicestate/kcmdline_test.go
+++ b/overlord/devicestate/kcmdline_test.go
@@ -20,17 +20,12 @@
 package devicestate_test
 
 import (
-	"encoding/json"
 	"errors"
-	"os"
-	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/testutil"
 )
 
 func checkExtraSnapdFragments(c *C, st *state.State, expected map[string]string) {
@@ -123,90 +118,4 @@ func (s *deviceMgrBootconfigSuite) TestRenderExtraSnapdKernelCommandLineFragment
 		"a": "aaa",
 		"c": "mmm",
 	}), Equals, "aaa mmm zzz")
-}
-
-func (s *deviceMgrBootconfigSuite) writeInstallTimeFragmentsFile(c *C, fragments map[string]string) {
-	c.Assert(os.MkdirAll(dirs.SnapDeviceSaveDir, 0755), IsNil)
-	data, err := json.Marshal(fragments)
-	c.Assert(err, IsNil)
-	path := filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json")
-	c.Assert(os.WriteFile(path, data, 0644), IsNil)
-}
-
-func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdNoFileNoState(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
-	c.Assert(err, IsNil)
-	c.Check(args, Equals, "")
-	// State is not touched when there is no file.
-	checkExtraSnapdFragments(c, s.state, nil)
-}
-
-func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdLazyInitFromFile(c *C) {
-	// File holds an expected key (xkb) and an unexpected one which must be
-	// ignored when initializing state.
-	s.writeInstallTimeFragmentsFile(c, map[string]string{
-		"xkb":     `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
-		"unknown": "should-be-ignored",
-	})
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
-	c.Assert(err, IsNil)
-	c.Check(args, Equals, `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`)
-
-	// Only the expected key was copied into state.
-	checkExtraSnapdFragments(c, s.state, map[string]string{
-		"xkb": `snapd.xkb="eg,pc105,,grp:alt_shift_toggle"`,
-	})
-
-	// File is kept as a record of the install-time choices.
-	c.Check(filepath.Join(dirs.SnapDeviceSaveDir, "kcmdline-extra-snapd-fragments.json"), testutil.FilePresent)
-}
-
-func (s *deviceMgrBootconfigSuite) TestKernelCommandLineAppendArgsFromSnapdAlreadySetNotReinitialized(c *C) {
-	// File has a different value from the one already in state.
-	s.writeInstallTimeFragmentsFile(c, map[string]string{
-		"xkb": `snapd.xkb="from-file"`,
-	})
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// State is already set, e.g. by a previous runtime detection.
-	s.state.Set("kcmdline-extra-snapd-fragments", map[string]string{
-		"xkb": `snapd.xkb="from-state"`,
-	})
-
-	args, err := devicestate.KernelCommandLineAppendArgsFromSnapd(s.state)
-	c.Assert(err, IsNil)
-	// State value takes precedence, file is not consulted.
-	c.Check(args, Equals, `snapd.xkb="from-state"`)
-	checkExtraSnapdFragments(c, s.state, map[string]string{
-		"xkb": `snapd.xkb="from-state"`,
-	})
-}
-
-func (s *deviceMgrBootconfigSuite) TestSetExtraSnapdKernelCommandLineFragmentOverridesInstallTimeFile(c *C) {
-	s.writeInstallTimeFragmentsFile(c, map[string]string{
-		"xkb": `snapd.xkb="from-file"`,
-	})
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.state.Set("seeded", true)
-
-	fragmentID := devicestate.ExtraSnapdKernelCmdlineFragmentID("xkb")
-	err := devicestate.SetExtraSnapdKernelCommandLineFragment(s.state, fragmentID, `snapd.xkb="runtime"`)
-	c.Assert(err, IsNil)
-	// Runtime value overrides the install-time file value.
-	checkExtraSnapdFragments(c, s.state, map[string]string{
-		"xkb": `snapd.xkb="runtime"`,
-	})
-	checkPendingExtraSnapdFragments(c, s.state, true)
 }


### PR DESCRIPTION
On TPM-FDE Ubuntu systems where a passphrase/PIN is configured during installation, the user must enter credentials at the plymouth prompt on first-boot - before snapd has had a chance to detect the runtime keyboard layout. This commit extends the "/v2/systems/{system-label}" install API so that the installer can pass the selected keyboard layout through to first boot (written as kernel command line arguments), ensuring plymouth detects the correct XKB configuration even on first-boot.

The mechanism for passing extra snapd kcmdline args from install-time is generic but only currently used to pass xkb configs. The install-time extra kcmdline args are persisted to a file under ubuntu-save to be used for initialization by snapd on first-boot.

Relevant spec: [SD272](https://docs.google.com/document/d/1R8LoZ8lp9LQzdvVC9s68aE_llmbIL9Xz6uLkN6Ck9JU/edit?tab=t.0)
JIRA: [SNAPDENG-37018](https://warthogs.atlassian.net/browse/SNAPDENG-37018)

---

**Note that a separate follow up PR will enable passphrase/PIN auth on the "/v2/systems/{system-label}" install API and add the corresponding spread test.**


[SNAPDENG-37018]: https://warthogs.atlassian.net/browse/SNAPDENG-37018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ