### PR TITLE
wrappers: update test to handle multiple ActiveState queries

### DIFF
--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -4676,11 +4676,16 @@ apps:
 	sysdLog = nil
 	err = wrappers.StopServices(services, nil, nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, `really failed to stop service`)
-	c.Check(sysdLog, DeepEquals, [][]string{
-		{"stop", filepath.Base(fooUnitFile)},
-		{"show", "--property=ActiveState", filepath.Base(fooUnitFile)},
-		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", filepath.Base(fooUnitFile)},
-	})
+
+	// systemd.Stop may poll ActiveState more than once while the stop command
+	// completes. the important part is that StopServices checks the full
+	// service status before reporting that the failed stop is fatal.
+	c.Assert(len(sysdLog) >= 3, Equals, true)
+	c.Check(sysdLog[0], DeepEquals, []string{"stop", filepath.Base(fooUnitFile)})
+	for _, cmd := range sysdLog[1 : len(sysdLog)-1] {
+		c.Check(cmd, DeepEquals, []string{"show", "--property=ActiveState", filepath.Base(fooUnitFile)})
+	}
+	c.Check(sysdLog[len(sysdLog)-1], DeepEquals, []string{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", filepath.Base(fooUnitFile)})
 }
 
 func (s *servicesTestSuite) TestStartSnapSocketEnableStart(c *C) {


### PR DESCRIPTION
Saw this unit test failure in CI:

```
FAIL: services_test.go:4618: servicesTestSuite.TestStopServiceFailsAndServiceStillRunsSoMustFail

services_test.go:4679:
    c.Check(sysdLog, DeepEquals, [][]string{
        {"stop", filepath.Base(fooUnitFile)},
        {"show", "--property=ActiveState", filepath.Base(fooUnitFile)},
        {"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", filepath.Base(fooUnitFile)},
    })
... obtained [][]string = [][]string{[]string{"stop", "snap.basic-snap.foo.service"}, []string{"show", "--property=ActiveState", "snap.basic-snap.foo.service"}, []string{"show", "--property=ActiveState", "snap.basic-snap.foo.service"}, []string{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", "snap.basic-snap.foo.service"}}
... expected [][]string = [][]string{[]string{"stop", "snap.basic-snap.foo.service"}, []string{"show", "--property=ActiveState", "snap.basic-snap.foo.service"}, []string{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", "snap.basic-snap.foo.service"}}
... Difference:
...     [][]string[4] != [][]string[3]
```

The middle range of commands we're checking could contain an arbitrary number of `ActiveState` queries. This updates the test to reflect this reality.