### PR TITLE
github: remove variants from the skipped tests PR comment

### DIFF
--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -162,12 +162,8 @@ jobs:
 
           if find . -name skipped_tests_list.txt | grep -q .; then
             echo "## Skipped tests from [snapd-testing-skip](https://github.com/canonical/snapd-testing-skip)" >> report
-            echo "<details>" >> report
-            echo "<summary><em>If you wish to have any of the below tests run in your PR, in your PR description, add 'unskip:' followed by a copy-and-pasted list (without variants) of the below tests you wish to run (unskip plus test list must be valid yaml)</em></summary>" >> report
-            echo "" >> report
-            find . -name skipped_tests_list.txt -exec cat {} \; | tr ' ' '\n' | grep . | sort -u | awk '{print "- "$1}' >> report
-            echo "" >> report
-            echo "</details>" >> report
+            echo "*If you wish to have any of the below tests run in your PR, in your PR description, add 'unskip:' followed by a copy-and-pasted list of the below tests you wish to run (unskip plus test list must be valid yaml)*" >> report
+            find . -name skipped_tests_list.txt -exec cat {} \; | tr ' ' '\n' | grep . | sed 's/:[^/:]*$//' | sort -u | awk '{print "- "$1}' >> report
           fi
 
           # display the report

--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -162,8 +162,12 @@ jobs:
 
           if find . -name skipped_tests_list.txt | grep -q .; then
             echo "## Skipped tests from [snapd-testing-skip](https://github.com/canonical/snapd-testing-skip)" >> report
-            echo "*If you wish to have any of the below tests run in your PR, in your PR description, add 'unskip:' followed by a copy-and-pasted list (without variants) of the below tests you wish to run (unskip plus test list must be valid yaml)*" >> report
+            echo "<details>" >> report
+            echo "<summary><em>If you wish to have any of the below tests run in your PR, in your PR description, add 'unskip:' followed by a copy-and-pasted list (without variants) of the below tests you wish to run (unskip plus test list must be valid yaml)</em></summary>" >> report
+            echo "" >> report
             find . -name skipped_tests_list.txt -exec cat {} \; | tr ' ' '\n' | grep . | sort -u | awk '{print "- "$1}' >> report
+            echo "" >> report
+            echo "</details>" >> report
           fi
 
           # display the report


### PR DESCRIPTION
Lately the skipped spread tests list in the PR comment has gotten too big.
**Note**: the effect of this change won't be visible until it is merged to master.