### PR TITLE
packaging/debian-sid: drop SNAP_TAGS

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -59,13 +59,11 @@ export GOMAXPROCS=2
 endif
 
 # check if we need to include the testkeys in the binary
-# TAGS are the go build tags for all binaries, SNAP_TAGS are for snap
+# TAGS are the go build tags for all binaries,  are for snap
 # build only.
 TAGS=nosecboot
-SNAP_TAGS=nosecboot nomanagers
 ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS+= withtestkeys
-	SNAP_TAGS+= withtestkeys
 endif
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)


### PR DESCRIPTION
SNAP_TAGS isn't used anywhere. It's been entirely replaced with the use of snapd.mk

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
