### PR TITLE
o/snapshotstate/backend: snapshot restore handles mounts

### DIFF
--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -49,6 +49,8 @@ import (
 	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -58,6 +60,7 @@ type snapshotSuite struct {
 	restore   []func()
 	tarPath   string
 	isTesting bool
+	sysd      *systemdtest.FakeSystemd
 }
 
 // silly wrappers to get better failure messages
@@ -114,6 +117,7 @@ func (s *snapshotSuite) SetUpTest(c *check.C) {
 	cur, err := user.Current()
 	c.Assert(err, check.IsNil)
 
+	s.sysd = &systemdtest.FakeSystemd{}
 	s.restore = append(s.restore, backend.MockUserLookup(func(username string) (*user.User, error) {
 		if username != "snapuser" {
 			return nil, user.UnknownUserError(username)
@@ -124,6 +128,10 @@ func (s *snapshotSuite) SetUpTest(c *check.C) {
 		return &rv, nil
 	}),
 		backend.MockIsTesting(s.isTesting),
+		osutil.MockMountInfo(""),
+		systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
+			return s.sysd
+		}),
 	)
 
 	s.tarPath, err = exec.LookPath("tar")

--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -42,6 +42,8 @@ var (
 	NewMultiError = newMultiError
 
 	AddSnapDirToZip = addSnapDirToZip
+
+	IsPathAtOrUnderDir = isPathAtOrUnderDir
 )
 
 func MockIsTesting(newIsTesting bool) func() {

--- a/overlord/snapshotstate/backend/mounts.go
+++ b/overlord/snapshotstate/backend/mounts.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/systemd"
+)
+
+// listMountsAtOrUnder returns active mount points at or under baseDir,
+// divided into snapctl and non-snapctl mount groups.
+func listMountsAtOrUnder(snapName, baseDir string) (snapctlMPs, nonSnapctlMPs []string, err error) {
+	sysd := systemd.New(systemd.SystemMode, nil)
+	// mounts created using snapctl have the "mount-control" origin
+	mcMountPoints, err := sysd.ListMountUnits(snapName, "mount-control")
+	if err != nil {
+		return nil, nil, err
+	}
+	mcMounts := make(map[string]bool, len(mcMountPoints))
+	for _, mp := range mcMountPoints {
+		mcMounts[mp] = true
+	}
+
+	mountInfo, err := osutil.LoadMountInfo()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, entry := range mountInfo {
+		mp := entry.MountDir
+		if !isPathAtOrUnderDir(mp, baseDir) {
+			continue
+		}
+		if mcMounts[mp] {
+			snapctlMPs = append(snapctlMPs, mp)
+		} else {
+			nonSnapctlMPs = append(nonSnapctlMPs, mp)
+		}
+	}
+	return snapctlMPs, nonSnapctlMPs, nil
+}
+
+// stopMountUnits stops the mount units corresponding to the given mount points,
+// one by one. It returns an error if any unit could not be stopped or if any
+// mount point did not have a corresponding unit file.
+// It returns all successfully stopped units (even on partial failure).
+func stopMountUnits(mountPoints []string) (stoppedUnits []string, err error) {
+	if len(mountPoints) == 0 {
+		return nil, nil
+	}
+	sysd := systemd.New(systemd.SystemMode, nil)
+	for _, mp := range mountPoints {
+		unitPath := systemd.ExistingMountUnitPath(dirs.StripRootDir(mp))
+		if unitPath == "" {
+			return stoppedUnits, fmt.Errorf("cannot find mount unit file for %q", mp)
+		}
+
+		unit := filepath.Base(unitPath)
+		if stopErr := sysd.Stop([]string{unit}); stopErr != nil {
+			return stoppedUnits, stopErr
+		}
+		stoppedUnits = append(stoppedUnits, unit)
+	}
+	return stoppedUnits, nil
+}
+
+func startMountUnits(units []string) error {
+	if len(units) == 0 {
+		return nil
+	}
+	sysd := systemd.New(systemd.SystemMode, nil)
+	return sysd.Start(units)
+}
+
+func isPathAtOrUnderDir(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	// rel starts with ".." when path is outside dir
+	return !strings.HasPrefix(rel, "..")
+}

--- a/overlord/snapshotstate/backend/mounts.go
+++ b/overlord/snapshotstate/backend/mounts.go
@@ -74,7 +74,7 @@ func stopMountUnits(mountPoints []string) (stoppedUnits []string, err error) {
 	for _, mp := range mountPoints {
 		unitPath := systemd.ExistingMountUnitPath(dirs.StripRootDir(mp))
 		if unitPath == "" {
-			return stoppedUnits, fmt.Errorf("cannot find mount unit file for %q", mp)
+			return stoppedUnits, fmt.Errorf("cannot find mount unit file for mount point %q", mp)
 		}
 
 		unit := filepath.Base(unitPath)

--- a/overlord/snapshotstate/backend/mounts_test.go
+++ b/overlord/snapshotstate/backend/mounts_test.go
@@ -1,0 +1,436 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// makeMountUnitFile creates a persistent mount unit file under the root dir for the
+// given mount point path and returns the unit name (base filename).
+func makeMountUnitFile(c *C, mountPoint string) string {
+	stripped := dirs.StripRootDir(mountPoint)
+	escaped := systemd.EscapeUnitNamePath(stripped)
+	c.Assert(os.MkdirAll(dirs.SnapServicesDir, 0755), IsNil)
+	unitName := escaped + ".mount"
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapServicesDir, unitName), []byte("[Unit]\n"), 0644), IsNil)
+	return unitName
+}
+
+// mountInfoLine returns a single mountinfo line for a bind mount at mountPoint.
+func mountInfoLine(mountPoint string) string {
+	return fmt.Sprintf("100 1 8:1 / %s rw,relatime - tmpfs tmpfs rw\n", mountPoint)
+}
+
+// saveAndOpenSnapshot creates a snapshot of "hello-snap" rev 42 (whose data
+// dirs are created by snapshotSuite.SetUpTest) and opens it for reading.
+func saveAndOpenSnapshot(c *C) *backend.Reader {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (runuser will fail)")
+	}
+	info := &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "hello-snap",
+			Revision: snap.R(42),
+			SnapID:   "hello-id",
+		},
+		Version: "v1.33",
+	}
+	shw, err := backend.Save(context.TODO(), 1, info, nil, []string{"snapuser"}, nil, nil)
+	c.Assert(err, IsNil)
+	shr, err := backend.Open(backend.Filename(shw), backend.ExtractFnameSetID)
+	c.Assert(err, IsNil)
+	return shr
+}
+
+func (s *snapshotSuite) TestIsPathAtOrUnderDir(c *C) {
+	for _, tc := range []struct {
+		path, dir string
+		expected  bool
+		comment   string
+	}{
+		{"/foo/bar", "/foo/bar", true, "exact match"},
+		{"/foo/bar/baz", "/foo/bar", true, "direct child"},
+		{"/foo/bar/baz/qux", "/foo/bar", true, "deep child"},
+		{"/foo/bar/baz/", "/foo/bar", true, "trailing slash on path"},
+		{"/foo/bar/baz", "/foo/bar/", true, "trailing slash on dir"},
+		{"/foo/bar/baz/", "/foo/bar/", true, "trailing slash on both"},
+		{"/foo/bar/", "/foo/bar", true, "exact match, trailing slash on path"},
+		{"/foo/bar", "/foo/bar/", true, "exact match, trailing slash on dir"},
+		{"/foo/bar-extra", "/foo/bar", false, "sibling with common prefix"},
+		{"/foo", "/foo/bar", false, "parent of dir"},
+		{"/other", "/foo/bar", false, "unrelated path"},
+		{"/foo/bar/../../other", "/foo/bar", false, "path escapes dir via .."},
+		{"/foo//bar/baz", "/foo/bar", true, "double slash in path"},
+		{"/foo/bar/baz", "foo/bar", false, "relative dir"},
+	} {
+		c.Check(backend.IsPathAtOrUnderDir(tc.path, tc.dir), Equals, tc.expected,
+			Commentf(tc.comment))
+	}
+}
+
+func (s *snapshotSuite) TestRestoreNoMountsAtDst(c *C) {
+	// No active mounts under the snap data dirs.
+	// Restore succeeds with no Stop or Start calls.
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	rs, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, IsNil)
+	rs.Cleanup()
+
+	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
+	})
+	c.Check(s.sysd.StopCalls, HasLen, 0)
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+}
+
+func (s *snapshotSuite) TestRestoreStopsAndRestartsSnapctlMounts(c *C) {
+	// A snapctl (mount-control) mount lives under the snap revision data dir.
+	// Restore must Stop it before renaming and Start it afterwards.
+	si := snap.MinimalPlaceInfo("hello-snap", snap.R(42))
+	mountPoint := filepath.Join(si.DataDir(), "target")
+	unitName := makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	rs, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, IsNil)
+	rs.Cleanup()
+
+	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
+	})
+	c.Assert(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
+	c.Assert(s.sysd.StartCalls, HasLen, 1)
+	c.Check(s.sysd.StartCalls[0], DeepEquals, []string{unitName})
+}
+
+func (s *snapshotSuite) TestRestoreNonSnapctlMountReturnsError(c *C) {
+	// A non-snapctl mount under the snap revision data dir.
+	// Restore returns an error, no Stop called.
+	si := snap.MinimalPlaceInfo("hello-snap", snap.R(42))
+	mountPoint := filepath.Join(si.DataDir(), "user-target")
+
+	// sysd reports no mount-control mounts (ListMountUnitsResult empty default)
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	_, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, ErrorMatches, `.*cannot move data with unknown mount.*`)
+
+	// ListMountUnits called at least once
+	c.Assert(s.sysd.ListMountUnitsCalls, Not(HasLen), 0)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.StopCalls, HasLen, 0)
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+}
+
+func (s *snapshotSuite) TestRestoreListMountErrorReturnsError(c *C) {
+	// ListMountUnits returns an error.
+	// Restore propagates it.
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		Err: errors.New("mock ListMountUnits error"),
+	}
+
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	_, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, ErrorMatches, `.*cannot list mounts.*mock ListMountUnits error.*`)
+
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.StopCalls, HasLen, 0)
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+}
+
+func (s *snapshotSuite) TestRestoreStopFailureReturnsError(c *C) {
+	// Stop returns an error.
+	// Restore propagates it and Start is not called since no
+	// units were successfully stopped.
+	si := snap.MinimalPlaceInfo("hello-snap", snap.R(42))
+	mountPoint := filepath.Join(si.DataDir(), "target")
+	makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+	s.sysd.StopResult = errors.New("systemd stop failed")
+
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	_, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, ErrorMatches, `.*cannot stop mount unit.*systemd stop failed.*`)
+
+	c.Assert(s.sysd.ListMountUnitsCalls, Not(HasLen), 0)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+}
+
+func (s *snapshotSuite) TestRestoreRestartFailureIsLoggedNotReturned(c *C) {
+	// Start fails after successful Stop.
+	// Restore still returns nil (restart failure is best-effort, only logged).
+	si := snap.MinimalPlaceInfo("hello-snap", snap.R(42))
+	mountPoint := filepath.Join(si.DataDir(), "target")
+	unitName := makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	s.sysd.StartResult = errors.New("systemd start failed")
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	shr := saveAndOpenSnapshot(c)
+	defer shr.Close()
+
+	rs, err := shr.Restore(context.TODO(), snap.R(0), nil, logger.Debugf, nil)
+	c.Assert(err, IsNil)
+	rs.Cleanup()
+
+	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
+		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
+	})
+	c.Assert(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
+	c.Assert(s.sysd.StartCalls, HasLen, 1)
+	c.Check(s.sysd.StartCalls[0], DeepEquals, []string{unitName})
+	c.Check(logbuf.String(), testutil.Contains, `cannot restart mount unit`)
+	c.Check(logbuf.String(), testutil.Contains, `systemd start failed`)
+}
+
+func (s *snapshotSuite) TestRevertSkipsMountHandlingWhenSnapEmpty(c *C) {
+	// rs.Snap == "" (older snapd persisted state).
+	// No ListMountUnits call.
+	dir := c.MkDir()
+	rs := &backend.RestoreState{
+		Snap:    "",
+		Created: []string{dir},
+	}
+	rs.Revert()
+
+	c.Check(s.sysd.ListMountUnitsCalls, HasLen, 0)
+	// dir should have been removed
+	_, err := os.Stat(dir)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *snapshotSuite) TestRevertStopsAndRestartsSnapctlMounts(c *C) {
+	// rs.Created contains a dir with a snapctl mount under it.
+	// Stop before RemoveAll, Start after Revert returns.
+	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
+	mountPoint := filepath.Join(createdDir, "target")
+	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	unitName := makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	// Also set up a Moved entry so Revert renames it back
+	movedDir := createdDir + ".~aBcDeFgHi~"
+	c.Assert(os.MkdirAll(movedDir, 0755), IsNil)
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{createdDir},
+		Moved:   []string{movedDir},
+	}
+	rs.Revert()
+
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+
+	c.Assert(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
+	c.Assert(s.sysd.StartCalls, HasLen, 1)
+	c.Check(s.sysd.StartCalls[0], DeepEquals, []string{unitName})
+	// createdDir was removed but the movedDir should have been renamed to createdDir
+	_, err := os.Stat(createdDir)
+	c.Check(err, IsNil)
+	// movedDir (the backup) should be deleted
+	_, err = os.Stat(movedDir)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *snapshotSuite) TestRevertLogsAndContinuesOnNonSnapctlMounts(c *C) {
+	// Non-snapctl mount under a Created dir.
+	// Logged, no Stop called, Revert continues.
+	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
+	mountPoint := filepath.Join(createdDir, "user-target")
+	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+
+	// sysd reports no mount-control mounts (ListMountUnitsResult empty default)
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{createdDir},
+	}
+	rs.Revert()
+
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.StopCalls, HasLen, 0)
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+	c.Check(logbuf.String(), testutil.Contains, `cannot move data with unknown mount`)
+}
+
+func (s *snapshotSuite) TestRevertLogsAndContinuesOnStopFailure(c *C) {
+	// Stop fails for a snapctl mount under a Created dir.
+	// Logged, no Start called (nothing was stopped).
+	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
+	mountPoint := filepath.Join(createdDir, "target")
+	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	unitName := makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	s.sysd.StopResult = errors.New("systemd stop failed")
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{createdDir},
+	}
+	rs.Revert()
+
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
+	c.Check(s.sysd.StartCalls, HasLen, 0)
+	c.Check(logbuf.String(), testutil.Contains, `cannot stop mount unit`)
+	c.Check(logbuf.String(), testutil.Contains, `systemd stop failed`)
+}
+
+func (s *snapshotSuite) TestRevertLogsAndContinuesOnStartFailure(c *C) {
+	// Stop succeeds but Start fails for a snapctl mount under a Created dir.
+	// Logged, Revert continues, dir removed (best-effort restart).
+	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
+	mountPoint := filepath.Join(createdDir, "target")
+	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	unitName := makeMountUnitFile(c, mountPoint)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mountPoint},
+	}
+	s.sysd.StartResult = errors.New("systemd start failed")
+	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{createdDir},
+	}
+	rs.Revert()
+
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Assert(s.sysd.StopCalls, HasLen, 1)
+	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
+	c.Assert(s.sysd.StartCalls, HasLen, 1)
+	c.Check(s.sysd.StartCalls[0], DeepEquals, []string{unitName})
+	c.Check(logbuf.String(), testutil.Contains, `cannot restart mount unit`)
+	c.Check(logbuf.String(), testutil.Contains, `systemd start failed`)
+	// dir was removed
+	_, err := os.Stat(createdDir)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *snapshotSuite) TestRevertLogsAndContinuesOnListMountError(c *C) {
+	// ListMountUnits error.
+	// Logged, no Stop called, Revert continues.
+	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
+	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		Err: errors.New("mock ListMountUnits error"),
+	}
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{createdDir},
+	}
+	rs.Revert()
+
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(logbuf.String(), testutil.Contains, `cannot list mounts`)
+	c.Check(logbuf.String(), testutil.Contains, `mock ListMountUnits error`)
+	// dir was still removed despite the error
+	_, err := os.Stat(createdDir)
+	c.Check(os.IsNotExist(err), Equals, true)
+}

