### PR TITLE
many: merge snap and snapd binaries

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,10 +89,12 @@ signed with the well-known, insecure test key.
 
 Building several elements of snapd individually:
 ```bash
-go build -o /tmp/build/snap ./cmd/snap
 go build -o /tmp/build/snapd ./cmd/snapd
 go build -o /tmp/build ./...  # All binaries
 ```
+
+The snapd binary implements both the daemon and the client functionality. The
+client functionality is invoked when `argv[0]` equals to `snap`.
 
 You may want to build the snapd snap package with `snapcraft pack` instead, as that constructs a complete, cohesive set of programs.
 

--- a/.github/workflows/ci-macos-quick.yaml
+++ b/.github/workflows/ci-macos-quick.yaml
@@ -23,12 +23,12 @@ jobs:
         run: |
           go mod vendor
           ./mkversion.sh
-          go build -tags nosecboot -o /tmp/snp ./cmd/snap
+          go build -tags nosecboot -o /tmp/snap ./cmd/snapd
 
       - name: Runtime quick checks
         run: |
-          /tmp/snp download hello
-          /tmp/snp version
+          /tmp/snap download hello
+          /tmp/snap version
           if command -v mksquashfs; then
-            /tmp/snp pack tests/lib/snaps/test-snapd-tools/ /tmp
+            /tmp/snap pack tests/lib/snaps/test-snapd-tools/ /tmp
           fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,14 +26,14 @@ Because `/usr/bin/snap` is a symlink to the `snapd` binary and dispatch is based
 On a high level, execution of a snap application is carried out in the following manner:
 
 ```
-      /snap/bin/<app> or `snap run <snap.app>`
+ /snap/bin/<app>, /snap/bin/<snap.app> or `snap run <snap.app>`
                 |
           (re-exec into snapd snap if newer)
                 |
               exec(2)
                 |
                 v
-          snap run <snap.app>   [snap CLI, argv[0]="snap" or app-name]
+          snap run <snap.app>   [snap CLI, argv[0]="snap" or <snap.app>]
                 |
               exec(2)
                 |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ For security, snap applications and services are executed in a sandbox by defaul
 
 For robustness, snapd ensures that all operations either succeed or revert their changes to the previous state of the system, even in the face of restarts, reboots or failures. To achieve this robustness, much of both the internal state and operational state of snapd is persisted to disk (as [`overlord/state.State`](https://pkg.go.dev/github.com/snapcore/snapd/overlord/state#State)).
 
-All the binaries, and their entry points, are defined under the [`cmd`](https://github.com/canonical/snapd/tree/master/cmd) package. It contains [`cmd/snap`](https://github.com/canonical/snapd/tree/master/cmd/snap) for the `snap` command and daemon client, and both `snap-confine` and `snap-exec` to handle the execution pipeline for snaps, alongside the `snap run` subcommand.
+All the binaries, and their entry points, are defined under the [`cmd`](https://github.com/canonical/snapd/tree/master/cmd) package. The `snap` command and the `snapd` daemon share a single multi-call binary built from [`cmd/snapd`](https://github.com/canonical/snapd/tree/master/cmd/snapd). The real binary is installed as `snapd` (e.g. `/usr/lib/snapd/snapd`); `/usr/bin/snap` is a symlink pointing to it. At runtime, the binary dispatches on `argv[0]`: when invoked as `snapd` it runs the daemon; when invoked as `snap` (or any other name, as happens for snap application symlinks in `/snap/bin`) it runs the CLI. The execution sandbox helpers `snap-confine` and `snap-exec` handle the execution pipeline for snaps alongside the `snap run` subcommand.
 
 ## Entry points and the execution pipeline
 
@@ -19,16 +19,26 @@ Entry points for launching software in a snap are mainly either:
 
 In both cases, execution starts within the `snap run` command provided with the application (via the symlink) or the service (provided explicitly) reference information.
 
+Both the daemon and the `snap` CLI support *re-exec*: on startup they compare their own version against the `snapd` or `core` snap installed on the system. If the snap is newer, execution restarts from the binary inside that snap — ensuring users always run the most up-to-date snapd without requiring a system package update.
+
+Because `/usr/bin/snap` is a symlink to the `snapd` binary and dispatch is based on `argv[0]`, re-exec into the snap preserves the original `argv[0]` so the same dispatch (CLI vs daemon) applies in the new process.
+
 On a high level, execution of a snap application is carried out in the following manner:
 
 ```
-          snap run <snap.app>
+      /snap/bin/<app> or `snap run <snap.app>`
+                |
+          (re-exec into snapd snap if newer)
+                |
+              exec(2)
+                |
+                v
+          snap run <snap.app>   [snap CLI, argv[0]="snap" or app-name]
                 |
               exec(2)
                 |
                 v
           snap-confine (sandbox setup)
-                |
                 |
              unshare(2)   HOST
         ------------------

--- a/HACKING.md
+++ b/HACKING.md
@@ -187,22 +187,29 @@ to identify which snap file is which.
 
 ### Building natively
 
-To build the `snap` command line client:
-
-<!-- test:build-snap -->
-```
-cd ~/snapd
-mkdir -p /tmp/build
-go build -o /tmp/build/snap ./cmd/snap
-```
-
-To build the `snapd` REST API daemon:
+The `snap` command line client and `snapd` are the exact same binary, with
+different entrypoints that are selected by inspecting the value of `argv[0]`. To
+build it:
 
 <!-- test:build-snapd -->
 ```
 cd ~/snapd
 mkdir -p /tmp/build
 go build -o /tmp/build/snapd ./cmd/snapd
+```
+
+At this point you can invoke the `snap` functionality by creating a symbolic
+link named `snap`:
+
+<!-- test:build-snap -->
+```
+ln -s -r /tmp/build/snapd /tmp/build/snap
+```
+
+or setting `argv[0]` explicitly when running the binary:
+
+```
+/bin/bash -c 'exec -a snap /tmp/build/snapd'
 ```
 
 To build all the `snapd` Go components:

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -332,8 +332,7 @@ parts:
       #    the main directory, and it fails.
       EXTRA_GO_FLAGS="-buildvcs=false"
 
-      CMDS=(bin/snap
-            lib/snapd/snapd
+      CMDS=(lib/snapd/snapd
             # core-initrd for UC20 still depends on snap-bootstrap
             # being started from snap because of broken re-execution
             # and fixes that were not yet backported
@@ -397,21 +396,14 @@ parts:
         # triggers testing specific build tags which produce binaries that are
         # insecure for use in production systems
         case "${cmd}" in
-          bin/snap|lib/snapd/snap-bootstrap)
+          lib/snapd/snap-bootstrap)
             TAGS+=(nomanagers)
             ;;
         esac
 
         case "${VERSION}" in
           1337.*)
-            case "${cmd}" in
-              bin/snap)
-                TAGS+=(withtestkeys faultinject statelocktrace structuredlogging)
-                ;;
-              *)
-                TAGS+=(withtestkeys withbootassetstesting faultinject statelocktrace structuredlogging)
-                ;;
-            esac
+            TAGS+=(withtestkeys withbootassetstesting faultinject statelocktrace structuredlogging)
             ;;
         esac
 
@@ -433,7 +425,7 @@ parts:
             # snap, snap-repair and snap-bootstrap, tags:
             # - goexperiment.opensslcrypto - enable openssl crypto backend
             # - snapdfips - enable additional FIPS support (enforce FIPS compliant TLS)
-            bin/snap|lib/snapd/snapd|lib/snapd/snap-repair|lib/snapd/snap-bootstrap)
+            lib/snapd/snapd|lib/snapd/snap-repair|lib/snapd/snap-bootstrap)
               TAGS+=(goexperiment.opensslcrypto snapdfips)
               ;;
           esac
@@ -464,21 +456,29 @@ parts:
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" data/completion/bash/complete.sh data/completion/bash/etelpmoc.sh
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/share/bash-completion/completions" ./data/completion/bash/snap
 
