### PR TITLE
daemon: refactor the snap command advisory check

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -495,31 +496,25 @@ func isRequestFromSnapCmd(r *http.Request) (bool, error) {
 		return false, err
 	}
 
-	// SNAP_REEXEC=0
-	if exe == filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap") {
-		return true, nil
-	}
+	// There aren't too many options, but overall possibilities are:
+	// - we are re-executed and the client isn't
+	// - the client re-executed but we did not
+	// - TODO the client could be a merged snapd-snap binary
 
-	// Check if re-exec in snapd
-	path := filepath.Join(dirs.SnapMountDir, "snapd/*/usr/bin/*")
-	if matched, err := filepath.Match(path, exe); err != nil {
-		return false, err
-	} else if matched {
-		base := filepath.Base(exe)
-		// Depending on the build variant of the snapd snap, the command could
-		// either be $SNAPD_MOUNT/usr/bin/snap or $SNAPD_MOUNT/usr/bin/snap-fips
-		if base == "snap" || base == "snap-fips" {
-			return true, nil
-		}
-
+	switch filepath.Base(exe) {
+	case "snap", "snap-fips": // the standalone snap binary, or its FIPS build variant
+	default:
 		return false, nil
 	}
 
-	// Check if re-exec in core
-	path = filepath.Join(dirs.SnapMountDir, "core/*/usr/bin/snap")
-	if matched, err := filepath.Match(path, exe); err != nil {
-		return false, err
-	} else if matched {
+	if strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "snapd")+"/") ||
+		strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "core")+"/") {
+		// client with expected name from snap or core snap
+		return true, nil
+	}
+
+	if strings.HasPrefix(exe, filepath.Join(dirs.GlobalRootDir, "usr/bin")+"/") {
+		// client with expected name from one of the system locations
 		return true, nil
 	}
 

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -27,9 +27,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -480,43 +478,4 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 	}
 
 	return checker.CheckAccess(d, r, ucred, user)
-}
-
-// isRequestFromSnapCmd checks that the request is coming from snap command.
-//
-// It checks that the request process "/proc/PID/exe" points to one of the
-// known locations of the snap command. This not a security-oriented check.
-func isRequestFromSnapCmd(r *http.Request) (bool, error) {
-	ucred, err := ucrednetGet(r.RemoteAddr)
-	if err != nil {
-		return false, err
-	}
-	exe, err := osReadlink(fmt.Sprintf("/proc/%d/exe", ucred.Pid))
-	if err != nil {
-		return false, err
-	}
-
-	// There aren't too many options, but overall possibilities are:
-	// - we are re-executed and the client isn't
-	// - the client re-executed but we did not
-	// - TODO the client could be a merged snapd-snap binary
-
-	switch filepath.Base(exe) {
-	case "snap", "snap-fips": // the standalone snap binary, or its FIPS build variant
-	default:
-		return false, nil
-	}
-
-	if strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "snapd")+"/") ||
-		strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "core")+"/") {
-		// client with expected name from snap or core snap
-		return true, nil
-	}
-
-	if strings.HasPrefix(exe, filepath.Join(dirs.GlobalRootDir, "usr/bin")+"/") {
-		// client with expected name from one of the system locations
-		return true, nil
-	}
-
-	return false, nil
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -1070,40 +1069,4 @@ func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil)
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
-}
-
-func (s *accessSuite) TestIsFromSnapCmd(c *C) {
-	req, err := http.NewRequest("GET", "/v2/system-volumes", nil)
-	c.Assert(err, IsNil)
-
-	restore := daemon.MockUcrednetGet(func(remoteAddr string) (ucred *daemon.Ucrednet, err error) {
-		return &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}, nil
-	})
-	defer restore()
-
-	for _, tc := range []struct {
-		exe string
-		res bool
-	}{
-		{filepath.Join(dirs.SnapMountDir, "core/123/usr/bin/snap"), true},
-		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap"), true},
-		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap-fips"), true},
-		{filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap"), true},
-
-		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/snap"), false},
-		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/not-a-snap"), false},
-	} {
-		c.Logf("tc: %+v", tc)
-		func() {
-			restore = daemon.MockOsReadlink(func(p string) (string, error) {
-				c.Check(p, Equals, "/proc/100/exe")
-				return tc.exe, nil
-			})
-			defer restore()
-
-			res, err := daemon.IsRequestFromSnapCmd(req)
-			c.Check(err, IsNil)
-			c.Check(res, Equals, tc.res)
-		}()
-	}
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -1069,4 +1070,40 @@ func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil)
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
+}
+
+func (s *accessSuite) TestIsFromSnapCmd(c *C) {
+	req, err := http.NewRequest("GET", "/v2/system-volumes", nil)
+	c.Assert(err, IsNil)
+
+	restore := daemon.MockUcrednetGet(func(remoteAddr string) (ucred *daemon.Ucrednet, err error) {
+		return &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}, nil
+	})
+	defer restore()
+
+	for _, tc := range []struct {
+		exe string
+		res bool
+	}{
+		{filepath.Join(dirs.SnapMountDir, "core/123/usr/bin/snap"), true},
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap"), true},
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap-fips"), true},
+		{filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap"), true},
+
+		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/snap"), false},
+		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/not-a-snap"), false},
+	} {
+		c.Logf("tc: %+v", tc)
+		func() {
+			restore = daemon.MockOsReadlink(func(p string) (string, error) {
+				c.Check(p, Equals, "/proc/100/exe")
+				return tc.exe, nil
+			})
+			defer restore()
+
+			res, err := daemon.IsRequestFromSnapCmd(req)
+			c.Check(err, IsNil)
+			c.Check(res, Equals, tc.res)
+		}()
+	}
 }

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -268,7 +268,7 @@ func postNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 	defer st.Unlock()
 
 	if err := inst.validate(r); err != nil {
-		return err
+		return BadRequest(`%v (can only record notices from the "snap" command)`, err)
 	}
 
 	noticeId, err := st.AddNotice(&requestUID, state.SnapRunInhibitNotice, inst.Key, nil)