--- a/overlord/snapshotstate/backend/mounts_test.go
+++ b/overlord/snapshotstate/backend/mounts_test.go
@@ -320,13 +320,17 @@ func (s *snapshotSuite) TestRevertStopsAndRestartsSnapctlMounts(c *C) {
 }
 
 func (s *snapshotSuite) TestRevertLogsAndContinuesOnNonSnapctlMounts(c *C) {
-	// Non-snapctl mount under a Created dir.
-	// Logged, no Stop called, Revert continues.
-	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
-	mountPoint := filepath.Join(createdDir, "user-target")
-	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	// Non-snapctl mount under the first Created dir; second dir is clean.
+	// Logged for dir1, no Stop called, Revert continues to dir2 and removes it
+	// (verifies the loop is not aborted on a non-snapctl mount).
+	dir1 := filepath.Join(s.root, "var/snap/mysnap/x1")
+	dir2 := filepath.Join(s.root, "var/snap/mysnap/x2")
+	mountPoint := filepath.Join(dir1, "user-target")
+	c.Assert(os.MkdirAll(dir1, 0755), IsNil)
+	c.Assert(os.MkdirAll(dir2, 0755), IsNil)
 
-	// sysd reports no mount-control mounts (ListMountUnitsResult empty default)
+	// sysd reports no mount-control mounts (ListMountUnitsResult empty default);
+	// the non-snapctl mount is only under dir1.
 	defer osutil.MockMountInfo(mountInfoLine(mountPoint))()
 
 	logbuf, restoreLogger := logger.MockLogger()
@@ -334,26 +338,38 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnNonSnapctlMounts(c *C) {
 
 	rs := &backend.RestoreState{
 		Snap:    "mysnap",
-		Created: []string{createdDir},
+		Created: []string{dir1, dir2},
 	}
 	rs.Revert()
 
+	// Both dirs must have been visited (loop continued past dir1).
 	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
-	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)
 	c.Check(s.sysd.StopCalls, HasLen, 0)
 	c.Check(s.sysd.StartCalls, HasLen, 0)
 	c.Check(logbuf.String(), testutil.Contains, `cannot remove data with unknown mount`)
+	c.Check(logbuf.String(), testutil.Contains, dir1)
+	// dir1 was skipped (non-snapctl mount present), dir2 was removed.
+	_, err := os.Stat(dir1)
+	c.Check(err, IsNil)
+	_, err = os.Stat(dir2)
+	c.Check(os.IsNotExist(err), Equals, true)
 }
 
 func (s *snapshotSuite) TestRevertLogsAndContinuesOnStopFailure(c *C) {
-	// Stop fails for a snapctl mount under a Created dir.
-	// Logged, no Start called (nothing was stopped).
-	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
-	mountPoint := filepath.Join(createdDir, "target")
-	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	// Stop fails for a snapctl mount under the first Created dir; second dir is clean.
+	// Logged for dir1, no Start called, Revert continues to dir2 and removes it
+	// (verifies the loop is not aborted on a stop failure).
+	dir1 := filepath.Join(s.root, "var/snap/mysnap/x1")
+	dir2 := filepath.Join(s.root, "var/snap/mysnap/x2")
+	mountPoint := filepath.Join(dir1, "target")
+	c.Assert(os.MkdirAll(dir1, 0755), IsNil)
+	c.Assert(os.MkdirAll(dir2, 0755), IsNil)
 	unitName := makeMountUnitFile(c, mountPoint)
 
+	// The snapctl mount is only under dir1; dir2 has no mounts.
 	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
 		MountPoints: []string{mountPoint},
 	}