+      # link usr/bin/snap -> usr/lib/snapd/snapd
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/bin"
+      ln -v -s -r "${CRAFT_PART_INSTALL}/usr/lib/snapd/snapd" "${CRAFT_PART_INSTALL}/usr/bin/snap"
+
       if [ -f fips-build ]; then
         # Set up FIPS dispatch: replace each original binary with a symlink
         # to snap-fips-dispatch, and rename the original to a -fips suffix.
         #
-        # Symlink (original path)               Dispatch target (renamed binary)
-        # <root>/usr/bin/snap                -> <root>/usr/bin/snap-fips
-        # <root>/usr/lib/snapd/snapd         -> <root>/usr/lib/snapd/snapd-fips
-        # <root>/usr/lib/snapd/snap-repair   -> <root>/usr/lib/snapd/snap-repair-fips
-        # <root>/usr/lib/snapd/snap-bootstrap -> <root>/usr/lib/snapd/snap-bootstrap-fips
+        # Real binary (renamed)                       Dispatch symlink (original path)
+        # <root>/usr/lib/snapd/snapd-fips          <- <root>/usr/lib/snapd/snapd
+        # <root>/usr/lib/snapd/snap-repair-fips    <- <root>/usr/lib/snapd/snap-repair
+        # <root>/usr/lib/snapd/snap-bootstrap-fips <- <root>/usr/lib/snapd/snap-bootstrap
+        #
+        # usr/bin/snap is a symlink to usr/lib/snapd/snapd (now the dispatch symlink),
+        # so the dispatcher sees argv[0]="snap" and resolves to usr/bin/snap-fips.
+        # Create that symlink pointing at the renamed FIPS binary.
+
         for cmd in lib/snapd/snapd lib/snapd/snap-repair lib/snapd/snap-bootstrap; do
           mv -v "${CRAFT_PART_INSTALL}/usr/${cmd}" "${CRAFT_PART_INSTALL}/usr/lib/snapd/$(basename $cmd)-fips"
           ln -v -s -r "${CRAFT_PART_INSTALL}/usr/lib/snapd/snap-fips-dispatch" "${CRAFT_PART_INSTALL}/usr/${cmd}"
         done
-        mv -v "${CRAFT_PART_INSTALL}/usr/bin/snap" "${CRAFT_PART_INSTALL}/usr/bin/snap-fips"
-        ln -v -s -r "${CRAFT_PART_INSTALL}/usr/lib/snapd/snap-fips-dispatch" "${CRAFT_PART_INSTALL}/usr/bin/snap"
+        # usr/bin/snap-fips is the dispatch target when argv[0]="snap"; point it at snapd-fips.
+        ln -v -s -r "${CRAFT_PART_INSTALL}/usr/lib/snapd/snapd-fips" "${CRAFT_PART_INSTALL}/usr/bin/snap-fips"
       fi
 
       # TODO: For now snapd expects a renamed apparmor profile to

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -34,7 +34,8 @@ subdirs = \
 		  snap-update-ns \
 		  snapd-env-generator \
 		  snapd-generator \
-		  system-shutdown
+		  system-shutdown \
+		  snap-cli-wrap
 
 # Run check-syntax when checking
 # TODO: conver those to autotools-style tests later
@@ -447,6 +448,21 @@ CLEANFILES += snap-mgmt/$(am__dirstamp) snap-mgmt/snap-mgmt-selinux
 
 snap-mgmt/snap-mgmt-selinux: snap-mgmt/snap-mgmt-selinux.sh.in Makefile snap-mgmt/$(am__dirstamp)
 	sed -e 's,[@]STATIC_SNAP_MOUNT_DIR[@],$(STATIC_SNAP_MOUNT_DIR),' <$< >$@
