### PR TITLE
.github/workflows: port permissions fix snapd security fork

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -3,6 +3,18 @@ on:
   pull_request:
     branches: [ "release/**" ]
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
   run-gate:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip spread') }}

--- a/.github/workflows/ci-sru-validation.yaml
+++ b/.github/workflows/ci-sru-validation.yaml
@@ -13,6 +13,18 @@ on:
         description: 'The version of snapd to use for SRU validation (see tests/main/sru-validation-check test for details)'
         required: true
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
   run-validation:
     uses: ./.github/workflows/spread-tests.yaml

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -9,6 +9,18 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
   go-channels:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -25,6 +25,18 @@ on:
           - spread-master-not-fundamental
           - spread-master-nested
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
 
   spread-nightly:

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -62,6 +62,25 @@ on:
 
 jobs:
   run-spread:
+    # A job-level `permissions:` block fully overrides the caller workflow's
+    # grant: any scope not listed here is reset to `none`, even if the caller
+    # granted it. List every scope this reusable job actually uses:
+    #   contents:      checkout, `gh api repos/.../rules/branches/master`
+    #   pull-requests: `gh pr view --json body/labels` (PR metadata in a
+    #                  private repo)
+    #   actions:       `listWorkflowRunArtifacts` / `downloadArtifact` in
+    #                  "Download and extract pre-built packages if they exist"
+    #                  and the cross-attempt `download-artifact` restore
+    #   packages:      ghcr.io image pulls used by setup actions and
+    #                  download-snapd-snap
+    # Callers must also grant these at workflow level (see ci-test.yaml,
+    # ci-release.yaml), because reusable workflows cannot elevate caller
+    # scopes.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+      actions: read
     env:
       SPREAD_EXPERIMENTAL_FEATURES: ${{ inputs.spread-experimental-features }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -18,6 +18,18 @@ on:
   schedule:
     - cron: '30 4 * * 6'
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
   set-inputs:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-state-locks.yaml
+++ b/.github/workflows/weekly-state-locks.yaml
@@ -5,6 +5,18 @@ on:
   schedule:
     - cron: '30 4 * * 0'
 
+# Granted at workflow level so the reusable spread-tests.yaml `run-spread`
+# job (which declares `pull-requests: read` for `gh pr view`) can be called
+# from a private repo. Reusable workflows cannot elevate caller scopes; an
+# explicit `permissions:` block also resets unlisted scopes to `none`, so
+# `contents`, `packages` and `actions` are listed to preserve defaults
+# (checkout, image pulls, cross-run artifact downloads).
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+  actions: read
+
 jobs:
   run-spread-tests:
     uses: ./.github/workflows/spread-tests.yaml


### PR DESCRIPTION
Port permissions fix for snapd security fork from https://github.com/canonical/snapd-security-release/pull/32/changes/b65a325dd169f4d245a5d8c0fb6569dec6af32fd

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-36856