### PR TITLE
github/workflows/spread-tests: temporarily disable ASLR

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -510,7 +510,8 @@ jobs:
           # undesired changes elsewhere
           echo "Running command: $SPREAD $TESTS_TO_RUN"
           (
-            set -o pipefail 
+            set -o pipefail
+            setarch --addr-no-randomize -- \
             $SPREAD $SPREAD_FLAGS $TESTS_TO_RUN | \
               ./tests/lib/external/snapd-testing-tools/utils/log-filter $FILTER_PARAMS | \
               tee spread.log


### PR DESCRIPTION
Temporarily disable ASLR when running to debug issues on the runners in PS7.

Related: [SNAPDENG-36498](https://warthogs.atlassian.net/browse/SNAPDENG-36498)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-36948]: https://warthogs.atlassian.net/browse/SNAPDENG-36948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNAPDENG-36498]: https://warthogs.atlassian.net/browse/SNAPDENG-36498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