+
+##
+## snap-cli-wrap (SELinux only)
+##
+## A minimal wrapper binary installed as /usr/bin/snap on SELinux systems.
+## It carries the snappy_cli_exec_t label, ensuring the correct domain
+## transition to snappy_cli_t fires on exec, and simply execs the real
+## snapd binary with argv[0]="snap".
+##
+
+noinst_PROGRAMS += snap-cli-wrap/snap-cli-wrap
+snap_cli_wrap_snap_cli_wrap_SOURCES = snap-cli-wrap/snap-cli-wrap.c
+snap_cli_wrap_snap_cli_wrap_CFLAGS = $(AM_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"
+snap_cli_wrap_snap_cli_wrap_LDFLAGS = $(STATIC_LDFLAGS)
+
 endif
 
 ##

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -449,12 +449,14 @@ CLEANFILES += snap-mgmt/$(am__dirstamp) snap-mgmt/snap-mgmt-selinux
 snap-mgmt/snap-mgmt-selinux: snap-mgmt/snap-mgmt-selinux.sh.in Makefile snap-mgmt/$(am__dirstamp)
 	sed -e 's,[@]STATIC_SNAP_MOUNT_DIR[@],$(STATIC_SNAP_MOUNT_DIR),' <$< >$@
 
+endif
+
 ##
-## snap-cli-wrap (SELinux only)
+## snap-cli-wrap
 ##
-## A minimal wrapper binary installed as /usr/bin/snap on SELinux systems.
-## It carries the snappy_cli_exec_t label, ensuring the correct domain
-## transition to snappy_cli_t fires on exec, and simply execs the real
+## A minimal wrapper binary installed as /usr/bin/snap on SELinux systems, but
+## not necessarily. It carries the snappy_cli_exec_t label, ensuring the correct
+## domain transition to snappy_cli_t fires on exec, and simply execs the real
 ## snapd binary with argv[0]="snap".
 ##
 
@@ -462,8 +464,6 @@ noinst_PROGRAMS += snap-cli-wrap/snap-cli-wrap
 snap_cli_wrap_snap_cli_wrap_SOURCES = snap-cli-wrap/snap-cli-wrap.c
 snap_cli_wrap_snap_cli_wrap_CFLAGS = $(AM_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"
 snap_cli_wrap_snap_cli_wrap_LDFLAGS = $(STATIC_LDFLAGS)
-
-endif
 
 ##
 ## snap-device-helper

--- a/cmd/snap-cli-wrap/snap-cli-wrap.c
+++ b/cmd/snap-cli-wrap/snap-cli-wrap.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * snap-cli-wrap is an explicit entrypoint to the snap CLI invoked either
+ * directly through /usr/bin/snap or through a special symlink under
+ * $SNAP_BIN_DIR.
+ *
+ * Its only purpose is to act as a policy attachment point acted on during
+ * exec(), should a given host system ship an extended security policy covering
+ * the functionality of the snap command (e.g. the SELinux policy distributed
+ * with the snapd package).
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#define SNAPD_PATH LIBEXECDIR "/snapd"
+
+int main(int argc, char **argv) {
+    /* preserve unchanged argv[0], which could be 'snap' if acting as the CLI
+     * tool, or a magic symlink at /snap/bin/<app-name>  */
+    execv(SNAPD_PATH, argv);
+    /* execv only returns on error */
+    perror("execv " SNAPD_PATH);
+    return 1;
+}

--- a/cmd/snapd/cli/cmd_run.go
+++ b/cmd/snapd/cli/cmd_run.go
@@ -767,21 +767,17 @@ func snapdHelperPath(toolName string) (string, error) {
 	if !strings.HasPrefix(exe, dirs.SnapMountDir) {
 		return filepath.Join(dirs.DistroLibExecDir, toolName), nil
 	}
-	// The logic below only works if the last two path components
-	// are /usr/bin
-	// FIXME: use a snap warning?
-	if !strings.HasSuffix(exe, "/usr/bin/"+filepath.Base(exe)) {
+
+	// usr/bin/snap and usr/lib/snapd/snapd are the same binary, so our exe
+	// (snapd) is already at the desired path
+
+	if !strings.HasSuffix(exe, filepath.Join(dirs.CoreLibExecDir, filepath.Base(exe))) {
 		logger.Noticef("(internal error): unexpected exe input in snapdHelperPath: %v", exe)
 		return filepath.Join(dirs.DistroLibExecDir, toolName), nil
 	}
-	// snapBase will be "/snap/{core,snapd}/$rev/" because
-	// the snap binary is always at $root/usr/bin/snap
-	snapBase := filepath.Clean(filepath.Join(filepath.Dir(exe), "..", ".."))
-	// Run snap-confine from the core/snapd snap.  The tools in
-	// core/snapd snap are statically linked, or mostly
-	// statically, with the exception of libraries such as libudev
-	// and libc.
-	return filepath.Join(snapBase, dirs.CoreLibExecDir, toolName), nil
+
+	// internal tools are at the same directory as this binary
+	return filepath.Join(filepath.Dir(exe), toolName), nil
 }
 
 /* Kerberos tickets live in /tmp, or in the place specified by KRB5CCNAME

--- a/cmd/snapd/cli/cmd_run_test.go
+++ b/cmd/snapd/cli/cmd_run_test.go
@@ -1194,7 +1194,7 @@ func (s *RunSuite) TestSnapRunClassicAppIntegrationReexecedFromCore(c *check.C) 
 
 	restore := snaprun.MockOsReadlink(func(name string) (string, error) {
 		// pretend 'snap' is reexeced from 'core'
-		return filepath.Join(mountedCorePath, "usr/bin/snap"), nil
+		return filepath.Join(mountedCorePath, "usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -1227,7 +1227,7 @@ func (s *RunSuite) TestSnapRunClassicAppIntegrationReexecedFromSnapd(c *check.C)
 
 	restore := snaprun.MockOsReadlink(func(name string) (string, error) {
 		// pretend 'snap' is reexeced from 'core'
-		return filepath.Join(mountedSnapdPath, "usr/bin/snap"), nil
+		return filepath.Join(mountedSnapdPath, "usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -1674,11 +1674,11 @@ func (s *RunSuite) TestSnapRunSnapdHelperPath(c *check.C) {
 		expected string
 	}{
 		{
-			filepath.Join(dirs.SnapMountDir, "core/current/usr/bin/snap"),
+			filepath.Join(dirs.SnapMountDir, "core/current/usr/lib/snapd/snapd"),
 			filepath.Join(dirs.SnapMountDir, "core/current", dirs.CoreLibExecDir, tool),
 		},
 		{
-			filepath.Join(dirs.SnapMountDir, "snapd/current/usr/bin/snap"),
+			filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd/snapd"),
 			filepath.Join(dirs.SnapMountDir, "snapd/current", dirs.CoreLibExecDir, tool),
 		},
 		{
@@ -1689,9 +1689,9 @@ func (s *RunSuite) TestSnapRunSnapdHelperPath(c *check.C) {
 			filepath.Join("/home/foo/ws/snapd/snap"),
 			filepath.Join(dirs.DistroLibExecDir, tool),
 		},
-		// unexpected case
+		// unexpected case: under snap mount dir but not at expected path
 		{
-			filepath.Join(dirs.SnapMountDir, "snapd2/current/bin/snap"),
+			filepath.Join(dirs.SnapMountDir, "snapd2/current/bin/snapd"),
 			filepath.Join(dirs.DistroLibExecDir, tool),
 		},
 	} {
@@ -1712,7 +1712,7 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 
 	// pretend to be running from core
 	restorer := snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restorer()
 
@@ -1751,7 +1751,7 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
 
 	// pretend to be running from snapd
 	restorer := snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "snapd/222/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "snapd/222/usr/lib/snapd/snapd"), nil
 	})
 	defer restorer()
 
@@ -2654,7 +2654,7 @@ func (s *RunSuite) TestSnapRunTrackingApps(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -2728,7 +2728,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureBaseMatrix(c *check.C) {
 
 		// pretend to be running from core
 		restoreReadlink := snaprun.MockOsReadlink(func(string) (string, error) {
-			return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+			return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 		})
 
 		restoreCreate := snaprun.MockCreateTransientScopeForTracking(func(securityTag string, opts *cgroup.TrackingOptions) error {
@@ -2783,7 +2783,7 @@ func (s *RunSuite) TestSnapRunTrackingHooks(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -2839,7 +2839,7 @@ func (s *RunSuite) TestSnapRunTrackingServices(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -2893,7 +2893,7 @@ func (s *RunSuite) TestSnapRunTrackingServicesWhenRunByUser(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -2955,7 +2955,7 @@ func (s *RunSuite) TestSnapRunTrackingFailure(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -3021,7 +3021,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26(c *check.C) {
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -3066,7 +3066,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26SelfManagedAllowed(c *check.C
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 
@@ -3124,7 +3124,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26NonStrictOnlyFails(c *check.C
 
 	// pretend to be running from core
 	restore = snaprun.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/lib/snapd/snapd"), nil
 	})
 	defer restore()
 

--- a/cmd/snapd/cli/main.go
+++ b/cmd/snapd/cli/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2023 Canonical Ltd
+ * Copyright (C) 2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -50,10 +50,7 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
-func init() {
-	// set User-Agent for when 'snap' talks to the store directly (snap download etc...)
-	snapdenv.SetUserAgentFromVersion(snapdtool.Version, nil, "snap")
-
+func lateInit() {
 	// plug/slot sanitization not used by snap commands (except for snap
 	// pack and snap prepare-iamge, which re-sets it), make it no-op.
 	snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
@@ -478,6 +475,9 @@ func Main() {
 
 	snapdtool.MaybeCompleteFIPSSetup()
 
+	// late initialization, cross package settings etc.
+	lateInit()
+
 	// check for magic symlink to /usr/bin/snap:
 	// 1. symlink from command-not-found to /usr/bin/snap: run c-n-f
 	if os.Args[0] == filepath.Join(dirs.GlobalRootDir, "/usr/lib/command-not-found") {
@@ -618,8 +618,12 @@ func makeCommandHandler(allCommands []*flags.Command) func(flags.Commander, []st
 var timeAfter func(d time.Duration) <-chan time.Time = time.After
 
 func run() error {
+	// set User-Agent for when 'snap' talks to the store directly (snap download etc...)
+	snapdenv.SetUserAgentFromVersion(snapdtool.Version, nil, "snap")
+
 	apiClient := mkClient()
 	parser := Parser(apiClient)
+
 	if osutil.GetenvBool("SNAPD_TRACE") {
 		parser.CommandHandler = makeCommandHandler(parser.Command.Commands())
 	}

--- a/cmd/snapd/daemon/main.go
+++ b/cmd/snapd/daemon/main.go
@@ -29,11 +29,13 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/syscheck"
@@ -51,13 +53,11 @@ const (
 	secLogMinLevel seclog.Level = seclog.LevelInfo
 )
 
-func init() {
-	logger.SimpleSetup(nil)
-}
-
 // Main is the entyrpoint to the snapd daemon. It is equivalent to a main()
 // function and should be used as such.
 func Main() {
+	logger.SimpleSetup(nil)
+
 	// When preseeding re-exec is not used
 	if snapdenv.Preseeding() {
 		logger.Noticef("running for preseeding")
@@ -71,7 +71,6 @@ func Main() {
 	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"argon2-proc"})
 
 	snapdtool.MaybeCompleteFIPSSetup()
-
 	// TODO look into signal.NotifyContext
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -151,6 +150,9 @@ var checkRunningConditionsRetryDelay = 300 * time.Second
 
 func run(ch chan os.Signal) error {
 	ctx := context.Background()
+
+	// ensure plug and slot checks are enforced
+	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
 
 	t0 := time.Now().Truncate(time.Millisecond)
 	snapdenv.SetUserAgentFromVersion(snapdtool.Version, sandbox.ForceDevMode)

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -1,7 +1,9 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
+//go:build linux
+
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,9 +22,24 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/cmd/snapd/cli"
 	"github.com/snapcore/snapd/cmd/snapd/daemon"
 )
 
 func main() {
-	daemon.Main()
+	argv0 := filepath.Base(os.Args[0])
+
+	// dispatch the binary multi entry point
+	// TODO add snap-preseed
+	switch argv0 {
+	case "snapd":
+		daemon.Main()
+	default:
+		// "snap" needs to be handled last, as it's a special entrypoint for
+		// snap application execution through symlinks at /snap/bin/<name>
+		cli.Main()
+	}
 }

--- a/cmd/snapd/main_other.go
+++ b/cmd/snapd/main_other.go
@@ -1,5 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
+//go:build !linux
+
 /*
  * Copyright (C) 2026 Canonical Ltd
  *
@@ -20,9 +22,23 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/snapcore/snapd/cmd/snapd/cli"
 )
 
 func main() {
-	cli.Main()
+	argv0 := filepath.Base(os.Args[0])
+
+	switch argv0 {
+	case "snap":
+		// we only expose the 'snap' command on non Linux so that folks can
+		// pack snaps
+		cli.Main()
+	default:
+		fmt.Fprintf(os.Stderr, "error: %q mode is not supported on this system\n", argv0)
+		os.Exit(1)
+	}
 }

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -319,10 +319,10 @@ func isRequestFromSnapCmd(r *http.Request) (bool, error) {
 	// There aren't too many options, but overall possibilities are:
 	// - we are re-executed and the client isn't
 	// - the client re-executed but we did not
-	// - TODO the client could be a merged snapd-snap binary
 
 	switch filepath.Base(exe) {
 	case "snap", "snap-fips": // the standalone snap binary, or its FIPS build variant
+	case "snapd", "snapd-fips": // the merged snap binary
 	default:
 		return false, nil
 	}
@@ -333,7 +333,8 @@ func isRequestFromSnapCmd(r *http.Request) (bool, error) {
 		return true, nil
 	}
 
-	if strings.HasPrefix(exe, filepath.Join(dirs.GlobalRootDir, "usr/bin")+"/") {
+	if strings.HasPrefix(exe, filepath.Join(dirs.GlobalRootDir, "usr/bin")+"/") ||
+		strings.HasPrefix(exe, dirs.DistroLibExecDir+"/") {
 		// client with expected name from one of the system locations
 		return true, nil
 	}

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -45,6 +46,9 @@ type noticesSuite struct {
 
 func (s *noticesSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
+
+	dirstest.MustMockDefaultLibExecDir(dirs.GlobalRootDir)
+	dirs.SetRootDir(dirs.GlobalRootDir)
 
 	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "snap-interfaces-requests-control"}})
 	s.expectWriteAccess(daemon.OpenAccess{})
@@ -987,6 +991,25 @@ func (s *noticesSuite) TestAddNoticesSnapCmdUnknownBinary(c *C) {
 	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "bad-c0re/12/usr/bin/snap"), true)
 }
 
+func (s *noticesSuite) TestAddNoticesSnapCmdReexecMergedSnapd(c *C) {
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "snapd/11/usr/lib/snapd/snapd"), false)
+}
+
+func (s *noticesSuite) TestAddNoticesSnapCmdReexecMergedSnapdFIPS(c *C) {
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.SnapMountDir, "snapd/11/usr/lib/snapd/snapd-fips"), false)
+}
+
+func (s *noticesSuite) TestAddNoticesSnapCmdMergedSnapd(c *C) {
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.GlobalRootDir, "/usr/lib/snapd/snapd"), false)
+}
+
+func (s *noticesSuite) TestAddNoticesSnapCmdMergedSnapdAltLibexecdir(c *C) {
+	r := c.MkDir()
+	dirstest.MustMockAltLibExecDir(r)
+	dirs.SetRootDir(r)
+	s.testAddNoticesSnapCmd(c, filepath.Join(dirs.GlobalRootDir, "/usr/libexec/snapd/snapd"), false)
+}
+
 func (s *noticesSuite) testAddNoticesSnapCmd(c *C, exePath string, shouldFail bool) {
 	s.daemon(c)
 
@@ -1243,6 +1266,10 @@ func (s *noticesSuite) TestIsFromSnapCmd(c *C) {
 		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap"), true},
 		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap-fips"), true},
 		{filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap"), true},
+		// merged snapd & snap
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/snapd/snapd-fips"), true},
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/lib/snapd/snapd"), true},
+		{filepath.Join(dirs.GlobalRootDir, "/usr/lib/snapd/snapd"), true},
 
 		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/snap"), false},
 		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/not-a-snap"), false},

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -74,6 +74,9 @@ type snappy_cli_t;
 type snappy_cli_exec_t;
 domain_type(snappy_cli_t)
 domain_entry_file(snappy_cli_t, snappy_cli_exec_t)
+# allow snappy_cli_t to exec() into the snapd binary which implements
+# snap CLI handler
+can_exec(snappy_cli_t, snappy_exec_t)
 
 # helper tools: snap-{update,discard}-ns
 type snappy_mount_t;

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -74,9 +74,6 @@ type snappy_cli_t;
 type snappy_cli_exec_t;
 domain_type(snappy_cli_t)
 domain_entry_file(snappy_cli_t, snappy_cli_exec_t)
-# allow snappy_cli_t to exec() into the snapd binary which implements
-# snap CLI handler
-can_exec(snappy_cli_t, snappy_exec_t)
 
 # helper tools: snap-{update,discard}-ns
 type snappy_mount_t;
@@ -877,8 +874,8 @@ userdom_search_user_tmp_dirs(snappy_cli_t)
 # create /run/user/<uid>/snap.<name> directories
 userdom_manage_tmp_dirs(snappy_cli_t)
 
-# execute snapd internal tools
-# needed to grab a version information from snap-seccomp
+# allow snappy_cli_t to exec() into the snapd binary which implements
+# snap CLI handler and other internal snapd tools
 can_exec(snappy_cli_t, snappy_exec_t)
 
 # probing cgroup version, /sys/fs/cgroup is a tmpfs for v1 or cgroup for v2

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -895,6 +895,10 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
   # to the actual snap-confine profile
   /usr/bin/snap ixr,
   /snap/{snapd,core}/*/usr/bin/snap ixr,
+  # allow executing snapd binary through a symlink. snapd implements the actual
+  # usr/bin/snap functionality
+  /usr/lib{,exec}/snapd/snapd ixr,
+  /snap/{snapd,core}/*/usr/lib/snapd/snapd ixr,
 
   # allow transitioning to snap-confine to support executing strict snaps from
   # inside devmode confined snaps

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -15,12 +15,11 @@ export DH_GOPKG := github.com/snapcore/snapd
 #export DEB_BUILD_OPTIONS=nocheck
 export DH_GOLANG_EXCLUDES=tests
 export DH_GOLANG_BUILDPKG = $(strip $(addprefix $(DH_GOPKG)/, \
-    cmd/snap \
+    cmd/snapd \
     cmd/snap-exec \
     cmd/snap-seccomp \
     cmd/snap-update-ns \
     cmd/snapctl \
-    cmd/snapd \
     cmd/snapd-apparmor \
     ))
 # skip Go generate, all source code should have been committed
@@ -173,7 +172,7 @@ override_dh_auto_build: snapd.defines.mk
 	# remove snap built by dh_auto_build and build it again using the right tags
 	rm -v $(CURDIR)/_build/bin/snap
 	GO111MODULE=off GOPATH=$(CURDIR)/_build \
-		$(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snap SNAPD_DEFINES_DIR=$(CURDIR)
+		$(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snapd SNAPD_DEFINES_DIR=$(CURDIR)
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
@@ -297,7 +296,7 @@ snap.8:
 	# fix reproducible builds as reported by:
 	#   https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/snapd.html
 	# once golang-go-flags is fixed we can remove the "sed" expression
-	$(CURDIR)/_build/bin/snap help --man | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
+	bash -c 'exec -a snap $(CURDIR)/_build/bin/snapd help --man' | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -169,7 +169,8 @@ override_dh_auto_build: snapd.defines.mk
 	# dependencies from the distro, and this would require further updates to the
 	# go.mod file
 	GO111MODULE=off dh_auto_build -- $(BUILDFLAGS) -tags "$(TAGS)" $(GCCGOFLAGS)
-	# remove snap built by dh_auto_build and build it again using the right tags
+	# remove snapd built by dh_auto_build and build it again using the right tags
+	rm -v $(CURDIR)/_build/bin/snapd
 	GO111MODULE=off GOPATH=$(CURDIR)/_build \
 		$(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snapd SNAPD_DEFINES_DIR=$(CURDIR)
 

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -170,7 +170,6 @@ override_dh_auto_build: snapd.defines.mk
 	# go.mod file
 	GO111MODULE=off dh_auto_build -- $(BUILDFLAGS) -tags "$(TAGS)" $(GCCGOFLAGS)
 	# remove snap built by dh_auto_build and build it again using the right tags
-	rm -v $(CURDIR)/_build/bin/snap
 	GO111MODULE=off GOPATH=$(CURDIR)/_build \
 		$(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snapd SNAPD_DEFINES_DIR=$(CURDIR)
 

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -10,12 +10,11 @@ data/completion/zsh/_snap /usr/share/zsh/vendor-completions
 data/info /usr/lib/snapd/
 # snap-confine stuff
 etc/apparmor.d/usr.lib.snapd.snap-confine.real
-usr/bin/snap
+usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
-usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapd-apparmor /usr/lib/snapd/
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-confine.caps

--- a/packaging/debian-sid/snapd.links
+++ b/packaging/debian-sid/snapd.links
@@ -3,3 +3,4 @@
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapd usr/bin/snap

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -717,6 +717,14 @@ popd
             SNAPD_DEFINES_DIR=$PWD \
             install
 
+%if 0%{?with_selinux}
+# Install the CLI wrapper as /usr/bin/snap, replacing the symlink installed by
+# snapd.mk. The wrapper is a real binary carrying snappy_cli_exec_t so that
+# the SELinux domain transition to snappy_cli_t fires correctly on exec.
+rm -f %{buildroot}%{_bindir}/snap
+install -m 0755 cmd/snap-cli-wrap/snap-cli-wrap %{buildroot}%{_bindir}/snap
+%endif
+
 %if 0%{?rhel} == 7
 # Install kernel tweaks
 # See: https://access.redhat.com/articles/3128691

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -717,13 +717,12 @@ popd
             SNAPD_DEFINES_DIR=$PWD \
             install
 
-%if 0%{?with_selinux}
 # Install the CLI wrapper as /usr/bin/snap, replacing the symlink installed by
-# snapd.mk. The wrapper is a real binary carrying snappy_cli_exec_t so that
-# the SELinux domain transition to snappy_cli_t fires correctly on exec.
+# snapd.mk. The wrapper is a real binary carrying snappy_cli_exec_t so that the
+# SELinux domain transition to snappy_cli_t fires correctly on exec. This works
+# even if not using SElinux.
 rm -f %{buildroot}%{_bindir}/snap
 install -m 0755 cmd/snap-cli-wrap/snap-cli-wrap %{buildroot}%{_bindir}/snap
-%endif
 
 %if 0%{?rhel} == 7
 # Install kernel tweaks

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -352,7 +352,6 @@ Provides:      golang(%{import_path}/bootloader/lkenv) = %{version}-%{release}
 Provides:      golang(%{import_path}/bootloader/ubootenv) = %{version}-%{release}
 Provides:      golang(%{import_path}/client) = %{version}-%{release}
 Provides:      golang(%{import_path}/client/clientutil) = %{version}-%{release}
-Provides:      golang(%{import_path}/cmd/snap) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snap-bootstrap) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snap-bootstrap/triggerwatch) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snap-exec) = %{version}-%{release}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -390,6 +390,12 @@ export SNAPD_SKIP_SLOW_TESTS=1
             install
 
 %if %{with selinux}
+# Install the CLI wrapper as /usr/bin/snap, replacing the symlink installed by
+# snapd.mk. The wrapper is a real binary carrying snappy_cli_exec_t so that
+# the SELinux domain transition to snappy_cli_t fires correctly on exec.
+rm -f %{buildroot}%{_bindir}/snap
+install -m 0755 %{indigo_srcdir}/cmd/snap-cli-wrap/snap-cli-wrap %{buildroot}%{_bindir}/snap
+
 # Install SELinux module
 install -D -p -m 0644 %{indigo_srcdir}/data/selinux/snappy.if \
     %{buildroot}%{_datadir}/selinux/devel/include/contrib/snappy.if

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -62,7 +62,7 @@ snap_mount_dir = /snap
 endif
 
 # The list of go binaries we are expected to build.
-go_binaries = $(addprefix $(builddir)/, snap snapctl snap-seccomp snap-update-ns snap-exec snapd snapd-apparmor)
+go_binaries = $(addprefix $(builddir)/, snapd snapctl snap-seccomp snap-update-ns snap-exec snapd-apparmor)
 
 GO_TAGS = nosecboot
 ifeq ($(with_testkeys),1)
@@ -128,8 +128,7 @@ prepare-debian-build-tree:
 # FIXME: not all Go toolchains we build with support '-B gobuildid', replace a
 # random GNU build ID with something more predictable, use something similar to
 # https://pagure.io/go-rpm-macros/c/1980932bf3a21890a9571effaa23fbe034fd388d
-$(builddir)/snap: GO_TAGS += nomanagers
-$(builddir)/snap $(builddir)/snap-seccomp $(builddir)/snapd-apparmor:
+$(builddir)/snapd $(builddir)/snap-seccomp $(builddir)/snapd-apparmor:
 	go build -o $@ $(if $(GO_TAGS),-tags "$(GO_TAGS)") \
 		-buildmode=pie \
 		-ldflags="$(EXTRA_GO_LDFLAGS)" \
@@ -194,38 +193,28 @@ check-static-binaries:
 	fi
 	@echo "All static binary checks passed."
 
-# XXX see the note about build ID in rule for building 'snap'
-# Snapd can be built with test keys. This is only used by the internal test
-# suite to add test assertions. Do not enable this in distribution packages.
-$(builddir)/snapd:
-	go build -o $@ -buildmode=pie \
-		-ldflags="$(EXTRA_GO_LDFLAGS)" \
-		$(GO_MOD) \
-		$(if $(GO_TAGS),-tags "$(GO_TAGS)") \
-		$(EXTRA_GO_BUILD_FLAGS) \
-		$(import_path)/cmd/$(notdir $@)
-
 # Know how to create certain directories.
 $(addprefix $(DESTDIR),$(libexecdir)/snapd $(bindir) $(mandir)/man8 /$(sharedstatedir)/snapd $(localstatedir)/cache/snapd $(snap_mount_dir)):
 	install -m 755 -d $@
 
 .PHONY: install
 
-# Install snap into /usr/bin/.
-install:: $(builddir)/snap | $(DESTDIR)$(bindir)
-	install -m 755 $^ $|
-
-# Install snapctl snapd, snap-{exec,update-ns,seccomp} into /usr/lib/snapd/
-install:: $(addprefix $(builddir)/,snapctl snapd snap-exec snap-update-ns snap-seccomp snapd-apparmor) | $(DESTDIR)$(libexecdir)/snapd
+# Install snapd, snapctl, snap-{exec,update-ns,seccomp} into /usr/lib/snapd/
+install:: $(addprefix $(builddir)/,snapd snapctl snap-exec snap-update-ns snap-seccomp snapd-apparmor) | $(DESTDIR)$(libexecdir)/snapd
 	install -m 755 $^ $|
 
 # Ensure /usr/bin/snapctl is a relative symlink to /usr/lib/snapd/snapctl
 install:: | $(DESTDIR)$(bindir)
 	ln -v -s -r $(DESTDIR)$(libexecdir)/snapd/snapctl $|/snapctl
 
-# Generate and install man page for snap command
-install:: $(builddir)/snap | $(DESTDIR)$(mandir)/man8
-	$(builddir)/snap help --man > $|/snap.8
+# Ensure /usr/bin/snap is a symlink to $(libexecdir)/snapd/snapd
+install:: | $(DESTDIR)$(bindir)
+	ln -v -s -r $(DESTDIR)$(libexecdir)/snapd/snapd $|/snap
+
+# Generate and install man page for snap command.
+# The binary dispatches on argv[0]; invoke it as "snap" to get the CLI help.
+install:: $(builddir)/snapd | $(DESTDIR)$(mandir)/man8
+	bash -c 'exec -a snap $(builddir)/snapd help --man' > $|/snap.8
 
 # Install the directory structure in /var/lib/snapd
 install::
@@ -318,7 +307,7 @@ clean:
 .PHONY: check-trusted-account-keys
 check-trusted-account-keys:
 	@echo "Checking trusted account keys in snapd and related binaries..."
-	@# Check snapd binary (2 keys expected)
+	@# Check snap binary (2 keys expected)
 	@if [ ! -f "$(builddir)/snapd" ]; then \
 		echo "ERROR: snapd binary not found at $(builddir)/snapd" >&2; \
 		exit 1; \
@@ -330,27 +319,10 @@ check-trusted-account-keys:
 			exit 1; \
 		fi; \
 		strings $(builddir)/snapd | grep -q "^public-key-sha3-384: $(SNAPD_STORE_ROOT_KEY)$$" || \
-			{ echo "ERROR: snapd store root key not found" >&2; exit 1; }; \
-		strings $(builddir)/snapd | grep -q "^public-key-sha3-384: $(SNAPD_STORE_GENERIC_MODELS_KEY)$$" || \
-			{ echo "ERROR: snapd store generic models key not found" >&2; exit 1; }; \
-		echo "  snapd: OK (2 keys)"; \
-	fi
-	@# Check snap binary (2 keys expected)
-	@if [ ! -f "$(builddir)/snap" ]; then \
-		echo "ERROR: snap binary not found at $(builddir)/snap" >&2; \
-		exit 1; \
-	fi
-	@if true; then \
-		count=$$(strings $(builddir)/snap | grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}"); \
-		if [ "$$count" -ne 2 ]; then \
-			echo "ERROR: Expected 2 public keys in snap, found $$count" >&2; \
-			exit 1; \
-		fi; \
-		strings $(builddir)/snap | grep -q "^public-key-sha3-384: $(SNAPD_STORE_ROOT_KEY)$$" || \
 			{ echo "ERROR: snap store root key not found" >&2; exit 1; }; \
-		strings $(builddir)/snap | grep -q "^public-key-sha3-384: $(SNAPD_STORE_GENERIC_MODELS_KEY)$$" || \
+		strings $(builddir)/snapd | grep -q "^public-key-sha3-384: $(SNAPD_STORE_GENERIC_MODELS_KEY)$$" || \
 			{ echo "ERROR: snap store generic models key not found" >&2; exit 1; }; \
-		echo "  snap: OK (2 keys)"; \
+		echo "  snapd: OK (2 keys)"; \
 	fi
 	@# Check snap-bootstrap if it exists (Ubuntu 16.04+)
 	@if [ -f "$(builddir)/snap-bootstrap" ]; then \

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -95,26 +95,26 @@ export GOMAXPROCS=2
 endif
 
 # build with "tpm" support on ubuntu by default TAGS are the go build tags for
-# all binaries, SNAP_TAGS are for snap-bootstrap build only.
+# all binaries
 _TAGS=
-_SNAP_TAGS=
+_SNAP_BOOTSTRAP_TAGS=
 # check if we need to include the testkeys in the binary
 ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
   # if enabled also enable bootloader assets testing and fault injection
 	_TAGS := withtestkeys,withbootassetstesting,faultinject,statelocktrace
-	_SNAP_TAGS := nomanagers,withtestkeys,faultinject,statelocktrace
+	_SNAP_BOOTSTRAP_TAGS := nomanagers,withtestkeys,faultinject,statelocktrace
 else
-	_SNAP_TAGS=nomanagers
+	_SNAP_BOOTSTRAP_TAGS=nomanagers
 endif
 
 ifeq (${FIPSBUILD},1)
   # if enabled also enable bootloader assets testing and fault injection
 	_TAGS := $(_TAGS),goexperiment.opensslcrypto,snapdfips
-	_SNAP_TAGS := $(_SNAP_TAGS),goexperiment.opensslcrypto,snapdfips
+	_SNAP_BOOTSTRAP_TAGS := $(_SNAP_BOOTSTRAP_TAGS),goexperiment.opensslcrypto,snapdfips
 endif
 
 TAGS=-tags "$(_TAGS)"
-SNAP_TAGS=-tags "$(_SNAP_TAGS)"
+SNAP_BOOTSTRAP_TAGS=-tags "$(_SNAP_BOOTSTRAP_TAGS)"
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
@@ -253,7 +253,7 @@ endif
 	PATH="$$(pwd)/packaging/build-tools/:$$PATH" \
 		dh_auto_build -- -mod=vendor $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS) $(DH_GOPKG)/cmd/...
 
-	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
+	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_BOOTSTRAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
 	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
 	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -94,9 +94,8 @@ export DH_GOLANG_GO_GENERATE=0
 export GOMAXPROCS=2
 endif
 
-# build with "tpm" support on ubuntu by default
-# TAGS are the go build tags for all binaries, SNAP_TAGS are for snap and
-# snap-bootstrap build only.
+# build with "tpm" support on ubuntu by default TAGS are the go build tags for
+# all binaries, SNAP_TAGS are for snap-bootstrap build only.
 _TAGS=
 _SNAP_TAGS=
 # check if we need to include the testkeys in the binary
@@ -254,7 +253,6 @@ endif
 	PATH="$$(pwd)/packaging/build-tools/:$$PATH" \
 		dh_auto_build -- -mod=vendor $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS) $(DH_GOPKG)/cmd/...
 
-	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
 	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
@@ -373,7 +371,7 @@ snap.8:
 	# fix reproducible builds as reported by:
 	#   https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/snapd.html
 	# once golang-go-flags is fixed we can remove the "sed" expression
-	$(CURDIR)/_build/bin/snap help --man | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
+	bash -c 'exec -a snap $(CURDIR)/_build/bin/snapd help --man' | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -1,11 +1,10 @@
-usr/bin/snap
+usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/lib/snapd/system-shutdown
 usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-repair /usr/lib/snapd/
 usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
-usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-bootstrap /usr/lib/snapd/
 usr/bin/snap-preseed /usr/lib/snapd/

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -3,3 +3,4 @@
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapd usr/bin/snap

--- a/packaging/ubuntu-26.10/rules
+++ b/packaging/ubuntu-26.10/rules
@@ -66,9 +66,8 @@ export DH_GOLANG_GO_GENERATE=0
 export GOMAXPROCS=2
 endif
 
-# build with "tpm" support on ubuntu by default
-# TAGS are the go build tags for all binaries, SNAP_TAGS are for snap and
-# snap-bootstrap build only.
+# build with "tpm" support on ubuntu by default TAGS are the go build tags for
+# all binaries, SNAP_TAGS are for snap-bootstrap build only.
 _TAGS=
 _SNAP_TAGS=
 # check if we need to include the testkeys in the binary
@@ -223,7 +222,6 @@ endif
 	PATH="$$(pwd)/packaging/build-tools/:$$PATH" \
 		dh_auto_build -- -mod=vendor $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS) $(DH_GOPKG)/cmd/...
 
-	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
 	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
@@ -342,7 +340,7 @@ snap.8:
 	# fix reproducible builds as reported by:
 	#   https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/snapd.html
 	# once golang-go-flags is fixed we can remove the "sed" expression
-	$(CURDIR)/_build/bin/snap help --man | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
+	bash -c 'exec -a snap $(CURDIR)/_build/bin/snapd help --man' | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang

--- a/packaging/ubuntu-26.10/rules
+++ b/packaging/ubuntu-26.10/rules
@@ -67,26 +67,26 @@ export GOMAXPROCS=2
 endif
 
 # build with "tpm" support on ubuntu by default TAGS are the go build tags for
-# all binaries, SNAP_TAGS are for snap-bootstrap build only.
+# all binaries
 _TAGS=
-_SNAP_TAGS=
+_SNAP_BOOTSTRAP_TAGS=
 # check if we need to include the testkeys in the binary
 ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
   # if enabled also enable bootloader assets testing and fault injection
 	_TAGS := withtestkeys,withbootassetstesting,faultinject,statelocktrace
-	_SNAP_TAGS := nomanagers,withtestkeys,faultinject,statelocktrace
+	_SNAP_BOOTSTRAP_TAGS := nomanagers,withtestkeys,faultinject,statelocktrace
 else
-	_SNAP_TAGS=nomanagers
+	_SNAP_BOOTSTRAP_TAGS=nomanagers
 endif
 
 ifeq (${FIPSBUILD},1)
   # if enabled also enable bootloader assets testing and fault injection
 	_TAGS := $(_TAGS),goexperiment.opensslcrypto,snapdfips
-	_SNAP_TAGS := $(_SNAP_TAGS),goexperiment.opensslcrypto,snapdfips
+	_SNAP_BOOTSTRAP_TAGS := $(_SNAP_BOOTSTRAP_TAGS),goexperiment.opensslcrypto,snapdfips
 endif
 
 TAGS=-tags "$(_TAGS)"
-SNAP_TAGS=-tags "$(_SNAP_TAGS)"
+SNAP_BOOTSTRAP_TAGS=-tags "$(_SNAP_BOOTSTRAP_TAGS)"
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
@@ -222,7 +222,7 @@ endif
 	PATH="$$(pwd)/packaging/build-tools/:$$PATH" \
 		dh_auto_build -- -mod=vendor $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS) $(DH_GOPKG)/cmd/...
 
-	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
+	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_BOOTSTRAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
 	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
 	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl

--- a/packaging/ubuntu-26.10/snapd.install.in
+++ b/packaging/ubuntu-26.10/snapd.install.in
@@ -1,10 +1,9 @@
-usr/bin/snap
+usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-repair /usr/lib/snapd/
 usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
-usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-bootstrap /usr/lib/snapd/
 usr/bin/snap-preseed /usr/lib/snapd/

--- a/packaging/ubuntu-26.10/snapd.links
+++ b/packaging/ubuntu-26.10/snapd.links
@@ -1,2 +1,3 @@
 /usr/lib/snapd/snap-device-helper  /usr/lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapd usr/bin/snap

--- a/tests/core/snapd-refresh/task.yaml
+++ b/tests/core/snapd-refresh/task.yaml
@@ -37,7 +37,7 @@ execute: |
             exit 1
         fi
         running="$(readlink -f /proc/"$(pidof snapd)"/exe)"
-        if echo "$running" | grep "/snap/snapd/$current/usr/lib/"; then
+        if echo "$running" | grep "/snap/snapd/$current/usr/"; then
             echo "The current running snapd is not $running"
             exit 1
         fi
@@ -48,7 +48,7 @@ execute: |
         snap list | MATCH "snapd.*$current "
         echo "And we see the original snapd running"
         running="$(readlink -f /proc/"$(pidof snapd)"/exe)"
-        echo "$running" | MATCH "/snap/snapd/$current/usr/lib/"
+        echo "$running" | MATCH "/snap/snapd/$current/usr/"
     done
     snap changes | MATCH 'Install "snapd"'
     snap changes | MATCH 'Revert "snapd" snap'

--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -34,20 +34,29 @@ execute: |
   unsquashfs -d ./snapd-modified "/var/lib/snapd/snaps/snapd_${old_current}.snap"
   for binary in snapd snapd-apparmor; do
     mv "./snapd-modified/usr/lib/snapd/${binary}" "./snapd-modified/usr/lib/snapd/${binary}.real"
-  cat <<\EOF >"./snapd-modified/usr/lib/snapd/${binary}"
+    # for snap & snapd, usr/bin/snap is a symlink to usr/lib/snapd/snapd, so
+    # this wrapper may be invoked as either "snap" or "snapd". Map argv[0] back
+    # to the correct .real binary name.
+    cat <<\EOF >"./snapd-modified/usr/lib/snapd/${binary}"
   #!/bin/bash
   set -eux
-  binary="$(basename "$0")"
-  dir="$(dirname "$0")"
-  realpath "${dir}/${binary}.real" || true
-  realpath "/snap/snapd/current/usr/lib/snapd/${binary}.real" || true
-  stat "${dir}/${binary}.real" || true
-  stat "/snap/snapd/current/usr/lib/snapd/${binary}.real" || true
-  if ! [ "${dir}/${binary}.real" -ef "/snap/snapd/current/usr/lib/snapd/${binary}.real" ]; then
-    echo "Trying to execute the binary '${binary}' before it is available at the right place" 1>&2
+  # Resolve symlinks to find the real location of this script, since
+  # usr/bin/snap is a symlink to usr/lib/snapd/snapd and this wrapper
+  # may be invoked under either name.
+  self="$(readlink -f "$0")"
+  dir="$(dirname "${self}")"
+  # Map argv[0] to the correct .real binary name. usr/bin/snap is a symlink
+  # to usr/lib/snapd/snapd, so "snap" must be mapped to "snapd". All other
+  # names (snapd, snapd-apparmor) are used as-is.
+  case "$(basename "$0")" in
+    snap) real_binary="snapd" ;;
+    *)    real_binary="$(basename "$0")" ;;
+  esac
+  if ! [ "${dir}/${real_binary}.real" -ef "/snap/snapd/current/usr/lib/snapd/${real_binary}.real" ]; then
+    echo "Trying to execute the binary '${real_binary}' before it is available at the right place" 1>&2
     exit 1
   fi
-  exec "${dir}/${binary}.real" "$@"
+  exec -a "$(basename "$0")" "${dir}/${real_binary}.real" "$@"
   EOF
     chmod +x "./snapd-modified/usr/lib/snapd/${binary}"
   done

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -238,8 +238,8 @@ update_core_snap_for_classic_reexec() {
     rm squashfs-root/usr/lib/snapd/* squashfs-root/usr/bin/snap
     # and copy in the current libexec
     cp -a "$LIBEXEC_DIR"/snapd/* squashfs-root/usr/lib/snapd/
-    # also the binaries themselves
-    cp -a /usr/bin/snap squashfs-root/usr/bin/
+    # also the binaries themselves; snap is now a symlink to usr/lib/snapd/snapd
+    ln -s -r squashfs-root/usr/lib/snapd/snapd squashfs-root/usr/bin/snap
     # make sure bin/snapctl is a symlink to lib/
     if [ ! -L squashfs-root/usr/bin/snapctl ]; then
         rm -f squashfs-root/usr/bin/snapctl

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -310,14 +310,13 @@ update_core_snap_for_classic_reexec() {
         check_file "$p" "$core/usr/lib/snapd/$(basename "$p")"
     done
     check_file /usr/bin/snapctl "${core}/usr/bin/snapctl"
-    if ! command -v selinuxenabled ; then
+    if ! command -v selinuxenabled; then
         # systems without SELinux have or point to the exact same binary in the
         # core snap and on the host
         check_file "/usr/bin/snap" "${core}/usr/bin/snap"
     else
-        # on SELinux enabled systems /usr/bin/snap is a thin wrapper which
-        # serves as an policy attachment point, and is not the same binary as in
-        # the core/snapd snap
+        # on SELinux enabled systems /usr/bin/snap is a thin wrapper which serves as an policy
+        # attachment point, and is not the same binary as in the core/snapd snap
         if cmp  "/usr/bin/snap" "${core}/usr/bin/snap"; then
             echo "host /usr/bin/snap is unexpectedly the same as one from ${core}"
             exit 1

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -309,9 +309,24 @@ update_core_snap_for_classic_reexec() {
     for p in "$LIBEXEC_DIR/snapd/snap-exec" "$LIBEXEC_DIR/snapd/snap-confine" "$LIBEXEC_DIR/snapd/snap-discard-ns" "$LIBEXEC_DIR/snapd/snapd" "$LIBEXEC_DIR/snapd/snap-update-ns"; do
         check_file "$p" "$core/usr/lib/snapd/$(basename "$p")"
     done
-    for p in /usr/bin/snapctl /usr/bin/snap; do
-        check_file "$p" "$core$p"
-    done
+    check_file /usr/bin/snapctl "${core}/usr/bin/snapctl"
+    if ! command -v selinuxenabled ; then
+        # systems without SELinux have or point to the exact same binary in the
+        # core snap and on the host
+        check_file "/usr/bin/snap" "${core}/usr/bin/snap"
+    else
+        # on SELinux enabled systems /usr/bin/snap is a thin wrapper which
+        # serves as an policy attachment point, and is not the same binary as in
+        # the core/snapd snap
+        if cmp  "/usr/bin/snap" "${core}/usr/bin/snap"; then
+            echo "host /usr/bin/snap is unexpectedly the same as one from ${core}"
+            exit 1
+        fi
+        if [ -L /usr/bin/snap ]; then
+            echo "/usr/bin/snap is a symbolic link"
+            exit 1
+        fi
+    fi
 }
 
 prepare_memory_limit_override() {

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -40,7 +40,7 @@ execute: |
             else
                 # UC18+ with snapd snap
                 MATCH 'is-reexecd: true' < snap-default.out
-                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-default.out
+                MATCH 'self-exe: /snap/snapd/.*/usr/lib/snapd/snapd' < snap-default.out
             fi
 
             echo "Checking Ubuntu Core with reexec scenario"
@@ -52,7 +52,7 @@ execute: |
             if os.query is-core16; then
                 MATCH 'self-exe: /snap/core/.*/usr/bin/snap' < snap-yes-reexec.out
             else
-                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
+                MATCH 'self-exe: /snap/snapd/.*/usr/lib/snapd/snapd' < snap-yes-reexec.out
             fi
 
             echo "Checking Ubuntu Core without reexec scenario"
@@ -65,7 +65,7 @@ execute: |
             else
                 MATCH 'is-reexec-enabled: true' < snap-no-reexec.out
                 MATCH 'is-reexecd: true' < snap-no-reexec.out
-                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-no-reexec.out
+                MATCH 'self-exe: /snap/snapd/.*/usr/lib/snapd/snapd' < snap-no-reexec.out
             fi
 
             echo "Checking Ubuntu Core AppArmor"
@@ -85,7 +85,7 @@ execute: |
             if [ "$SNAP_REEXEC" = 0 ]; then
                 MATCH 'is-reexec-enabled: false' < snap-default.out
                 MATCH 'is-reexecd: false' < snap-default.out
-                MATCH 'self-exe: /usr/bin/snap' < snap-default.out
+                MATCH 'self-exe: /usr/lib/snapd/snapd' < snap-default.out
             else
                 MATCH 'is-reexec-enabled: true' < snap-default.out
                 MATCH 'is-reexecd: true' < snap-default.out
@@ -150,7 +150,7 @@ execute: |
             MATCH 'is-reexec-enabled: true' < snap-default.out
             MATCH 'is-reexec-explicitly-enabled: false' < snap-default.out
             MATCH 'is-reexecd: false' < snap-default.out
-            MATCH 'self-exe: /usr/bin/snap' < snap-default.out
+            MATCH 'self-exe: /usr/lib(exec)?/snapd/snapd' < snap-default.out
 
             echo "Checking with reexec scenario"
             MATCH 'distro-supports-reexec: false' < snap-yes-reexec.out
@@ -167,14 +167,14 @@ execute: |
                 arch-linux-*|fedora-*|centos-*|opensuse-*)
                     # no /snap -> /var/lib/snapd/snap symlink by default
                     MATCH 'is-reexecd: false' < snap-yes-reexec.out
-                    MATCH 'self-exe: /usr/bin/snap' < snap-yes-reexec.out
+                    MATCH 'self-exe: /usr/lib(exec)?/snapd/snapd' < snap-yes-reexec.out
 
                     MATCH 'is-reexecd: false' < snap-force-reexec.out
                     ;;
                 amazon-linux-*)
                     # has /snap -> /var/lib/snapd symlink
                     MATCH 'is-reexecd: true' < snap-yes-reexec.out
-                    MATCH 'self-exe: /var/lib/snapd/snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
+                    MATCH 'self-exe: /var/lib/snapd/snap/snapd/.*/usr/lib/snapd/snapd' < snap-yes-reexec.out
 
                     MATCH 'is-reexecd: true' < snap-force-reexec.out
                     ;;

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -97,7 +97,7 @@ execute: |
             MATCH 'is-reexec-enabled: false' < snap-no-reexec.out
             MATCH 'is-reexec-explicitly-enabled: false' < snap-no-reexec.out
             MATCH 'is-reexecd: false' < snap-no-reexec.out
-            MATCH 'self-exe: /usr/bin/snap' < snap-no-reexec.out
+            MATCH 'self-exe: /usr/lib/snapd/snapd' < snap-no-reexec.out
 
             echo "Checking forced reexec"
             # when using native package it reexecs as instructed, when using the

--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -1,7 +1,7 @@
-summary: Check that snap binary does not inadvertently import snapstate.
+summary: Check that snap-bootstrap binary does not inadvertently import snapstate.
 
 details: |
-  This test checks that snap binary does not import snapstate when built
+  This test checks that snapstate is not imported when binaries are built
   with -tags nomanagers.
 
 systems: [-ubuntu-core-*]
@@ -15,8 +15,7 @@ execute: |
     fi
   }
 
