### PR TITLE
tests: move trusty to openstack and remove alternative-backend from workflows

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -556,7 +556,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -596,7 +595,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -631,7 +629,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -658,7 +655,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}

--- a/.github/workflows/data-fundamental-systems.json
+++ b/.github/workflows/data-fundamental-systems.json
@@ -4,7 +4,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "debian-req",
         "backend": "openstack",
-        "alternative-backend": "google-distro-1", 
         "systems": "debian-12-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -13,7 +12,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-focal",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -22,7 +20,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-noble",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -31,7 +28,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-daily",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-26.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -40,7 +36,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-core-18",
         "backend": "openstack",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-18-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -49,7 +44,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-core-20",
         "backend": "openstack",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-20-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -58,7 +52,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-core-24",
         "backend": "openstack",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-24-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -67,7 +60,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "arch-linux",
         "backend": "openstack",
-        "alternative-backend": "google-distro-2",
         "systems": "arch-linux-64",
         "tasks": "tests/...",
         "rules": "main"

--- a/.github/workflows/data-nested-systems.json
+++ b/.github/workflows/data-nested-systems.json
@@ -4,7 +4,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-18.04",
         "backend": "openstack-ext",
-        "alternative-backend": "google-nested",
         "systems": "ubuntu-18.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -13,7 +12,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-20.04",
         "backend": "openstack-ext",
-        "alternative-backend": "google-nested",
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -22,7 +20,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-22.04",
         "backend": "openstack-ext",
-        "alternative-backend": "google-nested",
         "systems": "ubuntu-22.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -31,7 +28,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-24.04",
         "backend": "openstack-ext",
-        "alternative-backend": "google-nested",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -40,7 +36,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-24.04-arm64",
         "backend": "openstack-arm-ext",
-        "alternative-backend": "google-nested-arm",
         "systems": "ubuntu-24.04-arm-64",
         "tasks": "tests/nested/core/core20-basic tests/nested/manual/optee-fde",
         "rules": "nested"
@@ -49,7 +44,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "nested-ubuntu-26.04",
         "backend": "openstack-ext",
-        "alternative-backend": "google-nested",
         "systems": "ubuntu-26.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"

--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -4,7 +4,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "amazon-linux",
         "backend": "openstack",
-        "alternative-backend": "google-distro-1",
         "systems": "amazon-linux-2-64 amazon-linux-2023-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -13,7 +12,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "centos",
         "backend": "openstack",
-        "alternative-backend": "google-distro-2",
         "systems": "centos-9-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -22,7 +20,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "debian-not-req",
         "backend": "openstack",
-        "alternative-backend": "google-distro-1",
         "systems": "debian-sid-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -32,7 +29,6 @@
         "group": "fedora",
         "backend": "openstack",
         "systems": "fedora-44-64",
-        "alternative-backend": "openstack",
         "tasks": "tests/...",
         "rules": "main"
       },
@@ -40,7 +36,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "opensuse",
         "backend": "openstack",
