### PR TITLE
overlord/hookstate, data/selinux: use explicit context when running snap hooks

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -136,6 +136,9 @@ read_files_pattern(snappy_t, snappy_config_t, snappy_config_t)
 admin_pattern(snappy_t, snappy_home_t)
 userdom_search_user_home_dirs(snappy_t)
 userdom_list_user_home_dirs(snappy_t)
+# Allow snapd to call setexeccon() so that runcon can be used to run the snap
+# CLI hook runner in the snappy_cli_t domain.
+allow snappy_t self:process setexec;
 
 # Allow snapd to read DNS config
 sysnet_dns_name_resolve(snappy_t)

--- a/overlord/confdbstate/confdbmgr_test.go
+++ b/overlord/confdbstate/confdbmgr_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 type hookHandlerSuite struct {
+	testutil.BaseTest
+
 	state *state.State
 
 	repo *interfaces.Repository
@@ -48,6 +50,8 @@ type hookHandlerSuite struct {
 var _ = Suite(&hookHandlerSuite{})
 
 func (s *hookHandlerSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	dirs.SetRootDir(c.MkDir())
 	s.state = overlord.Mock().State()
 

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -56,6 +56,8 @@ import (
 )
 
 type confdbTestSuite struct {
+	testutil.BaseTest
+
 	state *state.State
 	o     *overlord.Overlord
 
@@ -69,6 +71,8 @@ var _ = Suite(&confdbTestSuite{})
 func Test(t *testing.T) { TestingT(t) }
 
 func (s *confdbTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	dirs.SetRootDir(c.MkDir())
 	s.o = overlord.Mock()
 	s.state = s.o.State()

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -75,6 +75,7 @@ var (
 
 func (s *kernelSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 
 	var err error
 

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -43,6 +43,8 @@ import (
 )
 
 type tasksetsSuite struct {
+	testutil.BaseTest
+
 	state *state.State
 }
 
@@ -54,6 +56,8 @@ var (
 )
 
 func (s *tasksetsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	s.state = state.New(nil)
 }
 
@@ -289,6 +293,7 @@ type configcoreHijackSuite struct {
 
 func (s *configcoreHijackSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	hookMgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
@@ -416,6 +421,7 @@ type earlyConfigSuite struct {
 
 func (s *earlyConfigSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 
 	s.state = state.New(nil)
 

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -63,6 +63,7 @@ var _ = Suite(&configureHandlerSuite{})
 
 func (s *configureHandlerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 	hookstate.IsConfdbHookname = confdbstate.IsConfdbHookname
@@ -279,6 +280,7 @@ var _ = Suite(&defaultConfigureHandlerSuite{})
 
 func (s *defaultConfigureHandlerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 
@@ -439,6 +441,7 @@ var _ = Suite(&configcoreHandlerSuite{})
 
 func (s *configcoreHandlerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -181,6 +181,7 @@ var (
 func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.BaseTest.SetUpTest(c)
 
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	s.AddCleanup(release.MockOnClassic(classic))
 
 	dirs.SetRootDir(c.MkDir())

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -57,6 +57,7 @@ var _ = check.Suite(&healthSuite{})
 func (s *healthSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	s.AddCleanup(healthstate.MockCheckTimeout(time.Second))
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	dirs.SetRootDir(c.MkDir())
 	hookstate.IsConfdbHookname = confdbstate.IsConfdbHookname
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox/selinux"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 )
@@ -543,6 +544,24 @@ func MockRunHook(hookInvoke func(c *Context, tomb *tomb.Tomb) ([]byte, error)) (
 
 var osReadlink = os.Readlink
 
+var selinuxProbedLevel = selinux.ProbedLevel
+
+// MockSELinuxProbedLevel replaces the SELinux level probe used by the hook
+// runner. For use in tests.
+func MockSELinuxProbedLevel(f func() selinux.LevelType) func() {
+	old := selinuxProbedLevel
+	selinuxProbedLevel = f
+	return func() {
+		selinuxProbedLevel = old
+	}
+}
+
+// MockSELinuxUnsupported makes the hook runner believe SELinux is not
+// supported, preventing mountinfo probing. For use in test SetUpTest.
+func MockSELinuxUnsupported() func() {
+	return MockSELinuxProbedLevel(func() selinux.LevelType { return selinux.Unsupported })
+}
+
 // snapCmd returns the "snap" command to run. If snapd is re-execed
 // it will be the snap command from the core snap, otherwise it will
 // be the system "snap" command (c.f. LP: #1668738).
@@ -570,6 +589,11 @@ func runHookAndWait(hookSource string, revision snap.Revision, hookName, hookCon
 	argv := []string{snapCmd(), "run", "--hook", hookName, "-r", revision.String(), hookSource}
 	if timeout == 0 {
 		timeout = defaultHookTimeout
+	}
+
+	// TODO: if selinux call through
+	if selinuxProbedLevel() != selinux.Unsupported {
+		argv = selinux.SnapRunCall(argv)
 	}
 
 	env := []string{

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox/selinux"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -71,6 +72,9 @@ var (
 
 func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+
+	// SELinux is not relevant in unit tests; prevent mountinfo probing
+	s.AddCleanup(hookstate.MockSELinuxProbedLevel(func() selinux.LevelType { return selinux.Unsupported }))
 
 	hookstate.IsConfdbHookname = confdbstate.IsConfdbHookname
 	hooktype1 := snap.NewHookType(regexp.MustCompile("^do-something$"))
@@ -971,6 +975,28 @@ func (s *hookManagerSuite) TestHookTaskRunsRightSnapCmd(c *C) {
 		"snap", "run", "--hook", "configure", "-r", "1", "test-snap",
 	}})
 
+}
+
+func (s *hookManagerSuite) TestHookTaskRunsWithRunconOnSELinux(c *C) {
+	// Mock SELinux as enforcing so that SnapRunCall wraps argv with runcon.
+	restore := hookstate.MockSELinuxProbedLevel(func() selinux.LevelType { return selinux.Enforcing })
+	defer restore()
+
+	// runcon is looked up in PATH; mock it so the hook runner finds it.
+	runconCmd := testutil.MockCommand(c, "runcon", "")
+	defer runconCmd.Restore()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(s.context, NotNil, Commentf("Expected handler generator to be called with a valid context"))
+	c.Check(runconCmd.Calls(), DeepEquals, [][]string{{
+		"runcon", "system_u:system_r:snappy_cli_t:s0",
+		"snap", "run", "--hook", "configure", "-r", "1", "test-snap",
+	}})
 }
 
 func (s *hookManagerSuite) TestHookTasksForSameSnapAreSerialized(c *C) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -242,6 +242,7 @@ plugs:
 
 func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 	s.mockSnapCmd = testutil.MockCommand(c, "snap", "")
 	hookstate.IsConfdbHookname = confdbstate.IsConfdbHookname
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -259,6 +259,7 @@ func verifyApplyDelayedEffectsForSnaps(c *C, tasks []*state.Task, expectedSnaps 
 
 func (s *baseMgrsSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(hookstate.MockSELinuxUnsupported())
 
 	// TODO: temporary: skip due to timeouts on riscv64
 	if runtime.GOARCH == "riscv64" || os.Getenv("SNAPD_SKIP_SLOW_TESTS") != "" {

--- a/sandbox/selinux/label_darwin.go
+++ b/sandbox/selinux/label_darwin.go
@@ -34,3 +34,7 @@ func RestoreContext(aPath string, mode RestoreMode) error {
 func SnapMountContext() string {
 	return ""
 }
+
+func SnapRunContext() string {
+	return ""
+}

--- a/sandbox/selinux/label_linux.go
+++ b/sandbox/selinux/label_linux.go
@@ -107,3 +107,10 @@ func SnapMountContext() string {
 	// podman do for container volumes.
 	return "system_u:object_r:snappy_snap_t:s0"
 }
+
+func SnapRunContext() string {
+	// The snap CLI must run in the snappy_cli_t domain so that it can perform
+	// actions like creating ~/snap with the correct snappy_home_t label and
+	// transitioning into snappy_confine_t when exec-ing snap-confine.
+	return "system_u:system_r:snappy_cli_t:s0"
+}

--- a/sandbox/selinux/selinux.go
+++ b/sandbox/selinux/selinux.go
@@ -95,3 +95,15 @@ func MockIsEnforcing(isEnforcing func() (bool, error)) (restore func()) {
 		selinuxIsEnforcing = old
 	}
 }
+
+// SnapRunCall wraps the given argv with runcon to run in the snap command with
+// a specific SELinux context if applicable. This is intended to be used when
+// invoking `snap run` directly from the snapd daemon and forcing a domain
+// transition.
+func SnapRunCall(args []string) []string {
+	ctx := SnapRunContext()
+	if ctx == "" {
+		return args
+	}
+	return append([]string{"runcon", ctx}, args...)
+}

--- a/sandbox/selinux/selinux_test.go
+++ b/sandbox/selinux/selinux_test.go
@@ -96,3 +96,13 @@ func (s *selinuxBasicSuite) TestProbePermissive(c *C) {
 	c.Assert(selinux.ProbedLevel(), Equals, level)
 	c.Assert(selinux.Summary(), Equals, status)
 }
+
+func (s *selinuxBasicSuite) TestSnapRunCallWrapsArgv(c *C) {
+	argv := []string{"snap", "run", "--hook", "configure", "-r", "1", "test-snap"}
+	result := selinux.SnapRunCall(argv)
+	// Extended with runcon and appropriate context.
+	c.Check(result, DeepEquals, []string{
+		"runcon", "system_u:system_r:snappy_cli_t:s0",
+		"snap", "run", "--hook", "configure", "-r", "1", "test-snap",
+	})
+}


### PR DESCRIPTION
Set an explicit target context when invoking snap hooks on a SELinux capable system. The SELinux policy already prescribes an implicit transition to snappy_cli_t when /usr/bin/snap is used as an entrypoint by init_t or snappy_t (the snapd daemon). In the context of the snapd daemon, it would be preferable to make the transition explicit. 

Cherry picked from #17208 