-  check_imports /usr/bin/snap
-
+  # but snap-bootstrap does not
   # snap-bootstrap is shipped only on ubuntu (except for 14.04)
   if [[ "$SPREAD_SYSTEM" = ubuntu-2* ]] || os.query is-bionic || os.query is-xenial; then
     check_imports /usr/lib/snapd/snap-bootstrap

--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -15,7 +15,6 @@ execute: |
     fi
   }
 
-  # but snap-bootstrap does not
   # snap-bootstrap is shipped only on ubuntu (except for 14.04)
   if [[ "$SPREAD_SYSTEM" = ubuntu-2* ]] || os.query is-bionic || os.query is-xenial; then
     check_imports /usr/lib/snapd/snap-bootstrap

--- a/tests/smoke/hacking-md/task.yaml
+++ b/tests/smoke/hacking-md/task.yaml
@@ -65,13 +65,13 @@ execute: |
     su -c "bash -ex /tmp/deps.sh" test
 
     # Extract and prepare all build scripts (as root)
-    echo "Preparing snap build script"
-    python3 tests/smoke/hacking-md/extract-snippets.py HACKING.md build-snap > /tmp/build-snap.sh
-    sed -i "s|~/snapd|$TESTDIR|g" /tmp/build-snap.sh
-
     echo "Preparing snapd build script"
     python3 tests/smoke/hacking-md/extract-snippets.py HACKING.md build-snapd > /tmp/build-snapd.sh
     sed -i "s|~/snapd|$TESTDIR|g" /tmp/build-snapd.sh
