### PR TITLE
o/confdbstate: remove/simplify code

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -150,7 +150,7 @@ func (e *UnmatchedConstraintsError) Is(err error) bool {
 	return ok
 }
 
-func NewUnmatchedConstraintsError(view *View, requests, constraints []string) *UnmatchedConstraintsError {
+func newUnmatchedConstraintsError(view *View, requests, constraints []string) *UnmatchedConstraintsError {
 	return &UnmatchedConstraintsError{
 		view:        view.ID(),
 		requests:    requests,
@@ -1748,7 +1748,7 @@ func (e *UnconstrainedParamsError) Is(err error) bool {
 	return ok
 }
 
-func NewUnconstrainedParamsError(op string, unconstrained map[string][]string) error {
+func newUnconstrainedParamsError(op string, unconstrained map[string][]string) error {
 	return &UnconstrainedParamsError{
 		operation:     op,
 		unconstrained: unconstrained,
@@ -1794,7 +1794,7 @@ func (v *View) checkUnconstrainedParams(op string, matches []requestMatch, const
 	}
 
 	if len(unconstrainedReqs) != 0 {
-		return NewUnconstrainedParamsError(op, unconstrainedReqs)
+		return newUnconstrainedParamsError(op, unconstrainedReqs)
 	}
 	return nil
 }
@@ -1848,7 +1848,7 @@ func (v *View) CheckAllConstraintsAreUsed(requests []string, constraints map[str
 
 	unusedConstraints := keys(constraintPlaceholders)
 	sort.Strings(unusedConstraints)
-	return NewUnmatchedConstraintsError(v, requests, unusedConstraints)
+	return newUnmatchedConstraintsError(v, requests, unusedConstraints)
 }
 
 func getVisibilitiesToPrune(userAccess Access) []Visibility {

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -3178,17 +3178,6 @@ func (s JSONDatabag) Copy() JSONDatabag {
 	return JSONDatabag(copy)
 }
 
-// Overwrite replaces the entire databag with the provided data.
-func (s *JSONDatabag) Overwrite(data []byte) error {
-	var unmarshalledBag map[string]json.RawMessage
-	if err := json.Unmarshal(data, &unmarshalledBag); err != nil {
-		return err
-	}
-
-	*s = JSONDatabag(unmarshalledBag)
-	return nil
-}
-
 // JSONSchema is the Schema implementation corresponding to JSONDatabag and it's
 // able to validate its data.
 type JSONSchema struct{}

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -1134,28 +1134,6 @@ func (s *viewSuite) TestJSONDatabagCopy(c *C) {
 	c.Assert(string(data), Equals, `{"foo":"baz"}`)
 }
 
-func (s *viewSuite) TestJSONDataOverwrite(c *C) {
-	bag := confdb.NewJSONDatabag()
-	err := bag.Set(parsePath(c, "foo"), "bar")
-	c.Assert(err, IsNil)
-
-	// precondition check
-	data, err := bag.Data()
-	c.Assert(err, IsNil)
-	c.Assert(string(data), Equals, `{"foo":"bar"}`)
-
-	err = bag.Overwrite([]byte(`{"bar":"foo"}`))
-	c.Assert(err, IsNil)
-
-	val, err := bag.Get(parsePath(c, "bar"), nil)
-	c.Assert(err, IsNil)
-	c.Assert(val, Equals, "foo")
-
-	data, err = bag.Data()
-	c.Assert(err, IsNil)
-	c.Assert(string(data), Equals, `{"bar":"foo"}`)
-}
-
 func (s *viewSuite) TestViewGetResultNamespaceMatchesRequest(c *C) {
 	databag := confdb.NewJSONDatabag()
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{

--- a/confdb/export_test.go
+++ b/confdb/export_test.go
@@ -19,6 +19,8 @@
 
 package confdb
 
+import "github.com/snapcore/snapd/testutil"
+
 type (
 	ViewRef = viewRef
 )
@@ -49,9 +51,5 @@ func PathValuePairsIntoMap(pairs []pathValuePair) map[string]any {
 }
 
 func MockMaxValueDepth(newDepth int) (restore func()) {
-	oldDepth := maxValueDepth
-	maxValueDepth = newDepth
-	return func() {
-		maxValueDepth = oldDepth
-	}
+	return testutil.Mock(&maxValueDepth, newDepth)
 }

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -426,13 +426,13 @@ func unsetOngoingTransaction(st *state.State, account, schemaName, id string) er
 		}
 	}
 
-	if len(txs.ReadTxIDs) > 0 {
-		// there are other transactions running (can only be reads) so skip this.
-		// The last one will unblock the next accesses
-		return nil
+	// if there are other transactions running, skip this. The last one will
+	// unblock the next access
+	if len(txs.ReadTxIDs) == 0 {
+		maybeUnblockAccesses(txs)
 	}
 
-	return maybeUnblockAccesses(txs)
+	return nil
 }
 
 // maybeUnblockAccesses unblocks as many consecutive pending accesses as
@@ -447,9 +447,9 @@ func unsetOngoingTransaction(st *state.State, account, schemaName, id string) er
 //
 // If accesses are unblocked, they're removed from the Pending list and put into
 // the Scheduling list so we can track unblocked but still unscheduled accesses.
-func maybeUnblockAccesses(txs *confdbTransactions) error {
+func maybeUnblockAccesses(txs *confdbTransactions) {
 	if len(txs.Pending) == 0 || txs.WriteTxID != "" || len(txs.ReadTxIDs) > 0 || len(txs.Scheduling) != 0 {
-		return nil
+		return
 	}
 
 	var upTo int
@@ -471,8 +471,6 @@ func maybeUnblockAccesses(txs *confdbTransactions) error {
 
 	txs.Scheduling = append([]access{}, txs.Pending[:upTo+1]...)
 	txs.Pending = txs.Pending[upTo+1:]
-
-	return nil
 }
 
 func (m *ConfdbManager) noop(*state.Task, *tomb.Tomb) error { return nil }

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -139,7 +139,7 @@ func (m *ConfdbManager) doCommitTransaction(t *state.Task, _ *tomb.Tomb) (err er
 		}
 
 		view := confdbAssert.Schema().View(viewName)
-		paths := tx.AlteredPaths()
+		paths := tx.alteredPaths()
 		mightAffectEph, err := view.WriteAffectsEphemeral(paths)
 		if err != nil {
 			return fmt.Errorf("cannot commit transaction: cannot check for ephemeral paths: %v", err)

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -1014,13 +1013,4 @@ func createLoadConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, 
 	linkTask(clearTxTask)
 
 	return ts, clearTxTask, nil
-}
-
-func MockFetchConfdbSchemaAssertion(f func(*state.State, int, string, string) error) func() {
-	osutil.MustBeTestBinary("mocking can only be done in tests")
-	old := assertstateFetchConfdbSchemaAssertion
-	assertstateFetchConfdbSchemaAssertion = f
-	return func() {
-		assertstateFetchConfdbSchemaAssertion = old
-	}
 }

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -473,7 +473,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: no custodian snap connected", view.ID())
 	}
 
-	paths := tx.AlteredPaths()
+	paths := tx.alteredPaths()
 	mightAffectEph, err := view.WriteAffectsEphemeral(paths)
 	if err != nil {
 		return nil, nil, nil, err

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -284,11 +284,7 @@ func waitForAccess(ctx context.Context, st *state.State, view *confdb.View, accK
 			}
 		}
 
-		err = maybeUnblockAccesses(txs)
-		if err != nil {
-			return "", fmt.Errorf("cannot cleanup state after timeout/cancel: %v", err)
-		}
-
+		maybeUnblockAccesses(txs)
 		updateTxs(txs)
 
 		return "", fmt.Errorf("cannot %s %s: timed out waiting for access", accKind, view.ID())
@@ -870,11 +866,8 @@ func cleanupAccess(st *state.State, accessID, account, schema string) {
 		}
 	}
 
-	// this may actually not unblock anything, if other accesses are being processed
-	uerr = maybeUnblockAccesses(txs)
-	if uerr != nil {
-		logger.Noticef("cannot unblock next access after failed access: %v", uerr)
-	}
+	// this may not actually unblock anything if other accesses are being processed
+	maybeUnblockAccesses(txs)
 }
 
 // ReadConfdb schedules a change to load a confdb, running any appropriate

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -2974,8 +2974,7 @@ func (s *confdbTestSuite) endOngoingAccess(c *C, newPending *confdbstate.Access)
 	txs.ReadTxIDs = nil
 	txs.WriteTxID = ""
 
-	err = confdbstate.MaybeUnblockAccesses(txs)
-	c.Assert(err, IsNil)
+	confdbstate.MaybeUnblockAccesses(txs)
 
 	if newPending != nil {
 		txs.Pending = append(txs.Pending, *newPending)

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -52,43 +53,23 @@ func SaveViewHandlerGenerator(ctx *hookstate.Context) hookstate.Handler {
 }
 
 func MockReadDatabag(f func(st *state.State, account, confdbName string) (confdb.JSONDatabag, error)) func() {
-	old := readDatabag
-	readDatabag = f
-	return func() {
-		readDatabag = old
-	}
+	return testutil.Mock(&readDatabag, f)
 }
 
 func MockWriteDatabag(f func(st *state.State, databag confdb.JSONDatabag, account, confdbName string) error) func() {
-	old := writeDatabag
-	writeDatabag = f
-	return func() {
-		writeDatabag = old
-	}
+	return testutil.Mock(&writeDatabag, f)
 }
 
 func MockEnsureNow(f func(*state.State)) func() {
-	old := ensureNow
-	ensureNow = f
-	return func() {
-		ensureNow = old
-	}
+	return testutil.Mock(&ensureNow, f)
 }
 
 func MockTransactionTimeout(dur time.Duration) func() {
-	old := transactionTimeout
-	transactionTimeout = dur
-	return func() {
-		transactionTimeout = old
-	}
+	return testutil.Mock(&transactionTimeout, dur)
 }
 
 func MockDefaultWaitTimeout(dur time.Duration) func() {
-	old := defaultWaitTimeout
-	defaultWaitTimeout = dur
-	return func() {
-		defaultWaitTimeout = old
-	}
+	return testutil.Mock(&defaultWaitTimeout, dur)
 }
 
 func SetBlockingSignal(key string, signalChan chan struct{}) {
@@ -111,9 +92,5 @@ func GetOngoingTxs(st *state.State, account, schemaName string) (ongoingTxs *con
 }
 
 func MockFetchConfdbSchemaAssertion(f func(*state.State, int, string, string) error) func() {
-	old := assertstateFetchConfdbSchemaAssertion
-	assertstateFetchConfdbSchemaAssertion = f
-	return func() {
-		assertstateFetchConfdbSchemaAssertion = old
-	}
+	return testutil.Mock(&assertstateFetchConfdbSchemaAssertion, f)
 }

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -109,3 +109,11 @@ func MaybeUnblockAccesses(txs *confdbTransactions) error {
 func GetOngoingTxs(st *state.State, account, schemaName string) (ongoingTxs *confdbTransactions, updateTxStateFunc func(*confdbTransactions), err error) {
 	return getOngoingTxs(st, account, schemaName)
 }
+
+func MockFetchConfdbSchemaAssertion(f func(*state.State, int, string, string) error) func() {
+	old := assertstateFetchConfdbSchemaAssertion
+	assertstateFetchConfdbSchemaAssertion = f
+	return func() {
+		assertstateFetchConfdbSchemaAssertion = old
+	}
+}

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -102,8 +102,8 @@ func ResetBlockingSignals() {
 	blockingSignals = nil
 }
 
-func MaybeUnblockAccesses(txs *confdbTransactions) error {
-	return maybeUnblockAccesses(txs)
+func MaybeUnblockAccesses(txs *confdbTransactions) {
+	maybeUnblockAccesses(txs)
 }
 
 func GetOngoingTxs(st *state.State, account, schemaName string) (ongoingTxs *confdbTransactions, updateTxStateFunc func(*confdbTransactions), err error) {

--- a/overlord/confdbstate/transaction.go
+++ b/overlord/confdbstate/transaction.go
@@ -250,7 +250,7 @@ func (t *Transaction) Clear(st *state.State) error {
 	return nil
 }
 
-func (t *Transaction) AlteredPaths() [][]confdb.Accessor {
+func (t *Transaction) alteredPaths() [][]confdb.Accessor {
 	// TODO: maybe we can extend this to recurse into delta's value and figure out
 	// the most specific key possible
 	paths := make([][]confdb.Accessor, 0, len(t.deltas))

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -21,6 +21,7 @@ package ctlcmd_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -48,7 +49,6 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -952,14 +952,13 @@ func (s *confdbSuite) TestConfdbExperimentalFlag(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbGetPreviousInvalid(c *C) {
-	restore := confdbstate.MockFetchConfdbSchemaAssertion(func(*state.State, int, string, string) error {
-		return store.ErrStoreOffline
+	success := fmt.Sprintf(`mock error`)
+	forbidMsg := `cannot use --previous outside of save-view, change-view or observe-view hooks`
+
+	restore := ctlcmd.MockConfdbstateGetView(func(*state.State, string, string, string) (*confdb.View, error) {
+		return nil, errors.New(success)
 	})
 	defer restore()
-
-	// the parsing succeeded
-	success := fmt.Sprintf(`confdb-schema (other; account-id:%s) not found`, s.devAccID)
-	forbidMsg := `cannot use --previous outside of save-view, change-view or observe-view hooks`
 
 	type testcase struct {
 		hook string


### PR DESCRIPTION
Various simplifications that popped up during the validation-sets spike.