### PR TITLE
o/devicestate: Set target hostname from install-mode

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -824,6 +824,13 @@ func (s *deviceMgrInstallModeSuite) TestInstallExpTasks(c *C) {
 	})
 	defer restore()
 
+	var copyHostnameRootDir string
+	restore = devicestate.MockCopyInstallModeHostname(func(rootdir string) error {
+		copyHostnameRootDir = rootdir
+		return nil
+	})
+	defer restore()
+
 	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
@@ -871,6 +878,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallExpTasks(c *C) {
 
 	// we did request a restart through restartSystemToRunModeTask
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
+	c.Check(s.SystemctlDaemonReloadCalls, Equals, 0)
+	c.Check(copyHostnameRootDir, Equals, filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data"))
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallExpTasksWithKMods(c *C) {
@@ -1429,6 +1438,56 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookExpTasks(c *
 
 	// ensure systemctl daemon-reload gets called
 	c.Assert(s.SystemctlDaemonReloadCalls, Equals, 1)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookCopiesHostname(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot string, kernelSnapInfo *install.KernelSnapInfo, device string, options install.Options, _ gadget.ContentObserver, _ timings.Measurer) (*install.InstalledSystemSideData, error) {
+		return nil, nil
+	})
+	defer restore()
+
+	restore = hookstate.MockRunHook(func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
+		hostnamePath := filepath.Join(dirs.GlobalRootDir, "etc/hostname")
+		c.Assert(os.MkdirAll(filepath.Dir(hostnamePath), 0755), IsNil)
+		c.Assert(os.WriteFile(hostnamePath, []byte("device-hostname\n"), 0644), IsNil)
+		return nil, nil
+	})
+	defer restore()
+
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+		[]byte("mode=install\n"), 0644)
+	c.Assert(err, IsNil)
+
+	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
+		return fmt.Errorf("unexpected copy call")
+	}
+	seedOpts := mockSystemSeedWithLabelOpts{
+		isClassic:     false,
+		hasSystemSeed: true,
+		hasPartial:    false,
+		types:         []snap.Type{snap.TypeKernel},
+	}
+	s.mockSystemSeedWithLabel(c, "1234", seedCopyFn, seedOpts)
+
+	s.state.Lock()
+	s.makeMockInstallModel(c, "dangerous")
+	s.makeMockInstalledPcKernelAndGadget(c, "install-device-hook-content", "", core20SnapID)
+	devicestate.SetSystemMode(s.mgr, "install")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem.Err(), IsNil)
+
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/_writable_defaults/etc/writable/hostname"),
+		testutil.FileEquals, "device-hostname\n")
 }
 
 func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboot(c *C, arg string, rst restart.RestartType) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -431,6 +431,10 @@ func MockInstallLogicPrepareRunSystemData(f func(mod *asserts.Model, gadgetDir s
 	return r
 }
 
+func MockCopyInstallModeHostname(f func(rootdir string) error) (restore func()) {
+	return testutil.Mock(&copyInstallModeHostname, f)
+}
+
 func MockInstallRun(f func(model gadget.Model, gadgetRoot string, kernelSnapInfo *install.KernelSnapInfo, device string, options install.Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*install.InstalledSystemSideData, error)) (restore func()) {
 	old := installRun
 	installRun = f

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	_ "golang.org/x/crypto/sha3"
 	"gopkg.in/tomb.v2"
@@ -58,6 +59,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
@@ -85,6 +87,7 @@ var (
 	fdestateGenerateRecoveryKey          = fdestate.GenerateRecoveryKey
 
 	installLogicPrepareRunSystemData = installLogic.PrepareRunSystemData
+	copyInstallModeHostname          = copyInstallModeHostnameImpl
 )
 
 func writeLogs(rootdir string, fromMode string) error {
@@ -196,6 +199,32 @@ func writeTimings(st *state.State, rootdir, fromMode string) error {
 
 	if err := gz.Flush(); err != nil {
 		return fmt.Errorf("cannot flush timings output: %v", err)
+	}
+
+	return nil
+}
+
+func copyInstallModeHostnameImpl(rootdir string) error {
+	hostnamePath := filepath.Join(dirs.GlobalRootDir, "etc/hostname")
+	hostnameBytes, err := os.ReadFile(hostnamePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot read install-mode hostname: %v", err)
+	}
+
+	hostname := strings.TrimSpace(string(hostnameBytes))
+	if hostname == "" {
+		return nil
+	}
+
+	targetHostnamePath := sysconfig.WritableDefaultsDir(rootdir, "etc/writable/hostname")
+	if err := os.MkdirAll(filepath.Dir(targetHostnamePath), 0755); err != nil {
+		return err
+	}
+	if err := osutil.AtomicWriteFile(targetHostnamePath, []byte(hostname+"\n"), 0644, 0); err != nil {
+		return fmt.Errorf("cannot write install-mode hostname: %v", err)
 	}
 
 	return nil
@@ -415,6 +444,10 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 		if err := sd.DaemonReload(); err != nil {
 			return err
 		}
+	}
+
+	if err := copyInstallModeHostname(boot.InstallHostWritableDir(model)); err != nil {
+		return err
 	}
 
 	// ensure the next boot goes into run mode

--- a/tests/nested/manual/install-device-hostname/defaults.yaml
+++ b/tests/nested/manual/install-device-hostname/defaults.yaml
@@ -1,0 +1,6 @@
+defaults:
+  system:
+    refresh:
+      hold: "@HOLD-TIME@"
+    journal:
+      persistent: true

--- a/tests/nested/manual/install-device-hostname/install-device
+++ b/tests/nested/manual/install-device-hostname/install-device
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+hostnamectl set-hostname install-device-hostname

--- a/tests/nested/manual/install-device-hostname/pc-snap-decl-extras.json
+++ b/tests/nested/manual/install-device-hostname/pc-snap-decl-extras.json
@@ -1,0 +1,9 @@
+{
+    "plugs": {
+        "hostname-control": {
+            "allow-installation": "true",
+            "allow-auto-connection": "true"
+        }
+    },
+    "format": "1"
+}

--- a/tests/nested/manual/install-device-hostname/snap-yaml-extras.yaml
+++ b/tests/nested/manual/install-device-hostname/snap-yaml-extras.yaml
@@ -1,0 +1,4 @@
+hooks:
+  install-device:
+    plugs:
+      - hostname-control

--- a/tests/nested/manual/install-device-hostname/task.yaml
+++ b/tests/nested/manual/install-device-hostname/task.yaml
@@ -1,0 +1,126 @@
+summary: Verify install-device hostname is copied to run mode
+
+details: |
+    Check that a hostname set by the gadget install-device hook during install
+    mode is copied to the target run-mode system before the device reboots.
+    On UC26 this also verifies that the presence of the install-device hook
+    prevents the single-boot initramfs install path and that the hook runs.
+
+backends: [-garden]
+systems: [ubuntu-24.04-64, ubuntu-26.04-64]
+
+environment:
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_SIGN_SNAPS_FAKESTORE: true
+    NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-dangerous.model
+    NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+    NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+    NESTED_USE_CLOUD_INIT: false
+
+prepare: |
+    # shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    "$TESTSTOOLS"/store-state setup-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
+    "$TESTSTOOLS"/store-state teardown-staging-store
+
+    echo "Expose the needed assertions through the fakestore"
+    cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$NESTED_FAKESTORE_BLOB_DIR/asserts"
+
+    VERSION="$(tests.nested show version)"
+
+    echo "Generate a system-user assertion for the dangerous model"
+    gojq --arg model "testkeys-snapd-dangerous-core-${VERSION}-amd64" \
+        ".models += [\$model] | .models |= unique" \
+        "$TESTSLIB/assertions/developer1-${VERSION}-auto-import.json" > auto-import.json
+    "$TESTSLIB/gendeveloper1assert/main.sh" auto-import.json auto-import.assert
+    export NESTED_CUSTOM_AUTO_IMPORT_ASSERTION="$PWD/auto-import.assert"
+
+    echo "Grab and prepare the gadget snap"
+    snap download --basename=pc --channel="$VERSION/edge" pc
+    unsquashfs -d pc-gadget pc.snap
+
+    echo "Add the install-device hook"
+    mkdir -p pc-gadget/meta/hooks
+    cp install-device pc-gadget/meta/hooks/install-device
+    chmod +x pc-gadget/meta/hooks/install-device
+
+    echo "Disable serial registration for this test"
+    test -f pc-gadget/meta/hooks/prepare-device
+    sed -i '0,/^set -eu$/s//set -eu\n\nsnapctl set device-service.access=offline/' pc-gadget/meta/hooks/prepare-device
+    grep -q '^snapctl set device-service.access=offline$' pc-gadget/meta/hooks/prepare-device
+    chmod +x pc-gadget/meta/hooks/prepare-device
+
+    echo "Add the install-device hook plug to snap.yaml"
+    gojq -s --yaml-input --yaml-output '.[0] * .[1]' snap-yaml-extras.yaml pc-gadget/meta/snap.yaml > snap.yaml.tmp
+    cp -v snap.yaml.tmp pc-gadget/meta/snap.yaml
+
+    echo "Hold refreshes and make the journal persistent"
+    sed defaults.yaml -e "s/@HOLD-TIME@/$(date --date='next week' +%Y-%m-%dT%H:%M:%S%:z)/" >> pc-gadget/meta/gadget.yaml
+
+    snap pack pc-gadget/ "$(tests.nested get extra-snaps-path)"
+    rm -rf pc-gadget/
+
+    NESTED_FAKESTORE_SNAP_DECL_PC_GADGET="pc-snap-decl-extras.json"
+    export NESTED_FAKESTORE_SNAP_DECL_PC_GADGET
+
+    tests.nested build-image core
+    unset NESTED_FAKESTORE_SNAP_DECL_PC_GADGET
+
+    tests.nested create-vm core
+
+restore: |
+    "$TESTSTOOLS"/store-state teardown-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
+    tests.cleanup restore
+
+debug: |
+    # shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    cat "$NESTED_LOGS_DIR/ubuntu-image.log" || true
+    journalctl -u nested-vm --no-pager || true
+    nested_print_serial_log || true
+    remote.exec "sudo snap changes" || true
+    remote.exec "sudo snap changes | awk '/Initialize device/ { print \$1 }' | xargs -r -n1 sudo snap change" || true
+    remote.exec "cat /proc/cmdline" || true
+    remote.exec "cat /var/lib/snapd/modeenv" || true
+    remote.exec "cat /etc/hostname" || true
+    remote.exec "hostnamectl status --static" || true
+    remote.exec "snap get pc device-service.access" || true
+    remote.exec "snap connections pc" || true
+    remote.exec "sudo journalctl -b --no-pager" || true
+    remote.exec "zcat /var/log/install-mode.log.gz" || true
+
+execute: |
+    # shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    echo "Wait for device initialisation to be done"
+    INITIALIZE_DEVICE_CHANGE="$(remote.exec snap changes | awk '/Initialize device/ { print $1; exit }')"
+    test -n "$INITIALIZE_DEVICE_CHANGE"
+    retry -n 200 --wait 1 --env "INITIALIZE_DEVICE_CHANGE=$INITIALIZE_DEVICE_CHANGE" sh -c \
+        "remote.exec snap changes | MATCH \"^${INITIALIZE_DEVICE_CHANGE}\\s+(Done|Error).*Initialize device\""
+    remote.exec "sudo snap change $INITIALIZE_DEVICE_CHANGE" || true
+    remote.exec snap changes | MATCH "^${INITIALIZE_DEVICE_CHANGE}\\s+Done.*Initialize device"
+
+    echo "Check the system booted into run mode"
+    remote.exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=run"
+    remote.exec "cat /var/lib/snapd/modeenv" | MATCH "mode=run"
+
+    echo "Check that install-device ran"
+    remote.exec "zcat /var/log/install-mode.log.gz" | MATCH "Run install-device hook"
+
+    echo "Check the gadget hook has hostname-control connected"
+    remote.exec "snap connections pc" | MATCH 'hostname-control\s+pc:hostname-control\s+:hostname-control'
+
+    echo "Check that serial registration was disabled for the test"
+    remote.exec "snap get pc device-service.access" | MATCH "^offline$"
+
+    echo "Check that the install-device hostname reached run mode"
+    remote.exec "cat /etc/hostname" | MATCH "^install-device-hostname$"
+    remote.exec "hostnamectl status --static" | MATCH "^install-device-hostname$"


### PR DESCRIPTION
Copy install-mode system hostname to run-mode target

This adds support to set the hostname for the run-mode target install, by copying it from install-mode.  The install-mode hostname can be set from the install-device hook of a gadget snap, assuming it has the hostname-control interface plug, using hostnamectl.  If no static hostname is set in install-mode, the hostname won't be copied.