### PR TITLE
tests: adjust dd during reflash to write faster to VMs

### DIFF
--- a/tests/lib/reflash.sh
+++ b/tests/lib/reflash.sh
@@ -69,7 +69,7 @@ set -eu
 
 umount -l /oldroot
 
-gunzip -c /image.gz | dd of='${DISK}' bs=32M
+gunzip -c /image.gz | dd of='${DISK}' bs=32M iflag=fullblock oflag=direct conv=fsync
 
 exec '${systemd_shutdown}' "\${@}"
 EOF


### PR DESCRIPTION
### core 26
Without change:
```
2026-06-23 04:37:10 Rebooting on jun230423-911751 (openstack:ubuntu-core-26-64:tests/core/) as requested...
2026-06-23 04:50:52 Connected after reboot to jun230423-911751 (openstack:ubuntu-core-26-64:tests/core/)
```

With change:
```
2026-06-23 19:45:52 Rebooting on jun231935-933383 (openstack:ubuntu-core-26-64:tests/core/) as requested...
2026-06-23 19:47:20 Connected after reboot to jun231935-933383 (openstack:ubuntu-core-26-64:tests/core/)
```