-        "alternative-backend": "google-distro-2",
         "systems": "opensuse-16.0-64 opensuse-tumbleweed-64 opensuse-tumbleweed-selinux-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -48,8 +43,7 @@
       {
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-trusty",
-        "backend": "google",
-        "alternative-backend": "google",
+        "backend": "openstack",
         "systems": "ubuntu-14.04-64",
         "tasks": "tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04",
         "rules": "trusty"
@@ -58,7 +52,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-xenial-bionic",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-16.04-64 ubuntu-18.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -67,7 +60,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-jammy",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-22.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -76,7 +68,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-core-22",
         "backend": "openstack",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-22-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -85,7 +76,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-core-26",
         "backend": "openstack",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-26-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -94,7 +84,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-arm64",
         "backend": "openstack-arm",
-        "alternative-backend": "google-arm",
         "systems": "ubuntu-24.04-arm-64 ubuntu-core-24-arm-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -103,7 +92,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-secboot",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-secboot-24.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -112,7 +100,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-fips-snap",
         "backend": "openstack",
-        "alternative-backend": "google-pro",
         "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
         "tasks": "tests/fips-snap/...",
         "rules": "fips"
@@ -121,7 +108,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-fips-deb",
         "backend": "openstack",
-        "alternative-backend": "google-pro",
         "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
         "tasks": "tests/fips-deb/...",
         "rules": "fips"
@@ -130,7 +116,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-deb",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -139,7 +124,6 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-interim",
         "backend": "openstack",
-        "alternative-backend": "google",
         "systems": "ubuntu-25.10-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -148,7 +132,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "jammy (garden)",
         "backend": "garden",
-        "alternative-backend": "google",
         "systems": "ubuntu-22.04-64",
         "tasks": "tests/main/apparmor-prompting-integration-tests tests/main/interfaces-requests-activates-handlers tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
@@ -157,7 +140,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "ubuntu-core-18 (garden)",
         "backend": "garden",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-18-64",
         "tasks": "tests/core/auto-refresh-backoff-after-reboot:kernel tests/core/failover:emptyinitrd tests/core/gadget-kernel-refs-update-pc tests/core/kernel-base-gadget-pair-single-reboot-failover tests/core/kernel-base-gadget-pair-single-reboot tests/core/kernel-base-gadget-single-reboot tests/core/kernel-base-gadget-single-reboot-failover tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
@@ -166,7 +148,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "ubuntu-core-24 (garden)",
         "backend": "garden",
-        "alternative-backend": "google-core",
         "systems": "ubuntu-core-24-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
@@ -175,7 +156,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "focal (garden)",
         "backend": "garden",
-        "alternative-backend": "google",
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
@@ -184,7 +164,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "questing (garden)",
         "backend": "garden",
-        "alternative-backend": "google",
         "systems": "ubuntu-25.10-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""
@@ -193,7 +172,6 @@
         "runs-on": "['ubuntu-latest']",
         "group": "fedora-44 (garden)",
         "backend": "garden",
-        "alternative-backend": "google",
         "systems": "fedora-44-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
         "rules": ""

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -145,7 +145,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -169,7 +168,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -192,7 +190,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -195,10 +195,6 @@ jobs:
             echo "$TASKS_TO_RUN"
           }
 
-          # Determine if the alternative backend has to be used for the current group
-          # Alternative backends usage depends on the value stored in the file USE_ALTERNATIVE_BACKEND,
-          # where it is defined the backend to use when images are ready in both google and openstack.
-          USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/use_alternative_backend.json)"
           SPREAD_BACKEND="${{ inputs.backend }}"
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -15,10 +15,6 @@ on:
         description: 'The spread backend to use (for possible values, check spread.yaml). This cannot be empty'
         required: true
         type: string
-      alternative-backend:
-        description: 'The spread backend to use when the backend cannot be used'
-        required: false
-        type: string
       systems:
         description: 'The spread system(s) to use (for possible values, check spread.yaml). If more than one, separate them with a space. To run all, write ALL. To run none, write NONE'
         required: true
@@ -204,9 +200,6 @@ jobs:
           # where it is defined the backend to use when images are ready in both google and openstack.
           USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/use_alternative_backend.json)"
           SPREAD_BACKEND="${{ inputs.backend }}"
-          if [ -n "${{ inputs.alternative-backend }}" ] && [ $(jq -r ".\"${{ inputs.group }}\"" <<< "$USE_ALTERNATIVE_BACKEND") == true ]; then
-              SPREAD_BACKEND="${{ inputs.alternative-backend }}"
-          fi
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV
 
           CHANGES_PARAM=""

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -83,7 +83,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}  
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -106,7 +105,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}  
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -128,7 +126,6 @@ jobs:
       runs-on: '${{ matrix.runs-on }}'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
-      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}  
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}


### PR DESCRIPTION
As google cannot be reached from ps7 runners, the alternative-backend doesn't make sense any more.

This change removes the alternative-backend from the gh workflows and migrates ubuntu trusty from google to openstack.

There is a new image ready for ubuntu trusty.

