### PR TITLE
cmd/snap: move debug device-cgroup implementation file under cmd/snapd/cli

### DIFF
--- a/cmd/snapd/cli/cmd_debug_device_cgroup.go
+++ b/cmd/snapd/cli/cmd_debug_device_cgroup.go
@@ -18,7 +18,7 @@
  *
  */
 
-package main
+package cli
 
 import (
 	"fmt"


### PR DESCRIPTION
The branch that moved the files https://github.com/canonical/snapd/pull/17274 and one adding snap debug device-cgroup landed https://github.com/canonical/snapd/pull/17141 independently and showed no conflicts. Yet, the code in master does not build right now.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
