### PR TITLE
tests: cleanup redundant tests.cleanup restore

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -34,7 +34,6 @@ debug: |
 execute: |
   err_and_exit(){
     echo "$1"
-    tests.cleanup restore
     exit 1
   }
 

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -117,8 +117,6 @@ restore: |
         fi      
     done
 
-    tests.cleanup restore
-
 execute: |
     echo "The network-setup-control interface is disconnected by default"
     snap connections netplan-snap | MATCH 'network-setup-control +netplan-snap:network-setup-control +- +-'

--- a/tests/main/interfaces-mount-control-cifs/task.yaml
+++ b/tests/main/interfaces-mount-control-cifs/task.yaml
@@ -67,9 +67,6 @@ prepare: |
     # credentials here
     smbclient --user test --password test -L //localhost | MATCH "var-cifs-share-with-password .* test CIFS share"
 
-restore: |
-    tests.cleanup restore
-
 execute: |
     snap install test-snapd-mount-control-cifs
     mkdir -p /media/mounted

--- a/tests/main/interfaces-mount-control-nfs/task.yaml
+++ b/tests/main/interfaces-mount-control-nfs/task.yaml
@@ -50,10 +50,6 @@ prepare: |
     # Later on remove the exports file and reload exported filesystems.
     tests.cleanup defer retry -n 10 exportfs -r
 
-restore: |
-    # Run cleanup handlers registered earlier.
-    tests.cleanup restore
-
 execute: |
     snap install --edge   test-snapd-mount-control-nfs
     mkdir -p /media/mounted

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -89,8 +89,6 @@ prepare: |
     echo "documentation" > /usr/share/nvidia/nvidia-application-profiles-535.54.03-key-documentation
 
 restore: |
-    tests.cleanup restore
-
     rm -rf /usr/share/vulkan
 
     if ! os.query is-xenial; then

--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -205,9 +205,6 @@ prepare: |
     tests.cleanup defer rm -f test-this-permutation
     touch test-this-permutation
 
-restore: |
-    tests.cleanup restore
-
 debug: |
     if [ -f install.txt ]; then cat install.txt; fi
     if [ -f log-32.txt ]; then cat log-32.txt; fi

--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -164,10 +164,6 @@ prepare: |
 
     gojq '.["nfs-home"]' < /var/lib/snapd/system-key | MATCH false
 
-restore: |
-    # Run cleanup handlers registered earlier.
-    tests.cleanup restore
-
 debug: |
     set +e
     uname -a

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -31,11 +31,6 @@ prepare: |
 
     tests.nested build-image core
 
-restore: |
-    # Cleanup restore is needed in this case because nested tests are not
-    # doing automatic cleanups
-    tests.cleanup restore
-
 execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -38,14 +38,10 @@ prepare: |
         snap pack classic-container-mgr-snap
         snap install --dangerous --classic test-snapd-classic-container-mgrs*.snap
     fi
-
-restore: |
-    tests.cleanup restore
     if os.query is-xenial || os.query is-bionic; then
-        # old system is not doing cleanups
-        find /sys/fs/cgroup/ -type d -name "snap.*" -prune | while read -r svc; do
-             rmdir "$svc" || true
-        done
+        # Old kernels do not clean up snap cgroup dirs on snap removal.
+        # Must run after snap remove --purge docker (LIFO).
+        tests.cleanup defer find /sys/fs/cgroup/ -type d -name snap.\* -prune -exec rmdir '{}' '+' '||' true
     fi
 
 execute: |


### PR DESCRIPTION
Remove redundant 'tests.cleanup restore' which is not required at test level, because its automatically done at suite level.