### PR TITLE
logger, tests: add coverage logging

### DIFF
--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -22,22 +22,27 @@ package logger
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
 )
 
 type StructuredLog struct {
-	log   *slog.Logger
-	debug bool
-	trace bool
-	quiet bool
-	flags int
+	log      *slog.Logger
+	debug    bool
+	trace    bool
+	quiet    bool
+	flags    int
+	seenMu   sync.RWMutex
+	seenLogs map[string]bool
 }
 
 const (
@@ -94,14 +99,41 @@ func (l *StructuredLog) traceEnabled() bool {
 	return false
 }
 
-// Trace only prints if SNAPD_TRACE is set and structured logging is active
+// logKeyHash generates a unique hash for a message and its attributes
+// to use for deduplication purposes.
+func (l *StructuredLog) logKeyHash(msg string, attrs ...any) string {
+	h := md5.New()
+	fmt.Fprintf(h, "%s", msg)
+	for _, attr := range attrs {
+		fmt.Fprintf(h, "%v", attr)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// alreadyLogged checks if the given message+attrs combination has been logged before
+func (l *StructuredLog) alreadyLogged(msg string, attrs ...any) bool {
+	key := l.logKeyHash(msg, attrs...)
+	l.seenMu.RLock()
+	defer l.seenMu.RUnlock()
+	return l.seenLogs[key]
+}
+
+// markLogged records that a message+attrs combination has been logged
+func (l *StructuredLog) markLogged(msg string, attrs ...any) {
+	key := l.logKeyHash(msg, attrs...)
+	l.seenMu.Lock()
+	defer l.seenMu.Unlock()
+	l.seenLogs[key] = true
+}
+
 func (l *StructuredLog) Trace(msg string, attrs ...any) {
-	if l.traceEnabled() {
+	if l.traceEnabled() && !l.alreadyLogged(msg, attrs...) {
 		var pcs [1]uintptr
 		runtime.Callers(3, pcs[:])
 		r := slog.NewRecord(time.Now(), levelTrace, msg, pcs[0])
 		r.Add(attrs...)
 		l.log.Handler().Handle(context.Background(), r)
+		l.markLogged(msg, attrs...)
 	}
 }
 
@@ -153,10 +185,11 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		},
 	}
 	logger := &StructuredLog{
-		log:   slog.New(slog.NewJSONHandler(w, options)),
-		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
-		flags: flag,
-		trace: false,
+		log:      slog.New(slog.NewJSONHandler(w, options)),
+		debug:    opts.ForceDebug || debugEnabledOnKernelCmdline(),
+		flags:    flag,
+		trace:    false,
+		seenLogs: make(map[string]bool),
 	}
 	return logger
 }

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -74,6 +74,27 @@ type TestLogEntry struct {
 	Source TestSourceLogEntry
 }
 
+func decodeStructuredEntries(c *C, buf *bytes.Buffer) []TestLogEntry {
+	raw := bytes.TrimSpace(buf.Bytes())
+	if len(raw) == 0 {
+		return nil
+	}
+
+	lines := bytes.Split(raw, []byte("\n"))
+	entries := make([]TestLogEntry, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var data TestLogEntry
+		err := json.Unmarshal(line, &data)
+		c.Assert(err, IsNil)
+		entries = append(entries, data)
+	}
+
+	return entries
+}
+
 func (s *LogStructuredSuite) TestNewStructured(c *C) {
 	os.Setenv("SNAPD_JSON_LOGGING", "1")
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
@@ -104,6 +125,37 @@ func (s *LogStructuredSuite) TestTraceEnvStructured(c *C) {
 	c.Check(data.Level, Equals, "TRACE")
 	c.Check(data.Attr, Equals, "val")
 	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvStructuredDeduplicatesRepeatedEntry(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Trace("xyzzy", "attr", "val")
+	logger.Trace("xyzzy", "attr", "val")
+
+	entries := decodeStructuredEntries(c, s.logbuf)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Msg, Equals, "xyzzy")
+	c.Check(entries[0].Level, Equals, "TRACE")
+	c.Check(entries[0].Attr, Equals, "val")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvStructuredAllowsDistinctEntries(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Trace("xyzzy", "attr", "val")
+	logger.Trace("xyzzy", "attr", "different")
+
+	entries := decodeStructuredEntries(c, s.logbuf)
+	c.Assert(entries, HasLen, 2)
+	c.Check(entries[0].Msg, Equals, "xyzzy")
+	c.Check(entries[0].Level, Equals, "TRACE")
+	c.Check(entries[0].Attr, Equals, "val")
+	c.Check(entries[1].Msg, Equals, "xyzzy")
+	c.Check(entries[1].Level, Equals, "TRACE")
+	c.Check(entries[1].Attr, Equals, "different")
 }
 
 func (s *LogStructuredSuite) TestTraceEnvDebugStructured(c *C) {

--- a/tests/lib/collect-artifacts.sh
+++ b/tests/lib/collect-artifacts.sh
@@ -72,14 +72,14 @@ features_after_suite() {
     # make sure this is only run once per suite
     if ! [ -f "$TESTSTMP/initial-coverage-collected-${SPREAD_SUITE//\//--}" ]; then
         suite_dir="$(_prepare_suite_artifacts_path feature-tags)"
-        find / -name install-mode.log.gz -exec gzip -dc {} > "/tmp/install-mode.log" \;
+        find / -name install-mode.log.gz -exec gzip -dc {} \; > "/tmp/install-mode.log"
         if [ -f /tmp/install-mode.log ]; then
             cat /tmp/install-mode.log | _extract_trace_entries >> "$suite_dir"/journal.txt
         fi
 
         journalctl --sync || true
         journalctl --flush || true
-        journalctl --list-boots -q | awk '{print $1}' | while read boot_id; do journalctl -b "$boot_id" --no-pager | _extract_trace_entries; done >> "$suite_dir"/journal.txt
+        journalctl --list-boots -q | awk '{print $1}' | while read -r boot_id; do journalctl -b "$boot_id" --no-pager | _extract_trace_entries; done >> "$suite_dir"/journal.txt
         cp /var/lib/snapd/state.json "$suite_dir" || true
 
         touch "$TESTSTMP/initial-coverage-collected-${SPREAD_SUITE//\//--}"

--- a/tests/lib/collect-artifacts.sh
+++ b/tests/lib/collect-artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_prepare_artifacts_path() {
+_prepare_task_artifacts_path() {
     artifact=$1
     local artifacts_dir task_dir
     artifacts_dir="${SPREAD_PATH}/${artifact}"
@@ -9,34 +9,85 @@ _prepare_artifacts_path() {
     echo "$task_dir"
 }
 
+_prepare_suite_artifacts_path() {
+    artifact=$1
+    local artifacts_dir task_dir
+    artifacts_dir="${SPREAD_PATH}/${artifact}"
+    suite_dir="${artifacts_dir}/${SPREAD_BACKEND}:${SPREAD_SYSTEM}:${SPREAD_SUITE//\//--}"
+    mkdir -p "$suite_dir"
+    echo "$suite_dir"
+}
+
+_extract_trace_entries() {
+    # On some systems, JSON log entries can be split across lines; join those
+    # fragments before filtering for TRACE entries.
+    grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*"TRACE".*[^}]$/ { N; s/\n//; ba }' | grep '"TRACE"'
+}
+
 features_after_non_nested_task() {
     # Write to the directory specified in the spread.yaml file for artifacts
     local task_dir
-    task_dir="$(_prepare_artifacts_path feature-tags)"
+    task_dir="$(_prepare_task_artifacts_path feature-tags)"
     # On some systems, some log lines get broken into separate entries
     # So for lines with snapd/snap identifiers, search for lines that begin with `{` 
     # but don't end with `}` and have "TRACE", remove their new lines to recompose the entry.
     # Then only grab TRACE-level entries.
-    "$TESTSTOOLS"/journal-state get-log --no-pager | grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*\"TRACE\".*[^}]$/ { N; s/\n//; ba }' | grep '"TRACE"' > "$task_dir"/journal.txt
+    systemctl stop snapd || true
+    "$TESTSTOOLS"/journal-state get-log --no-pager | _extract_trace_entries > "$task_dir"/journal.txt
     cp /var/lib/snapd/state.json "$task_dir" || true
+    systemctl start snapd || true
 }
 
 features_after_nested_task() {
     local task_dir
-    task_dir="$(_prepare_artifacts_path feature-tags)"
+    task_dir="$(_prepare_task_artifacts_path feature-tags)"
 
     # When a nested test is skipped, its vm will not be available
-    "$TESTSTOOLS"/remote.exec "sudo journalctl --no-pager | grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*\\\"TRACE\\\".*[^}]$/ { N; s/\n//; ba }' | grep '\"TRACE\"'" > "$task_dir"/journal.txt || true
+    "$TESTSTOOLS"/remote.exec "sudo systemctl stop snapd" || true
+    "$TESTSTOOLS"/remote.exec "journalctl --sync" || true
+    "$TESTSTOOLS"/remote.exec "journalctl --flush" || true
+    # Collect TRACE logs from all boots, appending each boot's logs to journal.txt
+    "$TESTSTOOLS"/remote.exec "journalctl --list-boots -q | awk '{print \$1}' | while read boot_id; do sudo journalctl -b \"\$boot_id\" --no-pager | grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*\\\"TRACE\\\".*[^}]$/ { N; s/\n//; ba }' | grep '\"TRACE\"'; done" > "$task_dir"/journal.txt || true
+
+    # install-mode.log.gz may exist on nested systems; pull it, extract and append TRACE entries
+    "$TESTSTOOLS"/remote.exec "install_mode_log=\$(find / -name install-mode.log.gz 2>/dev/null | head -n 1); if [ -n \"\$install_mode_log\" ]; then sudo cp \"\$install_mode_log\" /tmp/install-mode.log.gz && sudo chmod 644 /tmp/install-mode.log.gz; fi" || true
+    "$TESTSTOOLS"/remote.pull "/tmp/install-mode.log.gz" "$task_dir" || true
+    if [ -f "$task_dir"/install-mode.log.gz ]; then
+        gzip -dc "$task_dir"/install-mode.log.gz | _extract_trace_entries >> "$task_dir"/journal.txt || true
+        rm -f "$task_dir"/install-mode.log.gz
+    fi
     "$TESTSTOOLS"/remote.exec "sudo chmod 777 /var/lib/snapd/state.json" || true
     "$TESTSTOOLS"/remote.pull "/var/lib/snapd/state.json" "$task_dir" || true
 }
 
 locks(){
     local task_dir
-    task_dir="$(_prepare_artifacts_path state-locks)"
+    task_dir="$(_prepare_task_artifacts_path state-locks)"
 
     cp -f "$TESTSTMP"/snapd_lock_traces "$task_dir"
 }
+
+features_after_suite() {
+    systemctl stop snapd || true
+    # make sure this is only run once per suite
+    if ! [ -f "$TESTSTMP/initial-coverage-collected-${SPREAD_SUITE//\//--}" ]; then
+        suite_dir="$(_prepare_suite_artifacts_path feature-tags)"
+        find / -name install-mode.log.gz -exec gzip -dc {} > "/tmp/install-mode.log" \;
+        if [ -f /tmp/install-mode.log ]; then
+            cat /tmp/install-mode.log | _extract_trace_entries >> "$suite_dir"/journal.txt
+        fi
+
+        journalctl --sync || true
+        journalctl --flush || true
+        journalctl --list-boots -q | awk '{print $1}' | while read boot_id; do journalctl -b "$boot_id" --no-pager | _extract_trace_entries; done >> "$suite_dir"/journal.txt
+        cp /var/lib/snapd/state.json "$suite_dir" || true
+
+        touch "$TESTSTMP/initial-coverage-collected-${SPREAD_SUITE//\//--}"
+    fi
+    systemctl start snapd || true
+}
+
+
 
 if [ "$#" == 0 ]; then
     echo "collect-artifacts: Illegal number of parameters"
@@ -60,6 +111,9 @@ case "$artifact" in
                 ;;
             --after-nested-task)
                 features_after_nested_task
+                ;;
+            --after-suite)
+                features_after_suite
                 ;;
             *)
                 echo "collect-artifacts: unsupported action $1" >&2

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -703,7 +703,8 @@ _add_nested_coverage_tweaks() {
     mkdir -p "${SNAP_CACHE}/unpack"
     unsquashfs -no-progress -f -d "${SNAP_CACHE}/unpack" "${SNAP_PATH}"
 
-    # add tweaks to run mode for spread tests
+    # add tweaks to install and run mode for spread tests
+    # shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
     _add_coverage_tweaks "${SNAP_CACHE}/unpack"
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -683,6 +683,35 @@ nested_ensure_ubuntu_save() {
     fi
 }
 
+_add_nested_coverage_tweaks() {
+    local TARGET
+    TARGET="${1}"
+    if [ "$TAG_FEATURES" = "false" ]; then
+        return
+    fi
+
+    SNAP_CACHE="$SNAPD_WORK_DIR/snapd_snap_with_tweaks"
+
+    mkdir -p "${SNAP_CACHE}"
+
+    SNAP_PATH=
+    for f in "${TARGET}"/snapd_*.snap; do
+        SNAP_PATH="$f"
+        break
+    done
+
+    mkdir -p "${SNAP_CACHE}/unpack"
+    unsquashfs -no-progress -f -d "${SNAP_CACHE}/unpack" "${SNAP_PATH}"
+
+    # add tweaks to run mode for spread tests
+    . "$TESTSLIB"/prepare.sh
+    _add_coverage_tweaks "${SNAP_CACHE}/unpack"
+
+    snap pack "${SNAP_CACHE}/unpack" "${SNAP_CACHE}/"
+    cp "${SNAP_CACHE}"/snapd_*.snap "${SNAP_PATH}"
+    rm -rf "${SNAP_CACHE}"
+}
+
 nested_prepare_snapd() {
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
         echo "Repacking snapd snap"
@@ -705,6 +734,7 @@ nested_prepare_snapd() {
                 # shellcheck source=tests/lib/prepare.sh
                 . "$TESTSLIB"/prepare.sh
                 build_snapd_snap "$NESTED_ASSETS_DIR"
+                _add_nested_coverage_tweaks "$NESTED_ASSETS_DIR"
                 for f in "${NESTED_ASSETS_DIR}"/snapd_*.snap; do
                     snap_name="$(basename "${f}")"
                     break
@@ -1797,6 +1827,7 @@ nested_start_classic_vm() {
     # Copy tools to be used on tests
     nested_wait_for_ssh
     nested_prepare_tools
+    nested_setup_feature_tagging
     nested_setup_vm
 }
 
@@ -1817,6 +1848,23 @@ remote.exec_as() {
     local PASSWD="$2"
     shift 2
     sshpass -p "$PASSWD" ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$USER"@localhost "$@"
+}
+
+nested_setup_feature_tagging() {
+    if [ -n "$TAG_FEATURES" ]; then
+        remote.exec "printf 'SNAPD_DEBUG=1\nSNAPD_TRACE=1\nSNAPD_JSON_LOGGING=1\nSNAP_LOG_TO_JOURNAL=1\n' | sudo tee -a /etc/environment"
+        CONF_FILE=99-generate-coverage.conf
+        while IFS= read -r line; do
+            dir=$(sed -E 's|^(.*)\.in$|/etc/systemd/system/\1.d|' <<<"$line")
+            remote.exec "mkdir -p $dir"
+            remote.exec "printf '[Service]\nEnvironment=SNAPD_TRACE=1\nEnvironment=SNAPD_JSON_LOGGING=1\n' | sudo tee $dir/$CONF_FILE"    
+        done < <(find "$SPREAD_PATH"/data/systemd "$SPREAD_PATH"/data/systemd-user -type f -name '*.service.in' -exec basename {} \;)
+        remote.exec "sudo systemctl daemon-reload"
+        remote.exec "sudo systemctl restart snapd"
+
+        remote.exec "sudo snap set system journal.persistent=true"
+        
+    fi
 }
 
 nested_prepare_tools() {
@@ -1867,20 +1915,8 @@ nested_prepare_tools() {
     fi
 
     if [ -n "$TAG_FEATURES" ]; then
-        # If feature tagging is enabled, then we need to enable debug logging
-        remote.exec "sudo mkdir -p /etc/systemd/system/snapd.service.d"
-        remote.exec "printf '[Service]\nEnvironment=SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_TRACE=1 SNAPD_JSON_LOGGING=1\n' | sudo tee /etc/systemd/system/snapd.service.d/99-feature-tags.conf"
-        # Persist journal logs
+        # Persist journal logs if gadget snap wasn't repacked
         remote.exec "sudo snap set system journal.persistent=true"
-        # Add trace structured logging to journal for snap commands
-        remote.exec "printf 'SNAPD_DEBUG=1\nSNAPD_TRACE=1\nSNAPD_JSON_LOGGING=1\nSNAP_LOG_TO_JOURNAL=1\n' | sudo tee -a /etc/environment"
-        # We changed the service configuration so we need to reload and restart
-        # the units to get them applied
-        remote.exec "sudo systemctl daemon-reload"
-        # stop the socket (it pulls down the service)
-        remote.exec "sudo systemctl stop snapd.socket"
-        # start the service (it pulls up the socket)
-        remote.exec "sudo systemctl start snapd.service"
     fi
 }
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -569,6 +569,12 @@ prepare_project() {
             ;;
     esac
 
+    if [ "$TAG_FEATURES" = "true" ]; then
+        pushd "$SPREAD_PATH"
+        go run ./tests/utils/features/instrument-funcs
+        popd
+    fi
+
     # Retry go mod vendor to minimize the number of connection errors during the sync
     # It is required in any case because the testing tools like the fakestore are always compiled
     retry -n 10 go mod vendor

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -773,6 +773,10 @@ prepare_suite_each() {
         "$TESTSTOOLS"/cleanup-state pre-invariant
     fi
     tests.invariant check
+
+    if [[ "$TAG_FEATURES" = true ]]; then
+        "$TESTSLIB"/collect-artifacts.sh features --after-suite
+    fi
 }
 
 restore_suite_each() {
@@ -867,6 +871,10 @@ restore_suite() {
             # A snap-confine package never existed on openSUSE or Arch
             distro_purge_package snap-confine
         fi
+    fi
+    if [ "$TAG_FEATURES" = "true" ]; then
+        journalctl --rotate || true
+        journalctl --vacuum-time=1s || true
     fi
 }
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -422,6 +422,10 @@ prepare_classic() {
     # Configure the proxy in the system when it is required
     setup_system_proxy
 
+    if ! tests.nested is-nested; then
+        prepare_tag_features
+    fi
+
     # Skip building snapd when REUSE_SNAPD is set to 1
     if [ "$REUSE_SNAPD" != 1 ]; then
         distro_install_build_snapd
@@ -734,6 +738,113 @@ slots:
 EOF
 }
 
+_add_coverage_tweaks() {
+    if [[ "$TAG_FEATURES" = "false" ]]; then
+        return
+    fi
+    local UNPACK_DIR
+    UNPACK_DIR="${1}"
+
+    cat > "${UNPACK_DIR}"/lib/systemd/system/snapd.spread-tests-coverage-tweaks.service <<'EOF'
+[Unit]
+Description=Tweaks to run mode for spread tests
+Before=snapd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/snapd/snapd.spread-tests-coverage-tweaks.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    cat > "${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-coverage-tweaks.sh <<EOF
+#!/bin/sh
+set -ex
+if [ -f /var/lib/snapd/modeenv ]; then
+    if ! grep -E '^mode=(run|recover)$' /var/lib/snapd/modeenv; then
+        echo "not in run or recovery mode - script not running"
+        exit 0
+    fi
+elif ! grep -E 'snapd_recovery_mode=(run|recover)' /proc/cmdline; then
+    echo "not in run or recovery mode - script not running"
+    exit 0
+fi
+if [ -e /root/spread-coverage-setup-done ]; then
+    exit 0
+fi
+echo "SNAPD_TRACE=1" >> /etc/environment
+echo "SNAPD_JSON_LOGGING=1" >> /etc/environment
+EOF
+    CONF_FILE=99-generate-coverage.conf
+    while IFS= read -r line; do
+        dir=$(sed -E 's|^(.*)\.in$|/etc/systemd/system/\1.d|' <<<"$line")
+        cat >> "${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-coverage-tweaks.sh <<EOF
+mkdir -p "$dir"
+cat <<EOF2 >"$dir/$CONF_FILE"
+[Service]
+Environment=SNAPD_TRACE=1
+Environment=SNAPD_JSON_LOGGING=1
+EOF2
+EOF
+    done < <(find "$SPREAD_PATH"/data/systemd "$SPREAD_PATH"/data/systemd-user -type f -name '*.service.in' -exec basename {} \;)
+    cat >>"${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-coverage-tweaks.sh <<EOF
+systemctl daemon-reload
+touch /root/spread-coverage-setup-done
+EOF
+    chmod 0755 "${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-coverage-tweaks.sh
+
+    if os.query is-core26; then
+        return
+    fi
+
+    # Install mode tweaks for cores less than 26
+    # now install a unit that sets up enough so that we can connect
+    cat > "${UNPACK_DIR}"/lib/systemd/system/snapd.spread-tests-install-mode-tweaks.service <<'EOF'
+[Unit]
+Description=Tweaks to install mode for spread tests
+Before=snapd.service
+Documentation=man:snap(1)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/snapd/snapd.spread-tests-install-mode-tweaks.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    # XXX: this duplicates a lot of setup_test_user_by_modify_writable()
+    cat > "${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-install-mode-tweaks.sh <<EOF
+#!/bin/sh
+set -ex
+# We look at modeenv as that is authoritative if installing from the initramfs.
+if [ -f /var/lib/snapd/modeenv ]; then
+    if ! grep -E '^mode=install$' /var/lib/snapd/modeenv; then
+        echo "not in install mode - script not running"
+        exit 0
+    fi
+elif ! grep -E 'snapd_recovery_mode=install' /proc/cmdline; then
+    echo "not in install mode - script not running"
+    exit 0
+fi
+if [ -e /root/spread-install-setup-done ]; then
+    exit 0
+fi
+mkdir -p "/etc/systemd/system/snapd.service.d"
+# this will be gone after reboot
+cat <<EOF2 >/etc/systemd/system/snapd.service.d/45-generate-coverage.conf
+[Service]
+Environment=SNAPD_TRACE=1
+Environment=SNAPD_JSON_LOGGING=1
+EOF2
+systemctl daemon-reload
+touch /root/spread-install-setup-done
+EOF
+    chmod 0755 "${UNPACK_DIR}"/usr/lib/snapd/snapd.spread-tests-install-mode-tweaks.sh
+}
+
 _add_run_mode_tweaks() {
     local UNPACK_DIR
     UNPACK_DIR="${1}"
@@ -865,6 +976,7 @@ build_snapd_snap_with_run_mode_firstboot_tweaks() {
 
     # add tweaks to run mode for spread tests
     _add_run_mode_tweaks "${SNAP_CACHE}/unpack"
+    _add_coverage_tweaks "${SNAP_CACHE}/unpack"
 
     # add gpio and iio slots required for the tests
     _add_gpio_iio_slots "${SNAP_CACHE}/unpack"
@@ -997,6 +1109,14 @@ set -eux
 if [ "$1" != initramfs-mounts ]; then
     exec /usr/lib/snapd/snap-bootstrap.real "$@"
 fi
+EOF
+    if [ "$TAG_FEATURES" = "true" ]; then
+        cat <<'EOF' >>"$SKELETON_PATH"/usr/lib/snapd/snap-bootstrap
+export SNAPD_TRACE=1
+export SNAPD_JSON_LOGGING=1
+EOF
+    fi
+    cat <<'EOF' >>"$SKELETON_PATH"/usr/lib/snapd/snap-bootstrap
 beforeDate="$(date --utc '+%s')"
 /usr/lib/snapd/snap-bootstrap.real "$@"
 if [ -d /run/mnt/data/system-data ]; then
@@ -1618,6 +1738,12 @@ EOF
                 echo "$cmd" >> pc-gadget/cmdline.extra
             done
         fi
+        cat >> pc-gadget/meta/gadget.yaml << EOF
+defaults:
+  system:
+    journal:
+      persistent: true
+EOF
 
         # TODO: this probably means it's time to move this helper out of 
         # nested.sh to somewhere more general
@@ -1885,30 +2011,20 @@ EOF
 }
 
 prepare_tag_features(){
-    CONF_FILE="/etc/systemd/system/snapd.service.d/99-feature-tags.conf"
-    RESTART=false
-
     if [ -n "$TAG_FEATURES" ]; then
-        # Generate the config file when it does not exist and when the threshold has changed different
-        if ! [ -f "$CONF_FILE" ]; then
-            cat <<EOF > "$CONF_FILE"
+        CONF_FILE="99-feature-coverage.conf"
+        while IFS= read -r line; do
+            dir=$(sed -E 's|^(.*)\.in$|/etc/systemd/system/\1.d|' <<<"$line")
+            mkdir -p "$dir"
+            if ! [ -f "$dir/$CONF_FILE" ]; then
+                cat <<EOF > "$dir/$CONF_FILE"
 [Service]
-Environment=SNAPPY_TESTING=1
 Environment=SNAPD_TRACE=1
 Environment=SNAPD_JSON_LOGGING=1
 EOF
-            RESTART=true
-        fi
-    elif [ -f "$CONF_FILE" ]; then
-        rm -f "$CONF_FILE"
-        RESTART=true
-    fi
-
-    if [ "$RESTART" = "true" ]; then
-        # the service setting may have changed in the service so we need
-        # to ensure snapd is reloaded
+            fi
+        done < <(find "$SPREAD_PATH"/data/systemd "$SPREAD_PATH"/data/systemd-user -type f -name '*.service.in' -exec basename {} \;)
         systemctl daemon-reload
-        systemctl restart snapd
     fi
 }
 
@@ -2038,7 +2154,10 @@ prepare_ubuntu_core() {
         remove_disabled_snaps
         prepare_memory_limit_override
         prepare_state_lock "SNAPD PROJECT"
-        prepare_tag_features
+        if [ "$TAG_FEATURES" = "true" ]; then
+            # ensure persistent journal is set
+            snap set system journal.persistent=true
+        fi
         setup_experimental_features
         systemctl stop snapd.service snapd.socket
         save_snapd_state

--- a/tests/utils/features/featcomposer.py
+++ b/tests/utils/features/featcomposer.py
@@ -34,8 +34,13 @@ def _parse_file_name(file_name: str) -> SpreadTaskNames:
     file_name = _remove_json_extension(file_name)
     original_name = file_name.replace('--', '/')
     task = ':'.join(original_name.split(':')[2:])
-    suite_name = '/'.join(task.split('/')[:-1])
-    task_name = task.split('/')[-1]
+    task_split=task.split('/')
+    if len(task_split) == 2 or (len(task_split) > 2 and not task_split[2]):
+        suite_name = task
+        task_name = ''
+    else:
+        suite_name = '/'.join(task_split[:-1])
+        task_name = task_split[-1]
     variant_name = ''
     if task_name.count(':') == 1:
         variant_name = task_name.split(':')[1]

--- a/tests/utils/features/featextractor.py
+++ b/tests/utils/features/featextractor.py
@@ -6,7 +6,7 @@ import json
 from typing import Any, TextIO
 import sys
 
-from features import Cmd, Endpoint, Interface, Task, Change, Ensure, CmdLogLine, EndpointLogLine, InterfaceLogLine, EnsureLogLine, ChangeLogLine, TaskLogLine
+from features import Coverage, Cmd, Endpoint, Interface, Task, Change, Ensure, CoverageLogLine, CmdLogLine, EndpointLogLine, InterfaceLogLine, EnsureLogLine, ChangeLogLine, TaskLogLine
 from state import State, NotInStateError
 
 
@@ -18,6 +18,22 @@ def _remove_duplicate_features(key: str, dictionary: dict[str, Any]):
     if key in dictionary:
         l = dictionary[key]
         dictionary[key] = [i for n, i in enumerate(l) if i not in l[n + 1:]]
+
+
+class CoverageFeature:
+    name = 'coverage'
+    parent = 'coverages'
+    msg = 'coverage'
+
+    @staticmethod
+    def handle_feature(feature_dict: dict[str, list[Any]], json_entry: dict[str, Any], _):
+        coverage = Coverage(file=json_entry[CoverageLogLine.file], func=json_entry[CoverageLogLine.func])
+        if CoverageFeature.parent not in feature_dict or coverage not in feature_dict[CoverageFeature.parent]:
+            feature_dict[CoverageFeature.parent].append(coverage)
+
+    @staticmethod
+    def cleanup_dict(_):
+        pass
 
 
 class CmdFeature:
@@ -141,7 +157,7 @@ class TaskFeature:
                 del entry['id']
 
 
-FEATURE_LIST = [CmdFeature, EndpointFeature, InterfaceFeature,
+FEATURE_LIST = [CoverageFeature, CmdFeature, EndpointFeature, InterfaceFeature,
                 EnsureFeature, ChangeFeature, TaskFeature]
 
 

--- a/tests/utils/features/features.py
+++ b/tests/utils/features/features.py
@@ -65,6 +65,7 @@ class TaskFeatures(TypedDict):
     tasks: list[Task]
     changes: list[Change]
     ensures: list[Ensure]
+    coverages: list[Coverage]
     runtime: float
 
 

--- a/tests/utils/features/features.py
+++ b/tests/utils/features/features.py
@@ -7,6 +7,11 @@ from enum import Enum
 from typing import TypedDict
 
 
+class Coverage(TypedDict):
+    file: str
+    func: str
+
+
 class Cmd(TypedDict):
     cmd: str
 
@@ -69,6 +74,11 @@ class SystemFeatures(TypedDict):
     scenarios: list[str]
     env_variables: list[EnvVariables]
     tests: list[TaskFeatures]
+
+
+class CoverageLogLine:
+    file = 'file'
+    func = 'func'
 
 
 class CmdLogLine:

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	wd, _ := os.Getwd()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", path, err)
+			return nil
+		}
+		if info.IsDir() && (info.Name() == "vendor" || info.Name() == ".git" ||
+			info.Name() == "logger" || info.Name() == "osutil" ||
+			info.Name() == "randutil" || info.Name() == "strutil" ||
+			info.Name() == "testutil" || info.Name() == "dbusutil" ||
+			info.Name() == "tests" || info.Name() == "release" ||
+			info.Name() == "blkid" || info.Name() == "snap-seccomp" ||
+			info.Name() == "snap-update-ns" || info.Name() == "dirs") {
+			return filepath.SkipDir
+		}
+		if !strings.HasSuffix(path, ".go") || info.IsDir() || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if err := instrumentFile(path, wd); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: %v\n", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "walk error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func instrumentFile(path, wd string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse: %v", err)
+	}
+
+	relPath := filepath.ToSlash(path)
+	if r, err := filepath.Rel(wd, path); err == nil {
+		relPath = filepath.ToSlash(r)
+	}
+
+	inLoggerPkg := f.Name.Name == "logger"
+
+	type insertion struct {
+		offset int
+		text   string
+	}
+	var insertions []insertion
+
+	for _, decl := range f.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok || funcDecl.Body == nil {
+			continue
+		}
+
+		if isAlreadyInstrumented(funcDecl.Body) {
+			continue
+		}
+
+		lbrace := fset.Position(funcDecl.Body.Lbrace).Offset
+		insOffset := lbrace + 1
+
+		bodyOnSameLine := insOffset < len(src) && src[insOffset] != '\n'
+
+		funcName := funcDecl.Name.Name
+
+		insText := fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
+			"logger.Trace", strLit(relPath), strLit(funcName))
+		if inLoggerPkg {
+			insText = fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
+				"Trace", strLit(relPath), strLit(funcName))
+		}
+		if bodyOnSameLine {
+			insText += "\n"
+		}
+
+		insertions = append(insertions, insertion{insOffset, insText})
+	}
+
+	if len(insertions) == 0 {
+		return nil
+	}
+
+	sort.Slice(insertions, func(i, j int) bool {
+		return insertions[i].offset > insertions[j].offset
+	})
+
+	for _, ins := range insertions {
+		src = append(src[:ins.offset], append([]byte(ins.text), src[ins.offset:]...)...)
+	}
+
+	if !inLoggerPkg && !hasLoggerImport(f) {
+		src = addImportToSource(src, fset, f, `"github.com/snapcore/snapd/logger"`)
+	}
+
+	result, err := format.Source(src)
+	if err != nil {
+		return fmt.Errorf("format: %v", err)
+	}
+
+	return os.WriteFile(path, result, 0644)
+}
+
+func strLit(s string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+func hasLoggerImport(f *ast.File) bool {
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"github.com/snapcore/snapd/logger"` {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlreadyInstrumented(body *ast.BlockStmt) bool {
+	if len(body.List) == 0 {
+		return false
+	}
+	stmt, ok := body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := stmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if x, ok := fun.X.(*ast.Ident); !ok || x.Name != "logger" {
+			return false
+		}
+		if fun.Sel.Name != "Trace" {
+			return false
+		}
+	case *ast.Ident:
+		if fun.Name != "Trace" {
+			return false
+		}
+	default:
+		return false
+	}
+
+	if len(call.Args) < 1 {
+		return false
+	}
+	if lit, ok := call.Args[0].(*ast.BasicLit); !ok || lit.Kind != token.STRING || lit.Value != `"coverage"` {
+		return false
+	}
+
+	return true
+}
+
+func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath string) []byte {
+	importLine := "\n\t" + importPath
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.IMPORT {
+			continue
+		}
+
+		if genDecl.Lparen.IsValid() {
+			// Grouped import: `import ( ... )`
+			endOffset := fset.Position(genDecl.End()).Offset
+			insertAt := endOffset - 1
+			src = append(src[:insertAt], append([]byte(importLine+"\n"), src[insertAt:]...)...)
+		} else {
+			// Single import: `import "..."` — convert to grouped form
+			startOffset := fset.Position(genDecl.Pos()).Offset
+			endOffset := fset.Position(genDecl.End()).Offset
+			existingImport := src[startOffset:endOffset]
+			grouped := "import (\n\t" + string(existingImport[len("import "):]) + importLine + "\n)"
+			before := make([]byte, startOffset)
+			copy(before, src[:startOffset])
+			src = append(before, append([]byte(grouped), src[endOffset:]...)...)
+		}
+		return src
+	}
+
+	pkgEnd := fset.Position(f.Name.End()).Offset
+	newImportBlock := "\nimport (" + importLine + "\n)\n"
+	src = append(src[:pkgEnd], append([]byte(newImportBlock), src[pkgEnd:]...)...)
+	return src
+}

--- a/tests/utils/features/process-features.sh
+++ b/tests/utils/features/process-features.sh
@@ -4,7 +4,7 @@ shopt -s nullglob
 
 work_dir="${WORK_DIR:-$(mktemp -d)}"
 run_id="${RUN_ID:-}"
-features="${FEATURES:-cmd,task,change,ensure,endpoint,interface}"
+features="${FEATURES:-coverage,cmd,task,change,ensure,endpoint,interface}"
 
 if ! [ -d "$work_dir/feature-tags-artifacts" ]; then
     if [ -z "$run_id" ]; then

--- a/tests/utils/features/test_featcomposer.py
+++ b/tests/utils/features/test_featcomposer.py
@@ -27,6 +27,7 @@ class TestCompose(unittest.TestCase):
         features['tasks'] = [
             Task(kind=msg, snap_type='snap', last_status=Status.done.value)]
         features['changes'] = [Change(kind=msg, snap_type='snap')]
+        features['coverages'] = [Coverage(file=f'{msg}.go', func=msg)]
         return features
 
     @staticmethod
@@ -41,7 +42,8 @@ class TestCompose(unittest.TestCase):
             endpoints=features['endpoints'],
             interfaces=features['interfaces'],
             tasks=features['tasks'],
-            changes=features['changes']
+            changes=features['changes'],
+            coverages=features['coverages']
         )
 
     @staticmethod
@@ -131,6 +133,44 @@ class TestCompose(unittest.TestCase):
                         check_test_equal(sys2test1, test, True)
                     if test['task_name'] == 'test3':
                         check_test_equal(sys2test3, test, False)
+
+    def test_coverage_preservation(self):
+        """Test that coverage data is preserved during composition"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create test files with coverage data
+            test_file = os.path.join(tmpdir, 'backend:system1:tests--main--test1')
+            test_data = {
+                'suite': 'tests/main',
+                'task_name': 'test1',
+                'variant': '',
+                'success': True,
+                'cmds': [],
+                'endpoints': [],
+                'interfaces': [],
+                'tasks': [],
+                'changes': [],
+                'ensures': [],
+                'coverages': [
+                    {'file': 'core/overlord/snapstate.go', 'func': 'doInstall'},
+                    {'file': 'core/daemon/api.go', 'func': 'handleGet'},
+                ]
+            }
+            with open(test_file, 'w', encoding='utf-8') as f:
+                json.dump(test_data, f)
+            
+            systems = featcomposer.get_system_list(tmpdir)
+            self.assertEqual(1, len(systems))
+            composed = featcomposer.compose_system(tmpdir, systems.pop(),
+                                                       'backend:system1:tests/main/test1',
+                                                       [], [])
+            
+            # Verify coverage data is present in composed output
+            assert 'tests' in composed and len(composed['tests']) == 1
+            test = composed['tests'][0]
+            assert 'coverages' in test
+            assert len(test['coverages']) == 2
+            assert {'file': 'core/overlord/snapstate.go', 'func': 'doInstall'} in test['coverages']
+            assert {'file': 'core/daemon/api.go', 'func': 'handleGet'} in test['coverages']
 
 
 class TestReplace(unittest.TestCase):

--- a/tests/utils/features/test_featcomposer.py
+++ b/tests/utils/features/test_featcomposer.py
@@ -25,7 +25,7 @@ class TestCompose(unittest.TestCase):
         features['endpoints'] = [Endpoint(method='POST', path=msg)]
         features['interfaces'] = [Interface(name=msg)]
         features['tasks'] = [
-            Task(kind=msg, snap_type='snap', last_status=Status.done)]
+            Task(kind=msg, snap_type='snap', last_status=Status.done.value)]
         features['changes'] = [Change(kind=msg, snap_type='snap')]
         return features
 
@@ -80,18 +80,18 @@ class TestCompose(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             res = os.path.join(tmpdir, 'res')
             os.mkdir(res)
-            sys1test1 = TestCompose.get_features('sys1test1')
-            sys1test2 = TestCompose.get_features('sys1test2')
-            sys2test1 = TestCompose.get_features('sys2test1')
-            sys2test3 = TestCompose.get_features('sys2test3')
+            sys1test1 = TestCompose.get_json('tests/main', 'test1', '', False, 'sys1test1')
+            sys1test2 = TestCompose.get_json('tests/main', 'test2', 'variant1', False, 'sys1test2')
+            sys2test1 = TestCompose.get_json('tests/main', 'test1', '', True, 'sys2test1')
+            sys2test3 = TestCompose.get_json('tests/main', 'test3', '', False, 'sys2test3')
 
-            with open(os.path.join(res, 'backend:system1:tests--test1'), mode='w', encoding='utf-8') as f:
+            with open(os.path.join(res, 'backend:system1:tests--main--test1'), mode='w', encoding='utf-8') as f:
                 json.dump(sys1test1, f)
-            with open(os.path.join(res, 'backend:system1:tests--test2:variant1'), mode='w', encoding='utf-8') as f:
+            with open(os.path.join(res, 'backend:system1:tests--main--test2:variant1'), mode='w', encoding='utf-8') as f:
                 json.dump(sys1test2, f)
-            with open(os.path.join(res, 'backend:system2:tests--test1'), mode='w', encoding='utf-8') as f:
+            with open(os.path.join(res, 'backend:system2:tests--main--test1'), mode='w', encoding='utf-8') as f:
                 json.dump(sys2test1, f)
-            with open(os.path.join(res, 'backend:system2:tests--test3'), mode='w', encoding='utf-8') as f:
+            with open(os.path.join(res, 'backend:system2:tests--main--test3'), mode='w', encoding='utf-8') as f:
                 json.dump(sys2test3, f)
             out = os.path.join(tmpdir, 'out')
             os.mkdir(out)
@@ -120,6 +120,8 @@ class TestCompose(unittest.TestCase):
                     if test['task_name'] == 'test1':
                         check_test_equal(sys1test1, test, False)
                     if test['task_name'] == 'test2':
+                        print(f'test is {test}')
+                        print(f'sys1test2 is {sys1test2}')
                         check_test_equal(sys1test2, test, False)
             with open(os.path.join(out, 'backend:system2_1.json'), mode='r', encoding='utf-8') as f:
                 sys1 = json.load(f)

--- a/tests/utils/features/test_featextractor.py
+++ b/tests/utils/features/test_featextractor.py
@@ -10,7 +10,7 @@ from io import StringIO
 import unittest
 
 import featextractor
-from featextractor import CmdFeature, EndpointFeature, InterfaceFeature, TaskFeature, ChangeFeature, EnsureFeature 
+from featextractor import CmdFeature, EndpointFeature, InterfaceFeature, TaskFeature, ChangeFeature, EnsureFeature, CoverageFeature
 from features import *
 from state import State
 
@@ -125,6 +125,23 @@ class TestExtract(unittest.TestCase):
         assert Change(kind="kind1", snap_types=["snapd"]) in d['changes']
         assert Change(kind="kind2", snap_types=["app"]) in d['changes']
         assert Change(kind="kind3", snap_types=[]) in d['changes']
+
+    def test_extract_coverage(self):
+        file1 = "core/overlord/snapstate.go"
+        func1 = "snapstate.doInstall"
+        file2 = "core/daemon/api.go"
+        func2 = "daemon.handleGet"
+        loglines = [
+            {"msg":CoverageFeature.msg, CoverageLogLine.file:file1, CoverageLogLine.func:func1},
+            {"msg":CoverageFeature.msg, CoverageLogLine.file:file2, CoverageLogLine.func:func2},
+            {"msg":CoverageFeature.msg, CoverageLogLine.file:file1, CoverageLogLine.func:func1},
+        ]
+        logs = _get_stringio_from_loglines(loglines)
+        d = featextractor.get_feature_dictionary(logs, ['coverage'], State({}))
+        assert len(d) == 1
+        assert 'coverages' in d and len(d['coverages']) == 2
+        assert Coverage(file=file1, func=func1) in d['coverages']
+        assert Coverage(file=file2, func=func2) in d['coverages']
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The idea of this approach is to use a trace log line added to each function in snapd to gather coverage information of what functions are executed during tests and suite preparation. So as to not burden the code base, this data is added during the feature tagging run. 

This also adds suite-level feature gathering to collect early boot information for ubuntu core and general startup feature data across all systems. 

Commits:
- 97237c592bb95bffc2ae2325fe6c70cf1b1f3750: enable coverage-based feature tagging during early boot
- 797827331498a2058a1df2ec1f9e74ed9b53feab: collect early boot feature tags and also all data up to the first test in each suite
- d113059aa1e71cfd2d3b5ed559911b943ffc7734: adds a tool to add a log line to every single function in snapd
- 2937c71915458f83a3fd46b543c6ba435e3ab6c6: disallows logging of identical lines. Logging every single function generates a lot of unnecessary data since we're only interested in if a function is called, not how many times. This uses an in-memory cache to store previously logged features and does not log them again. To clean the cache, we restart snapd after each log gathering.
- 7b896ed6151e71771a857fa082a367d3443ce0c8: adds the additional feature type to feature extraction and composition