### PR TITLE
seclog, o/auth: seclog events for token create/remove

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -205,8 +205,46 @@ func generateMacaroonKey() ([]byte, error) {
 
 const snapdMacaroonLocation = "snapd"
 
-// newUserMacaroon returns a snapd macaroon for the given username
-func newUserMacaroon(macaroonKey []byte, userID int) (string, error) {
+// isSnapdMacaroon reports whether serializedMacaroon is a snapd
+// macaroon (location "snapd").
+func isSnapdMacaroon(serializedMacaroon string) bool {
+	if serializedMacaroon == "" {
+		return false
+	}
+	m, err := MacaroonDeserialize(serializedMacaroon)
+	if err != nil {
+		// Unparseable data is not treated as a snapd macaroon; token audit
+		// events are omitted rather than guessed.
+		return false
+	}
+	return m.Location() == snapdMacaroonLocation
+}
+
+// logTokenMacaroonChanges emits token lifecycle events when a user's local
+// macaroon changes between prev and user.
+func logTokenMacaroonChanges(prev, user *UserState) {
+	if prev.Macaroon == user.Macaroon {
+		return
+	}
+
+	su := user.snapdUser()
+	tokenID := user.ID
+	prevSnapd := isSnapdMacaroon(prev.Macaroon)
+	newSnapd := isSnapdMacaroon(user.Macaroon)
+
+	switch {
+	case prevSnapd && !newSnapd:
+		seclog.LogTokenDeleted(su, tokenID)
+	case !prevSnapd && newSnapd:
+		seclog.LogTokenCreated(su, tokenID)
+	case prevSnapd && newSnapd:
+		seclog.LogTokenDeleted(su, tokenID)
+		seclog.LogTokenCreated(su, tokenID)
+	}
+}
+
+// newUserMacaroonImpl returns a snapd macaroon for the given username.
+func newUserMacaroonImpl(macaroonKey []byte, userID int) (string, error) {
 	userMacaroon, err := macaroon.New(macaroonKey, strconv.Itoa(userID), snapdMacaroonLocation)
 	if err != nil {
 		return "", fmt.Errorf("cannot create macaroon for snapd user: %s", err)
@@ -219,6 +257,8 @@ func newUserMacaroon(macaroonKey []byte, userID int) (string, error) {
 
 	return serializedMacaroon, nil
 }
+
+var newUserMacaroon = newUserMacaroonImpl
 
 // TODO: possibly move users' related functions to a userstate package
 
@@ -236,8 +276,8 @@ type NewUserParams struct {
 	Expiration time.Time
 }
 
-// NewUser tracks a new authenticated user and saves its details in the state
-// Note that this logs a security event via the security logger.
+// NewUser tracks a new authenticated user and saves its details in the state.
+// Note that this logs security events via the security logger.
 func NewUser(st *state.State, userParams NewUserParams) (*UserState, error) {
 	var authStateData AuthState
 
@@ -276,7 +316,9 @@ func NewUser(st *state.State, userParams NewUserParams) (*UserState, error) {
 
 	st.Set("auth", authStateData)
 
-	seclog.LogUserCreated(authenticatedUser.snapdUser())
+	su := authenticatedUser.snapdUser()
+	seclog.LogTokenCreated(su, authenticatedUser.ID)
+	seclog.LogUserCreated(su)
 
 	return &authenticatedUser, nil
 }
@@ -284,13 +326,13 @@ func NewUser(st *state.State, userParams NewUserParams) (*UserState, error) {
 var ErrInvalidUser = errors.New("invalid user")
 
 // RemoveUser removes a user from the state given its ID.
-// Note that this logs a security event via the security logger.
+// Note that this logs security events via the security logger.
 func RemoveUser(st *state.State, userID int) (removed *UserState, err error) {
 	return removeUser(st, func(u *UserState) bool { return u.ID == userID })
 }
 
 // RemoveUserByUsername removes a user from the state given its username. Returns a *UserState with the identification information for them.
-// Note that this logs a security event via the security logger.
+// Note that this logs security events via the security logger.
 func RemoveUserByUsername(st *state.State, username string) (removed *UserState, err error) {
 	return removeUser(st, func(u *UserState) bool { return u.Username == username })
 }
@@ -311,6 +353,8 @@ func removeUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 		u := &authStateData.Users[i]
 		if p(u) {
 			su := u.snapdUser()
+			tokenID := u.ID
+			hadSnapdMacaroon := isSnapdMacaroon(u.Macaroon)
 			removed := u.identificationOnly()
 			// delete without preserving order
 			n := len(authStateData.Users) - 1
@@ -319,6 +363,9 @@ func removeUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 			authStateData.Users = authStateData.Users[:n]
 			st.Set("auth", authStateData)
 
+			if hadSnapdMacaroon {
+				seclog.LogTokenDeleted(su, tokenID)
+			}
 			seclog.LogUserRemoved(su)
 
 			return removed, nil
@@ -377,8 +424,8 @@ func findUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 	return nil, ErrInvalidUser
 }
 
-// UpdateUser updates user in state
-// Note that this logs a security event via the security logger.
+// UpdateUser updates user in state.
+// Note that this logs security events via the security logger.
 func UpdateUser(st *state.State, user *UserState) error {
 	var authStateData AuthState
 
@@ -395,6 +442,8 @@ func UpdateUser(st *state.State, user *UserState) error {
 			prev := authStateData.Users[i]
 			authStateData.Users[i] = *user
 			st.Set("auth", authStateData)
+
+			logTokenMacaroonChanges(&prev, user)
 
 			changed := prev.changedFields(user)
 			if len(changed) > 0 {

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -206,7 +206,9 @@ func generateMacaroonKey() ([]byte, error) {
 const snapdMacaroonLocation = "snapd"
 
 // isSnapdMacaroon reports whether serializedMacaroon is a snapd
-// macaroon (location "snapd").
+// macaroon (location "snapd"). Used when auditing snapd local macaroon
+// lifecycle; legacy users may have store macaroons in UserState.Macaroon —
+// see CheckMacaroon token-style fallback.
 func isSnapdMacaroon(serializedMacaroon string) bool {
 	if serializedMacaroon == "" {
 		return false
@@ -220,9 +222,14 @@ func isSnapdMacaroon(serializedMacaroon string) bool {
 	return m.Location() == snapdMacaroonLocation
 }
 
-// logTokenMacaroonChanges emits token lifecycle events when a user's local
-// macaroon changes between prev and user.
-func logTokenMacaroonChanges(prev, user *UserState) {
+// logAuthnTokenEventsOnSnapdMacaroonChange emits authn_token_created /
+// authn_token_delete events when UserState.Macaroon transitions involve a
+// snapd local macaroon (location "snapd"). UserState.Macaroon may still
+// hold a legacy store macaroon for old users — see the token-style fallback
+// in CheckMacaroon — so isSnapdMacaroon is used to ignore non-snapd values.
+// token_id is always UserState.ID; update-path events represent credential
+// replacement for the same user slot, not a new identity.
+func logAuthnTokenEventsOnSnapdMacaroonChange(prev, user *UserState) {
 	if prev.Macaroon == user.Macaroon {
 		return
 	}
@@ -234,17 +241,16 @@ func logTokenMacaroonChanges(prev, user *UserState) {
 
 	switch {
 	case prevSnapd && !newSnapd:
-		seclog.LogTokenDeleted(su, tokenID)
+		seclog.LogAuthnTokenDeleted(su, tokenID)
 	case !prevSnapd && newSnapd:
-		seclog.LogTokenCreated(su, tokenID)
+		seclog.LogAuthnTokenCreated(su, tokenID)
 	case prevSnapd && newSnapd:
-		seclog.LogTokenDeleted(su, tokenID)
-		seclog.LogTokenCreated(su, tokenID)
+		seclog.LogAuthnTokenDeleted(su, tokenID)
+		seclog.LogAuthnTokenCreated(su, tokenID)
 	}
 }
 
-// newUserMacaroonImpl returns a snapd macaroon for the given username.
-func newUserMacaroonImpl(macaroonKey []byte, userID int) (string, error) {
+var newUserMacaroon = func(macaroonKey []byte, userID int) (string, error) {
 	userMacaroon, err := macaroon.New(macaroonKey, strconv.Itoa(userID), snapdMacaroonLocation)
 	if err != nil {
 		return "", fmt.Errorf("cannot create macaroon for snapd user: %s", err)
@@ -257,8 +263,6 @@ func newUserMacaroonImpl(macaroonKey []byte, userID int) (string, error) {
 
 	return serializedMacaroon, nil
 }
-
-var newUserMacaroon = newUserMacaroonImpl
 
 // TODO: possibly move users' related functions to a userstate package
 
@@ -317,7 +321,7 @@ func NewUser(st *state.State, userParams NewUserParams) (*UserState, error) {
 	st.Set("auth", authStateData)
 
 	su := authenticatedUser.snapdUser()
-	seclog.LogTokenCreated(su, authenticatedUser.ID)
+	seclog.LogAuthnTokenCreated(su, authenticatedUser.ID)
 	seclog.LogUserCreated(su)
 
 	return &authenticatedUser, nil
@@ -364,7 +368,7 @@ func removeUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 			st.Set("auth", authStateData)
 
 			if hadSnapdMacaroon {
-				seclog.LogTokenDeleted(su, tokenID)
+				seclog.LogAuthnTokenDeleted(su, tokenID)
 			}
 			seclog.LogUserRemoved(su)
 
@@ -443,7 +447,7 @@ func UpdateUser(st *state.State, user *UserState) error {
 			authStateData.Users[i] = *user
 			st.Set("auth", authStateData)
 
-			logTokenMacaroonChanges(&prev, user)
+			logAuthnTokenEventsOnSnapdMacaroonChange(&prev, user)
 
 			changed := prev.changedFields(user)
 			if len(changed) > 0 {

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -22,6 +22,8 @@ package auth_test
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -674,7 +676,7 @@ func (as *authSuite) TestChangedFieldsExpirationMonotonicIndependent(c *C) {
 	c.Check(a.ChangedFields(b), HasLen, 0)
 }
 
-func (as *authSuite) TestNewUserLogsCreated(c *C) {
+func (as *authSuite) TestNewUserLogsSecurityEvents(c *C) {
 	as.state.Lock()
 	_, err := auth.NewUser(as.state, auth.NewUserParams{
 		Username:   "jdoe",
@@ -685,9 +687,54 @@ func (as *authSuite) TestNewUserLogsCreated(c *C) {
 	as.state.Unlock()
 	c.Assert(err, IsNil)
 
-	c.Check(as.seclogBuf.String(), testutil.Contains, "user_created")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe@test.com")
+	output := as.seclogBuf.String()
+	c.Check(output, testutil.Contains, "authn_token_created")
+	c.Check(output, testutil.Contains, "user_created")
+	c.Check(output, testutil.Contains, "Token created for user 1:jdoe@test.com:jdoe")
+	c.Check(output, testutil.Contains, "[token_id=1]")
+	c.Check(output, testutil.Contains, "jdoe")
+	c.Check(output, testutil.Contains, "jdoe@test.com")
+
+	tokenIdx := strings.Index(output, "authn_token_created")
+	userIdx := strings.Index(output, "user_created")
+	c.Check(tokenIdx >= 0 && userIdx > tokenIdx, Equals, true)
+}
+
+func (as *authSuite) TestNewUserErrorSkipsLogging(c *C) {
+	restore := auth.MockNewUserMacaroon(func(_ []byte, _ int) (string, error) {
+		return "", fmt.Errorf("cannot create macaroon for snapd user: mocked")
+	})
+	defer restore()
+
+	as.state.Lock()
+	_, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
+	as.state.Unlock()
+	c.Assert(err, ErrorMatches, "cannot create macaroon for snapd user: mocked")
+	c.Check(as.seclogBuf.String(), Equals, "")
+}
+
+func (as *authSuite) TestIsSnapdMacaroon(c *C) {
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
+	c.Assert(err, IsNil)
+
+	storeMac := user.StoreMacaroon
+	as.state.Unlock()
+
+	c.Check(auth.IsSnapdMacaroon(user.Macaroon), Equals, true)
+	c.Check(auth.IsSnapdMacaroon(storeMac), Equals, false)
+	c.Check(auth.IsSnapdMacaroon(""), Equals, false)
+	c.Check(auth.IsSnapdMacaroon("not-a-macaroon"), Equals, false)
 }
 
 func (as *authSuite) TestUpdateUserLogsUpdated(c *C) {
@@ -733,6 +780,115 @@ func (as *authSuite) TestUpdateUserNoChangeSkipsLog(c *C) {
 	c.Check(as.seclogBuf.String(), Not(testutil.Contains), "user_updated")
 }
 
+func (as *authSuite) TestUpdateUserSnapdToStoreMacaroonLogsTokenDeleted(c *C) {
+	m, err := macaroon.New([]byte("secret"), "some-id", "location")
+	c.Assert(err, IsNil)
+	serializedStoreMacaroon, err := auth.MacaroonSerialize(m)
+	c.Assert(err, IsNil)
+
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   serializedStoreMacaroon,
+		Discharges: []string{"discharge"},
+	})
+	c.Assert(err, IsNil)
+
+	as.seclogBuf.Reset()
+	user.Macaroon = user.StoreMacaroon
+	user.Discharges = user.StoreDischarges
+	err = auth.UpdateUser(as.state, user)
+	as.state.Unlock()
+	c.Assert(err, IsNil)
+
+	output := as.seclogBuf.String()
+	c.Check(output, testutil.Contains, "authn_token_delete")
+	c.Check(output, testutil.Contains, "user_updated")
+	c.Check(output, testutil.Contains, "local_macaroon")
+
+	tokenIdx := strings.Index(output, "authn_token_delete")
+	userIdx := strings.Index(output, "user_updated")
+	c.Check(tokenIdx >= 0 && userIdx > tokenIdx, Equals, true)
+}
+
+func (as *authSuite) TestUpdateUserSnapdMacaroonRotationLogsTokenLifecycle(c *C) {
+	rotatedMac, err := macaroon.New([]byte("rotated-secret"), "rotated-id", "snapd")
+	c.Assert(err, IsNil)
+	serializedRotatedMacaroon, err := auth.MacaroonSerialize(rotatedMac)
+	c.Assert(err, IsNil)
+
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
+	c.Assert(err, IsNil)
+	c.Check(user.Macaroon, Not(Equals), serializedRotatedMacaroon)
+
+	as.seclogBuf.Reset()
+	user.Macaroon = serializedRotatedMacaroon
+	err = auth.UpdateUser(as.state, user)
+	as.state.Unlock()
+	c.Assert(err, IsNil)
+
+	output := as.seclogBuf.String()
+	c.Check(output, testutil.Contains, "authn_token_delete")
+	c.Check(output, testutil.Contains, "authn_token_created")
+	c.Check(output, testutil.Contains, "user_updated")
+	c.Check(output, testutil.Contains, "local_macaroon")
+	c.Check(output, testutil.Contains, "[token_id=1]")
+
+	deleteIdx := strings.Index(output, "authn_token_delete")
+	createIdx := strings.Index(output, "authn_token_created")
+	userIdx := strings.Index(output, "user_updated")
+	c.Check(deleteIdx >= 0 && createIdx > deleteIdx && userIdx > createIdx, Equals, true)
+}
+
+func (as *authSuite) TestUpdateUserStoreToSnapdMacaroonLogsTokenCreated(c *C) {
+	m, err := macaroon.New([]byte("secret"), "some-id", "location")
+	c.Assert(err, IsNil)
+	serializedStoreMacaroon, err := auth.MacaroonSerialize(m)
+	c.Assert(err, IsNil)
+
+	snapdMac, err := macaroon.New([]byte("snapd-secret"), "snapd-id", "snapd")
+	c.Assert(err, IsNil)
+	serializedSnapdMacaroon, err := auth.MacaroonSerialize(snapdMac)
+	c.Assert(err, IsNil)
+
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   serializedStoreMacaroon,
+		Discharges: []string{"discharge"},
+	})
+	c.Assert(err, IsNil)
+	user.Macaroon = user.StoreMacaroon
+	user.Discharges = user.StoreDischarges
+	err = auth.UpdateUser(as.state, user)
+	c.Assert(err, IsNil)
+
+	as.seclogBuf.Reset()
+	user.Macaroon = serializedSnapdMacaroon
+	err = auth.UpdateUser(as.state, user)
+	as.state.Unlock()
+	c.Assert(err, IsNil)
+
+	output := as.seclogBuf.String()
+	c.Check(output, Not(testutil.Contains), "authn_token_delete")
+	c.Check(output, testutil.Contains, "authn_token_created")
+	c.Check(output, testutil.Contains, "user_updated")
+	c.Check(output, testutil.Contains, "local_macaroon")
+	c.Check(output, testutil.Contains, "[token_id=1]")
+
+	createIdx := strings.Index(output, "authn_token_created")
+	userIdx := strings.Index(output, "user_updated")
+	c.Check(createIdx >= 0 && userIdx > createIdx, Equals, true)
+}
+
 func (as *authSuite) TestRemoveUserLogsRemoved(c *C) {
 	as.state.Lock()
 	user, err := auth.NewUser(as.state, auth.NewUserParams{
@@ -748,9 +904,46 @@ func (as *authSuite) TestRemoveUserLogsRemoved(c *C) {
 	as.state.Unlock()
 	c.Assert(err, IsNil)
 
-	c.Check(as.seclogBuf.String(), testutil.Contains, "user_removed")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe@test.com")
+	output := as.seclogBuf.String()
+	c.Check(output, testutil.Contains, "authn_token_delete")
+	c.Check(output, testutil.Contains, "Token deleted for user 1:jdoe@test.com:jdoe")
+	c.Check(output, testutil.Contains, "[token_id=1]")
+	c.Check(output, testutil.Contains, "user_removed")
+	c.Check(output, testutil.Contains, "jdoe")
+	c.Check(output, testutil.Contains, "jdoe@test.com")
+
+	tokenIdx := strings.Index(output, "authn_token_delete")
+	userIdx := strings.Index(output, "user_removed")
+	c.Check(tokenIdx >= 0 && userIdx > tokenIdx, Equals, true)
+}
+
+func (as *authSuite) TestRemoveOldStyleUserSkipsTokenDelete(c *C) {
+	m, err := macaroon.New([]byte("secret"), "some-id", "location")
+	c.Assert(err, IsNil)
+	serializedStoreMacaroon, err := auth.MacaroonSerialize(m)
+	c.Assert(err, IsNil)
+
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, auth.NewUserParams{
+		Username:   "jdoe",
+		Email:      "jdoe@test.com",
+		Macaroon:   serializedStoreMacaroon,
+		Discharges: []string{"discharge"},
+	})
+	c.Assert(err, IsNil)
+	user.Macaroon = user.StoreMacaroon
+	user.Discharges = user.StoreDischarges
+	err = auth.UpdateUser(as.state, user)
+	c.Assert(err, IsNil)
+
+	as.seclogBuf.Reset()
+	_, err = auth.RemoveUser(as.state, user.ID)
+	as.state.Unlock()
+	c.Assert(err, IsNil)
+
+	output := as.seclogBuf.String()
+	c.Check(output, Not(testutil.Contains), "authn_token_delete")
+	c.Check(output, testutil.Contains, "user_removed")
 }
 
 func (as *authSuite) TestRemoveUserByUsernameLogsRemoved(c *C) {
@@ -768,7 +961,15 @@ func (as *authSuite) TestRemoveUserByUsernameLogsRemoved(c *C) {
 	as.state.Unlock()
 	c.Assert(err, IsNil)
 
-	c.Check(as.seclogBuf.String(), testutil.Contains, "user_removed")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe")
-	c.Check(as.seclogBuf.String(), testutil.Contains, "jdoe@test.com")
+	output := as.seclogBuf.String()
+	c.Check(output, testutil.Contains, "authn_token_delete")
+	c.Check(output, testutil.Contains, "Token deleted for user 1:jdoe@test.com:jdoe")
+	c.Check(output, testutil.Contains, "[token_id=1]")
+	c.Check(output, testutil.Contains, "user_removed")
+	c.Check(output, testutil.Contains, "jdoe")
+	c.Check(output, testutil.Contains, "jdoe@test.com")
+
+	tokenIdx := strings.Index(output, "authn_token_delete")
+	userIdx := strings.Index(output, "user_removed")
+	c.Check(tokenIdx >= 0 && userIdx > tokenIdx, Equals, true)
 }

--- a/overlord/auth/export_test.go
+++ b/overlord/auth/export_test.go
@@ -19,7 +19,18 @@
 
 package auth
 
+import "github.com/snapcore/snapd/testutil"
+
+var IsSnapdMacaroon = isSnapdMacaroon
+
 // ChangedFields exports changedFields for testing.
 func (u *UserState) ChangedFields(other *UserState) []string {
 	return u.changedFields(other)
+}
+
+// MockNewUserMacaroon replaces newUserMacaroon for the duration of a test.
+func MockNewUserMacaroon(f func(macaroonKey []byte, userID int) (string, error)) (restore func()) {
+	restore = testutil.Backup(&newUserMacaroon)
+	newUserMacaroon = f
+	return restore
 }

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -153,9 +153,9 @@ func LogLoginFailure(user SnapdUser, reason Reason) {
 	)
 }
 
-// LogTokenCreated logs a local snapd macaroon creation event using the
+// LogAuthnTokenCreated logs a local snapd macaroon creation event using the
 // global security logger.
-func LogTokenCreated(user SnapdUser, tokenID int) {
+func LogAuthnTokenCreated(user SnapdUser, tokenID int) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -167,9 +167,9 @@ func LogTokenCreated(user SnapdUser, tokenID int) {
 	)
 }
 
-// LogTokenDeleted logs a local snapd macaroon deletion event using the
+// LogAuthnTokenDeleted logs a local snapd macaroon deletion event using the
 // global security logger.
-func LogTokenDeleted(user SnapdUser, tokenID int) {
+func LogAuthnTokenDeleted(user SnapdUser, tokenID int) {
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -153,6 +153,34 @@ func LogLoginFailure(user SnapdUser, reason Reason) {
 	)
 }
 
+// LogTokenCreated logs a local snapd macaroon creation event using the
+// global security logger.
+func LogTokenCreated(user SnapdUser, tokenID int) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "AUTHN", Name: "authn_token_created", Level: LevelInfo},
+		fmt.Sprintf("Token created for user %s", user.String()),
+		Attr{Key: "user", Value: user},
+		Attr{Key: "token_id", Value: tokenID},
+	)
+}
+
+// LogTokenDeleted logs a local snapd macaroon deletion event using the
+// global security logger.
+func LogTokenDeleted(user SnapdUser, tokenID int) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "AUTHN", Name: "authn_token_delete", Level: LevelInfo},
+		fmt.Sprintf("Token deleted for user %s", user.String()),
+		Attr{Key: "user", Value: user},
+		Attr{Key: "token_id", Value: tokenID},
+	)
+}
+
 // LogUserCreated logs a user creation event using the global security logger.
 func LogUserCreated(user SnapdUser) {
 	lock.Lock()

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -129,6 +129,32 @@ func (s *SecLogSuite) TestLogLoginFailure(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "invalid-credentials")
 }
 
+func (s *SecLogSuite) TestLogTokenCreated(c *C) {
+	user := seclog.SnapdUser{
+		ID:             7,
+		StoreUserEmail: "user@example.com",
+		StoreUserName:  "jdoe",
+	}
+	seclog.LogTokenCreated(user, 99)
+
+	c.Check(s.buf.String(), testutil.Contains, "authn_token_created")
+	c.Check(s.buf.String(), testutil.Contains, "Token created for user 7:user@example.com:jdoe")
+	c.Check(s.buf.String(), testutil.Contains, "[token_id=99]")
+}
+
+func (s *SecLogSuite) TestLogTokenDeleted(c *C) {
+	user := seclog.SnapdUser{
+		ID:             7,
+		StoreUserEmail: "user@example.com",
+		StoreUserName:  "jdoe",
+	}
+	seclog.LogTokenDeleted(user, 99)
+
+	c.Check(s.buf.String(), testutil.Contains, "authn_token_delete")
+	c.Check(s.buf.String(), testutil.Contains, "Token deleted for user 7:user@example.com:jdoe")
+	c.Check(s.buf.String(), testutil.Contains, "[token_id=99]")
+}
+
 func (s *SecLogSuite) TestLogLoggerEnabledLogsEvent(c *C) {
 	seclog.LogLoggerEnabled()
 

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -129,26 +129,26 @@ func (s *SecLogSuite) TestLogLoginFailure(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "invalid-credentials")
 }
 
-func (s *SecLogSuite) TestLogTokenCreated(c *C) {
+func (s *SecLogSuite) TestLogAuthnTokenCreated(c *C) {
 	user := seclog.SnapdUser{
 		ID:             7,
 		StoreUserEmail: "user@example.com",
 		StoreUserName:  "jdoe",
 	}
-	seclog.LogTokenCreated(user, 99)
+	seclog.LogAuthnTokenCreated(user, 99)
 
 	c.Check(s.buf.String(), testutil.Contains, "authn_token_created")
 	c.Check(s.buf.String(), testutil.Contains, "Token created for user 7:user@example.com:jdoe")
 	c.Check(s.buf.String(), testutil.Contains, "[token_id=99]")
 }
 
-func (s *SecLogSuite) TestLogTokenDeleted(c *C) {
+func (s *SecLogSuite) TestLogAuthnTokenDeleted(c *C) {
 	user := seclog.SnapdUser{
 		ID:             7,
 		StoreUserEmail: "user@example.com",
 		StoreUserName:  "jdoe",
 	}
-	seclog.LogTokenDeleted(user, 99)
+	seclog.LogAuthnTokenDeleted(user, 99)
 
 	c.Check(s.buf.String(), testutil.Contains, "authn_token_delete")
 	c.Check(s.buf.String(), testutil.Contains, "Token deleted for user 7:user@example.com:jdoe")

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -254,25 +254,6 @@ func (s *SlogSuite) TestSnapdUserLogValue(c *C) {
 	}
 }
 
-func (s *SlogSuite) TestTokenIDAttr(c *C) {
-	type tokenRecord struct {
-		TokenID int `json:"token_id"`
-	}
-
-	s.buf.Reset()
-	logger := s.newLogger(c)
-	logger.LogEvent(
-		seclog.Event{Category: "AUTHN", Name: "authn_token_created", Level: seclog.LevelInfo},
-		"Token created for user 42:user@example.com:jdoe",
-		seclog.Attr{Key: "token_id", Value: 42},
-	)
-
-	var obtained tokenRecord
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(obtained.TokenID, Equals, 42)
-}
-
 func (s *SlogSuite) TestReasonLogValue(c *C) {
 	type errorRecord struct {
 		Error struct {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -254,6 +254,25 @@ func (s *SlogSuite) TestSnapdUserLogValue(c *C) {
 	}
 }
 
+func (s *SlogSuite) TestTokenIDAttr(c *C) {
+	type tokenRecord struct {
+		TokenID int `json:"token_id"`
+	}
+
+	s.buf.Reset()
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "AUTHN", Name: "authn_token_created", Level: seclog.LevelInfo},
+		"Token created for user 42:user@example.com:jdoe",
+		seclog.Attr{Key: "token_id", Value: 42},
+	)
+
+	var obtained tokenRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.TokenID, Equals, 42)
+}
+
 func (s *SlogSuite) TestReasonLogValue(c *C) {
 	type errorRecord struct {
 		Error struct {

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -8,7 +8,9 @@ details: |
     an "authn_login_success" event in the audit log. It also checks that
     user lifecycle events (user_created, user_updated, user_removed) are
     recorded when users are created via login, updated on re-login, and
-    removed via logout.
+    removed via logout. Token lifecycle events (authn_token_created,
+    authn_token_delete) are recorded when a local snapd macaroon is
+    created on first login and removed on logout.
 
 # Amazon Linux 2: systemd-journald-audit.socket is not available
 systems: [ -amazon-linux-2-64 ]
@@ -113,6 +115,9 @@ execute: |
         echo "Checking that user creation produces an audit event"
         journal_match '"category":"USER","event":"user_created","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\}'
 
+        echo "Checking that first login creates a local snapd macaroon audit event"
+        journal_match '"category":"AUTHN","event":"authn_token_created".*"token_id":[0-9]+'
+
         echo "Checking that a second login produces a user_updated audit event"
         # A second login refreshes the store macaroon and discharges, so the
         # store always returns new tokens and changed_fields will be non-empty.
@@ -128,4 +133,7 @@ execute: |
         snap logout
 
         journal_match '"category":"USER","event":"user_removed","user":\{"snapd_user_id":[0-9]+,"store_user_name":"[^"]*","store_user_email":"[^"]*","expiration":"[^"]*"\}'
+
+        echo "Checking that logout removes the local snapd macaroon audit event"
+        journal_match '"category":"AUTHN","event":"authn_token_delete".*"token_id":[0-9]+'
     fi


### PR DESCRIPTION
Add authn_token_created and authn_token_delete security audit events for local snapd macaroons. Emit them from user create/remove/update paths in auth, only when a snapd-location macaroon is involved, and before the corresponding user lifecycle events.

Spec: [SD236- Security Event Logging - Token Created/Removed](https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0#heading=h.7e8w9gfexu14)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37101