### PR TITLE
o/certstate: support ca-certificate.crt only systems like core26

### DIFF
--- a/overlord/certstate/certs.go
+++ b/overlord/certstate/certs.go
@@ -429,11 +429,12 @@ func writeUniqueCACertificates(certs *certificates, certsDir string, bundle io.W
 	// certificates layout, but fall back to a digest-derived name when a
 	// distinct certificate would otherwise overwrite an existing copy.
 	outputNameFor := func(cert certificate) string {
-		base := filepath.Base(cert.RealPath)
-		if base == "." {
+		if cert.RealPath == "" {
+			// individual certificate from a bundle file
 			return ""
 		}
 
+		base := filepath.Base(cert.RealPath)
 		if ownerDigest, ok := usedOutputNames[base]; !ok || ownerDigest == cert.Sha256 {
 			usedOutputNames[base] = cert.Sha256
 			return base

--- a/overlord/certstate/certs.go
+++ b/overlord/certstate/certs.go
@@ -603,8 +603,13 @@ type certificates struct {
 	BlockedDigests     []string
 }
 
-// loadCertificates retrieves the system certificates, user added certificates
-// and blocked certificate digests, and returns as a convenient structure.
+// loadCertificates builds the certificate view snapd will publish.
+//
+// System certificates are loaded from /etc/ssl/certs by preferring
+// individually discoverable certificate files and falling back to parsing the
+// ca-certificates.crt bundle only when the directory does not expose usable
+// per-certificate entries. User-added certificates and blocked digests are
+// then considered on top.
 func loadCertificates() (*certificates, error) {
 	certs := &certificates{}
 

--- a/overlord/certstate/certs.go
+++ b/overlord/certstate/certs.go
@@ -56,10 +56,22 @@ type CertificateData struct {
 }
 
 type certificate struct {
-	Name            string
-	Path            string
-	RealPath        string
-	Sha256          string
+	// Name is the logical certificate name without its on-disk extension.
+	// It is empty for nameless certificates parsed from ca-certificates.crt.
+	Name string
+	// Path is the directory entry snapd discovered for the certificate before
+	// resolving any symlinks. It is empty for bundle-derived certificates.
+	Path string
+	// RealPath is the resolved backing file path used to read file-backed
+	// certificates. It is empty for bundle-derived certificates.
+	RealPath string
+	// Data holds the certificate payload for entries that do not have a stable
+	// backing file path, such as certificates parsed from ca-certificates.crt.
+	Data []byte
+	// Sha256 is the semantic content digest of the certificate payload.
+	Sha256 string
+	// SubjectNameSha1 is the OpenSSL subject-name hash used for c_rehash-style
+	// lookup symlinks when the payload contains a single certificate.
 	SubjectNameSha1 string
 }
 
@@ -72,6 +84,10 @@ type certificateManifest struct {
 
 func (m *certificateManifest) addFile(name, digest string) {
 	m.records = append(m.records, fmt.Sprintf("file\x00%s\x00%s", name, digest))
+}
+
+func (m *certificateManifest) addDbEntry(digest string) {
+	m.records = append(m.records, fmt.Sprintf("ca-db\x00%s", digest))
 }
 
 func (m *certificateManifest) addLink(name, target string) {
@@ -245,6 +261,10 @@ func isBlocked(cert certificate, blockedCertDigests []string) bool {
 		return true
 	}
 
+	if cert.RealPath == "" {
+		return len(cert.Data) == 0 || strutil.ListContains(blockedCertDigests, cert.Sha256)
+	}
+
 	// Check that the real underlying filepath to the
 	// certificate ends with a supported extension
 	if !isAllowedExtension(cert.RealPath) {
@@ -314,6 +334,66 @@ func parseCertificates(certsPath string) ([]certificate, error) {
 	return certsObjects, nil
 }
 
+// parseCertificatesDb reads the system ca-certificates.crt bundle and returns
+// one certificate entry per parsed certificate block. The returned entries are
+// nameless and carry their payload inline because the bundle does not provide a
+// stable per-certificate source path.
+func parseCertificatesDb(certsPath string) ([]certificate, error) {
+	certDbPath := filepath.Join(certsPath, "ca-certificates.crt")
+	logger.Debugf("Reading certificates from %s", certDbPath)
+
+	// If no ca-certificates.crt file exists, we return an empty list of certificates.
+	if !osutil.FileExists(certDbPath) {
+		return nil, nil
+	}
+
+	certDb, err := os.ReadFile(certDbPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read certificate database %q: %v", certDbPath, err)
+	}
+	var certsObjects []certificate
+	rest := certDb
+	for {
+		block, next := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = next
+
+		if !certificatePEMBlockTypePattern.MatchString(block.Type) {
+			logger.Debugf("encountered unsupported pem-block type in %q: %s", certDbPath, block.Type)
+			continue
+		}
+
+		pemBytes := pem.EncodeToMemory(&pem.Block{Type: block.Type, Headers: block.Headers, Bytes: block.Bytes})
+		cert, err := ParseCertificateData(pemBytes)
+		if err != nil {
+			logger.Noticef("cannot parse certificate database entry from %q: %v", certDbPath, err)
+			continue
+		}
+
+		certsObjects = append(certsObjects, certificate{
+			Data:            pemBytes,
+			Sha256:          cert.Sha256,
+			SubjectNameSha1: cert.SubjectNameSha1,
+		})
+	}
+	if len(certsObjects) != 0 {
+		return certsObjects, nil
+	}
+
+	cert, err := ParseCertificateData(certDb)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse certificate database %q: %v", certDbPath, err)
+	}
+
+	return []certificate{{
+		Data:            certDb,
+		Sha256:          cert.Sha256,
+		SubjectNameSha1: cert.SubjectNameSha1,
+	}}, nil
+}
+
 // readDigests reads the names of all files in the given directory
 // and returns them as a list of strings (with any extension trimmed).
 // It expects that the files in the directory are named by their digest.
@@ -350,6 +430,10 @@ func writeUniqueCACertificates(certs *certificates, certsDir string, bundle io.W
 	// distinct certificate would otherwise overwrite an existing copy.
 	outputNameFor := func(cert certificate) string {
 		base := filepath.Base(cert.RealPath)
+		if base == "." {
+			return ""
+		}
+
 		if ownerDigest, ok := usedOutputNames[base]; !ok || ownerDigest == cert.Sha256 {
 			usedOutputNames[base] = cert.Sha256
 			return base
@@ -372,8 +456,15 @@ func writeUniqueCACertificates(certs *certificates, certsDir string, bundle io.W
 		}
 	}
 
+	certData := func(cert certificate) ([]byte, error) {
+		if len(cert.Data) != 0 {
+			return cert.Data, nil
+		}
+		return os.ReadFile(cert.RealPath)
+	}
+
 	copyOne := func(cert certificate, outputName string) error {
-		data, err := os.ReadFile(cert.RealPath)
+		data, err := certData(cert)
 		if err != nil {
 			return err
 		}
@@ -381,6 +472,13 @@ func writeUniqueCACertificates(certs *certificates, certsDir string, bundle io.W
 		// Append it to the ca bundle
 		if _, err := bundle.Write(data); err != nil {
 			return err
+		}
+
+		// For certificates that are not backed by a real file, we don't
+		// create a copy in the merged directory.
+		if outputName == "" {
+			manifest.addDbEntry(cert.Sha256)
+			return nil
 		}
 
 		// Create a copy in the merged directory under the chosen unique name.
@@ -395,6 +493,13 @@ func writeUniqueCACertificates(certs *certificates, certsDir string, bundle io.W
 	// Create the c_rehash-style subject hash link for single-certificate files.
 	maybeSha1Link := func(cert certificate, outputName string) error {
 		if cert.SubjectNameSha1 == "" {
+			return nil
+		}
+
+		// Only generate c_rehash style Sha1 links for certificates that actually have
+		// a physical certificate backing them. For ca-certificates.crt derived certificates,
+		// we ignore this.
+		if outputName == "" {
 			return nil
 		}
 
@@ -511,6 +616,16 @@ func loadCertificates() (*certificates, error) {
 		return nil, err
 	}
 	certs.SystemCertificates = systemCerts
+
+	// Support systems that do not have the individual certs, but rather use
+	// the ca-certificates database only.
+	if len(systemCerts) == 0 {
+		systemDbCerts, err := parseCertificatesDb(dirs.SystemCertsDir)
+		if err != nil {
+			return nil, err
+		}
+		certs.SystemCertificates = systemDbCerts
+	}
 
 	// If the added directory exists, parse it
 	if exists, isDir, err := osutil.DirExists(filepath.Join(dirs.SnapdPKIV1Dir, "added")); err != nil {

--- a/overlord/certstate/certs_test.go
+++ b/overlord/certstate/certs_test.go
@@ -239,6 +239,42 @@ func (s *certsTestSuite) TestLoadCertificatesPropagatesBlockedDirLookupError(c *
 	c.Check(errors.Is(err, syscall.ELOOP), Equals, true)
 }
 
+func (s *certsTestSuite) TestLoadCertificatesFallsBackToCertificateDatabase(c *C) {
+	aPEM, _, err := makeTestCertPEM("A")
+	c.Assert(err, IsNil)
+	bPEM, _, err := makeTestCertPEM("B")
+	c.Assert(err, IsNil)
+
+	c.Assert(os.MkdirAll(dirs.SystemCertsDir, 0o755), IsNil)
+	sourceBundle := append(append([]byte{}, aPEM...), bPEM...)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SystemCertsDir, "ca-certificates.crt"), sourceBundle, 0o644), IsNil)
+
+	certs, err := certstate.LoadCertificates()
+	c.Assert(err, IsNil)
+	c.Assert(certs.SystemCertificates, HasLen, 2)
+	for _, cert := range certs.SystemCertificates {
+		c.Check(cert.Name, Equals, "")
+		c.Check(cert.Path, Equals, "")
+		c.Check(cert.RealPath, Equals, "")
+		c.Check(cert.Sha256, Not(Equals), "")
+	}
+
+	outDir := filepath.Join(c.MkDir(), "merged")
+	err = certstate.GenerateCACertificates(certs, outDir)
+	c.Assert(err, IsNil)
+
+	bundle, err := os.ReadFile(filepath.Join(outDir, "ca-certificates.crt"))
+	c.Assert(err, IsNil)
+	c.Check(bytes.Contains(bundle, aPEM), Equals, true)
+	c.Check(bytes.Contains(bundle, bPEM), Equals, true)
+	c.Check(bytes.Count(bundle, []byte("BEGIN CERTIFICATE")), Equals, 2)
+
+	entries, err := os.ReadDir(outDir)
+	c.Assert(err, IsNil)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Name(), Equals, "ca-certificates.crt")
+}
+
 func (s *certsTestSuite) TestParseCertificateDataMultipleCertificatesSkipsSubjectHash(c *C) {
 	cert1, _, err := makeTestCertPEM("Test Certificate Root CA 1")
 	c.Assert(err, IsNil)

--- a/tests/core/ca-certificates-gc/task.yaml
+++ b/tests/core/ca-certificates-gc/task.yaml
@@ -7,10 +7,6 @@ details: |
     mark it inactive, and the second reboot should remove it while merged
     still points at the current generation.
 
-# skip on UC26 for now, as it only has the ca-certificates db and this 
-# kind of setup needs some changes
-systems: [-ubuntu-core-26-*]
-
 environment:
     CERT_NAME: gccert
 

--- a/tests/core/ca-certificates/task.yaml
+++ b/tests/core/ca-certificates/task.yaml
@@ -4,10 +4,6 @@ details: |
     Check that snapd correctly generates the ca-certificates database
     upon first run, the change should be scheduled after seeding.
 
-# skip on UC26 for now, as it only has the ca-certificates db and this 
-# kind of setup needs some changes
-systems: [-ubuntu-core-26-*]
-
 execute: |
     CA_CERTIFICATES_DB=/var/lib/snapd/pki/v1/merged/ca-certificates.crt
     CA_CERTIFICATES_DIR=/var/lib/snapd/pki/v1/merged


### PR DESCRIPTION
Systems like core26 that carries just the ca-certificates.crt are still valid systems. Make sure that we generate a matching ca-certificates.crt db when the system only has the bundle.