### PR TITLE
o/confdbstate: run observe-view-* hooks after commit

### DIFF
--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -519,8 +519,19 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		}
 	}
 
-	// run observe-view hooks for any plug that references a view that could have
-	// changed with this data modification
+	// commit after custodians save ephemeral data
+	commitTask = st.NewTask("commit-confdb-tx", fmt.Sprintf("Commit changes to confdb (%s)", view.ID()))
+	commitTask.Set("confdb-transaction", tx)
+	commitTask.Set("view", view.Name)
+
+	// link all previous tasks to the commit task that carries the transaction
+	for _, t := range ts.Tasks() {
+		t.Set("tx-task", commitTask.ID())
+	}
+	linkTask(commitTask)
+
+	// run observe-view hooks after the commit for any plug that references a
+	// view that could have changed with this data modification
 	affectedPlugs, err := getPlugsAffectedByPaths(st, view.Schema(), paths)
 	if err != nil {
 		return nil, nil, nil, err
@@ -541,20 +552,10 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		for _, plug := range affectedPlugs[snapName] {
 			const ignoreError = true
 			task := setupConfdbHook(st, snapName, "observe-view-"+plug.Name, ignoreError)
+			task.Set("tx-task", commitTask.ID())
 			linkTask(task)
 		}
 	}
-
-	// commit after custodians save ephemeral data
-	commitTask = st.NewTask("commit-confdb-tx", fmt.Sprintf("Commit changes to confdb (%s)", view.ID()))
-	commitTask.Set("confdb-transaction", tx)
-	commitTask.Set("view", view.Name)
-
-	// link all previous tasks to the commit task that carries the transaction
-	for _, t := range ts.Tasks() {
-		t.Set("tx-task", commitTask.ID())
-	}
-	linkTask(commitTask)
 
 	// clear the ongoing tx from the state and unblock other writers waiting for it
 	clearTxTask = st.NewTask("clear-confdb-tx", "Clears the ongoing confdb transaction from state")

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -621,7 +621,7 @@ func (s *confdbTestSuite) TestConfdbTasksUserSetWithCustodianInstalled(c *C) {
 	chg.AddAll(ts)
 
 	// the custodian snap's hooks are run
-	tasks := []string{"clear-confdb-tx-on-error", "run-hook", "run-hook", "run-hook", "commit-confdb-tx", "clear-confdb-tx"}
+	tasks := []string{"clear-confdb-tx-on-error", "run-hook", "run-hook", "commit-confdb-tx", "run-hook", "clear-confdb-tx"}
 	hooks := []*hookstate.HookSetup{
 		{
 			Snap:        "custodian-snap",
@@ -713,7 +713,7 @@ func (s *confdbTestSuite) TestConfdbTasksObserverSnapSetWithCustodianInstalled(c
 
 	// we trigger hooks for the custodian snap and for the observe-view- for the
 	// observer snap that didn't trigger the change
-	tasks := []string{"clear-confdb-tx-on-error", "run-hook", "run-hook", "run-hook", "run-hook", "commit-confdb-tx", "clear-confdb-tx"}
+	tasks := []string{"clear-confdb-tx-on-error", "run-hook", "run-hook", "commit-confdb-tx", "run-hook", "run-hook", "clear-confdb-tx"}
 	hooks := []*hookstate.HookSetup{
 		{
 			Snap:        "custodian-snap",


### PR DESCRIPTION
Observe-view-* hooks should run after the commit task. Even though errors in these hooks are ignored and, therefore, cannot abort the change or affect the commit, the commit itself could abort after the observe-view-* hooks have run.