### PR TITLE
snap/naming: preserve component in hook security tags

### DIFF
--- a/snap/naming/tag.go
+++ b/snap/naming/tag.go
@@ -79,6 +79,9 @@ type hookSecurityTag struct {
 }
 
 func (t hookSecurityTag) String() string {
+	if t.componentName != "" {
+		return fmt.Sprintf("snap.%s+%s.hook.%s", t.instanceName, t.componentName, t.hookName)
+	}
 	return fmt.Sprintf("snap.%s.hook.%s", t.instanceName, t.hookName)
 }
 

--- a/snap/naming/tag_test.go
+++ b/snap/naming/tag_test.go
@@ -59,14 +59,14 @@ func (s *tagSuite) TestParseSecurityTag(c *C) {
 
 	tag, err = naming.ParseSecurityTag("snap.pkg+comp.hook.configure")
 	c.Assert(err, IsNil)
-	c.Check(tag.String(), Equals, "snap.pkg.hook.configure")
+	c.Check(tag.String(), Equals, "snap.pkg+comp.hook.configure")
 	c.Check(tag.InstanceName(), Equals, "pkg")
 	c.Check(tag.(naming.HookSecurityTag).HookName(), Equals, "configure")
 	c.Check(tag.(naming.HookSecurityTag).ComponentName(), Equals, "comp")
 
 	tag, err = naming.ParseSecurityTag("snap.pkg_key+comp.hook.configure")
 	c.Assert(err, IsNil)
-	c.Check(tag.String(), Equals, "snap.pkg_key.hook.configure")
+	c.Check(tag.String(), Equals, "snap.pkg_key+comp.hook.configure")
 	c.Check(tag.InstanceName(), Equals, "pkg_key")
 	c.Check(tag.(naming.HookSecurityTag).HookName(), Equals, "configure")
 	c.Check(tag.(naming.HookSecurityTag).ComponentName(), Equals, "comp")


### PR DESCRIPTION
While looking at security tag typing, I realized that component hooks, while parsed correctly, do not round-trip through the String method. This patch fixes that, updating a test that showed the problem in the first place.
