### PR TITLE
o/certstate: use 0755 for generation directories

### DIFF
--- a/overlord/certstate/certs.go
+++ b/overlord/certstate/certs.go
@@ -798,6 +798,10 @@ func refreshCertificateDatabaseImpl() error {
 	if exists, isDir, err := osutil.DirExists(nextPath); err != nil {
 		return err
 	} else if !exists {
+		// ensure proper permissions on the directory before moving it into place
+		if err := os.Chmod(stagedDir, 0o755); err != nil {
+			return fmt.Errorf("cannot set published certificates staging directory permissions: %v", err)
+		}
 		if err := os.Rename(stagedDir, nextPath); err != nil {
 			return fmt.Errorf("cannot publish certificates generation %q: %v", hash, err)
 		}

--- a/overlord/certstate/certs_test.go
+++ b/overlord/certstate/certs_test.go
@@ -910,6 +910,14 @@ func (s *certsTestSuite) TestRefreshCertificateDatabasePublishesImmutableGenerat
 	mergedBundle, err := os.ReadFile(filepath.Join(mergedDir, "ca-certificates.crt"))
 	c.Assert(err, IsNil)
 	c.Check(mergedBundle, DeepEquals, secondBundle)
+
+	firstInfo, err := os.Stat(filepath.Join(dirs.SnapdPKIV1Dir, firstTarget))
+	c.Assert(err, IsNil)
+	c.Check(firstInfo.Mode().Perm(), Equals, os.FileMode(0o755))
+
+	secondInfo, err := os.Stat(filepath.Join(dirs.SnapdPKIV1Dir, secondTarget))
+	c.Assert(err, IsNil)
+	c.Check(secondInfo.Mode().Perm(), Equals, os.FileMode(0o755))
 }
 
 func (s *certsTestSuite) TestRefreshCertificateDatabaseRenamedAcceptedCertificateGetsNewGeneration(c *C) {


### PR DESCRIPTION
Use 0755 permissions on the generated generation directories. This also fixes the two nested remodelling spread tests that use `remote.pull` as the 'ubuntu' remote user. `os.MkdirTemp` creates directories as 0700.

`tests/nested/manual/remodel-to-uc24/task.yaml`
`tests/nested/manual/remodel-uc20-to-uc22/task.yaml`

Both of these pulls the certificate database to verify it.