@@ -365,18 +381,27 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnStopFailure(c *C) {
 
 	rs := &backend.RestoreState{
 		Snap:    "mysnap",
-		Created: []string{createdDir},
+		Created: []string{dir1, dir2},
 	}
 	rs.Revert()
 
+	// Both dirs must have been visited (loop continued past dir1).
 	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
-	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)
+	// Stop attempted only for dir1's mount; dir2 had no mounts.
 	c.Check(s.sysd.StopCalls, HasLen, 1)
 	c.Check(s.sysd.StopCalls[0], DeepEquals, []string{unitName})
 	c.Check(s.sysd.StartCalls, HasLen, 0)
 	c.Check(logbuf.String(), testutil.Contains, `cannot stop mount unit`)
 	c.Check(logbuf.String(), testutil.Contains, `systemd stop failed`)
+	c.Check(logbuf.String(), testutil.Contains, dir1)
+	// dir1 was skipped (stop failed), dir2 was removed.
+	_, err := os.Stat(dir1)
+	c.Check(err, IsNil)
+	_, err = os.Stat(dir2)
+	c.Check(os.IsNotExist(err), Equals, true)
 }
 
 func (s *snapshotSuite) TestRevertLogsAndContinuesOnStartFailure(c *C) {
@@ -417,10 +442,13 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnStartFailure(c *C) {
 }
 
 func (s *snapshotSuite) TestRevertLogsAndContinuesOnListMountError(c *C) {
-	// ListMountUnits error.
-	// Logged, no Stop called, Revert continues.
-	createdDir := filepath.Join(s.root, "var/snap/mysnap/x1")
-	c.Assert(os.MkdirAll(createdDir, 0755), IsNil)
+	// ListMountUnits error on both Created dirs.
+	// Logged for each, no Stop called, Revert continues to the second dir
+	// after skipping the first (verifies the loop is not aborted on error).
+	dir1 := filepath.Join(s.root, "var/snap/mysnap/x1")
+	dir2 := filepath.Join(s.root, "var/snap/mysnap/x2")
+	c.Assert(os.MkdirAll(dir1, 0755), IsNil)
+	c.Assert(os.MkdirAll(dir2, 0755), IsNil)
 
 	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
 		Err: errors.New("mock ListMountUnits error"),
@@ -431,18 +459,26 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnListMountError(c *C) {
 
 	rs := &backend.RestoreState{
 		Snap:    "mysnap",
-		Created: []string{createdDir},
+		Created: []string{dir1, dir2},
 	}
 	rs.Revert()
 
+	// Both dirs must have been visited (loop continued past the first error).
 	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
-	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
+	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)
+	c.Check(s.sysd.StopCalls, HasLen, 0)
+	// Error logged for both dirs.
 	c.Check(logbuf.String(), testutil.Contains, `cannot list mounts`)
 	c.Check(logbuf.String(), testutil.Contains, `mock ListMountUnits error`)
-	// dir was still removed despite the error
-	_, err := os.Stat(createdDir)
-	c.Check(os.IsNotExist(err), Equals, true)
+	c.Check(logbuf.String(), testutil.Contains, dir1)
+	c.Check(logbuf.String(), testutil.Contains, dir2)
+	// Neither dir was removed because we couldn't determine their mounts.
+	_, err := os.Stat(dir1)
+	c.Check(err, IsNil)
+	_, err = os.Stat(dir2)
+	c.Check(err, IsNil)
 }
 
 func (s *snapshotSuite) TestRevertRestartsEachDirsMountsIndependently(c *C) {

--- a/overlord/snapshotstate/backend/mounts_test.go
+++ b/overlord/snapshotstate/backend/mounts_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -52,6 +53,15 @@ func makeMountUnitFile(c *C, mountPoint string) string {
 // mountInfoLine returns a single mountinfo line for a bind mount at mountPoint.
 func mountInfoLine(mountPoint string) string {
 	return fmt.Sprintf("100 1 8:1 / %s rw,relatime - tmpfs tmpfs rw\n", mountPoint)
+}
+
+// mountInfoLines returns one mountinfo line per mount point, with unique IDs.
+func mountInfoLines(mountPoints ...string) string {
+	var sb strings.Builder
+	for i, mp := range mountPoints {
+		fmt.Fprintf(&sb, "%d 1 8:1 / %s rw,relatime - tmpfs tmpfs rw\n", 100+i, mp)
+	}
+	return sb.String()
 }
 
 // saveAndOpenSnapshot creates a snapshot of "hello-snap" rev 42 (whose data
@@ -333,7 +343,7 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnNonSnapctlMounts(c *C) {
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 	c.Check(s.sysd.StopCalls, HasLen, 0)
 	c.Check(s.sysd.StartCalls, HasLen, 0)
-	c.Check(logbuf.String(), testutil.Contains, `cannot move data with unknown mount`)
+	c.Check(logbuf.String(), testutil.Contains, `cannot remove data with unknown mount`)
 }
 
 func (s *snapshotSuite) TestRevertLogsAndContinuesOnStopFailure(c *C) {
@@ -433,4 +443,43 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnListMountError(c *C) {
 	// dir was still removed despite the error
 	_, err := os.Stat(createdDir)
 	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *snapshotSuite) TestRevertRestartsEachDirsMountsIndependently(c *C) {
+	// Two Created dirs each with their own snapctl mount. Start fails for both.
+	// Without the loop-variable fix each deferred closure would capture the
+	// last value of `dir`, so the log would mention only dir2; with the fix
+	// both dirs are mentioned.
+	dir1 := filepath.Join(s.root, "var/snap/mysnap/x1")
+	mp1 := filepath.Join(dir1, "target1")
+	c.Assert(os.MkdirAll(dir1, 0755), IsNil)
+	makeMountUnitFile(c, mp1)
+
+	dir2 := filepath.Join(s.root, "var/snap/mysnap/x2")
+	mp2 := filepath.Join(dir2, "target2")
+	c.Assert(os.MkdirAll(dir2, 0755), IsNil)
+	makeMountUnitFile(c, mp2)
+
+	s.sysd.ListMountUnitsResult = systemdtest.ResultForListMountUnits{
+		MountPoints: []string{mp1, mp2},
+	}
+	s.sysd.StartResult = errors.New("systemd start failed")
+	defer osutil.MockMountInfo(mountInfoLines(mp1, mp2))()
+
+	logbuf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	rs := &backend.RestoreState{
+		Snap:    "mysnap",
+		Created: []string{dir1, dir2},
+	}
+	rs.Revert()
+
+	// Each dir contributes one stop and one (attempted) start.
+	c.Assert(s.sysd.StopCalls, HasLen, 2)
+	c.Assert(s.sysd.StartCalls, HasLen, 2)
+
+	// The error log must mention both dirs, not just the last one.
+	c.Check(logbuf.String(), testutil.Contains, dir1)
+	c.Check(logbuf.String(), testutil.Contains, dir2)
 }

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 
 	"github.com/snapcore/snapd/client"
@@ -197,7 +198,7 @@ type Logf func(format string, args ...any)
 // or the one in the snapshot) with that contained in the snapshot. It keeps
 // track of the old data in the task so it can be undone (or cleaned up).
 func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames []string, logf Logf, opts *dirs.SnapDirOptions) (rs *RestoreState, e error) {
-	rs = &RestoreState{}
+	rs = &RestoreState{Snap: r.Snap}
 	defer func() {
 		if e != nil {
 			logger.Noticef("Restore of snapshot %q failed (%v); undoing.", r.Name(), e)
@@ -393,6 +394,32 @@ func moveFile(rs *RestoreState, file, sourceDir, targetDir string) error {
 		return err
 	}
 	if exists {
+		// Handle mounts under dst before renaming it.
+		// * snapctl mounts are stopped and restarted after moveFile returns
+		//   (i.e., once the src data has been moved).
+		// * non-snapctl mounts cannot be stopped and could lead to dangling
+		//   mounts on move, so return an error if any are present.
+		snapctlMPs, nonSnapctlMPs, err := listMountsAtOrUnder(rs.Snap, dst)
+		if err != nil {
+			return fmt.Errorf("cannot list mounts for snap %q under %q: %v",
+				rs.Snap, dst, err)
+		}
+		if len(nonSnapctlMPs) > 0 {
+			return fmt.Errorf("cannot move data with unknown mount(s) under %q: %s",
+				dst, strings.Join(nonSnapctlMPs, ", "))
+		}
+		stoppedUnits, err := stopMountUnits(snapctlMPs)
+		defer func() {
+			// best effort restart
+			if startErr := startMountUnits(stoppedUnits); startErr != nil {
+				logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v",
+					rs.Snap, dst, startErr)
+			}
+		}()
+		if err != nil {
+			return fmt.Errorf("cannot stop mount unit(s) for snap %q under %q: %v",
+				rs.Snap, dst, err)
+		}
 		rsfn := restoreStateFilename(dst)
 		if err := os.Rename(dst, rsfn); err != nil {
 			return err

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -410,7 +410,8 @@ func moveFile(rs *RestoreState, file, sourceDir, targetDir string) error {
 		}
 		stoppedUnits, err := stopMountUnits(snapctlMPs)
 		defer func() {
-			// best effort restart
+			// best effort restart when we exit to restore the mounts in the newly
+			// restored directory, but also cover the error path
 			if startErr := startMountUnits(stoppedUnits); startErr != nil {
 				logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v",
 					rs.Snap, dst, startErr)

--- a/overlord/snapshotstate/backend/restorestate.go
+++ b/overlord/snapshotstate/backend/restorestate.go
@@ -91,18 +91,20 @@ func (rs *RestoreState) Revert() {
 			} else if len(nonSnapctlMPs) > 0 {
 				// Non-snapctl mounts are present; RemoveAll will fail on them
 				// anyway, so snapctl mounts are not stopped.
-				logger.Noticef("cannot move data with unknown mount(s) under %q: %s",
+				logger.Noticef("cannot remove data with unknown mount(s) under %q: %s",
 					dir, strings.Join(nonSnapctlMPs, ", "))
 			} else {
 				stoppedUnits, stopErr := stopMountUnits(snapctlMPs)
 				if stopErr != nil {
 					logger.Noticef("cannot stop mount unit(s) for snap %q under %q: %v", rs.Snap, dir, stopErr)
 				}
-				defer func(units []string) {
+				// Pass dir as a parameter to avoid capturing the loop
+				// variable by reference (Go < 1.22 reuses it each iteration).
+				defer func(units []string, d string) {
 					if startErr := startMountUnits(units); startErr != nil {
-						logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v", rs.Snap, dir, startErr)
+						logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v", rs.Snap, d, startErr)
 					}
-				}(stoppedUnits)
+				}(stoppedUnits, dir)
 			}
 		}
 		if err := os.RemoveAll(dir); err != nil {

--- a/overlord/snapshotstate/backend/restorestate.go
+++ b/overlord/snapshotstate/backend/restorestate.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/randutil"
@@ -35,6 +36,7 @@ import (
 // one failing necessitates undoing the Restore.
 type RestoreState struct {
 	Done    bool     `json:"done,omitempty"`
+	Snap    string   `json:"snap,omitempty"`
 	Created []string `json:"created,omitempty"`
 	Moved   []string `json:"moved,omitempty"`
 	// Config is here for convenience; this package doesn't touch it
@@ -77,6 +79,32 @@ func (rs *RestoreState) Revert() {
 	rs.Done = true
 	for _, dir := range rs.Created {
 		logger.Debugf("Removing %q.", dir)
+		// Handle mounts under dir before removing it.
+		// * snapctl mounts are stopped and restarted after Revert returns
+		//   (i.e., once the Moved loop has put old data back in place).
+		// * rs.Snap may be empty for a RestoreState persisted by an older
+		//   snapd, in that case skip mount handling.
+		if rs.Snap != "" {
+			snapctlMPs, nonSnapctlMPs, mountErr := listMountsAtOrUnder(rs.Snap, dir)
+			if mountErr != nil {
+				logger.Noticef("cannot list mounts for snap %q under %q: %v", rs.Snap, dir, mountErr)
+			} else if len(nonSnapctlMPs) > 0 {
+				// Non-snapctl mounts are present; RemoveAll will fail on them
+				// anyway, so snapctl mounts are not stopped.
+				logger.Noticef("cannot move data with unknown mount(s) under %q: %s",
+					dir, strings.Join(nonSnapctlMPs, ", "))
+			} else {
+				stoppedUnits, stopErr := stopMountUnits(snapctlMPs)
+				if stopErr != nil {
+					logger.Noticef("cannot stop mount unit(s) for snap %q under %q: %v", rs.Snap, dir, stopErr)
+				}
+				defer func(units []string) {
+					if startErr := startMountUnits(units); startErr != nil {
+						logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v", rs.Snap, dir, startErr)
+					}
+				}(stoppedUnits)
+			}
+		}
 		if err := os.RemoveAll(dir); err != nil {
 			logger.Noticef("While undoing changes because of a previous error: cannot remove %q: %v.", dir, err)
 		}

--- a/overlord/snapshotstate/backend/restorestate.go
+++ b/overlord/snapshotstate/backend/restorestate.go
@@ -82,22 +82,25 @@ func (rs *RestoreState) Revert() {
 		// Handle mounts under dir before removing it.
 		// * snapctl mounts are stopped and restarted after Revert returns
 		//   (i.e., once the Moved loop has put old data back in place).
+		// * if dir wasn't existing before Restore it would likely not have
+		//   any mounts now.
+		// * only Created dirs are checked for mounts because these are the
+		//   paths where the original data was located and where mounts could
+		//   have been present before Restore and hence also after moving data
+		//   during Restore.
 		// * rs.Snap may be empty for a RestoreState persisted by an older
 		//   snapd, in that case skip mount handling.
 		if rs.Snap != "" {
 			snapctlMPs, nonSnapctlMPs, mountErr := listMountsAtOrUnder(rs.Snap, dir)
 			if mountErr != nil {
-				logger.Noticef("cannot list mounts for snap %q under %q: %v", rs.Snap, dir, mountErr)
+				logger.Noticef("skipping removal of %q, cannot list mounts for snap %q under it: %v", dir, rs.Snap, mountErr)
+				continue
 			} else if len(nonSnapctlMPs) > 0 {
-				// Non-snapctl mounts are present; RemoveAll will fail on them
-				// anyway, so snapctl mounts are not stopped.
-				logger.Noticef("cannot remove data with unknown mount(s) under %q: %s",
+				logger.Noticef("skipping removal of %q, cannot remove data with unknown mount(s) under it: %s",
 					dir, strings.Join(nonSnapctlMPs, ", "))
+				continue
 			} else {
 				stoppedUnits, stopErr := stopMountUnits(snapctlMPs)
-				if stopErr != nil {
-					logger.Noticef("cannot stop mount unit(s) for snap %q under %q: %v", rs.Snap, dir, stopErr)
-				}
 				// Pass dir as a parameter to avoid capturing the loop
 				// variable by reference (Go < 1.22 reuses it each iteration).
 				defer func(units []string, d string) {
@@ -105,12 +108,18 @@ func (rs *RestoreState) Revert() {
 						logger.Noticef("cannot restart mount unit(s) for snap %q under %q: %v", rs.Snap, d, startErr)
 					}
 				}(stoppedUnits, dir)
+				if stopErr != nil {
+					logger.Noticef("skipping removal of %q, cannot stop mount unit(s) for snap %q under it: %v", dir, rs.Snap, stopErr)
+					continue
+				}
 			}
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			logger.Noticef("While undoing changes because of a previous error: cannot remove %q: %v.", dir, err)
 		}
 	}
+	// Restore makes sure that there are no active mounts under the Moved dirs,
+	// so we can just move them back without checking for mounts.
 	for _, dir := range rs.Moved {
 		orig := restoreState2orig(dir)
 		if orig == "" {

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -223,6 +223,7 @@ func prepareSave(task *state.Task) (snapshot *snapshotSetup, cur *snap.Info, cfg
 	return snapshot, cur, cfg, nil
 }
 
+// Expects that the snap's applications and services are not running.
 func doSave(task *state.Task, tomb *tomb.Tomb) error {
 	snapshot, cur, cfg, err := prepareSave(task)
 	if err != nil {
@@ -361,6 +362,7 @@ func unmarshalSnapConfig(st *state.State, snapName string) (map[string]any, erro
 	return cfg, nil
 }
 
+// Expects that the snap's applications and services are not running.
 func doRestore(task *state.Task, tomb *tomb.Tomb) error {
 	snapshot, oldCfg, reader, err := prepareRestore(task)
 	if err != nil {
@@ -407,6 +409,7 @@ func doRestore(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+// Expects that the snap's applications and services are not running.
 func undoRestore(task *state.Task, _ *tomb.Tomb) error {
 	var restoreState backend.RestoreState
 	var snapshot snapshotSetup

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -412,6 +412,8 @@ func Save(st *state.State, instanceNames []string, users []string, options map[s
 	ts = state.NewTaskSet()
 
 	for _, name := range instanceNames {
+		// TODO: add tasks to stop snap's applications and services
+
 		desc := fmt.Sprintf("Save data of snap %q in snapshot set #%d", name, setID)
 		task := st.NewTask("save-snapshot", desc)
 
@@ -435,6 +437,8 @@ func Save(st *state.State, instanceNames []string, users []string, options map[s
 		// Also note we aren't promising this behaviour; we can change
 		// it if we find it to be wrong.
 		ts.AddTask(task)
+
+		// TODO: add task to restart snap's services
 	}
 
 	return setID, instanceNames, ts, nil
@@ -454,6 +458,9 @@ func AutomaticSnapshot(st *state.State, snapName string) (ts *state.TaskSet, err
 	}
 
 	ts = state.NewTaskSet()
+
+	// TODO: add tasks to stop snap's applications and services
+
 	desc := fmt.Sprintf("Save data of snap %q in automatic snapshot set #%d", snapName, setID)
 	task := st.NewTask("save-snapshot", desc)
 	snapshot := snapshotSetup{
@@ -463,6 +470,8 @@ func AutomaticSnapshot(st *state.State, snapName string) (ts *state.TaskSet, err
 	}
 	task.Set("snapshot-setup", &snapshot)
 	ts.AddTask(task)
+
+	// TODO: add task to restart snap's services
 
 	return ts, nil
 }
@@ -511,6 +520,8 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 			current = snapst.Current
 		}
 
+		// TODO: add tasks to stop snap's applications and services
+
 		desc := fmt.Sprintf("Restore data of snap %q from snapshot set #%d", summary.snap, setID)
 		task := st.NewTask("restore-snapshot", desc)
 		snapshot := snapshotSetup{
@@ -533,6 +544,8 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 		task := st.NewTask("cleanup-after-restore", desc)
 		task.WaitAll(ts)
 		ts.AddTask(task)
+
+		// TODO: add task to restart snap's services
 	}
 
 	return snapsFound, ts, nil

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -114,6 +114,12 @@ type FakeSystemd struct {
 
 	ListMountUnitsCalls  []ParamsForListMountUnits
 	ListMountUnitsResult ResultForListMountUnits
+
+	StopCalls  [][]string
+	StopResult error
+
+	StartCalls  [][]string
+	StartResult error
 }
 
 type ParamsForConfigureMountUnitOptions struct {
@@ -171,4 +177,14 @@ func (s *FakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) 
 	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
 		ParamsForListMountUnits{SnapName: snapName, Origin: origin})
 	return s.ListMountUnitsResult.MountPoints, s.ListMountUnitsResult.Err
+}
+
+func (s *FakeSystemd) Stop(units []string) error {
+	s.StopCalls = append(s.StopCalls, append([]string{}, units...))
+	return s.StopResult
+}
+
+func (s *FakeSystemd) Start(units []string) error {
+	s.StartCalls = append(s.StartCalls, append([]string{}, units...))
+	return s.StartResult
 }

--- a/tests/main/snapshot-excludes-mounts/task.yaml
+++ b/tests/main/snapshot-excludes-mounts/task.yaml
@@ -18,8 +18,8 @@ environment:
     SNAP_NAME: test-snapd-mount-control
     SNAP_COMMON: /var/snap/$SNAP_NAME/common
     SNAP_DATA: /var/snap/$SNAP_NAME/x1
-    SNAP_USER_COMMON: /root/snap/$SNAP_NAME/common
-    SNAP_USER_DATA: /root/snap/$SNAP_NAME/x1
+    SNAP_USER_COMMON: $HOME/snap/$SNAP_NAME/common
+    SNAP_USER_DATA: $HOME/snap/$SNAP_NAME/x1
     MOUNT_SRC: /var/tmp/$SNAP_NAME
     SNAPCTL_MOUNT_DEST_COMMON: $SNAP_COMMON/target1
     SNAPCTL_MOUNT_DEST_DATA: $SNAP_DATA/target1
@@ -103,6 +103,8 @@ execute: |
         snap check-snapshot "${set_id}"
     }
 
+    # Depending on TEST_CASE, either just snapctl mounts are expected to be excluded,
+    # or both snapctl and user mounts are expected to be excluded
     then_snapshot_has_mount_point_excludes() {
         local set_id=$1
         echo "Verify snapshot ${set_id} has excludes for active mount points"
@@ -124,6 +126,8 @@ execute: |
         fi
     }
 
+    # Depending on TEST_CASE, either just snapctl mounts are expected to be excluded,
+    # or both snapctl and user mounts are expected to be excluded
     then_restore_and_verify_excludes() {
         local set_id=$1
         echo "Restore snapshot ${set_id} and verify that data outside mount points is present"

--- a/tests/main/snapshot-excludes-mounts/task.yaml
+++ b/tests/main/snapshot-excludes-mounts/task.yaml
@@ -1,4 +1,4 @@
-summary: Snapshot excludes active mount points under snap data directories
+summary: Snapshot excludes all mount points and restore preserves snapctl mounts
 
 details: |
     When taking a snapshot of a snap that has active mount points under its
@@ -6,6 +6,11 @@ details: |
     $SNAP_USER_COMMON), snapd automatically excludes those mount points from
     the snapshot. This prevents capturing data that was mounted into snap's
     data directories.
+
+    When restoring a snapshot while snapctl mount points are still active, snapd
+    preserves snapctl mounts so that they remain accessible at their original
+    paths after restore completes. However, if there are any non-snapctl mounts
+    active under the snap's data directories, restore will fail.
 
 systems: [-ubuntu-14.04-*]
 
@@ -24,8 +29,10 @@ environment:
     USER_MOUNT_DEST_USER_DATA: $SNAP_USER_DATA/target2
     # tar invoked when creating snapshots triggers OOM
     SNAPD_NO_MEMORY_LIMIT: 1
-    TEST_CASE/v1: snap_save
-    TEST_CASE/v2: snap_remove
+    TEST_CASE/v1: snap_save_excludes_all_mounts
+    TEST_CASE/v2: snap_remove_excludes_all_mounts
+    TEST_CASE/v3: snap_restore_preserves_snapctl_mounts
+    TEST_CASE/v4: snap_restore_fails_when_user_mounts
 
 prepare: |
     echo "Install test snap with mount-control interface"
@@ -61,7 +68,7 @@ prepare: |
     # Note: user mounts are intentionally not set up for the snap_remove test
     # case because `snap remove` will fail if there are any non-snapctl mounts under the
     # snap's data directories, which will forget the automatic snapshot.
-    if [ "${TEST_CASE}" = "snap_save" ]; then
+    if [ "${TEST_CASE}" = "snap_save_excludes_all_mounts" ] || [ "${TEST_CASE}" = "snap_restore_fails_when_user_mounts" ]; then
         echo "Set up user (non-snapctl) mounts in global and user data directories"
         mkdir -p "${USER_MOUNT_DEST_COMMON}" "${USER_MOUNT_DEST_DATA}" "${USER_MOUNT_DEST_USER_COMMON}" "${USER_MOUNT_DEST_USER_DATA}"
         tests.cleanup defer rm -rf "${USER_MOUNT_DEST_COMMON}" "${USER_MOUNT_DEST_DATA}" "${USER_MOUNT_DEST_USER_COMMON}" "${USER_MOUNT_DEST_USER_DATA}"
@@ -105,7 +112,7 @@ execute: |
         MATCH '^\$SNAP_COMMON/target1$' < options-exclude
         #shellcheck disable=SC2016
         MATCH '^\$SNAP_DATA/target1$' < options-exclude
-        if [ "${TEST_CASE}" = "snap_save" ]; then
+        if [ "${TEST_CASE}" = "snap_save_excludes_all_mounts" ]; then
             #shellcheck disable=SC2016
             MATCH '^\$SNAP_COMMON/target2$' < options-exclude
             #shellcheck disable=SC2016
@@ -127,7 +134,7 @@ execute: |
         echo "and data inside snapctl mount points was not captured"
         not test -e "${SNAPCTL_MOUNT_DEST_COMMON}/excluded-file-common.txt"
         not test -e "${SNAPCTL_MOUNT_DEST_DATA}/excluded-file-data.txt"
-        if [ "${TEST_CASE}" = "snap_save" ]; then
+        if [ "${TEST_CASE}" = "snap_save_excludes_all_mounts" ]; then
             echo "and data inside user mount points was not captured"
             not test -e "${USER_MOUNT_DEST_COMMON}/excluded-file-common.txt"
             not test -e "${USER_MOUNT_DEST_DATA}/excluded-file-data.txt"
@@ -136,7 +143,7 @@ execute: |
         fi
     }
 
-    test_snap_save() {
+    test_snap_save_excludes_all_mounts() {
         echo "Take a snapshot using snap save"
         local set_id
         set_id=$(snap save "${SNAP_NAME}" | cut -d\  -f1 | tail -n1)
@@ -158,7 +165,65 @@ execute: |
         then_restore_and_verify_excludes "${set_id}"
     }
 
-    test_snap_remove() {
+    then_restore_and_verify_mounts() {
+        local set_id=$1
+        echo "Restore snapshot ${set_id} and verify that data outside mount points is present"
+        snap restore "${set_id}" "${SNAP_NAME}"
+        MATCH "snap-common-data" < "${SNAP_COMMON}/data.txt"
+        MATCH "snap-data-data" < "${SNAP_DATA}/data.txt"
+
+        echo "Verify mount units are active after restore"
+        UNIT_NAME="$(systemd-escape -p "${SNAPCTL_MOUNT_DEST_COMMON}").mount"
+        systemctl is-active --quiet "${UNIT_NAME}"
+        UNIT_NAME="$(systemd-escape -p "${SNAPCTL_MOUNT_DEST_DATA}").mount"
+        systemctl is-active --quiet "${UNIT_NAME}"
+
+        echo "Verify mount data is intact after restore"
+        MATCH "after-save-before-restore" < "${SNAPCTL_MOUNT_DEST_COMMON}/excluded-file-common.txt"
+        MATCH "after-save-before-restore" < "${SNAPCTL_MOUNT_DEST_DATA}/excluded-file-data.txt"
+        MATCH "mounted-data" < "${SNAPCTL_MOUNT_DEST_COMMON}/mounted-data.txt"
+        MATCH "mounted-data" < "${SNAPCTL_MOUNT_DEST_DATA}/mounted-data.txt"
+
+        echo "Verify no temporary artifacts remain after restore (no mounts were moved)"
+        test -z "$(find "/var/snap/${SNAP_NAME}" -maxdepth 1 -mindepth 1 ! -name x1 ! -name current ! -name common)"
+    }
+
+    test_snap_restore_preserves_snapctl_mounts() {
+        echo "Take a snapshot using snap save"
+        local set_id
+        set_id=$(snap save "${SNAP_NAME}" | cut -d\  -f1 | tail -n1)
+        tests.cleanup defer snap forget "${set_id}"
+
+        echo "Remove non-mount files to test restore"
+        rm "${SNAP_COMMON}/data.txt" "${SNAP_DATA}/data.txt"
+        echo "and update files in mounts to verify they are preserved across restore"
+        echo "after-save-before-restore" > "${SNAPCTL_MOUNT_DEST_COMMON}/excluded-file-common.txt"
+        echo "after-save-before-restore" > "${SNAPCTL_MOUNT_DEST_DATA}/excluded-file-data.txt"
+
+        then_restore_and_verify_mounts "${set_id}"
+    }
+
+    test_snap_restore_fails_when_user_mounts() {
+        echo "Take a snapshot using snap save"
+        local set_id
+        set_id=$(snap save "${SNAP_NAME}" | cut -d\  -f1 | tail -n1)
+        tests.cleanup defer snap forget "${set_id}"
+
+        echo "Remove non-mount files to test restore"
+        rm "${SNAP_COMMON}/data.txt" "${SNAP_DATA}/data.txt"
+
+        echo "Try to restore snapshot, this should fail due to active user mounts"
+        if snap restore "${set_id}" "${SNAP_NAME}"; then
+            echo "ERROR: snap restore succeeded but should have failed due to active user mounts"
+            exit 1
+        fi
+
+        echo "Verify that data outside mount points was not restored"
+        not test -e "${SNAP_COMMON}/data.txt"
+        not test -e "${SNAP_DATA}/data.txt"
+    }
+
+    test_snap_remove_excludes_all_mounts() {
         if os.query is-core; then
             echo "Enable automatic snapshot creation on remove"
             snap set core snapshots.automatic.retention=24h


### PR DESCRIPTION
* Restore now stops snapctl mounts before moving the snap data dirs between the current state and that coming from the snapshot. Then, it restarts the snapctl mounts after the data is moved
  * if stopping a snapctl mount unit fails, restore aborts and restarts all the so far stopped mounts
  * restarting the snapctl mount is best-effort, it logs and continues
* If any non-snapctl mounts are present, then restore aborts and reverts.
* `Snap` is added to the `RestoreState` to help with searching of snapctl mounts for that snap
  * If `Snap` field is missing, say due to snapd version upgrades and undo task restart, then `RestoreState` revert skips checking for mounts
  * `Snap` field is guaranteed to be present (even across snapd version upgrades and task restarts) while doing restore (do handler), as `RestoreState` is created in the do handler
* `RestoreState` revert is best effort in stopping snapctl mounts, cleaning up, restarting mounts

[SNAPDENG-36990](https://warthogs.atlassian.net/browse/SNAPDENG-36990)

[SNAPDENG-36990]: https://warthogs.atlassian.net/browse/SNAPDENG-36990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