### PR TITLE
confdb: fix bug on reading uneven lists

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1658,6 +1658,12 @@ func namespaceResult(res any, unmatchedSuffix []Accessor) (any, error) {
 		return res, nil
 	}
 
+	// we use nil to indicate missing results in a list (if we just did not
+	// include them, the subsequent values would be out of order). Skip it
+	if res == nil {
+		return nil, nil
+	}
+
 	// check if the part is an unmatched placeholder which should have been filled
 	// by the databag with all possible values
 	switch part := unmatchedSuffix[0]; part.Type() {
@@ -2647,6 +2653,7 @@ func getList(accessors []Accessor, keyIndex int, list []json.RawMessage, constra
 	}
 
 	if matchAll {
+		var hasData bool
 		results := make([]any, 0, len(list))
 
 		for _, el := range list {
@@ -2672,16 +2679,20 @@ func getList(accessors []Accessor, keyIndex int, list []json.RawMessage, constra
 			var res any
 			if err := get(accessors, keyIndex+1, level, constraints, &res); err != nil {
 				if errors.Is(err, &NoDataError{}) {
+					// add a nil to maintain the order of nested results. When merging
+					// we'll check for nil values and skip them
+					results = append(results, nil)
 					continue
 				}
+
+				return err
 			}
 
-			if res != nil {
-				results = append(results, res)
-			}
+			hasData = true
+			results = append(results, res)
 		}
 
-		if len(results) == 0 {
+		if !hasData {
 			return &NoDataError{}
 		}
 

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -3707,6 +3707,41 @@ func (*viewSuite) TestGetListPlaceholderValueNotFound(c *C) {
 	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 }
 
+func (*viewSuite) TestGetListUnevenListMerge(c *C) {
+	// check that reading lists with values missing in early positions preserves
+	// the position of later elements when merging the results
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"request": "items[{n}]",
+					"storage": "items[{n}]",
+					"content": []any{
+						map[string]any{"storage": "name"},
+						map[string]any{"storage": "other"},
+					},
+				},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	bag := confdb.NewJSONDatabag()
+	err = bag.Set(parsePath(c, "items"), []any{
+		map[string]any{"name": "first"},
+		map[string]any{"name": "second", "other": "value"},
+	})
+	c.Assert(err, IsNil)
+
+	view := schema.View("foo")
+	val, err := view.Get(bag, "items", nil, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(val, DeepEquals, []any{
+		map[string]any{"name": "first"},
+		map[string]any{"name": "second", "other": "value"},
+	})
+}
+
 func (*viewSuite) TestDetectViewRulesExpectDifferentTypes(c *C) {
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{


### PR DESCRIPTION
When reading array elements through a content rule placeholder, elements missing the nested field were skipped, shortening the results list. The merge would then put values in the wrong positions.