### PR TITLE
docs/api: clarify confdb-control wording

### DIFF
--- a/docs/api/v2/components/schemas/ConfdbControlAction.yaml
+++ b/docs/api/v2/components/schemas/ConfdbControlAction.yaml
@@ -3,7 +3,7 @@
 
 type: object
 description: |-
-  Request to delegate or withdraw an operator's remote access to confdb views.
+  Request to delegate or withdraw an operator's control over confdb views.
 required:
   - action
   - operator-id

--- a/docs/api/v2/paths/confdb-control.yaml
+++ b/docs/api/v2/paths/confdb-control.yaml
@@ -6,15 +6,14 @@ post:
     - Experimental
     - AuthenticatedAccess
     - Synchronous
-  summary: Delegate remote confdb management to operators
+  summary: Delegate control of confdb views to operators
   description: |-
-    Grants or withdraws an operator's ability to remotely manage confdb values
-    on the device.
+    Grants or withdraws an operator's control over confdb views on the device.
 
-    Use the `delegate` action to allow an operator to remotely manage specific
+    Use the `delegate` action to grant an operator control over specific
     confdb views using the specified authentication methods.
 
-    Use the `undelegate` action to withdraw this ability. Omit `views` or
+    Use the `undelegate` action to withdraw this control. Omit `views` or
     `authentications` to withdraw all views or all authentication methods
     respectively.
   operationId: postConfdbControl
@@ -80,3 +79,5 @@ post:
       $ref: '../components/responses/BadRequest.yaml'
     401:
       $ref: '../components/responses/AccessDenied.yaml'
+    500:
+      $ref: '../components/responses/InternalError.yaml'


### PR DESCRIPTION
Following canonical/ubuntu-core-docs#371, I realized this documentation phrases delegation around remote management. Remote device management is the primary way this feature will be used, but the request messages that rely on confdb-control for authorization can also be delivered by other means, for instance via a USB stick. I've reworded it to describe granting and withdrawing operator control over confdb views rather than "remote" access.

Also documents the 500 response, which was previously missing.