### PR TITLE
data/selinux: allow snap-confine to mount on top of /etc/ld.so.cache

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -723,6 +723,7 @@ gen_require(`
 	type ifconfig_var_run_t;
 	type var_log_t;
 	type lib_t;
+    type ld_so_cache_t;
 ')
 
 admin_pattern(snappy_confine_t, snappy_tmp_t)
@@ -738,6 +739,7 @@ allow snappy_confine_t cert_t:dir { getattr mounton };
 allow snappy_confine_t device_t:filesystem unmount;
 allow snappy_confine_t devpts_t:dir mounton;
 allow snappy_confine_t etc_t:file mounton;
+allow snappy_confine_t ld_so_cache_t:file mounton;
 allow snappy_confine_t home_root_t:dir mounton;
 allow snappy_confine_t ifconfig_var_run_t:dir mounton;
 allow snappy_confine_t modules_object_t:dir mounton;


### PR DESCRIPTION
```
type=AVC msg=audit(06/23/26 06:15:30.414:1675) : avc:  denied  { mounton }
for  pid=8178 comm=snap-confine path=/tmp/snap.rootfs_thUlOX/etc/ld.so.cache dev="vda3" ino=101093 
scontext=system_u:system_r:snappy_confine_t:s0
tcontext=unconfined_u:object_r:ld_so_cache_t:s0 tclass=file permissive=1
```
