### PR TITLE
packaging/ubuntu-26.04: add back gbp.conf that sets build output directory

### DIFF
--- a/packaging/ubuntu-26.04/gbp.conf
+++ b/packaging/ubuntu-26.04/gbp.conf
@@ -1,0 +1,7 @@
+[buildpackage]
+# use a build area relative to the git repository
+export-dir = ../build-area
+# disable the since the sources are being exported first
+cleaner =
+# post export script that gets the vendored dependencies
+postexport = ./get-deps.sh


### PR DESCRIPTION
Add back gbp.conf that sets build output directory (it was removed with cleanup).
This is currently still required, as we expect output in build-area/snapd-<version> from where we modify changelogs.

This change will be made locally for 2.76 deb release iteration.