### PR TITLE
o/snapstate: make secondary prerequisite synchronization task handle same-change retries

### DIFF
--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -383,6 +383,8 @@ func ensurePrerequisite(t *state.Task, contentAttrs []string, sn StoreSnap, opts
 				return nil, fmt.Errorf("prerequisite %q is not available during prerequisites synchronization", sn.InstanceName)
 			}
 
+			// content providers are soft prerequisites. if we don't have it by
+			// now, we just proceed.
 			return nil, nil
 		}
 		_, ts, err = InstallOne(context.TODO(), st, StoreInstallGoal(sn), opts)

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -291,6 +291,13 @@ func checkForInFlightPrereqTasks(prereqs *state.Task, prerequisiteName string, b
 		return prereqProceed, nil
 	}
 
+	// the first prerequisites task must not block on work already scheduled in
+	// this same change. the secondary prerequisites synchronization task is
+	// responsible for polling until that in-flight work has completed.
+	if !prereqs.Has("prerequisites-sync") && link.Change().ID() == prereqs.Change().ID() {
+		return prereqSkip, nil
+	}
+
 	isContentProvider := !basePrerequisite && prerequisiteName != "snapd"
 	if isContentProvider {
 		// the content-provider snap is already being linked by this change, so
@@ -368,8 +375,25 @@ func ensurePrerequisite(t *state.Task, contentAttrs []string, sn StoreSnap, opts
 
 	var ts *state.TaskSet
 	if !installed {
+		if t.Has("prerequisites-sync") {
+			// prereqs that aren't just content providers must be available by
+			// the time the synchronization task runs. if not, we fail the
+			// change.
+			if sn.InstanceName == "snapd" || opts.Flags.RequireTypeBase {
+				return nil, fmt.Errorf("prerequisite %q is not available during prerequisites synchronization", sn.InstanceName)
+			}
+
+			return nil, nil
+		}
 		_, ts, err = InstallOne(context.TODO(), st, StoreInstallGoal(sn), opts)
 	} else {
+		if t.Has("prerequisites-sync") {
+			// prereqs that are content providers are considered soft
+			// prerequisites. by the time we hit this branch, we know that the
+			// content provider's update is neither finished nor in flight. in
+			// that case, we proceed without it.
+			return nil, nil
+		}
 		ts, err = maybeUpdateContentProvider(t, sn.InstanceName, contentAttrs, opts)
 	}
 	if err != nil {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -375,6 +375,67 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 	c.Check(linkedSnaps, testutil.DeepUnsortedMatches, expectedLinkedSnaps)
 }
 
+func (s *prereqSuite) TestDoPrereqSkipsSameChangeInFlightPrereq(c *C) {
+	s.runner.AddHandler("link-snap", func(task *state.Task, _ *tomb.Tomb) error {
+		st := task.State()
+		st.Lock()
+		defer st.Unlock()
+
+		snapsup, _ := snapstate.TaskSnapSetup(task)
+		var snapst snapstate.SnapState
+		snapstate.Get(st, snapsup.InstanceName(), &snapst)
+		snapst.Current = snapsup.Revision()
+		snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, sequence.NewRevisionSideState(snapsup.SideInfo, nil))
+		snapstate.Set(st, snapsup.InstanceName(), &snapst)
+
+		return nil
+	}, nil)
+
+	s.state.Lock()
+	link := s.state.NewTask("link-snap", "Pretend prereq gets installed")
+	link.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "some-prereq",
+			Revision: snap.R(11),
+		},
+	})
+
+	// install snapd so that prerequisites handler won't try to install it
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+	})
+
+	// pretend foo gets installed and needs some-prereq, which is in progress
+	prereq := s.state.NewTask("prerequisites", "foo")
+	prereq.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+		},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"some-prereq": nil},
+	})
+	link.WaitFor(prereq)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(prereq)
+	chg.AddTask(link)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(prereq.Status(), Equals, state.DoneStatus)
+	c.Check(prereq.AtTime().IsZero(), Equals, true)
+	c.Check(link.Status(), Equals, state.DoStatus)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+}
+
 func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	restore := snapstate.MockPrerequisitesRetryTimeout(1 * time.Millisecond)
 	defer restore()