@@ -286,19 +286,19 @@ type noticeInstruction struct {
 	// NOTE: Data and RepeatAfter fields are not needed for snap-run-inhibit notices.
 }
 
-func (inst *noticeInstruction) validate(r *http.Request) *apiError {
+func (inst *noticeInstruction) validate(r *http.Request) error {
 	if inst.Action != "add" {
-		return BadRequest("invalid action %q", inst.Action)
+		return fmt.Errorf("invalid action %q", inst.Action)
 	}
 	if err := state.ValidateNotice(inst.Type, inst.Key, nil); err != nil {
-		return BadRequest("%s", err)
+		return err
 	}
 
 	switch inst.Type {
 	case state.SnapRunInhibitNotice:
 		return inst.validateSnapRunInhibitNotice(r)
 	default:
-		return BadRequest(`cannot add notice with invalid type %q (can only add "snap-run-inhibit" notices)`, inst.Type)
+		return fmt.Errorf(`cannot add notice with invalid type %q`, inst.Type)
 	}
 }
 
@@ -341,19 +341,19 @@ func isRequestFromSnapCmd(r *http.Request) (bool, error) {
 	return false, nil
 }
 
-func (inst *noticeInstruction) validateSnapRunInhibitNotice(r *http.Request) *apiError {
+func (inst *noticeInstruction) validateSnapRunInhibitNotice(r *http.Request) error {
 	// double check that the request comes from snap so we can produce a
 	// reasonable error for misguided requests to this currently non-public API.
 	// Note this is not a security check, but merely a low key effort to prevent
 	// misuse of the API.
 	if fromSnapCmd, err := isRequestFromSnapCmd(r); err != nil {
-		return InternalError("cannot check request source: %v", err)
+		return fmt.Errorf("internal error: cannot check request source: %v", err)
 	} else if !fromSnapCmd {
-		return Forbidden(`cannot add notice (can only record %q notices from the "snap" command)`, state.SnapRunInhibitNotice)
+		return fmt.Errorf(`unexpected command of the calling process`)
 	}
 
 	if err := naming.ValidateInstance(inst.Key); err != nil {
-		return BadRequest("invalid key: %v", err)
+		return err
 	}
 
 	return nil

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -300,11 +302,54 @@ func (inst *noticeInstruction) validate(r *http.Request) *apiError {
 	}
 }
 
+// isRequestFromSnapCmd checks that the request is coming from snap command.
+//
+// It checks that the request process "/proc/PID/exe" points to one of the
+// known locations of the snap command. This not a security-oriented check.
+func isRequestFromSnapCmd(r *http.Request) (bool, error) {
+	ucred, err := ucrednetGet(r.RemoteAddr)
+	if err != nil {
+		return false, err
+	}
+	exe, err := osReadlink(fmt.Sprintf("/proc/%d/exe", ucred.Pid))
+	if err != nil {
+		return false, err
+	}
+
+	// There aren't too many options, but overall possibilities are:
+	// - we are re-executed and the client isn't
+	// - the client re-executed but we did not
+	// - TODO the client could be a merged snapd-snap binary
+
+	switch filepath.Base(exe) {
+	case "snap", "snap-fips": // the standalone snap binary, or its FIPS build variant
+	default:
+		return false, nil
+	}
+
+	if strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "snapd")+"/") ||
+		strings.HasPrefix(exe, filepath.Join(dirs.SnapMountDir, "core")+"/") {
+		// client with expected name from snap or core snap
+		return true, nil
+	}
+
+	if strings.HasPrefix(exe, filepath.Join(dirs.GlobalRootDir, "usr/bin")+"/") {
+		// client with expected name from one of the system locations
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func (inst *noticeInstruction) validateSnapRunInhibitNotice(r *http.Request) *apiError {
+	// double check that the request comes from snap so we can produce a
+	// reasonable error for misguided requests to this currently non-public API.
+	// Note this is not a security check, but merely a low key effort to prevent
+	// misuse of the API.
 	if fromSnapCmd, err := isRequestFromSnapCmd(r); err != nil {
 		return InternalError("cannot check request source: %v", err)
 	} else if !fromSnapCmd {
-		return Forbidden("only snap command can record notices")
+		return Forbidden(`cannot add notice (can only record %q notices from the "snap" command)`, state.SnapRunInhibitNotice)
 	}
 
 	if err := naming.ValidateInstance(inst.Key); err != nil {

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -919,15 +919,18 @@ func (s *noticesSuite) TestAddNoticeInvalidAction(c *C) {
 }
 
 func (s *noticesSuite) TestAddNoticeInvalidTypeUnkown(c *C) {
-	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "foo"}`, `cannot add notice with invalid type "foo"`)
+	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "foo"}`,
+		`cannot add notice with invalid type "foo" .*`)
 }
 
 func (s *noticesSuite) TestAddNoticeInvalidTypeKnown(c *C) {
-	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "change-update", "key": "test"}`, "cannot add notice with invalid type.*")
+	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "change-update", "key": "test"}`,
+		`cannot add notice with invalid type.*`)
 }
 
 func (s *noticesSuite) TestAddNoticeEmptyKey(c *C) {
-	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "snap-run-inhibit", "key": ""}`, `cannot add snap-run-inhibit notice with invalid key ""`)
+	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "snap-run-inhibit", "key": ""}`,
+		`cannot add snap-run-inhibit notice with invalid key "" \(can only record notices from the "snap" command\)`)
 }
 
 func (s *noticesSuite) TestAddNoticeKeyTooLong(c *C) {
@@ -937,11 +940,13 @@ func (s *noticesSuite) TestAddNoticeKeyTooLong(c *C) {
 		"key":    strings.Repeat("x", 257),
 	})
 	c.Assert(err, IsNil)
