### PR TITLE
tests/core/update-snapd-symlink: also run on UC24 and UC26

### DIFF
--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -7,8 +7,7 @@ details: |
   symlink.
 
 systems:
-  - ubuntu-core-20-*
-  - ubuntu-core-22-*
+  - ubuntu-core-2*
 
 restore: |
   current_rev="$(readlink /snap/snapd/current)"


### PR DESCRIPTION
Enable the test on UC24 and UC26

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
