### PR TITLE
o/snapstate: ensure that prereqs created by initial refresh run before create-recovery-system

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -631,6 +631,7 @@ type SnapInstallTaskSet = snapInstallTaskSet
 func NewSnapInstallTaskSetForTest(
 	snapsup *SnapSetup,
 	ts *state.TaskSet,
+	prerequisites *state.Task,
 	beforeLocalSystemModificationsTasks []*state.Task,
 	prerequisitesSync *state.Task,
 	mountSnap *state.Task,
@@ -639,6 +640,7 @@ func NewSnapInstallTaskSetForTest(
 	return SnapInstallTaskSet{
 		ts:                                  ts,
 		snapsup:                             snapsup,
+		prerequisites:                       prerequisites,
 		beforeLocalSystemModificationsTasks: beforeLocalSystemModificationsTasks,
 		prerequisitesSync:                   prerequisitesSync,
 		mountSnap:                           mountSnap,

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -458,12 +458,19 @@ func arrangeRebootAndUpdateSeed(
 	// ensure that everything waits on snapd. we do this pretty late to help
 	// prevent superfluous dependencies between tasks.
 	if finalSnapdTask != nil {
+		// make sure snaps wait on snapd
 		for _, sts := range stss {
 			if sts.snapsup.InstanceName() == "snapd" {
 				continue
 			}
 
 			waitForIfNeeded(sts.prerequisites, finalSnapdTask)
+		}
+
+		// make sure the seed waits on snapd. this dependency will usually
+		// already be set up, but might not be if only snapd is being refreshed.
+		if seedTS != nil {
+			waitForIfNeeded(seedTS.Create, finalSnapdTask)
 		}
 	}
 

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -160,50 +160,6 @@ func waitForIfNeeded(waiter, target *state.Task) {
 	waiter.WaitFor(target)
 }
 
-// addEarlyDownloadDeps sets up dependencies so that all early-download snaps'
-// beforeLocalSystemModificationsTasks complete before any snap's first local
-// system modification begins. The first local-modification task is the
-// prerequisites synchronization task.
-func addEarlyDownloadDeps(stss []snapInstallTaskSet, earlyDownloads map[string]bool) error {
-	if len(earlyDownloads) == 0 {
-		return nil
-	}
-
-	tail := func(tasks []*state.Task) *state.Task {
-		return tasks[len(tasks)-1]
-	}
-
-	downloadTails := make(map[string]*state.Task, len(earlyDownloads))
-	for _, sts := range stss {
-		if len(sts.beforeLocalSystemModificationsTasks) == 0 ||
-			sts.firstLocalMod() == nil {
-			return errors.New("internal error: snap install task set has empty slices")
-		}
-
-		name := sts.snapsup.InstanceName()
-		if earlyDownloads[name] {
-			downloadTails[name] = tail(sts.beforeLocalSystemModificationsTasks)
-		}
-	}
-
-	for _, sts := range stss {
-		firstLocalMod := sts.firstLocalMod()
-		for name, tail := range downloadTails {
-			if name == sts.snapsup.InstanceName() {
-				continue
-			}
-
-			// since there are already some cross-snap dependencies established, we use
-			// a smarter WaitFor alternative here that considers existing transitive
-			// dependencies. this reduces the number of superfluous dependencies in the
-			// final graph of tasks.
-			waitForIfNeeded(firstLocalMod, tail)
-		}
-	}
-
-	return nil
-}
-
 // arrangeRebootAndUpdateSeed arranges the correct link-order between all the
 // provided snap install task-sets, sets up restart boundaries for essential
 // snaps (base, gadget, kernel), and returns the task set needed to update the
@@ -211,8 +167,6 @@ func addEarlyDownloadDeps(stss []snapInstallTaskSet, earlyDownloads map[string]b
 //
 // The resulting ordering is defined here:
 //
-//	early download phase for model snaps (no local system modifications, just downloads)
-//	|
 //	snapd (all tasks)
 //	|
 //	boot-base -> gadget -> kernel (mount-snap, when present)
@@ -225,6 +179,12 @@ func addEarlyDownloadDeps(stss []snapInstallTaskSet, earlyDownloads map[string]b
 //	|
 //	non-essential bases and apps
 //
+// Seed refresh adds a phase before create-recovery-system. The seed creation
+// task waits on every snap's initial prerequisites task, because those tasks
+// can schedule prerequisite seed snaps. For snaps that are part of the new
+// seed, it also waits on the rest of their before-local-modifications tasks so
+// devicestate can consume the selected snap/component setup tasks.
+//
 // finalize-recovery-system's placement is dependent upon which snaps are being
 // refreshed. It runs after create-recovery-system is done, and it also waits
 // for all model snaps to be finished refreshing. The set of model snaps being
@@ -233,15 +193,16 @@ func addEarlyDownloadDeps(stss []snapInstallTaskSet, earlyDownloads map[string]b
 func arrangeRebootAndUpdateSeed(
 	st *state.State,
 	stss []snapInstallTaskSet,
-	earlyDownloads map[string]bool,
 	eviction SeedRefreshEvictionPolicy,
 	opts Options,
 ) (seedRefreshTS *state.TaskSet, err error) {
 	for _, sts := range stss {
-		if len(sts.beforeLocalSystemModificationsTasks) == 0 ||
+		if sts.prerequisites == nil ||
+			len(sts.beforeLocalSystemModificationsTasks) == 0 ||
+			sts.prerequisitesSync == nil ||
 			len(sts.upToLinkSnapAndBeforeReboot) == 0 ||
 			len(sts.afterLinkSnapAndPostReboot) == 0 {
-			return nil, errors.New("internal error: snap install task set has empty slices")
+			return nil, errors.New("internal error: snap install task set has empty task ranges")
 		}
 	}
 
@@ -254,15 +215,6 @@ func arrangeRebootAndUpdateSeed(
 	seedTS, seedSnapTaskSets, err := seedRefreshAndSeedSnapTaskSets(st, stss, eviction, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	// since we need seed snaps to be available before we create the seed
-	// itself, we add the seed snaps to the early download cohort
-	for name := range seedSnapTaskSets {
-		if earlyDownloads == nil {
-			earlyDownloads = make(map[string]bool, len(seedSnapTaskSets))
-		}
-		earlyDownloads[name] = true
 	}
 
 	head := func(tasks []*state.Task) *state.Task {
@@ -327,7 +279,7 @@ func arrangeRebootAndUpdateSeed(
 	beforeReboot := func(sts snapInstallTaskSet) (*state.Task, *state.Task) {
 		// on UC16, everything is before reboot
 		if isUC16 {
-			return head(sts.beforeLocalSystemModificationsTasks), tail(sts.afterLinkSnapAndPostReboot)
+			return sts.prerequisites, tail(sts.afterLinkSnapAndPostReboot)
 		}
 
 		// we let sts.beforeLocalSystemModificationsTasks happen in parallel
@@ -342,15 +294,12 @@ func arrangeRebootAndUpdateSeed(
 		return head(sts.afterLinkSnapAndPostReboot), tail(sts.afterLinkSnapAndPostReboot)
 	}
 
-	// snapd fully goes first, we rely on the existing ordering of the tasks
-	// updating snapd
-	if sts, ok := essentials[snap.TypeSnapd]; ok {
-		prev = tail(sts.afterLinkSnapAndPostReboot)
-	}
-
-	// enables us to require that downloads start after we've swapped to the new
+	// enables us to require that everything start after we've swapped to the new
 	// snapd, if we have one. might be nil!
-	finalSnapdTask := prev
+	var finalSnapdTask *state.Task
+	if sts, ok := essentials[snap.TypeSnapd]; ok {
+		finalSnapdTask = tail(sts.afterLinkSnapAndPostReboot)
+	}
 
 	// then all the mount-snap tasks for essential snaps, in order. this applies
 	// only to single-reboot systems where mount-snap is orchestrated separately
@@ -373,21 +322,6 @@ func arrangeRebootAndUpdateSeed(
 			continue
 		}
 
-		// if this essential snap is not one of the early downloads, we ensure
-		// that this snap's first before-local-modifications task waits on the
-		// final snapd task. this results in the new version of snapd executing
-		// all tasks created for this essential snap.
-		//
-		// alternatively, when this essential snap is part of the early download
-		// cohort, we omit this dependency, and we only require that this snap's
-		// modification inducing tasks wait for snapd. this frees up this
-		// essential snap's before-local-modifications tasks so that they can be
-		// freely arranged before all local modification inducing tasks, across
-		// all snaps.
-		if finalSnapdTask != nil && !earlyDownloads[sts.snapsup.InstanceName()] {
-			head(sts.beforeLocalSystemModificationsTasks).WaitFor(finalSnapdTask)
-		}
-
 		chain(beforeReboot(sts))
 	}
 
@@ -396,19 +330,6 @@ func arrangeRebootAndUpdateSeed(
 	// reboot to test the system, and another reboot to return to the run
 	// system.
 	if seedTS != nil {
-		// if no tasks have been added to the chain yet, appending the seed task
-		// to the end of the chain will not result in the seed tasks waiting on
-		// the early download phase. in that case, we must add those
-		// dependencies explicitly.
-		//
-		// this can happen if the seed is being updated due to non-essential
-		// snap refreshes
-		if prev == nil {
-			for _, sts := range seedSnapTaskSets {
-				seedTS.Create.WaitFor(tail(sts.beforeLocalSystemModificationsTasks))
-			}
-		}
-
 		chain(seedTS.Create, seedTS.Create)
 	}
 
@@ -493,16 +414,26 @@ func arrangeRebootAndUpdateSeed(
 		}
 	}
 
-	// some non-essential snaps might have been a part of the early download
-	// cohort. in that case, we need to make sure that we don't accidentally
-	// create a dependency cycle. thus, early downloaded snaps will have their
-	// first modification-inducing task wait on the final essential snap, rather
-	// than their first download task.
 	nonEssentialWaitHead := func(sts snapInstallTaskSet) *state.Task {
-		if earlyDownloads[sts.snapsup.InstanceName()] {
-			return sts.firstLocalMod()
+		// during a seed-refresh, all initial prerequisites tasks will run prior
+		// to seed creation.
+		if seedTS != nil {
+			// for seed snaps, their before-local-modifications tasks also run
+			// before seed creation, so schedule the synchronization task as the
+			// first post-essential task.
+			if _, ok := seedSnapTaskSets[sts.snapsup.InstanceName()]; ok {
+				return sts.prerequisitesSync
+			}
+
+			// for non-seed snaps, schedule the rest of the
+			// before-local-modifications phase as the first post-essential
+			// task.
+			return head(sts.beforeLocalSystemModificationsTasks)
 		}
-		return head(sts.beforeLocalSystemModificationsTasks)
+
+		// in the absence of a seed-refresh, the first post-essential tasks
+		// should simply be the first task of each snap's chain of tasks.
+		return sts.prerequisites
 	}
 
 	// make the bases just wait on the final essential snap to finish up
@@ -524,12 +455,41 @@ func arrangeRebootAndUpdateSeed(
 		}
 	}
 
-	if err := addEarlyDownloadDeps(stss, earlyDownloads); err != nil {
-		return nil, err
+	// ensure that everything waits on snapd. we do this pretty late to help
+	// prevent superfluous dependencies between tasks.
+	if finalSnapdTask != nil {
+		for _, sts := range stss {
+			if sts.snapsup.InstanceName() == "snapd" {
+				continue
+			}
+
+			waitForIfNeeded(sts.prerequisites, finalSnapdTask)
+		}
 	}
 
 	if seedTS == nil {
 		return nil, nil
+	}
+
+	// seed creation must wait on all initial prerequisites tasks, because those
+	// tasks can schedule seed snaps.
+	for _, sts := range stss {
+		// for seed snaps, seed creation must also wait on the rest of the
+		// before-local-modifications phase so it can consume the selected
+		// snap/component setup tasks.
+		if _, ok := seedSnapTaskSets[sts.snapsup.InstanceName()]; ok {
+			waitForIfNeeded(seedTS.Create, tail(sts.beforeLocalSystemModificationsTasks))
+			continue
+		}
+
+		// non-seed snaps only need to have their initial prerequisites task run
+		// before seed creation
+		for _, lane := range seedTS.Create.Lanes() {
+			if !contains(sts.prerequisites.Lanes(), lane) {
+				sts.prerequisites.JoinLane(lane)
+			}
+		}
+		waitForIfNeeded(seedTS.Create, sts.prerequisites)
 	}
 
 	// finalize-recovery-system only waits on create-recovery-system by default.

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -852,6 +852,38 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshBeforeLocalModifi
 	}
 }
 
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdSeedRefresh(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	_, restore := mockSeedRefreshHooks([]string{"snapd"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
+
+	stss := []snapstate.SnapInstallTaskSet{
+		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
+	}
+	seedTS, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	seedCreate, _, _ := splitSeedRefreshTasks(c, seedTS)
+
+	snapdEnd, err := stss[0].TaskSet().Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+
+	c.Check(waitsOnTransitively(seedCreate, snapdEnd), Equals, true)
+}
+
 func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdSeedRefreshBeforeLocalModificationsDeps(c *C) {
 	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
 	_, restore := mockSeedRefreshHooks([]string{"snapd"})

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -72,6 +72,7 @@ func (s *rebootSuite) snapInstallTaskSetForSnapSetup(snapName, base string, snap
 	prereq := s.state.NewTask("prerequisites", "...")
 	prereq.Set("snap-setup", snapsup)
 	prepareSnap := s.state.NewTask("prepare-snap", "...")
+	prepareSnap.Set("snap-setup", snapsup)
 	prepareSnap.WaitFor(prereq)
 	prereqSync := s.state.NewTask("prerequisites", "...")
 	prereqSync.WaitFor(prepareSnap)
@@ -88,6 +89,7 @@ func (s *rebootSuite) snapInstallTaskSetForSnapSetup(snapName, base string, snap
 	ts := state.NewTaskSet(prereq, prepareSnap, prereqSync, mountSnap, unlinkSnap, linkSnap, autoConnect, startServices)
 
 	ts.MarkEdge(prereq, snapstate.BeginEdge)
+	ts.MarkEdge(prepareSnap, snapstate.SnapSetupEdge)
 	ts.MarkEdge(prepareSnap, snapstate.LastBeforeLocalModificationsEdge)
 	ts.MarkEdge(linkSnap, snapstate.MaybeRebootEdge)
 	ts.MarkEdge(autoConnect, snapstate.MaybeRebootWaitEdge)
@@ -98,7 +100,8 @@ func (s *rebootSuite) snapInstallTaskSetForSnapSetup(snapName, base string, snap
 	return snapstate.NewSnapInstallTaskSetForTest(
 		snapsup,
 		ts,
-		[]*state.Task{prereq, prepareSnap}, // before local modification tasks
+		prereq,
+		[]*state.Task{prepareSnap}, // before local modification tasks
 		prereqSync,
 		mountSnap,
 		[]*state.Task{unlinkSnap, linkSnap}, // modification inducing tasks before reboot
@@ -404,7 +407,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsUC16NoSplits(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -438,7 +440,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssential(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -487,7 +488,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseKernel(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -567,7 +567,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadget(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -643,7 +642,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsGadgetKernel(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -720,7 +718,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadgetKernel(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -806,113 +803,129 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBaseGadgetKernel(c *C) {
 	c.Check(s.hasRestartBoundaries(c, stss[1].TaskSet()), Equals, false)
 }
 
-func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloads(c *C) {
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshBeforeLocalModificationsDeps(c *C) {
 	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	_, restore := mockSeedRefreshHooks([]string{"core20", "my-kernel"})
+	defer restore()
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
 
 	stss := []snapstate.SnapInstallTaskSet{
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
 		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
 	}
-	earlyDownloads := map[string]bool{
-		"core20":    true,
-		"my-kernel": true,
-	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+	seedTS, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		earlyDownloads,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
 		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
 	)
 	c.Assert(err, IsNil)
+	seedCreate, _, _ := splitSeedRefreshTasks(c, seedTS)
 
 	baseLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 	kernelLastBefore, err := stss[1].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 
-	for _, sts := range stss {
-		firstLocalModTask := firstTaskAfterLocalModifications(c, sts.TaskSet())
-		c.Check(waitsOnTransitively(firstLocalModTask, baseLastBefore), Equals, true)
-		c.Check(waitsOnTransitively(firstLocalModTask, kernelLastBefore), Equals, true)
+	for _, lastBefore := range []*state.Task{baseLastBefore, kernelLastBefore} {
+		c.Check(waitsOnTransitively(seedCreate, lastBefore), Equals, true)
 	}
-}
 
-func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdEarlyDownload(c *C) {
-	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	stss := []snapstate.SnapInstallTaskSet{
-		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
-		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
-		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
-	}
-	earlyDownloads := map[string]bool{
-		"snapd": true,
-	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(
-		s.state,
-		stss,
-		earlyDownloads,
-		snapstate.SeedRefreshEvictionPolicy{
-			SeedsToRetain: 1,
-		},
-		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
-	)
-	c.Assert(err, IsNil)
-
-	snapdLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
-	c.Assert(err, IsNil)
-
-	baseFirstLocalMod := firstTaskAfterLocalModifications(c, stss[1].TaskSet())
-	c.Check(waitsOnTransitively(baseFirstLocalMod, snapdLastBefore), Equals, true)
-
-	appFirstLocalMod := firstTaskAfterLocalModifications(c, stss[2].TaskSet())
-	c.Check(waitsOnTransitively(appFirstLocalMod, snapdLastBefore), Equals, true)
-
-	baseLastBefore, err := stss[1].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
+	appBegin, err := stss[2].TaskSet().Edge(snapstate.BeginEdge)
 	c.Assert(err, IsNil)
 	appLastBefore, err := stss[2].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 
-	snapdFirstLocalMod := firstTaskAfterLocalModifications(c, stss[0].TaskSet())
-	c.Check(waitsOnTransitively(snapdFirstLocalMod, baseLastBefore), Equals, false)
-	c.Check(waitsOnTransitively(snapdFirstLocalMod, appLastBefore), Equals, false)
+	c.Check(waitsOnTransitively(seedCreate, appBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, appLastBefore), Equals, false)
+	for _, lane := range seedCreate.Lanes() {
+		c.Check(appBegin.Lanes(), testutil.Contains, lane)
+		c.Check(appLastBefore.Lanes(), Not(testutil.Contains), lane)
+	}
 }
 
-func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssentialEarlyDownloadsNoCycle(c *C) {
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdSeedRefreshBeforeLocalModificationsDeps(c *C) {
 	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	_, restore := mockSeedRefreshHooks([]string{"snapd"})
+	defer restore()
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
 
 	stss := []snapstate.SnapInstallTaskSet{
 		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
 		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
 	}
-	earlyDownloads := map[string]bool{
-		"snapd":  true,
-		"core20": true,
-	}
-	_, err := snapstate.ArrangeRebootAndUpdateSeed(
+	seedTS, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		earlyDownloads,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
 		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
 	)
 	c.Assert(err, IsNil)
+	seedCreate, _, _ := splitSeedRefreshTasks(c, seedTS)
+
+	snapdLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+	baseLastBefore, err := stss[1].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+	appBegin, err := stss[2].TaskSet().Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	appLastBefore, err := stss[2].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+
+	for _, lastBefore := range []*state.Task{snapdLastBefore, baseLastBefore} {
+		c.Check(waitsOnTransitively(seedCreate, lastBefore), Equals, true)
+	}
+
+	c.Check(waitsOnTransitively(seedCreate, appBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, appLastBefore), Equals, false)
+	for _, lane := range seedCreate.Lanes() {
+		c.Check(appBegin.Lanes(), testutil.Contains, lane)
+		c.Check(appLastBefore.Lanes(), Not(testutil.Contains), lane)
+	}
+}
+
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssentialSeedRefreshNoCycle(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	_, restore := mockSeedRefreshHooks([]string{"snapd", "core20"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
+
+	stss := []snapstate.SnapInstallTaskSet{
+		s.snapInstallTaskSetForSnapSetup("snapd", "", snap.TypeSnapd),
+		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
+	}
+	seedTS, err := snapstate.ArrangeRebootAndUpdateSeed(
+		s.state,
+		stss,
+		snapstate.SeedRefreshEvictionPolicy{
+			SeedsToRetain: 1,
+		},
+		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
+	)
+	c.Assert(err, IsNil)
+	seedCreate, _, _ := splitSeedRefreshTasks(c, seedTS)
 
 	snapdEnd, err := stss[0].TaskSet().Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
@@ -920,27 +933,27 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapdAndEssentialEarlyDownlo
 	baseBegin, err := stss[1].TaskSet().Edge(snapstate.BeginEdge)
 	c.Assert(err, IsNil)
 
-	// if this dependency were present, it would create a cycle when snapd and
-	// an essential snap are both in the early download cohort.
-	c.Check(baseBegin.WaitTasks(), Not(testutil.Contains), snapdEnd)
+	c.Check(baseBegin.WaitTasks(), testutil.Contains, snapdEnd)
 
 	snapdLastBefore, err := stss[0].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 	baseLastBefore, err := stss[1].TaskSet().Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 
-	baseFirstLocalMod := firstTaskAfterLocalModifications(c, stss[1].TaskSet())
-	c.Check(waitsOnTransitively(baseFirstLocalMod, snapdLastBefore), Equals, true)
-
-	snapdFirstLocalMod := firstTaskAfterLocalModifications(c, stss[0].TaskSet())
-	c.Check(waitsOnTransitively(snapdFirstLocalMod, baseLastBefore), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, snapdLastBefore), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, baseLastBefore), Equals, true)
 }
 
-func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloadedAppWaitsAfterEssentials(c *C) {
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshAppsWaitAfterEssentials(c *C) {
 	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	_, restore := mockSeedRefreshHooks([]string{"core20", "my-kernel", "some-app"})
+	defer restore()
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.seed-refresh", true), IsNil)
+	tr.Commit()
 
 	stss := []snapstate.SnapInstallTaskSet{
 		s.snapInstallTaskSetForSnapSetup("core20", "", snap.TypeBase),
@@ -948,15 +961,9 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloadedAppWaitsAfter
 		s.snapInstallTaskSetForSnapSetup("some-app", "", snap.TypeApp),
 		s.snapInstallTaskSetForSnapSetup("some-other-snap", "", snap.TypeApp),
 	}
-	earlyDownloads := map[string]bool{
-		"core20":    true,
-		"my-kernel": true,
-		"some-app":  true,
-	}
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		earlyDownloads,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -967,19 +974,24 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsEarlyDownloadedAppWaitsAfter
 	finalEssential, err := stss[1].TaskSet().Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
 
-	beginEarlyAppTask, err := stss[2].TaskSet().Edge(snapstate.BeginEdge)
+	beginSeedAppTask, err := stss[2].TaskSet().Edge(snapstate.BeginEdge)
 	c.Assert(err, IsNil)
-	c.Check(beginEarlyAppTask.WaitTasks(), Not(testutil.Contains), finalEssential)
+	c.Check(beginSeedAppTask.WaitTasks(), Not(testutil.Contains), finalEssential)
 
-	firstLocalModEarlyApp := firstTaskAfterLocalModifications(c, stss[2].TaskSet())
-	c.Check(firstLocalModEarlyApp.WaitTasks(), testutil.Contains, finalEssential)
+	firstLocalModSeedApp := firstTaskAfterLocalModifications(c, stss[2].TaskSet())
+	c.Check(firstLocalModSeedApp.WaitTasks(), testutil.Contains, finalEssential)
 
-	beginNonEarlyAppTask, err := stss[3].TaskSet().Edge(snapstate.BeginEdge)
+	beginNonSeedAppTask, err := stss[3].TaskSet().Edge(snapstate.BeginEdge)
 	c.Assert(err, IsNil)
-	c.Check(beginNonEarlyAppTask.WaitTasks(), testutil.Contains, finalEssential)
+	c.Check(beginNonSeedAppTask.WaitTasks(), Not(testutil.Contains), finalEssential)
+
+	// non-seed app only performs initial prerequisites before seed creation;
+	// post-prerequisite work waits until all essential snaps are complete.
+	firstPostPrereqsNonSeedApp := firstTaskAfterPrerequisites(c, stss[3].TaskSet())
+	c.Check(firstPostPrereqsNonSeedApp.WaitTasks(), testutil.Contains, finalEssential)
 }
 
-func (s *rebootSuite) TestArrangeSnapInstallTaskSetsNoEarlyDownloads(c *C) {
+func (s *rebootSuite) TestArrangeSnapInstallTaskSetsNoSeedRefreshBeforeLocalModificationsDeps(c *C) {
 	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
 
 	s.state.Lock()
@@ -993,7 +1005,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsNoEarlyDownloads(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1063,6 +1074,7 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshComponentExclusiv
 	sts := snapstate.NewSnapInstallTaskSetForTest(
 		snapsup,
 		ts,
+		downloadComp,
 		[]*state.Task{downloadComp},
 		prereqSync,
 		nil,
@@ -1073,7 +1085,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSeedRefreshComponentExclusiv
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		[]snapstate.SnapInstallTaskSet{sts},
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1102,7 +1113,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsSnapd(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1135,7 +1145,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsBootBaseAndOtherBases(c *C) 
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1167,7 +1176,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBaseAndWithout(c 
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1205,7 +1213,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsForSnapWithBootBaseAndWithou
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1247,7 +1254,6 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsAll(c *C) {
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
@@ -1281,16 +1287,15 @@ func (s *rebootSuite) TestArrangeSnapInstallTaskSetsFailsSplit(c *C) {
 	defer s.state.Unlock()
 
 	stss := []snapstate.SnapInstallTaskSet{
-		snapstate.NewSnapInstallTaskSetForTest(nil, nil, nil, nil, nil, nil, nil),
+		snapstate.NewSnapInstallTaskSetForTest(nil, nil, nil, nil, nil, nil, nil, nil),
 	}
 	_, err := snapstate.ArrangeRebootAndUpdateSeed(
 		s.state,
 		stss,
-		nil,
 		snapstate.SeedRefreshEvictionPolicy{
 			SeedsToRetain: 1,
 		},
 		snapstate.Options{DeviceCtx: s.deviceCtx(c)},
 	)
-	c.Assert(err, ErrorMatches, `internal error: snap install task set has empty slices`)
+	c.Assert(err, ErrorMatches, `internal error: snap install task set has empty task ranges`)
 }

--- a/overlord/snapstate/snap.go
+++ b/overlord/snapstate/snap.go
@@ -652,6 +652,7 @@ func (sc *snapInstallChoreographer) choreograph(st *state.State, ic installConte
 	b.Append(prerequisites)
 	b.UpdateEdge(prerequisites, BeginEdge)
 
+	// the builder chains this phase after the initial prerequisites task.
 	beforeLocalSystemMods, err := sc.BeforeLocalSystemMod(st, b.OpenSpan(), ic)
 	if err != nil {
 		return snapInstallTaskSet{}, err

--- a/overlord/snapstate/snap.go
+++ b/overlord/snapstate/snap.go
@@ -55,15 +55,12 @@ type snapInstallTaskSet struct {
 	ts      *state.TaskSet
 	snapsup *SnapSetup
 
+	prerequisites                       *state.Task
 	beforeLocalSystemModificationsTasks []*state.Task
 	prerequisitesSync                   *state.Task
 	mountSnap                           *state.Task
 	upToLinkSnapAndBeforeReboot         []*state.Task
 	afterLinkSnapAndPostReboot          []*state.Task
-}
-
-func (sts snapInstallTaskSet) firstLocalMod() *state.Task {
-	return sts.prerequisitesSync
 }
 
 // snapInstallChoreographer orchestrates the construction of a task graph for
@@ -115,26 +112,6 @@ func (sc *snapInstallChoreographer) runRefreshHooks() bool {
 }
 
 func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *taskChainSpan, ic installContext) ([]*state.Task, error) {
-	if sc.revisionIsPresent() && sc.snapsup.RemoveSnapPath {
-		// If the revision is local, we will not need the temporary snap. This
-		// can happen when e.g. side-loading a local revision again. The
-		// SnapPath is only needed in the "mount-snap" handler and that is
-		// skipped for local revisions.
-		if err := os.Remove(sc.snapsup.SnapPath); err != nil {
-			return nil, err
-		}
-
-		// before snapsup is attached to the tasks, clear it out. a path that
-		// points to nothing isn't useful any more.
-		sc.snapsup.SnapPath = ""
-	}
-
-	prereq := st.NewTask("prerequisites", fmt.Sprintf(
-		i18n.G("Ensure prerequisites for %q are available"), sc.snapsup.InstanceName()))
-	prereq.Set("snap-setup", sc.snapsup)
-	s.AppendWithoutData(prereq)
-	s.UpdateEdge(prereq, BeginEdge)
-
 	var prepare *state.Task
 	// if we have a local revision here we go back to that
 	if sc.snapsup.SnapPath != "" || sc.revisionIsPresent() {
@@ -147,7 +124,6 @@ func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *tas
 	}
 
 	prepare.Set("snap-setup", sc.snapsup)
-	prepare.WaitFor(prereq)
 	s.AppendWithoutData(prepare)
 	s.UpdateEdge(prepare, SnapSetupEdge)
 	s.UpdateEdge(prepare, LastBeforeLocalModificationsEdge)
@@ -656,6 +632,26 @@ func (sc *snapInstallChoreographer) addCleanupTasks(st *state.State, s *taskChai
 func (sc *snapInstallChoreographer) choreograph(st *state.State, ic installContext) (snapInstallTaskSet, error) {
 	b := newTaskChainBuilder()
 
+	if sc.revisionIsPresent() && sc.snapsup.RemoveSnapPath {
+		// If the revision is local, we will not need the temporary snap. This
+		// can happen when e.g. side-loading a local revision again. The
+		// SnapPath is only needed in the "mount-snap" handler and that is
+		// skipped for local revisions.
+		if err := os.Remove(sc.snapsup.SnapPath); err != nil {
+			return snapInstallTaskSet{}, err
+		}
+
+		// before snapsup is attached to the tasks, clear it out. a path that
+		// points to nothing isn't useful any more.
+		sc.snapsup.SnapPath = ""
+	}
+
+	prerequisites := st.NewTask("prerequisites", fmt.Sprintf(
+		i18n.G("Ensure prerequisites for %q are available"), sc.snapsup.InstanceName()))
+	prerequisites.Set("snap-setup", sc.snapsup)
+	b.Append(prerequisites)
+	b.UpdateEdge(prerequisites, BeginEdge)
+
 	beforeLocalSystemMods, err := sc.BeforeLocalSystemMod(st, b.OpenSpan(), ic)
 	if err != nil {
 		return snapInstallTaskSet{}, err
@@ -699,6 +695,7 @@ func (sc *snapInstallChoreographer) choreograph(st *state.State, ic installConte
 		ts:      b.TaskSet(),
 		snapsup: sc.snapsup,
 
+		prerequisites:                       prerequisites,
 		beforeLocalSystemModificationsTasks: beforeLocalSystemMods,
 		prerequisitesSync:                   prerequisitesSync,
 		mountSnap:                           mountSnap,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1635,7 +1635,7 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 		scheduleUpdate(up.Setup.InstanceName(), sts.ts)
 	}
 
-	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, nil, SeedRefreshEvictionPolicy{SeedsToRetain: 1}, opts)
+	seedTS, err := arrangeRebootAndUpdateSeed(st, snapInstallTSS, SeedRefreshEvictionPolicy{SeedsToRetain: 1}, opts)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -3653,7 +3653,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 	// from, we use ReplaceLatest to indicate that the most recent seed should
 	// be replaced with the incoming one. this is only applicable if this snap
 	// triggers a seed refresh.
-	seedTS, err := arrangeRebootAndUpdateSeed(st, []snapInstallTaskSet{installTS}, nil, SeedRefreshEvictionPolicy{
+	seedTS, err := arrangeRebootAndUpdateSeed(st, []snapInstallTaskSet{installTS}, SeedRefreshEvictionPolicy{
 		SeedsToRetain: 1,
 		ReplaceLatest: true,
 	}, Options{

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20285,7 +20285,7 @@ func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshBeforeLocalModifications
 		seedRefreshSnap{name: "some-other-snap", snapID: "some-other-snap-id", snapType: "app", base: "core18"},
 	)
 
-	uts, _ := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{
 		{InstanceName: "kernel"},
 		{InstanceName: "core18"},
 		{InstanceName: "some-app"},
@@ -20328,18 +20328,17 @@ func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshBeforeLocalModifications
 
 	lastEssentialSnapTask, err := kernelTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
-	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
-	c.Assert(err, IsNil)
+	nonSeedAppFirstPrereq, _ := findPrereqTasksForSnap(c, chg, "some-other-snap")
 	lastBeforeLocalModelApp, err := appTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 	lastBeforeLocalNonSeedApp, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocalModelApp), Equals, true)
-	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppFirstPrereq), Equals, true)
 	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocalNonSeedApp), Equals, false)
 
 	for _, lane := range seedCreate.Lanes() {
-		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(nonSeedAppFirstPrereq.Lanes(), testutil.Contains, lane)
 		c.Check(lastBeforeLocalNonSeedApp.Lanes(), Not(testutil.Contains), lane)
 	}
 
@@ -20711,7 +20710,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBeforeLocalModifications
 		seedRefreshSnap{name: "some-other-snap", snapID: "some-other-snap-id", snapType: "app", base: "core18"},
 	)
 
-	uts, _ := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{
 		{InstanceName: "snapd"},
 		{InstanceName: "kernel"},
 		{InstanceName: "core18"},
@@ -20772,16 +20771,15 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBeforeLocalModifications
 		c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
 	}
 
-	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
-	c.Assert(err, IsNil)
+	nonSeedAppFirstPrereq, _ := findPrereqTasksForSnap(c, chg, "some-other-snap")
 	nonSeedAppLastBefore, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 
 	// assert seed creation waits only on initial prerequisites tasks of non-seed snaps.
-	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppFirstPrereq), Equals, true)
 	c.Check(waitsOnTransitively(seedCreate, nonSeedAppLastBefore), Equals, false)
 	for _, lane := range seedCreate.Lanes() {
-		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(nonSeedAppFirstPrereq.Lanes(), testutil.Contains, lane)
 		c.Check(nonSeedAppLastBefore.Lanes(), Not(testutil.Contains), lane)
 	}
 
@@ -20925,14 +20923,13 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshWithSnapdAndNonSeedSnapR
 		c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
 	}
 
-	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
-	c.Assert(err, IsNil)
+	nonSeedAppFirstPrereq, _ := findPrereqTasksForSnap(c, chg, "some-other-snap")
 	nonSeedAppLastBefore, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
-	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppFirstPrereq), Equals, true)
 	c.Check(waitsOnTransitively(seedCreate, nonSeedAppLastBefore), Equals, false)
 	for _, lane := range seedCreate.Lanes() {
-		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(nonSeedAppFirstPrereq.Lanes(), testutil.Contains, lane)
 		c.Check(nonSeedAppLastBefore.Lanes(), Not(testutil.Contains), lane)
 	}
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -136,6 +136,25 @@ func firstTaskAfterLocalModifications(c *C, ts *state.TaskSet) *state.Task {
 	return nil
 }
 
+func firstTaskAfterPrerequisites(c *C, ts *state.TaskSet) *state.Task {
+	begin, err := ts.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+
+	inSet := make(map[string]bool, len(ts.Tasks()))
+	for _, t := range ts.Tasks() {
+		inSet[t.ID()] = true
+	}
+
+	for _, ht := range begin.HaltTasks() {
+		if inSet[ht.ID()] {
+			return ht
+		}
+	}
+
+	c.Fatalf("cannot find first task after prerequisites")
+	return nil
+}
+
 func firstTaskAfterMount(c *C, ts *state.TaskSet) *state.Task {
 	mountTask := findKindInTaskSet(ts, "mount-snap")
 	c.Assert(mountTask, NotNil)
@@ -384,16 +403,20 @@ func mockSeedRefreshRebootHandlers(s *snapmgrTestSuite, c *C, finalizeErr error)
 	return &restartRequested
 }
 
-func assertLinkTaskStatus(c *C, ts *state.TaskSet, expected state.Status) {
-	var link *state.Task
+func assertTaskKindStatus(c *C, ts *state.TaskSet, kind string, expected state.Status) {
+	var task *state.Task
 	for _, t := range ts.Tasks() {
-		if t.Kind() == "link-snap" {
-			link = t
+		if t.Kind() == kind {
+			task = t
 			break
 		}
 	}
-	c.Assert(link, NotNil)
-	c.Check(link.Status(), Equals, expected)
+	c.Assert(task, NotNil)
+	c.Check(task.Status(), Equals, expected)
+}
+
+func assertLinkTaskStatus(c *C, ts *state.TaskSet, expected state.Status) {
+	assertTaskKindStatus(c, ts, "link-snap", expected)
 }
 
 func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
@@ -11289,12 +11312,9 @@ NextSnap1:
 		}
 
 		if prevRebootTs == nil {
-			// For the first of these snaps, only one other can precede it, and that is
-			// the snapd snap. If the snapd snap is present, make sure it's depending on
-			// that
 			if snapdEndTask != nil {
 				mountTaskOfCurrent := findMountSnap(c, currentTs)
-				c.Check(mountTaskOfCurrent.WaitTasks(), testutil.Contains, snapdEndTask)
+				c.Check(waitsOnTransitively(mountTaskOfCurrent, snapdEndTask), Equals, true)
 			}
 		} else {
 			mountTaskOfCurrent := findMountSnap(c, currentTs)
@@ -11527,7 +11547,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 	lastTaskOfSnapd, err := snapdTs.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
 	c.Check(beginTaskOfBase.WaitTasks(), testutil.Contains, lastTaskOfSnapd)
-	c.Check(mountTaskOfBase.WaitTasks(), testutil.Contains, lastTaskOfSnapd)
+	c.Check(waitsOnTransitively(mountTaskOfBase, lastTaskOfSnapd), Equals, true)
 
 	s.fakeBackend.linkSnapMaybeReboot = true
 	s.fakeBackend.linkSnapRebootFor = map[string]bool{
@@ -20243,20 +20263,9 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefresh(c *C) {
 
 	c.Check(hasDoRestartBoundary(seedCreate), Equals, true)
 	c.Check(hasDoRestartBoundary(kernelLinkTask), Equals, false)
-
-	// verify that all snaps' first task after local modifications waits for all
-	// model snaps' last download task
-	firstLocalModKernel := firstTaskAfterLocalModifications(c, kernelTS)
-	firstLocalModBase := firstTaskAfterLocalModifications(c, baseTS)
-	firstLocalModApp := firstTaskAfterLocalModifications(c, appTS)
-
-	for _, firstLocalMod := range []*state.Task{firstLocalModKernel, firstLocalModBase, firstLocalModApp} {
-		c.Check(waitsOnTransitively(firstLocalMod, lastBeforeLocalBase), Equals, true)
-		c.Check(waitsOnTransitively(firstLocalMod, lastBeforeLocalKernel), Equals, true)
-	}
 }
 
-func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c *C, classic bool) {
+func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshBeforeLocalModificationsModelSnap(c *C, classic bool) {
 	restore := snapstate.MockRevisionDate(nil)
 	defer restore()
 	observed, restore := s.setupSeedRefreshUpdateTest(c, classic, true, map[string]any{
@@ -20287,19 +20296,19 @@ func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c
 	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "core18")
 	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
-	extraAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
+	nonSeedAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
 	c.Assert(observed.initial, HasLen, 1)
 	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
 		seedRefreshCandidateFromTaskSet(c, kernelTS),
 		seedRefreshCandidateFromTaskSet(c, baseTS),
 		seedRefreshCandidateFromTaskSet(c, appTS),
-		seedRefreshCandidateFromTaskSet(c, extraAppTS),
+		seedRefreshCandidateFromTaskSet(c, nonSeedAppTS),
 	})
 	c.Check(observed.evictions, DeepEquals, []snapstate.SeedRefreshEvictionPolicy{{SeedsToRetain: 1}})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(baseTS, kernelTS, appTS), Equals, true)
-	c.Check(taskSetsShareLane(baseTS, extraAppTS), Equals, false)
+	c.Check(taskSetsShareLane(baseTS, nonSeedAppTS), Equals, false)
 	c.Check(taskSetLanes(seedTS), testutil.DeepUnsortedMatches, taskSetLanes(baseTS))
 
 	seedCreate, seedEnd, _ := splitSeedRefreshTasks(c, seedTS)
@@ -20319,45 +20328,47 @@ func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c
 
 	lastEssentialSnapTask, err := kernelTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
+	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
 	lastBeforeLocalModelApp, err := appTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
+	lastBeforeLocalNonSeedApp, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
 	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocalModelApp), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, lastBeforeLocalNonSeedApp), Equals, false)
 
-	// with seed-refresh early downloads enabled, essential snaps should defer
-	// local modifications until all early cohort downloads (including model
-	// apps) are complete.
-	firstLocalModBase := firstTaskAfterLocalModifications(c, baseTS)
-	firstLocalModKernel := firstTaskAfterLocalModifications(c, kernelTS)
-	c.Check(waitsOnTransitively(firstLocalModBase, lastBeforeLocalModelApp), Equals, true)
-	c.Check(waitsOnTransitively(firstLocalModKernel, lastBeforeLocalModelApp), Equals, true)
+	for _, lane := range seedCreate.Lanes() {
+		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(lastBeforeLocalNonSeedApp.Lanes(), Not(testutil.Contains), lane)
+	}
 
-	// model app downloads early, but doesn't perform any local modifications
-	// until all essential snaps are complete.
+	// model app performs before-local-modification tasks before seed creation, but
+	// doesn't perform any local modifications until all essential snaps are complete.
 	firstLocalModApp := firstTaskAfterLocalModifications(c, appTS)
 	c.Check(firstLocalModApp.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
 
-	firstTaskOfExtraSnap, err := extraAppTS.Edge(snapstate.BeginEdge)
-	c.Assert(err, IsNil)
+	// non-seed app performs its initial prerequisite check before seed creation,
+	// but defers post-prerequisite work until all essential snaps are complete.
+	firstPostPrereqsNonSeedApp := firstTaskAfterPrerequisites(c, nonSeedAppTS)
+	c.Check(firstPostPrereqsNonSeedApp.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
 
-	// non-model app starts download after all essential snaps are complete
-	c.Check(firstTaskOfExtraSnap.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
-
-	// ensure that seed finalize task doens't wait on non-seed snap
-	extraAppEndTask, err := extraAppTS.Edge(snapstate.EndEdge)
+	// ensure that seed finalize task doesn't wait on non-seed snap
+	nonSeedAppEndTask, err := nonSeedAppTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
-	c.Check(waitsOnTransitively(seedEnd, extraAppEndTask), Equals, false)
+	c.Check(waitsOnTransitively(seedEnd, nonSeedAppEndTask), Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBeforeLocalModificationsModelSnap(c *C) {
 	const classic = false
-	s.testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c, classic)
+	s.testUpdateWithGoalSeedRefreshBeforeLocalModificationsModelSnap(c, classic)
 }
 
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadModelSnapOnClassic(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBeforeLocalModificationsModelSnapOnClassic(c *C) {
 	// TODO: this variant will need to be more complex once seed-refresh mode
 	// does not disable split refresh.
 	const classic = true
-	s.testUpdateWithGoalSeedRefreshEarlyDownloadModelSnap(c, classic)
+	s.testUpdateWithGoalSeedRefreshBeforeLocalModificationsModelSnap(c, classic)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBaseAndModelSnapRun(c *C) {
@@ -20679,7 +20690,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelCont
 	c.Assert(chg.IsReady(), Equals, true)
 }
 
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadWithSnapd(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshBeforeLocalModificationsWithSnapd(c *C) {
 	restore := snapstate.MockRevisionDate(nil)
 	defer restore()
 	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
@@ -20713,7 +20724,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadWithSnapd(c
 	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "core18")
 	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
-	extraAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
+	nonSeedAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
 
 	c.Assert(observed.initial, HasLen, 1)
 	c.Check(observed.initial[0], testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
@@ -20721,12 +20732,12 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadWithSnapd(c
 		seedRefreshCandidateFromTaskSet(c, kernelTS),
 		seedRefreshCandidateFromTaskSet(c, baseTS),
 		seedRefreshCandidateFromTaskSet(c, appTS),
-		seedRefreshCandidateFromTaskSet(c, extraAppTS),
+		seedRefreshCandidateFromTaskSet(c, nonSeedAppTS),
 	})
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(snapdTS, baseTS, kernelTS, appTS), Equals, true)
-	c.Check(taskSetsShareLane(baseTS, extraAppTS), Equals, false)
+	c.Check(taskSetsShareLane(baseTS, nonSeedAppTS), Equals, false)
 	c.Check(taskSetLanes(seedTS), testutil.DeepUnsortedMatches, taskSetLanes(snapdTS))
 
 	seedCreate, seedEnd, _ := splitSeedRefreshTasks(c, seedTS)
@@ -20749,42 +20760,53 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshEarlyDownloadWithSnapd(c
 	baseBegin, err := baseTS.Edge(snapstate.BeginEdge)
 	c.Assert(err, IsNil)
 
-	// if this dependency were present, it would create a cycle when snapd and
-	// an essential snap are both in the early download cohort.
-	c.Check(baseBegin.WaitTasks(), Not(testutil.Contains), snapdEnd)
+	c.Check(baseBegin.WaitTasks(), testutil.Contains, snapdEnd)
 
 	snapdLastBefore, err := snapdTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
 	baseLastBefore, err := baseTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
 	c.Assert(err, IsNil)
-	c.Check(waitsOnTransitively(seedCreate, snapdLastBefore), Equals, true)
+
+	// assert seed creation waits on before-local-modification tasks of seed snaps.
+	for _, lastBeforeLocal := range []*state.Task{snapdLastBefore, baseLastBefore} {
+		c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
+	}
+
+	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	nonSeedAppLastBefore, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+
+	// assert seed creation waits only on initial prerequisites tasks of non-seed snaps.
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppLastBefore), Equals, false)
+	for _, lane := range seedCreate.Lanes() {
+		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(nonSeedAppLastBefore.Lanes(), Not(testutil.Contains), lane)
+	}
 
 	baseMount := findKindInTaskSet(baseTS, "mount-snap")
 	c.Assert(baseMount, NotNil)
-	c.Check(baseMount.WaitTasks(), testutil.Contains, snapdEnd)
+	c.Check(waitsOnTransitively(baseMount, snapdEnd), Equals, true)
 	c.Check(waitsOnTransitively(baseMount, snapdLastBefore), Equals, true)
-
-	snapdFirstLocalMod := firstTaskAfterLocalModifications(c, snapdTS)
-	c.Check(waitsOnTransitively(snapdFirstLocalMod, baseLastBefore), Equals, true)
 
 	lastEssentialSnapTask, err := kernelTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
 
-	// model app downloads early, but doesn't perform any local modifications
-	// until all essential snaps are complete.
+	// model app performs before-local-modification tasks before seed creation, but
+	// doesn't perform any local modifications until all essential snaps are complete.
 	firstLocalModApp := firstTaskAfterLocalModifications(c, appTS)
 	c.Check(firstLocalModApp.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
 
-	firstTaskOfExtraSnap, err := extraAppTS.Edge(snapstate.BeginEdge)
-	c.Assert(err, IsNil)
+	// non-seed app performs its initial prerequisite check before seed creation,
+	// but defers post-prerequisite work until all essential snaps are complete.
+	firstPostPrereqsNonSeedApp := firstTaskAfterPrerequisites(c, nonSeedAppTS)
+	c.Check(firstPostPrereqsNonSeedApp.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
 
-	// non-model app starts download after all essential snaps are complete.
-	c.Check(firstTaskOfExtraSnap.WaitTasks(), testutil.Contains, lastEssentialSnapTask)
-
-	// ensure that seed finalize task doens't wait on non-seed snap
-	extraAppEndTask, err := extraAppTS.Edge(snapstate.EndEdge)
+	// ensure that seed finalize task doesn't wait on non-seed snap
+	nonSeedAppEndTask, err := nonSeedAppTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
-	c.Check(waitsOnTransitively(seedEnd, extraAppEndTask), Equals, false)
+	c.Check(waitsOnTransitively(seedEnd, nonSeedAppEndTask), Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshUndo(c *C) {
@@ -20848,7 +20870,81 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshUndo(c *C) {
 	c.Check(*restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 }
 
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshExtraSnapFailureDoesNotUndoSeed(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshWithSnapdAndNonSeedSnapRun(c *C) {
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"some-app"},
+	}, []string{"snapd", "kernel", "core18", "some-app"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restartRequested := mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "snapd", snapID: "snapd-snap-id", snapType: "snapd"},
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-other-snap", snapID: "some-other-snap-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{
+		{InstanceName: "snapd"},
+		{InstanceName: "kernel"},
+		{InstanceName: "core18"},
+		{InstanceName: "some-app"},
+		{InstanceName: "some-other-snap"},
+	})
+
+	taskSetsBySnap, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, NotNil)
+
+	snapdTS := mustTaskSetForSnap(c, taskSetsBySnap, "snapd")
+	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "core18")
+	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
+	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
+	nonSeedAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
+	c.Check(taskSetsShareLane(snapdTS, baseTS, kernelTS, appTS), Equals, true)
+
+	seedCreate, _, _ := splitSeedRefreshTasks(c, seedTS)
+
+	snapdEnd, err := snapdTS.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+
+	baseBegin, err := baseTS.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+
+	c.Check(baseBegin.WaitTasks(), testutil.Contains, snapdEnd)
+
+	for _, ts := range []*state.TaskSet{snapdTS, baseTS, kernelTS, appTS} {
+		lastBeforeLocal, err := ts.Edge(snapstate.LastBeforeLocalModificationsEdge)
+		c.Assert(err, IsNil)
+		c.Check(waitsOnTransitively(seedCreate, lastBeforeLocal), Equals, true)
+	}
+
+	nonSeedAppBegin, err := nonSeedAppTS.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	nonSeedAppLastBefore, err := nonSeedAppTS.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppBegin), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, nonSeedAppLastBefore), Equals, false)
+	for _, lane := range seedCreate.Lanes() {
+		c.Check(nonSeedAppBegin.Lanes(), testutil.Contains, lane)
+		c.Check(nonSeedAppLastBefore.Lanes(), Not(testutil.Contains), lane)
+	}
+
+	s.settle(c)
+	s.mockRestartAndSettle(c, chg)
+
+	c.Check(chg.Err(), IsNil)
+	c.Check(chg.IsReady(), Equals, true)
+	c.Check(*restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartSystem})
+}
+
+func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshNonSeedSnapFailureDoesNotUndoSeed(c *C, failingTask string) {
 	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
 		"base":           "core18",
@@ -20879,19 +20975,19 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshExtraSnapFailureDoesNotU
 	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "core18")
 	kernelTS := mustTaskSetForSnap(c, taskSetsBySnap, "kernel")
 	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
-	extraAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
+	nonSeedAppTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-other-snap")
 
 	c.Assert(seedTS, NotNil)
 	c.Check(taskSetsShareLane(baseTS, kernelTS, appTS), Equals, true)
-	c.Check(taskSetsShareLane(baseTS, extraAppTS), Equals, false)
+	c.Check(taskSetsShareLane(baseTS, nonSeedAppTS), Equals, false)
 	c.Check(taskSetLanes(seedTS), testutil.DeepUnsortedMatches, taskSetLanes(baseTS))
 	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
 
 	errInjected := 0
 	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
-		if op.op == "auto-connect:Doing" && op.name == "some-other-snap" {
+		if op.op == failingTask+":Doing" && op.name == "some-other-snap" {
 			errInjected++
-			return fmt.Errorf("auto-connect-extra-snap mock error")
+			return errors.New("non-seed snap mock error")
 		}
 		return nil
 	}
@@ -20900,23 +20996,27 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshExtraSnapFailureDoesNotU
 	s.settle(c)
 
 	// simulate the reboot into the candidate recovery system and continue until
-	// the extra snap fails after the seed-refresh tasks have completed
+	// the non-seed snap fails.
 	s.mockRestartAndSettle(c, chg)
 	assertTaskSetStatus(c, baseTS, state.DoneStatus)
 	assertTaskSetStatus(c, kernelTS, state.DoneStatus)
-	assertLinkTaskStatus(c, extraAppTS, state.UndoneStatus)
+	assertTaskSetStatus(c, appTS, state.DoneStatus)
 	c.Check(seedCreate.Status(), Equals, state.DoneStatus)
 	c.Check(seedFinalize.Status(), Equals, state.DoneStatus)
-
-	// the model app is not part of the extra snap undo path
-	appLinkTask, err := appTS.Edge(snapstate.MaybeRebootEdge)
-	c.Assert(err, IsNil)
-	c.Check(appLinkTask.Status(), Not(Equals), state.UndoneStatus)
+	assertTaskKindStatus(c, nonSeedAppTS, failingTask, state.ErrorStatus)
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*\(auto-connect-extra-snap mock error\)`)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*\(non-seed snap mock error\)`)
 	c.Check(*restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 	c.Check(errInjected, Equals, 1)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNonSeedSnapFailureDoesNotUndoSeed(c *C) {
+	s.testUpdateWithGoalSeedRefreshNonSeedSnapFailureDoesNotUndoSeed(c, "auto-connect")
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNonSeedSnapValidateFailureDoesNotUndoSeed(c *C) {
+	s.testUpdateWithGoalSeedRefreshNonSeedSnapFailureDoesNotUndoSeed(c, "validate-snap")
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRemoveSystemFailureDoesNotUndoSeed(c *C) {
@@ -21889,7 +21989,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshDisabled(c *C) {
 	c.Assert(err, IsNil)
 
 	// note: this asserts that we do not have the dependencies set up by the
-	// early download phase. this check doesn't imply total ordering.
+	// seed-refresh before-local-modifications phase. this check doesn't imply total ordering.
 	firstLocalModApp := firstTaskAfterLocalModifications(c, appTS)
 	c.Check(firstLocalModApp.WaitTasks(), Not(testutil.Contains), lastBeforeLocalBase)
 	c.Check(firstLocalModApp.WaitTasks(), Not(testutil.Contains), lastBeforeLocalKernel)

--- a/overlord/snapstate/task_chain_builder.go
+++ b/overlord/snapstate/task_chain_builder.go
@@ -58,6 +58,12 @@ func (b *taskChainBuilder) Append(t *state.Task) {
 	tmp.Append(t)
 }
 
+// UpdateEdge marks the task as an edge. If the task set owned by this
+// taskChainBuilder already has that edge, it is overwritten.
+func (b *taskChainBuilder) UpdateEdge(t *state.Task, e state.TaskSetEdge) {
+	b.ts.MarkEdge(t, e)
+}
+
 // OpenSpan creates a new taskChainSpan that shares this taskChainBuilder's task
 // set and tail.
 func (b *taskChainBuilder) OpenSpan() *taskChainSpan {
@@ -130,7 +136,7 @@ func (s *taskChainSpan) AppendWithoutData(t *state.Task) {
 // UpdateEdge marks the task as an edge. If the task set owned by the parent
 // taskChainBuilder already has that edge, it is overwritten.
 func (s *taskChainSpan) UpdateEdge(t *state.Task, e state.TaskSetEdge) {
-	s.b.ts.MarkEdge(t, e)
+	s.b.UpdateEdge(t, e)
 }
 
 // UpdateEdgeIfUnset marks the task as an edge only if the edge is not already set.


### PR DESCRIPTION
This does not yet handle prerequisite tasks that are spawned by other prerequisite tasks. That will be handled later.

Note that I've also dropped the explicit early download phase, since we should just use the seed-creation task as the barrier for:
* all initial `prerequisites` tasks
* before-local-modification tasks for snaps going into the seed