### PR TITLE
tests: add back printer-driver-cups-pdf as a dependency

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -574,7 +574,8 @@ pkg_dependencies_ubuntu_classic(){
         fish
         fontconfig
         gnome-keyring
-        nfs-kernel-server        
+        nfs-kernel-server
+        printer-driver-cups-pdf
         python3-dbus
         python3-gi
         python3-yaml


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