+
+    echo "Preparing snap build script"
+    python3 tests/smoke/hacking-md/extract-snippets.py HACKING.md build-snap > /tmp/build-snap.sh
+    sed -i "s|~/snapd|$TESTDIR|g" /tmp/build-snap.sh
 
     echo "Preparing all components build script"
     python3 tests/smoke/hacking-md/extract-snippets.py HACKING.md build-go > /tmp/build-go.sh
@@ -82,11 +82,12 @@ execute: |
     sed -i "s|~/snapd|$TESTDIR|g" /tmp/build-c.sh
 
     # Execute all builds as test user
-    echo "Building snap from HACKING.md instructions"
-    su -c "bash -ex /tmp/build-snap.sh" test
-
     echo "Building snapd from HACKING.md instructions"
     su -c "bash -ex /tmp/build-snapd.sh" test
+
+    # Needs to run after snapd
+    echo "Building snap from HACKING.md instructions"
+    su -c "bash -ex /tmp/build-snap.sh" test
 
     echo "Building all Go components from HACKING.md instructions"
     su -c "bash -ex /tmp/build-go.sh" test


### PR DESCRIPTION
A branch which merges snap and snapd binaries into a single `usr/bin/snap` binary. As a result the snapd snap size goes down from ~51MB -> ~45MB. The run time performance should be improved on systems with cold page cache as there's just a single 33MB binary instead of two: 31MB (snapd) + 23MB (snap). There's tiny overhead of ~3.5ms of startup in the snap execution path caused by `init()` block from newly imported packages.

Related: [SNAPDENG-36950](https://warthogs.atlassian.net/browse/SNAPDENG-36950), [SNAPDENG-37094](https://warthogs.atlassian.net/browse/SNAPDENG-37094)

Cherry picked from https://github.com/canonical/snapd/pull/17145

[SNAPDENG-36950]: https://warthogs.atlassian.net/browse/SNAPDENG-36950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNAPDENG-37094]: https://warthogs.atlassian.net/browse/SNAPDENG-37094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