### PR TITLE
asserts: support sign-only external keypair backends

### DIFF
--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -54,6 +54,16 @@ func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, erro
 }
 
 // NewExternalKeypairManagerWithBackend creates a new ExternalKeypairManager using backend.
+//
+// Backends must implement ExtKeypairMgrBackend and either:
+//   - implement ExtKeypairMgrKeyVisitBackend, optionally with
+//     ExtKeypairMgrByNameLookupBackend and/or ExtKeypairMgrByKeyIDLookupBackend; or
+//   - implement ExtKeypairMgrByKeyIDLookupBackend without ExtKeypairMgrKeyVisitBackend
+//     for sign-only use.
+//
+// Backends that implement ExtKeypairMgrByNameLookupBackend must also implement
+// ExtKeypairMgrKeyVisitBackend. Sign-only backends support Get by key ID, while
+// GetByName, Export, and List return ExternalUnsupportedOpError.
 func NewExternalKeypairManagerWithBackend(backend ExtKeypairMgrBackend, config ExtKeypairMgrConfig) (*ExternalKeypairManager, error) {
 	impl, err := newExtKeypairMgrImpl(backend, config)
 	if err != nil {

--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -57,13 +57,13 @@ func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, erro
 //
 // Backends must implement ExtKeypairMgrBackend and either:
 //   - implement ExtKeypairMgrKeyVisitBackend, optionally with
-//     ExtKeypairMgrByNameLookupBackend and/or ExtKeypairMgrByKeyIDLookupBackend; or
+//     ExtKeypairMgrByKeyIDLookupBackend, or via ExtKeypairMgrByNameLookupBackend; or
 //   - implement ExtKeypairMgrByKeyIDLookupBackend without ExtKeypairMgrKeyVisitBackend
 //     for sign-only use.
 //
-// Backends that implement ExtKeypairMgrByNameLookupBackend must also implement
-// ExtKeypairMgrKeyVisitBackend. Sign-only backends support Get by key ID, while
-// GetByName, Export, and List return ExternalUnsupportedOpError.
+// ExtKeypairMgrByNameLookupBackend includes ExtKeypairMgrKeyVisitBackend.
+// Sign-only backends support Get by key ID, while GetByName, Export, and List
+// return ExternalUnsupportedOpError.
 func NewExternalKeypairManagerWithBackend(backend ExtKeypairMgrBackend, config ExtKeypairMgrConfig) (*ExternalKeypairManager, error) {
 	impl, err := newExtKeypairMgrImpl(backend, config)
 	if err != nil {
@@ -114,8 +114,8 @@ func (em *ExternalKeypairManager) List() ([]ExternalKeyInfo, error) {
 	return em.impl.List()
 }
 
-// externalCmdKeypairMgrBackend implements extKeypairMgrBackend and
-// extKeypairMgrByNameLookupBackend by invoking the configured external
+// externalCmdKeypairMgrBackend implements ExtKeypairMgrBackend and
+// ExtKeypairMgrByNameLookupBackend by invoking the configured external
 // keypair manager command.
 type externalCmdKeypairMgrBackend struct {
 	keyMgrPath string

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -78,6 +78,29 @@ func (b *fakePublicExtKeypairMgrBackend) Sign(keyHandle string, content []byte) 
 	return nil, errors.New("unexpected sign call")
 }
 
+type fakePublicSignOnlyExtKeypairMgrBackend struct {
+	loaded *asserts.ExtKeypairMgrLoadedKey
+}
+
+func (b *fakePublicSignOnlyExtKeypairMgrBackend) CheckFeatures() (asserts.ExtKeypairMgrSigning, error) {
+	return asserts.ExtKeypairMgrSigningRSAPKCS, nil
+}
+
+func (b *fakePublicSignOnlyExtKeypairMgrBackend) LoadByID(keyID string) (*asserts.ExtKeypairMgrLoadedKey, error) {
+	if b.loaded == nil || b.loaded.PublicKey.ID() != keyID {
+		return nil, errors.New("missing key")
+	}
+	return b.loaded, nil
+}
+
+func (b *fakePublicSignOnlyExtKeypairMgrBackend) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
+	return nil, errors.New("unexpected sign call")
+}
+
+func (b *fakePublicSignOnlyExtKeypairMgrBackend) Sign(keyHandle string, content []byte) ([]byte, error) {
+	return nil, errors.New("unexpected sign call")
+}
+
 func (s *extKeypairMgrSuite) SetUpSuite(c *C) {
 	tmpdir := c.MkDir()
 	s.keyDir = tmpdir
@@ -186,6 +209,41 @@ func (s *extKeypairMgrSuite) TestNewExternalKeypairManagerWithBackend(c *C) {
 	expected, err := asserts.EncodePublicKey(rsaPub)
 	c.Assert(err, IsNil)
 	c.Check(exported, DeepEquals, expected)
+}
+
+func (s *extKeypairMgrSuite) TestNewExternalKeypairManagerWithSignOnlyBackend(c *C) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	c.Assert(err, IsNil)
+	rsaPub := asserts.RSAPublicKey(&priv.PublicKey)
+	backend := &fakePublicSignOnlyExtKeypairMgrBackend{
+		loaded: &asserts.ExtKeypairMgrLoadedKey{
+			Name:      "default",
+			KeyHandle: "backend-default",
+			PublicKey: rsaPub,
+		},
+	}
+
+	kmgr, err := asserts.NewExternalKeypairManagerWithBackend(backend, asserts.ExtKeypairMgrConfig{
+		SigningWith: "fake backend",
+		KeyStore:    "fake store",
+	})
+	c.Assert(err, IsNil)
+
+	privKey, err := kmgr.Get(rsaPub.ID())
+	c.Assert(err, IsNil)
+	c.Check(privKey.PublicKey().ID(), Equals, rsaPub.ID())
+
+	_, err = kmgr.GetByName("default")
+	c.Assert(err, ErrorMatches, `cannot get key by name from sign-only external keypair manager`)
+	c.Check(err, FitsTypeOf, &asserts.ExternalUnsupportedOpError{})
+
+	_, err = kmgr.Export("default")
+	c.Assert(err, ErrorMatches, `cannot get key by name from sign-only external keypair manager`)
+	c.Check(err, FitsTypeOf, &asserts.ExternalUnsupportedOpError{})
+
+	_, err = kmgr.List()
+	c.Assert(err, ErrorMatches, `cannot list keys in sign-only external keypair manager`)
+	c.Check(err, FitsTypeOf, &asserts.ExternalUnsupportedOpError{})
 }
 
 func (s *extKeypairMgrSuite) TestFeatures(c *C) {

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -39,24 +39,33 @@ const (
 	ExtKeypairMgrSigningOpenPGP ExtKeypairMgrSigning = "OpenPGP"
 )
 
-// ExtKeypairMgrBackend defines the backend contract used by ExternalKeypairManager.
-// KeyHandle is the backend-native identifier and Visit is used for enumeration
-// and fallback lookup when direct by-name lookup is not available.
+// ExtKeypairMgrBackend defines the minimum backend contract used by ExternalKeypairManager for signing.
+// Additional key discovery and lookup capabilities are provided via optional interfaces.
 type ExtKeypairMgrBackend interface {
 	// CheckFeatures validates backend support and returns the supported signing method.
 	CheckFeatures() (ExtKeypairMgrSigning, error)
-	// Visit discovers keys and may be used for both enumeration and fallback search.
-	Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error
 	// RSAPKCSSign signs the caller-prepared RSA-PKCS input using keyHandle.
 	RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error)
 	// Sign signs content directly and returns a detached OpenPGP signature packet.
 	Sign(keyHandle string, content []byte) ([]byte, error)
 }
 
+// ExtKeypairMgrKeyVisitBackend adds key discovery and enumeration support.
+type ExtKeypairMgrKeyVisitBackend interface {
+	// Visit discovers keys and may be used for both enumeration and fallback search.
+	Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error
+}
+
 // ExtKeypairMgrByNameLookupBackend adds optional direct lookup by user-visible key name.
 type ExtKeypairMgrByNameLookupBackend interface {
 	// LoadByName resolves a user-visible name directly when the backend supports by-name lookup.
 	LoadByName(name string) (*ExtKeypairMgrLoadedKey, error)
+}
+
+// ExtKeypairMgrByKeyIDLookupBackend adds optional direct lookup by public key ID.
+type ExtKeypairMgrByKeyIDLookupBackend interface {
+	// LoadByID resolves a public key ID directly when the backend supports by-ID lookup.
+	LoadByID(keyID string) (*ExtKeypairMgrLoadedKey, error)
 }
 
 // ExtKeypairMgrLoadedKey carries the key information loaded by a backend.
@@ -85,32 +94,53 @@ type ExtKeypairMgrConfig struct {
 }
 
 type extKeypairMgrImpl struct {
-	backend       ExtKeypairMgrBackend
-	signingMethod ExtKeypairMgrSigning
-	signingWith   string
-	keyStore      string
-	nameToID      map[string]string
+	backend              ExtKeypairMgrBackend
+	keyVisitBackend      ExtKeypairMgrKeyVisitBackend
+	byNameLookupBackend  ExtKeypairMgrByNameLookupBackend
+	byKeyIDLookupBackend ExtKeypairMgrByKeyIDLookupBackend
+	signingMethod        ExtKeypairMgrSigning
+	signingWith          string
+	keyStore             string
+	nameToID             map[string]string
 	// cache is keyed by public key ID and contains the loaded key information, including the private key when it has been requested.
 	cache map[string]*extKeypairMgrCachedKey
 }
 
 func newExtKeypairMgrImpl(backend ExtKeypairMgrBackend, config ExtKeypairMgrConfig) (*extKeypairMgrImpl, error) {
+	keyVisitBackend, _ := backend.(ExtKeypairMgrKeyVisitBackend)
+	byNameLookupBackend, _ := backend.(ExtKeypairMgrByNameLookupBackend)
+	byKeyIDLookupBackend, _ := backend.(ExtKeypairMgrByKeyIDLookupBackend)
+
+	if byNameLookupBackend != nil && keyVisitBackend == nil {
+		return nil, fmt.Errorf("cannot use external keypair backend: backends that implement LoadByName must also implement Visit")
+	}
+	if keyVisitBackend == nil && byKeyIDLookupBackend == nil {
+		return nil, fmt.Errorf("cannot use external keypair backend: backends must implement Visit or, for sign-only use, LoadByID")
+	}
+
 	signingMethod, err := backend.CheckFeatures()
 	if err != nil {
 		return nil, err
 	}
 	return &extKeypairMgrImpl{
-		backend:       backend,
-		signingMethod: signingMethod,
-		signingWith:   config.SigningWith,
-		keyStore:      config.KeyStore,
-		nameToID:      make(map[string]string),
-		cache:         make(map[string]*extKeypairMgrCachedKey),
+		backend:              backend,
+		keyVisitBackend:      keyVisitBackend,
+		byNameLookupBackend:  byNameLookupBackend,
+		byKeyIDLookupBackend: byKeyIDLookupBackend,
+		signingMethod:        signingMethod,
+		signingWith:          config.SigningWith,
+		keyStore:             config.KeyStore,
+		nameToID:             make(map[string]string),
+		cache:                make(map[string]*extKeypairMgrCachedKey),
 	}, nil
 }
 
 func (m *extKeypairMgrImpl) keyNotFoundError() error {
 	return &keyNotFoundError{msg: fmt.Sprintf("cannot find key pair in %s", m.keyStore)}
+}
+
+func (m *extKeypairMgrImpl) signOnlyUnsupportedOpError(action string) error {
+	return &ExternalUnsupportedOpError{msg: fmt.Sprintf("cannot %s sign-only external keypair manager", action)}
 }
 
 func (m *extKeypairMgrImpl) cacheLoadedKey(loaded *ExtKeypairMgrLoadedKey) (*extKeypairMgrCachedKey, error) {
@@ -156,23 +186,27 @@ func (m *extKeypairMgrImpl) dropCachedKey(keyID string) {
 	delete(m.cache, keyID)
 }
 
+var errExtKeypairMgrStopVisit = errors.New("stop visiting external keypair manager keys")
+
 func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, error) {
+	if m.keyVisitBackend == nil {
+		return nil, m.signOnlyUnsupportedOpError("get key by name from")
+	}
 	if keyID, ok := m.nameToID[name]; ok {
 		if entry := m.cache[keyID]; entry != nil {
 			return entry, nil
 		}
 	}
-	if byNameLookupBackend, ok := m.backend.(ExtKeypairMgrByNameLookupBackend); ok {
-		loaded, err := byNameLookupBackend.LoadByName(name)
+	if m.byNameLookupBackend != nil {
+		loaded, err := m.byNameLookupBackend.LoadByName(name)
 		if err != nil {
 			return nil, err
 		}
 		return m.cacheLoadedKey(loaded)
 	}
 
-	stop := errors.New("stop marker")
 	var hit *extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
+	err := m.keyVisitBackend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
 		if loaded.Name != name {
 			return nil
 		}
@@ -181,9 +215,9 @@ func (m *extKeypairMgrImpl) loadByName(name string) (*extKeypairMgrCachedKey, er
 			return err
 		}
 		hit = entry
-		return stop
+		return errExtKeypairMgrStopVisit
 	})
-	if err == stop {
+	if err == errExtKeypairMgrStopVisit {
 		return hit, nil
 	}
 	if err != nil {
@@ -196,10 +230,16 @@ func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, err
 	if entry := m.cache[keyID]; entry != nil {
 		return entry, nil
 	}
+	if m.byKeyIDLookupBackend != nil {
+		loaded, err := m.byKeyIDLookupBackend.LoadByID(keyID)
+		if err != nil {
+			return nil, err
+		}
+		return m.cacheLoadedKey(loaded)
+	}
 
-	stop := errors.New("stop marker")
 	var hit *extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
+	err := m.keyVisitBackend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
 		entry, err := m.cacheLoadedKey(loaded)
 		if err != nil {
 			return err
@@ -208,9 +248,9 @@ func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, err
 			return nil
 		}
 		hit = entry
-		return stop
+		return errExtKeypairMgrStopVisit
 	})
-	if err == stop {
+	if err == errExtKeypairMgrStopVisit {
 		return hit, nil
 	}
 	if err != nil {
@@ -220,8 +260,11 @@ func (m *extKeypairMgrImpl) loadByID(keyID string) (*extKeypairMgrCachedKey, err
 }
 
 func (m *extKeypairMgrImpl) visitAll() ([]*extKeypairMgrCachedKey, error) {
+	if m.keyVisitBackend == nil {
+		return nil, m.signOnlyUnsupportedOpError("list keys in")
+	}
 	var entries []*extKeypairMgrCachedKey
-	err := m.backend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
+	err := m.keyVisitBackend.Visit(func(loaded *ExtKeypairMgrLoadedKey) error {
 		entry, err := m.cacheLoadedKey(loaded)
 		if err != nil {
 			return err

--- a/asserts/extkeypairmgrimpl.go
+++ b/asserts/extkeypairmgrimpl.go
@@ -56,8 +56,10 @@ type ExtKeypairMgrKeyVisitBackend interface {
 	Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error
 }
 
-// ExtKeypairMgrByNameLookupBackend adds optional direct lookup by user-visible key name.
+// ExtKeypairMgrByNameLookupBackend adds optional direct lookup by user-visible key name on top of key discovery.
 type ExtKeypairMgrByNameLookupBackend interface {
+	ExtKeypairMgrKeyVisitBackend
+
 	// LoadByName resolves a user-visible name directly when the backend supports by-name lookup.
 	LoadByName(name string) (*ExtKeypairMgrLoadedKey, error)
 }
@@ -94,7 +96,10 @@ type ExtKeypairMgrConfig struct {
 }
 
 type extKeypairMgrImpl struct {
-	backend              ExtKeypairMgrBackend
+	backend ExtKeypairMgrBackend
+	// optional interfaces implemented by the backend
+	// byNameLookupBackend includes keyVisitBackend so they they can only be nil together
+	// in which case we have a sign-only backend and byKeyIDLookupBackend must be non-nil
 	keyVisitBackend      ExtKeypairMgrKeyVisitBackend
 	byNameLookupBackend  ExtKeypairMgrByNameLookupBackend
 	byKeyIDLookupBackend ExtKeypairMgrByKeyIDLookupBackend
@@ -111,9 +116,6 @@ func newExtKeypairMgrImpl(backend ExtKeypairMgrBackend, config ExtKeypairMgrConf
 	byNameLookupBackend, _ := backend.(ExtKeypairMgrByNameLookupBackend)
 	byKeyIDLookupBackend, _ := backend.(ExtKeypairMgrByKeyIDLookupBackend)
 
-	if byNameLookupBackend != nil && keyVisitBackend == nil {
-		return nil, fmt.Errorf("cannot use external keypair backend: backends that implement LoadByName must also implement Visit")
-	}
 	if keyVisitBackend == nil && byKeyIDLookupBackend == nil {
 		return nil, fmt.Errorf("cannot use external keypair backend: backends must implement Visit or, for sign-only use, LoadByID")
 	}

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -40,8 +40,10 @@ var fakeExtKeypairMgrConfig = ExtKeypairMgrConfig{SigningWith: "fake", KeyStore:
 type fakeExtKeypairMgrBackendBase struct {
 	signingMethod   ExtKeypairMgrSigning
 	loadByName      map[string]*ExtKeypairMgrLoadedKey
+	loadByID        map[string]*ExtKeypairMgrLoadedKey
 	visitKeys       []*ExtKeypairMgrLoadedKey
 	loadCalls       []string
+	loadByIDCalls   []string
 	visitCalls      int
 	visitConsidered [][]string
 	rsaSignHandles  []string
@@ -52,20 +54,6 @@ type fakeExtKeypairMgrBackendBase struct {
 
 func (s *fakeExtKeypairMgrBackendBase) CheckFeatures() (ExtKeypairMgrSigning, error) {
 	return s.signingMethod, nil
-}
-
-func (s *fakeExtKeypairMgrBackendBase) Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error {
-	s.visitCalls++
-	considered := make([]string, 0, len(s.visitKeys))
-	for _, loaded := range s.visitKeys {
-		considered = append(considered, loaded.Name)
-		if err := consider(loaded); err != nil {
-			s.visitConsidered = append(s.visitConsidered, considered)
-			return err
-		}
-	}
-	s.visitConsidered = append(s.visitConsidered, considered)
-	return nil
 }
 
 func (s *fakeExtKeypairMgrBackendBase) RSAPKCSSign(keyHandle string, prepared []byte) ([]byte, error) {
@@ -90,8 +78,26 @@ func (s *fakeExtKeypairMgrBackendBase) Sign(keyHandle string, content []byte) ([
 	return buf.Bytes(), nil
 }
 
-type fakeExtKeypairMgrBackend struct {
+type fakeExtKeypairMgrBackendWithVisit struct {
 	fakeExtKeypairMgrBackendBase
+}
+
+func (s *fakeExtKeypairMgrBackendWithVisit) Visit(consider func(loaded *ExtKeypairMgrLoadedKey) error) error {
+	s.visitCalls++
+	considered := make([]string, 0, len(s.visitKeys))
+	for _, loaded := range s.visitKeys {
+		considered = append(considered, loaded.Name)
+		if err := consider(loaded); err != nil {
+			s.visitConsidered = append(s.visitConsidered, considered)
+			return err
+		}
+	}
+	s.visitConsidered = append(s.visitConsidered, considered)
+	return nil
+}
+
+type fakeExtKeypairMgrBackend struct {
+	fakeExtKeypairMgrBackendWithVisit
 }
 
 func (s *fakeExtKeypairMgrBackend) LoadByName(name string) (*ExtKeypairMgrLoadedKey, error) {
@@ -103,8 +109,47 @@ func (s *fakeExtKeypairMgrBackend) LoadByName(name string) (*ExtKeypairMgrLoaded
 	return loaded, nil
 }
 
+type fakeExtKeypairMgrBackendWithByIDLookup struct {
+	fakeExtKeypairMgrBackendWithVisit
+}
+
+func (s *fakeExtKeypairMgrBackendWithByIDLookup) LoadByID(keyID string) (*ExtKeypairMgrLoadedKey, error) {
+	s.loadByIDCalls = append(s.loadByIDCalls, keyID)
+	loaded := s.loadByID[keyID]
+	if loaded == nil {
+		return nil, &keyNotFoundError{msg: "missing key"}
+	}
+	return loaded, nil
+}
+
 type fakeExtKeypairMgrBackendWithoutByNameLookup struct {
+	fakeExtKeypairMgrBackendWithVisit
+}
+
+type fakeExtKeypairMgrSignOnlyBackend struct {
 	fakeExtKeypairMgrBackendBase
+}
+
+func (s *fakeExtKeypairMgrSignOnlyBackend) LoadByID(keyID string) (*ExtKeypairMgrLoadedKey, error) {
+	s.loadByIDCalls = append(s.loadByIDCalls, keyID)
+	loaded := s.loadByID[keyID]
+	if loaded == nil {
+		return nil, &keyNotFoundError{msg: "missing key"}
+	}
+	return loaded, nil
+}
+
+type fakeExtKeypairMgrSignOnlyBackendWithByName struct {
+	fakeExtKeypairMgrSignOnlyBackend
+}
+
+func (s *fakeExtKeypairMgrSignOnlyBackendWithByName) LoadByName(name string) (*ExtKeypairMgrLoadedKey, error) {
+	s.loadCalls = append(s.loadCalls, name)
+	loaded := s.loadByName[name]
+	if loaded == nil {
+		return nil, &keyNotFoundError{msg: "missing key"}
+	}
+	return loaded, nil
 }
 
 func (s *extKeypairMgrImplSuite) newLoadedKeyBits(c *check.C, name string, keyHandle string, bits int) (*rsa.PrivateKey, *ExtKeypairMgrLoadedKey) {
@@ -128,7 +173,7 @@ func (s *extKeypairMgrImplSuite) newSigningLoadedKey(c *check.C, name string, ke
 func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *check.C) {
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
@@ -136,7 +181,7 @@ func (s *extKeypairMgrImplSuite) TestLoadByNameCachesExportAndPrivateKey(c *chec
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -161,12 +206,12 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAfterFirstMatchingVisitedKey(c *che
 	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -186,12 +231,12 @@ func (s *extKeypairMgrImplSuite) TestGetStopsAtMatchingVisitedKeyAndCachesVisite
 	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -220,12 +265,12 @@ func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPr
 	privKey1, loaded1 := s.newLoadedKey(c, "default", "handle-default")
 	privKey2, loaded2 := s.newLoadedKey(c, "models", "handle-models")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded1, loaded2},
 			privByHandle:  map[string]*rsa.PrivateKey{"handle-default": privKey1, "handle-models": privKey2},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -243,7 +288,7 @@ func (s *extKeypairMgrImplSuite) TestGetRevisitsWhenRequestedKeyWasNotInCachedPr
 func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.C) {
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
@@ -252,7 +297,7 @@ func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -267,10 +312,10 @@ func (s *extKeypairMgrImplSuite) TestGetByNameUsesByNameLookupFastPath(c *check.
 
 func (s *extKeypairMgrImplSuite) TestGetByNamePropagatesNotFoundWithByNameLookup(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -283,16 +328,42 @@ func (s *extKeypairMgrImplSuite) TestGetByNamePropagatesNotFoundWithByNameLookup
 	c.Check(backend.visitCalls, check.Equals, 0)
 }
 
+func (s *extKeypairMgrImplSuite) TestGetUsesByIDLookupFastPath(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrBackendWithByIDLookup{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByID: map[string]*ExtKeypairMgrLoadedKey{
+				loaded.PublicKey.ID(): loaded,
+			},
+			visitKeys: []*ExtKeypairMgrLoadedKey{loaded},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		}},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.Get(loaded.PublicKey.ID())
+	c.Assert(err, check.IsNil)
+
+	c.Check(priv.PublicKey().ID(), check.Equals, loaded.PublicKey.ID())
+	c.Check(backend.loadByIDCalls, check.DeepEquals, []string{loaded.PublicKey.ID()})
+	c.Check(backend.visitCalls, check.Equals, 0)
+}
+
 func (s *extKeypairMgrImplSuite) TestGetByNameFallsBackToVisitWithoutByNameLookup(c *check.C) {
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded},
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -307,13 +378,13 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallsBackToVisitWithoutByNameLooku
 func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *check.C) {
 	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			visitKeys:     []*ExtKeypairMgrLoadedKey{loaded},
 			privByHandle: map[string]*rsa.PrivateKey{
 				"handle-default": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -335,9 +406,9 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackCachesVisitedEntry(c *chec
 
 func (s *extKeypairMgrImplSuite) TestGetByNameFallbackUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -351,10 +422,10 @@ func (s *extKeypairMgrImplSuite) TestGetByNameFallbackUsesKeyStoreError(c *check
 
 func (s *extKeypairMgrImplSuite) TestExportPropagatesNotFoundWithByNameLookup(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -369,9 +440,9 @@ func (s *extKeypairMgrImplSuite) TestExportPropagatesNotFoundWithByNameLookup(c 
 
 func (s *extKeypairMgrImplSuite) TestExportFallbackUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -394,9 +465,9 @@ func (pk *fakeNonRSAPublicKey) keyEncode(w io.Writer) error                     
 
 func (s *extKeypairMgrImplSuite) TestCacheLoadedKeyInvalidPublicKeyErrorIsNotRepetitive(c *check.C) {
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-		},
+		}},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
@@ -413,7 +484,7 @@ func (s *extKeypairMgrImplSuite) TestCacheLoadedKeyInvalidPublicKeyErrorIsNotRep
 func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.C) {
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	backend := &fakeExtKeypairMgrBackendWithoutByNameLookup{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			visitKeys: []*ExtKeypairMgrLoadedKey{
 				loaded,
@@ -423,7 +494,7 @@ func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.
 					PublicKey: loaded.PublicKey,
 				},
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -438,9 +509,9 @@ func (s *extKeypairMgrImplSuite) TestListPropagatesSameIDInconsistency(c *check.
 func (s *extKeypairMgrImplSuite) TestDropCachedKeyRemovesCachedAndNamedEntries(c *check.C) {
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-		},
+		}},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
@@ -456,9 +527,9 @@ func (s *extKeypairMgrImplSuite) TestDropCachedKeyRemovesCachedAndNamedEntries(c
 func (s *extKeypairMgrImplSuite) TestDropCachedKeyMissingKeyLeavesCacheUntouched(c *check.C) {
 	_, loaded := s.newLoadedKey(c, "default", "handle-default")
 	impl, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-		},
+		}},
 	}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.IsNil)
 
@@ -473,11 +544,11 @@ func (s *extKeypairMgrImplSuite) TestDropCachedKeyMissingKeyLeavesCacheUntouched
 
 func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName:    map[string]*ExtKeypairMgrLoadedKey{},
 			privByHandle:  map[string]*rsa.PrivateKey{},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -492,7 +563,7 @@ func (s *extKeypairMgrImplSuite) TestGetMissingUsesKeyStoreError(c *check.C) {
 func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
 	privKey, loaded := s.newSigningLoadedKey(c, "default", "rsa-handle")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningRSAPKCS,
 			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
@@ -500,7 +571,7 @@ func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
 			privByHandle: map[string]*rsa.PrivateKey{
 				"rsa-handle": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -518,7 +589,7 @@ func (s *extKeypairMgrImplSuite) TestRSAPKCSSigningUsesKeyHandle(c *check.C) {
 func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
 	privKey, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningOpenPGP,
 			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
@@ -526,7 +597,7 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
 			privByHandle: map[string]*rsa.PrivateKey{
 				"pgp-handle": privKey,
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -544,7 +615,7 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningUsesKeyHandle(c *check.C) {
 func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithInError(c *check.C) {
 	_, loaded := s.newSigningLoadedKey(c, "default", "pgp-handle")
 	backend := &fakeExtKeypairMgrBackend{
-		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+		fakeExtKeypairMgrBackendWithVisit: fakeExtKeypairMgrBackendWithVisit{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
 			signingMethod: ExtKeypairMgrSigningOpenPGP,
 			loadByName: map[string]*ExtKeypairMgrLoadedKey{
 				"default": loaded,
@@ -552,7 +623,7 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithI
 			pgpSignResult: map[string][]byte{
 				"pgp-handle": []byte("broken"),
 			},
-		},
+		}},
 	}
 
 	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
@@ -563,4 +634,60 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithI
 	_, err = RawSignWithKey([]byte("hello"), priv)
 	c.Assert(err, check.ErrorMatches, `bad fake produced signature: .*`)
 	c.Check(backend.pgpSignHandles, check.DeepEquals, []string{"pgp-handle"})
+}
+
+func (s *extKeypairMgrImplSuite) TestConstructorRejectsBackendsWithoutVisitOrLoadByID(c *check.C) {
+	_, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackendBase{signingMethod: ExtKeypairMgrSigningRSAPKCS}, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.ErrorMatches, `cannot use external keypair backend: backends must implement Visit or, for sign-only use, LoadByID`)
+}
+
+func (s *extKeypairMgrImplSuite) TestConstructorRejectsLoadByNameWithoutVisit(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrSignOnlyBackendWithByName{
+		fakeExtKeypairMgrSignOnlyBackend: fakeExtKeypairMgrSignOnlyBackend{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByName:    map[string]*ExtKeypairMgrLoadedKey{"default": loaded},
+			loadByID:      map[string]*ExtKeypairMgrLoadedKey{loaded.PublicKey.ID(): loaded},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		}},
+	}
+
+	_, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.ErrorMatches, `cannot use external keypair backend: backends that implement LoadByName must also implement Visit`)
+}
+
+func (s *extKeypairMgrImplSuite) TestSignOnlyOperationsUseUnsupportedError(c *check.C) {
+	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
+	backend := &fakeExtKeypairMgrSignOnlyBackend{
+		fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
+			signingMethod: ExtKeypairMgrSigningRSAPKCS,
+			loadByID: map[string]*ExtKeypairMgrLoadedKey{
+				loaded.PublicKey.ID(): loaded,
+			},
+			privByHandle: map[string]*rsa.PrivateKey{
+				"handle-default": privKey,
+			},
+		},
+	}
+
+	impl, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
+	c.Assert(err, check.IsNil)
+
+	priv, err := impl.Get(loaded.PublicKey.ID())
+	c.Assert(err, check.IsNil)
+	c.Check(priv.PublicKey().ID(), check.Equals, loaded.PublicKey.ID())
+
+	_, err = impl.GetByName("default")
+	c.Assert(err, check.ErrorMatches, `cannot get key by name from sign-only external keypair manager`)
+	c.Check(err, check.FitsTypeOf, &ExternalUnsupportedOpError{})
+
+	_, err = impl.Export("default")
+	c.Assert(err, check.ErrorMatches, `cannot get key by name from sign-only external keypair manager`)
+	c.Check(err, check.FitsTypeOf, &ExternalUnsupportedOpError{})
+
+	_, err = impl.List()
+	c.Assert(err, check.ErrorMatches, `cannot list keys in sign-only external keypair manager`)
+	c.Check(err, check.FitsTypeOf, &ExternalUnsupportedOpError{})
 }

--- a/asserts/extkeypairmgrimpl_test.go
+++ b/asserts/extkeypairmgrimpl_test.go
@@ -139,19 +139,6 @@ func (s *fakeExtKeypairMgrSignOnlyBackend) LoadByID(keyID string) (*ExtKeypairMg
 	return loaded, nil
 }
 
-type fakeExtKeypairMgrSignOnlyBackendWithByName struct {
-	fakeExtKeypairMgrSignOnlyBackend
-}
-
-func (s *fakeExtKeypairMgrSignOnlyBackendWithByName) LoadByName(name string) (*ExtKeypairMgrLoadedKey, error) {
-	s.loadCalls = append(s.loadCalls, name)
-	loaded := s.loadByName[name]
-	if loaded == nil {
-		return nil, &keyNotFoundError{msg: "missing key"}
-	}
-	return loaded, nil
-}
-
 func (s *extKeypairMgrImplSuite) newLoadedKeyBits(c *check.C, name string, keyHandle string, bits int) (*rsa.PrivateKey, *ExtKeypairMgrLoadedKey) {
 	privKey, err := rsa.GenerateKey(rand.Reader, bits)
 	c.Assert(err, check.IsNil)
@@ -639,23 +626,6 @@ func (s *extKeypairMgrImplSuite) TestOpenPGPSigningInvalidPacketUsesSigningWithI
 func (s *extKeypairMgrImplSuite) TestConstructorRejectsBackendsWithoutVisitOrLoadByID(c *check.C) {
 	_, err := newExtKeypairMgrImpl(&fakeExtKeypairMgrBackendBase{signingMethod: ExtKeypairMgrSigningRSAPKCS}, fakeExtKeypairMgrConfig)
 	c.Assert(err, check.ErrorMatches, `cannot use external keypair backend: backends must implement Visit or, for sign-only use, LoadByID`)
-}
-
-func (s *extKeypairMgrImplSuite) TestConstructorRejectsLoadByNameWithoutVisit(c *check.C) {
-	privKey, loaded := s.newLoadedKey(c, "default", "handle-default")
-	backend := &fakeExtKeypairMgrSignOnlyBackendWithByName{
-		fakeExtKeypairMgrSignOnlyBackend: fakeExtKeypairMgrSignOnlyBackend{fakeExtKeypairMgrBackendBase: fakeExtKeypairMgrBackendBase{
-			signingMethod: ExtKeypairMgrSigningRSAPKCS,
-			loadByName:    map[string]*ExtKeypairMgrLoadedKey{"default": loaded},
-			loadByID:      map[string]*ExtKeypairMgrLoadedKey{loaded.PublicKey.ID(): loaded},
-			privByHandle: map[string]*rsa.PrivateKey{
-				"handle-default": privKey,
-			},
-		}},
-	}
-
-	_, err := newExtKeypairMgrImpl(backend, fakeExtKeypairMgrConfig)
-	c.Assert(err, check.ErrorMatches, `cannot use external keypair backend: backends that implement LoadByName must also implement Visit`)
 }
 
 func (s *extKeypairMgrImplSuite) TestSignOnlyOperationsUseUnsupportedError(c *check.C) {


### PR DESCRIPTION
Split external keypair manager backend capabilities so ExtKeypairMgrBackend no longer requires Visit.

Introduce:
- ExtKeypairMgrKeyVisitBackend
- ExtKeypairMgrByKeyIDLookupBackend

Keep ExtKeypairMgrByNameLookupBackend as an optional fast path, but require Visit when LoadByName is implemented.

This allows narrow sign-only backends that support Get by key ID without implementing key enumeration.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