-	s.testAddNoticeBadRequest(c, string(request), "cannot add snap-run-inhibit notice with invalid key: key must be 256 bytes or less")
+	s.testAddNoticeBadRequest(c, string(request),
+		`cannot add snap-run-inhibit notice with invalid key: key must be 256 bytes or less \(can only record notices from the "snap" command\)`)
 }
 
 func (s *noticesSuite) TestAddNoticeInvalidSnapName(c *C) {
-	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "snap-run-inhibit", "key": "Snap-Name"}`, `invalid key: invalid snap name: "Snap-Name"`)
+	s.testAddNoticeBadRequest(c, `{"action": "add", "type": "snap-run-inhibit", "key": "Snap-Name"}`,
+		`invalid snap name: "Snap-Name" \(can only record notices from the "snap" command\)`)
 }
 
 func (s *noticesSuite) testAddNoticeBadRequest(c *C, body, errorMatch string) {
@@ -1012,8 +1017,8 @@ func (s *noticesSuite) testAddNoticesSnapCmd(c *C, exePath string, shouldFail bo
 
 	if shouldFail {
 		rsp := s.errorReq(c, req, nil, actionIsExpected)
-		c.Check(rsp.Status, Equals, 403)
-		c.Assert(rsp.Message, Matches, `cannot add notice \(can only record "snap-run-inhibit" notices from the "snap" command\)`)
+		c.Check(rsp.Status, Equals, 400)
+		c.Assert(rsp.Message, Matches, `unexpected command of the calling process \(can only record notices from the "snap" command\)`)
 	} else {
 		rsp := s.syncReq(c, req, nil, actionIsExpected)
 		c.Assert(rsp.Status, Equals, 200)

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -1013,7 +1013,7 @@ func (s *noticesSuite) testAddNoticesSnapCmd(c *C, exePath string, shouldFail bo
 	if shouldFail {
 		rsp := s.errorReq(c, req, nil, actionIsExpected)
 		c.Check(rsp.Status, Equals, 403)
-		c.Assert(rsp.Message, Matches, "only snap command can record notices")
+		c.Assert(rsp.Message, Matches, `cannot add notice \(can only record "snap-run-inhibit" notices from the "snap" command\)`)
 	} else {
 		rsp := s.syncReq(c, req, nil, actionIsExpected)
 		c.Assert(rsp.Status, Equals, 200)
@@ -1219,4 +1219,40 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 func addNotice(c *C, st *state.State, userID *uint32, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
 	_, err := st.AddNotice(userID, noticeType, key, options)
 	c.Assert(err, IsNil)
+}
+
+func (s *noticesSuite) TestIsFromSnapCmd(c *C) {
+	req, err := http.NewRequest("GET", "/v2/system-volumes", nil)
+	c.Assert(err, IsNil)
+
+	restore := daemon.MockUcrednetGet(func(remoteAddr string) (ucred *daemon.Ucrednet, err error) {
+		return &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}, nil
+	})
+	defer restore()
+
+	for _, tc := range []struct {
+		exe string
+		res bool
+	}{
+		{filepath.Join(dirs.SnapMountDir, "core/123/usr/bin/snap"), true},
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap"), true},
+		{filepath.Join(dirs.SnapMountDir, "snapd/123/usr/bin/snap-fips"), true},
+		{filepath.Join(dirs.GlobalRootDir, "/usr/bin/snap"), true},
+
+		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/snap"), false},
+		{filepath.Join(dirs.GlobalRootDir, "/foo/bar/baz/not-a-snap"), false},
+	} {
+		c.Logf("tc: %+v", tc)
+		func() {
+			restore = daemon.MockOsReadlink(func(p string) (string, error) {
+				c.Check(p, Equals, "/proc/100/exe")
+				return tc.exe, nil
+			})
+			defer restore()
+
+			res, err := daemon.IsRequestFromSnapCmd(req)
+			c.Check(err, IsNil)
+			c.Check(res, Equals, tc.res)
+		}()
+	}
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -398,6 +398,8 @@ var (
 	ErrToResponse      = errToResponse
 
 	MaxReadBuflen = maxReadBuflen
+
+	IsRequestFromSnapCmd = isRequestFromSnapCmd
 )
 
 func MockRebootNoticeWait(d time.Duration) (restore func()) {


### PR DESCRIPTION
Refactor how the is-originating-from-snap-command advisory check works.

Cherry picked from #17208 

Related: [SNAPDENG-37094](https://warthogs.atlassian.net/browse/SNAPDENG-37094)


[SNAPDENG-37094]: https://warthogs.atlassian.net/browse/SNAPDENG-37094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