@@ -435,6 +496,9 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 			RealName: "foo",
 		},
 	})
+	// mark this as the prerequisites synchronization task so same-change
+	// required prerequisites are retried
+	prereqTask.Set("prerequisites-sync", true)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(prereqTask)
@@ -521,6 +585,133 @@ func (s *prereqSuite) TestDoPrereqRetryWhenPrereqInstallInAnotherChange(c *C) {
 	c.Check(prereq.AtTime().IsZero(), Equals, false)
 }
 
+func (s *prereqSuite) TestDoPrereqSyncFailsForMissingBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+	})
+
+	setup := s.state.NewTask("download-snap", "foo setup")
+	setup.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+		},
+		Base: "core18",
+	})
+	setup.SetStatus(state.DoneStatus)
+
+	prereq := s.state.NewTask("prerequisites", "foo prerequisites synchronization")
+	prereq.Set("snap-setup-task", setup.ID())
+	prereq.Set("prerequisites-sync", true)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(setup)
+	chg.AddTask(prereq)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot install snap base "core18": prerequisite "core18" is not available during prerequisites synchronization.*`)
+	c.Check(s.fakeBackend.ops.Count("storesvc-snap-action:action"), Equals, 0)
+}
+
+func (s *prereqSuite) TestDoPrereqSyncDoesNotFailForMissingContentProviderUpdate(c *C) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
+		return nil, nil
+	}
+	s.AddCleanup(func() { snapstate.AutoAliases = nil })
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mockInstalledSnap(c, s.state, `name: some-snap`, false)
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+	})
+
+	setup := s.state.NewTask("download-snap", "foo setup")
+	setup.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+		},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"some-snap": {"this-does-not-match"}},
+	})
+	setup.SetStatus(state.DoneStatus)
+
+	prereq := s.state.NewTask("prerequisites", "foo prerequisites synchronization")
+	prereq.Set("snap-setup-task", setup.ID())
+	prereq.Set("prerequisites-sync", true)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(setup)
+	chg.AddTask(prereq)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(chg.Err(), IsNil)
+	c.Check(s.fakeBackend.ops.Count("storesvc-snap-action:action"), Equals, 0)
+}
+
+func (s *prereqSuite) TestDoPrereqSyncDoesNotFailForMissingContentProviderInstall(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+	})
+
+	setup := s.state.NewTask("download-snap", "foo setup")
+	setup.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+		},
+		Base:               "none",
+		PrereqContentAttrs: map[string][]string{"some-snap": {"some-content"}},
+	})
+	setup.SetStatus(state.DoneStatus)
+
+	prereq := s.state.NewTask("prerequisites", "foo prerequisites synchronization")
+	prereq.Set("snap-setup-task", setup.ID())
+	prereq.Set("prerequisites-sync", true)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(setup)
+	chg.AddTask(prereq)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(chg.Err(), IsNil)
+	c.Check(s.fakeBackend.ops.Count("storesvc-snap-action:action"), Equals, 0)
+}
+
 func (s *prereqSuite) TestDoPrereqRetryWhenDifferentLaneWaitsOnBaseInFlight(c *C) {
 	restore := snapstate.MockPrerequisitesRetryTimeout(1 * time.Millisecond)
 	defer restore()
@@ -584,6 +775,9 @@ func (s *prereqSuite) TestDoPrereqRetryWhenDifferentLaneWaitsOnBaseInFlight(c *C
 		},
 		Base: "core18",
 	})
+	// mark this as the prerequisites synchronization task so same-change
+	// required prerequisites are retried
+	prereqTask.Set("prerequisites-sync", true)
 	prereqTask.JoinLane(s.state.NewLane())
 
 	// this task belongs to the same snap and waits on the base link-snap, but
@@ -671,6 +865,9 @@ func (s *prereqSuite) TestDoPrereqFailWhenCircularDependencyDetected(c *C) {
 			RealName: "foo",
 		},
 	})
+	// mark this as the prerequisites synchronization task so circular waits are
+	// still detected
+	prereqs.Set("prerequisites-sync", true)
 
 	// prereqs waits on link, out of band.
 	// link waits on waiter, which waits on blocker.

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -163,7 +163,7 @@ func waitForIfNeeded(waiter, target *state.Task) {
 // addEarlyDownloadDeps sets up dependencies so that all early-download snaps'
 // beforeLocalSystemModificationsTasks complete before any snap's first local
 // system modification begins. The first local-modification task is the
-// prerequisites sync task.
+// prerequisites synchronization task.
 func addEarlyDownloadDeps(stss []snapInstallTaskSet, earlyDownloads map[string]bool) error {
 	if len(earlyDownloads) == 0 {
 		return nil

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5402,7 +5402,7 @@ func (s *snapmgrTestSuite) TestInstallPrereqIgnoreConflictInSameChange(c *C) {
 	s.settle(c)
 
 	// check that the prereq task wasn't retried
-	prereqTask, _ := findPrereqTasks(c, chg)
+	prereqTask, _ := findPrereqTasksForSnap(c, chg, "snap-content-plug")
 	c.Check(prereqTask.Status(), Equals, state.DoneStatus)
 	c.Assert(prereqTask.AtTime().IsZero(), Equals, true)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1110,7 +1110,7 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisitesSyncTask(c *C) {
 	chg := s.state.NewChange("refresh-snap", "test: update snap")
 	chg.AddAll(ts)
 
-	earlyPrereq, syncPrereq := findPrereqTasks(c, chg)
+	earlyPrereq, syncPrereq := findPrereqTasksForSnap(c, chg, "some-snap")
 
 	c.Check(earlyPrereq.Has("snap-setup"), Equals, true)
 	c.Check(earlyPrereq.Has("snap-setup-task"), Equals, false)
@@ -7557,7 +7557,7 @@ func (s *snapmgrTestSuite) TestUpdatePrereqDetectConflictWithPrereq(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	prereqTask, _ := findPrereqTasks(c, updateChg)
+	prereqTask, _ := findPrereqTasksForSnap(c, updateChg, "outdated-consumer")
 
 	// check that it's not done and that it was scheduled for a specific time
 	// (only done when retrying). This doesn't test that it's scheduled for
@@ -7610,7 +7610,7 @@ func (s *snapmgrTestSuite) TestUpdatePrereqWithConflictingTask(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	prereqTask, _ := findPrereqTasks(c, updateChg)
+	prereqTask, _ := findPrereqTasksForSnap(c, updateChg, "outdated-consumer")
 
 	// check that it's not done and that it was scheduled for a specific time
 	// (only done when retrying). This doesn't test that it's scheduled for
@@ -7653,7 +7653,7 @@ func (s *snapmgrTestSuite) TestUpdateNoRetryIfPrereqTaskFails(c *C) {
 
 	s.settle(c)
 
-	prereqTask, _ := findPrereqTasks(c, updateChg)
+	prereqTask, _ := findPrereqTasksForSnap(c, updateChg, "outdated-consumer")
 
 	// check that the task is done and that it wasn't ever rescheduled for a
 	// specific time (only done when retrying)
@@ -7707,23 +7707,129 @@ func (s *snapmgrTestSuite) TestUpdatePrereqIgnoreDuplOpInSameChange(c *C) {
 	defer s.state.Unlock()
 
 	// check that the prereq task wasn't retried
-	prereqTask, _ := findPrereqTasks(c, chg)
+	prereqTask, _ := findPrereqTasksForSnap(c, chg, "outdated-consumer")
 	c.Check(prereqTask.Status(), Equals, state.DoneStatus)
 	c.Assert(prereqTask.AtTime().IsZero(), Equals, true)
 }
 
-// findPrereqTasks looks for the early and sync prerequisites tasks in the
-// change and fails if either is missing or duplicated.
-func findPrereqTasks(c *C, chg *state.Change) (earlyPrereq, syncPrereq *state.Task) {
+func (s *snapmgrTestSuite) TestUpdateSyncPrereqRetriesForSameChangeBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restore := snapstate.MockPrerequisitesRetryTimeout(time.Millisecond)
+	s.AddCleanup(restore)
+
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: "snapd",
+			SnapID:   "snapd-snap-id",
+			Revision: snap.R(1),
+		}}),
+		Current:         snap.R(1),
+		TrackingChannel: "latest/stable",
+		SnapType:        "snapd",
+	})
+	snapstate.Set(s.state, "core18", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: "core18",
+			SnapID:   "core18-snap-id",
+			Revision: snap.R(1),
+		}}),
+		Current:         snap.R(1),
+		TrackingChannel: "latest/stable",
+		SnapType:        "base",
+	})
+	snapstate.Set(s.state, "some-snap-with-core18-base", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: "some-snap-with-core18-base",
+			SnapID:   "some-snap-with-core18-base",
+			Revision: snap.R(1),
+		}}),
+		Current:         snap.R(1),
+		TrackingChannel: "latest/stable",
+		SnapType:        "app",
+		Base:            "core18",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: "some-snap-with-core18-base",
+	})
+	appTasks, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+		UserID: s.user.ID,
+	})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh some-snap-with-core18-base")
+	chg.AddAll(appTasks)
+
+	// this uses a real task graph for the app, but injects in-flight same-change
+	// base work so that the generated sync prerequisites task has to poll for
+	// the base's link-snap to finish.
+	baseLink := s.state.NewTask("link-snap", "pretend core18 gets linked")
+	baseLink.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "core18",
+			SnapID:   "core18-snap-id",
+			Revision: snap.R(11),
+		},
+		Type: snap.TypeBase,
+	})
+	baseLink.At(time.Now().Add(time.Hour))
+	chg.AddTask(baseLink)
+
+	earlyPrereq, syncPrereq := findPrereqTasksForSnap(c, chg, "some-snap-with-core18-base")
+
+	s.state.Unlock()
+	err = s.o.SettleWithBreakCondition(testutil.HostScaledTimeout(10*time.Second), func() bool {
+		s.state.Lock()
+		defer s.state.Unlock()
+		return syncPrereq.Status() == state.DoingStatus && !syncPrereq.AtTime().IsZero()
+	})
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	// first prereq task is done
+	c.Check(earlyPrereq.Status(), Equals, state.DoneStatus)
+	c.Check(earlyPrereq.AtTime().IsZero(), Equals, true)
+
+	// sync prereq task has been attempted and is going to be retried
+	c.Check(syncPrereq.Status(), Equals, state.DoingStatus)
+	c.Check(syncPrereq.AtTime().IsZero(), Equals, false)
+	c.Check(baseLink.Status(), Equals, state.DoStatus)
+
+	baseLink.SetStatus(state.DoneStatus)
+
+	s.settle(c)
+
+	c.Check(syncPrereq.Status(), Equals, state.DoneStatus)
+	c.Check(baseLink.Status(), Equals, state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+}
+
+// findPrereqTasksForSnap looks for the early and sync prerequisites tasks for
+// the given snap and fails if either is missing or duplicated.
+func findPrereqTasksForSnap(c *C, chg *state.Change, snapName string) (earlyPrereq, syncPrereq *state.Task) {
 	checkDuplicate := func(kind string, task, existing *state.Task) {
 		if existing != nil {
-			c.Fatalf("encountered two %s prerequisites tasks in the change but only expected one: \n%s\n%s\n",
-				kind, task.Summary(), existing.Summary())
+			c.Fatalf("encountered two %s prerequisites tasks for %q in the change but only expected one: \n%s\n%s\n",
+				kind, snapName, task.Summary(), existing.Summary())
 		}
 	}
 
 	for _, task := range chg.Tasks() {
 		if task.Kind() != "prerequisites" {
+			continue
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		if snapsup.InstanceName() != snapName {
 			continue
 		}
 
@@ -8823,7 +8929,7 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {
 	chg := s.state.NewChange("update", "test: update snap")
 	chg.AddAll(tasks)
 
-	earlyPrereq, syncPrereq := findPrereqTasks(c, chg)
+	earlyPrereq, syncPrereq := findPrereqTasksForSnap(c, chg, "outdated-consumer")
 
 	// mimic tasks serialized by an "old" snapd without PrereqContentAttrs.
 	// The new code shouldn't update the prereq since it doesn't have the content attrs.


### PR DESCRIPTION
This makes the second `prerequisites` task just handle polling the state of other tasks, rather than actually spawning tasks itself. This will enable us to recursively resolve all prerequisites early enough for them all to be considered for the seed refresh.