### PR TITLE
interfaces: add atkey pid and 7 relative vid

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -43,6 +43,11 @@ type u2fDevice struct {
 // https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules
 var u2fDevices = []u2fDevice{
 	{
+		Name:             "Authentrend ATKey",
+		VendorIDPattern:  "31bb",
+		ProductIDPattern: "0620|0621|0622|0625|0635|0711|0713",
+	},
+	{
 		Name:             "Tokey 3 FIDO",
 		VendorIDPattern:  "0d7a",
 		ProductIDPattern: "0200",

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 37)
+	c.Assert(spec.Snippets(), HasLen, 38)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
=> Yes

This PR adds some ATKey as FIDO2/U2F authenticators into the u2f_devices list for the support in Snapd applications.
- "AuthenTrend Technology Inc."  VID can be found here https://www.usb.org/sites/default/files/vendor_ids03102026_0.pdf, i.e.  12731= 0x31bb
- ATKey authenticators product introduction can be found here https://authentrend.com/atkeypro
