### PR TITLE
cmd/snap: fix checking for self-managed device cgroups support

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1850,7 +1850,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 				snapTag := snap.SecurityTag(runner.info.InstanceName())
 				opts, err2 := cgroup.LoadSnapDeviceCgroupOptions(snapTag)
 				if err2 != nil {
-					logger.Noticef("cannot load snap device cgroup options: %s", err)
+					logger.Noticef("cannot load snap device cgroup options: %s", err2)
 				}
 
 				// NOTE: opts is never nil so this is safe to use even in the error case.

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1640,8 +1640,8 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 		}
 	}
 
-	securityTag := runner.SecurityTag()
-	cmd = append(cmd, securityTag)
+	appSecurityTag := runner.SecurityTag()
+	cmd = append(cmd, appSecurityTag)
 
 	// when under confinement, snap-exec is run from 'core' snap rootfs
 	snapExecPath := filepath.Join(dirs.CoreLibExecDir, "snap-exec")
@@ -1772,7 +1772,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 		// service) was invoked by the user, so it may be running inside
 		// a user's scope cgroup, in which case separate tracking group
 		// needs to be established
-		if err := cgroupConfirmSystemdServiceTracking(securityTag); err != nil {
+		if err := cgroupConfirmSystemdServiceTracking(appSecurityTag); err != nil {
 			if err == cgroup.ErrCannotTrackProcess {
 				// we are not being tracked in a service cgroup
 				// after all, go ahead and create a transient
@@ -1810,7 +1810,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 	// Allow using the session bus for all apps but not for hooks.
 	allowSessionBus := !runner.IsHook()
 	// Track, or confirm existing tracking from systemd.
-	if err := cgroupConfirmSystemdAppTracking(securityTag); err != nil {
+	if err := cgroupConfirmSystemdAppTracking(appSecurityTag); err != nil {
 		if err != cgroup.ErrCannotTrackProcess {
 			return err
 		}
@@ -1823,7 +1823,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 	}
 	if needsTracking {
 		opts := &cgroup.TrackingOptions{AllowSessionBus: allowSessionBus}
-		if err = cgroupCreateTransientScopeForTracking(securityTag, opts); err != nil {
+		if err = cgroupCreateTransientScopeForTracking(appSecurityTag, opts); err != nil {
 			if err != cgroup.ErrCannotTrackProcess {
 				return err
 			}
@@ -1847,7 +1847,8 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 				// For apps using core26+, fail hard unless they don't rely on
 				// cgroup for device control and have the self-managed=true
 				// setting.
-				opts, err2 := cgroup.LoadSnapDeviceCgroupOptions(securityTag)
+				snapTag := snap.SecurityTag(runner.info.InstanceName())
+				opts, err2 := cgroup.LoadSnapDeviceCgroupOptions(snapTag)
 				if err2 != nil {
 					logger.Noticef("cannot load snap device cgroup options: %s", err)
 				}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -3060,7 +3060,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26SelfManagedAllowed(c *check.C
 	defer restore()
 
 	// mock installed snap
-	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "core26")), &snap.SideInfo{
+	info := snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "core26")), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 
@@ -3088,7 +3088,8 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26SelfManagedAllowed(c *check.C
 	cgroupOptsData, err := cgroupOpts.MarshalText()
 	c.Assert(err, check.IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapCgroupPolicyDir, 0755), check.IsNil)
-	c.Assert(os.WriteFile(cgroup.SnapDeviceFile("snap.snapname.app"), cgroupOptsData, 0644), check.IsNil)
+	c.Assert(os.WriteFile(cgroup.SnapDeviceFile(snap.SecurityTag(info.InstanceName())),
+		cgroupOptsData, 0644), check.IsNil)
 
 	// redirect exec
 	execArg0 := ""

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -3118,7 +3118,7 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26NonStrictOnlyFails(c *check.C
 	defer restore()
 
 	// mock installed snap
-	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "core26")), &snap.SideInfo{
+	info := snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "core26")), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 
@@ -3146,7 +3146,8 @@ func (s *RunSuite) TestSnapRunTrackingFailureCore26NonStrictOnlyFails(c *check.C
 	cgroupOptsData, err := cgroupOpts.MarshalText()
 	c.Assert(err, check.IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapCgroupPolicyDir, 0755), check.IsNil)
-	c.Assert(os.WriteFile(cgroup.SnapDeviceFile("snap.snapname.app"), cgroupOptsData, 0644), check.IsNil)
+	c.Assert(os.WriteFile(cgroup.SnapDeviceFile(snap.SecurityTag(info.InstanceName())),
+		cgroupOptsData, 0644), check.IsNil)
 
 	// redirect exec
 	restore = snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -503,9 +503,10 @@ func SnapDeviceFile(securityTag string) string {
 	return filepath.Join(dirs.SnapCgroupPolicyDir, fmt.Sprintf("%s.device", securityTag))
 }
 
-// LoadSnapDeviceCgroupOptions loads the device cgroup options for a given security tag.
-func LoadSnapDeviceCgroupOptions(securityTag string) (opts SnapDeviceCgroupOptions, err error) {
-	b, err := os.ReadFile(SnapDeviceFile(securityTag))
+// LoadSnapDeviceCgroupOptions loads the device cgroup options for a given snap
+// security tag.
+func LoadSnapDeviceCgroupOptions(snapSecurityTag string) (opts SnapDeviceCgroupOptions, err error) {
+	b, err := os.ReadFile(SnapDeviceFile(snapSecurityTag))
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return opts, nil


### PR DESCRIPTION
The check for self-managed device cgroup used an app specific security
tag, while it should have been the snap one.

Related: SNAPDENG-37110