### PR TITLE
asserts: support Decode/Encode for builtins

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -1056,8 +1056,10 @@ func assemble(headers map[string]any, body, content, signature []byte) (Assertio
 		return nil, fmt.Errorf("assertion body is not utf8")
 	}
 
-	if _, err := checkDigest(headers, "sign-key-sha3-384", crypto.SHA3_384); err != nil {
-		return nil, fmt.Errorf("assertion: %v", err)
+	if !isBuiltinSignature(signature) {
+		if _, err := checkDigest(headers, "sign-key-sha3-384", crypto.SHA3_384); err != nil {
+			return nil, fmt.Errorf("assertion: %v", err)
+		}
 	}
 
 	typ, err := checkNotEmptyString(headers, "type")

--- a/asserts/base_declaration_test.go
+++ b/asserts/base_declaration_test.go
@@ -248,7 +248,8 @@ slots:
 	c.Assert(baseDecl, NotNil)
 
 	cont, _ := baseDecl.Signature()
-	c.Check(string(cont), Equals, strings.TrimSpace(headers))
+	c.Check(strings.HasPrefix(string(cont), strings.TrimSpace(headers)), Equals, true)
+	c.Check(strings.Contains(string(cont), "timestamp:"), Equals, true)
 
 	c.Check(baseDecl.AuthorityID(), Equals, "canonical")
 	c.Check(baseDecl.Series(), Equals, "16")
@@ -256,9 +257,9 @@ slots:
 	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotSnapTypes, DeepEquals, []string{"core"})
 
 	enc := asserts.Encode(baseDecl)
-	// it's expected that it cannot be decoded
-	_, err = asserts.Decode(enc)
-	c.Check(err, NotNil)
+	decoded, err := asserts.Decode(enc)
+	c.Assert(err, IsNil)
+	c.Check(decoded.Type(), Equals, asserts.BaseDeclarationType)
 }
 
 func (s *baseDeclSuite) TestBuiltinInitErrors(c *C) {

--- a/asserts/builtin.go
+++ b/asserts/builtin.go
@@ -22,10 +22,18 @@ package asserts
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"time"
 )
 
 var builtinAssertions []Assertion
+
+// builtinSignature is the special signature marker used for builtin assertions.
+var builtinSignature = []byte("$builtin")
+
+func isBuiltinSignature(sig []byte) bool {
+	return bytes.Equal(bytes.TrimRight(sig, "\n"), builtinSignature)
+}
 
 // Builtin returns a copy of the list of builtin assertions which is assembled
 // at init-time.
@@ -49,8 +57,8 @@ type builtinCheckParams struct {
 // expected headers in checkParams. The assembled assertion carries a special
 // "$builtin" signature marker and is not subject to normal trust verification.
 func assembleBuiltinAssertion(assertType *AssertionType, headerBytes, body []byte, checkParams builtinCheckParams) (Assertion, error) {
-	trimmed := bytes.TrimSpace(headerBytes)
-	h, err := parseHeaders(trimmed)
+	content := bytes.TrimSpace(headerBytes)
+	h, err := parseHeaders(content)
 	if err != nil {
 		return nil, err
 	}
@@ -73,18 +81,35 @@ func assembleBuiltinAssertion(assertType *AssertionType, headerBytes, body []byt
 		}
 	}
 
+	if _, ok := h["sign-key-sha3-384"]; ok {
+		return nil, fmt.Errorf(`cannot assemble builtin %s with "sign-key-sha3-384": cannot be signed`, assertType.Name)
+	}
+
 	revision, err := checkRevision(h)
 	if err != nil {
 		return nil, fmt.Errorf("cannot assemble the builtin %s: %v", assertType.Name, err)
 	}
 
-	h["timestamp"] = time.Now().UTC().Format(time.RFC3339)
+	// inject headers required for encode/decode roundtrip, if any are missing
+	if _, ok := h["timestamp"]; !ok {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		h["timestamp"] = ts
+		content = append(content, []byte("\ntimestamp: "+ts)...)
+	}
+
+	if _, ok := h["body-length"]; !ok && len(body) > 0 {
+		h["body-length"] = strconv.Itoa(len(body))
+		content = append(content, []byte(fmt.Sprintf("\nbody-length: %d", len(body)))...)
+		content = append(content, nlnl...)
+		content = append(content, body...)
+	}
+
 	a, err := assertType.assembler(assertionBase{
 		headers:   h,
 		body:      body,
 		revision:  revision,
-		content:   trimmed,
-		signature: []byte("$builtin"),
+		content:   content,
+		signature: builtinSignature,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot assemble the builtin %s: %v", assertType.Name, err)

--- a/asserts/builtin_test.go
+++ b/asserts/builtin_test.go
@@ -20,6 +20,9 @@
 package asserts_test
 
 import (
+	"bytes"
+	"io"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -30,27 +33,29 @@ type builtinSuite struct{}
 var _ = Suite(&builtinSuite{})
 
 func (s *builtinSuite) TestAssembleBuiltinAssertionChecks(c *C) {
-	headers := []byte(`type: test-only
-authority-id: canonical
-`)
+	basicHeaders := []byte("type: test-only\nauthority-id: canonical")
+	body := []byte(`{}`)
 
 	tests := []struct {
 		name            string
 		order           []string
 		expectedHeaders map[string]any
+		headers         []byte
 		error           string
 	}{
 		{
-			name:  "order/expectedHeaders length mismatch",
-			order: []string{"authority-id", "series"},
+			name:    "order/expectedHeaders length mismatch",
+			order:   []string{"authority-id", "series"},
+			headers: basicHeaders,
 			expectedHeaders: map[string]any{
 				"authority-id": "canonical",
 			},
 			error: `internal error: inconsistent length of order checking list \(2\) and expected values map \(1\)`,
 		},
 		{
-			name:  "field in order missing from expectedHeaders",
-			order: []string{"authority-id", "series"},
+			name:    "field in order missing from expectedHeaders",
+			order:   []string{"authority-id", "series"},
+			headers: basicHeaders,
 			expectedHeaders: map[string]any{
 				"authority-id": "canonical",
 				"other-field":  "bar",
@@ -58,19 +63,22 @@ authority-id: canonical
 			error: `the builtin test-only "series" header is missing an expected value`,
 		},
 		{
-			name:  "header value does not match expected",
-			order: []string{"authority-id"},
+			name:    "header value does not match expected",
+			order:   []string{"authority-id"},
+			headers: basicHeaders,
 			expectedHeaders: map[string]any{
 				"authority-id": "other-authority",
 			},
 			error: `the builtin test-only "authority-id" header is not set to expected value "other-authority"`,
 		},
 		{
-			name:  "happy",
-			order: []string{"authority-id"},
+			name:    "sign-key-sha3-384 header present",
+			order:   []string{"authority-id"},
+			headers: []byte("type: test-only\nauthority-id: canonical\nsign-key-sha3-384: abc\n"),
 			expectedHeaders: map[string]any{
 				"authority-id": "canonical",
 			},
+			error: `cannot assemble builtin test-only with "sign-key-sha3-384": cannot be signed`,
 		},
 	}
 
@@ -81,7 +89,7 @@ authority-id: canonical
 			ExpectedHeaders: t.expectedHeaders,
 		}
 
-		as, err := asserts.AssembleBuiltinAssertion(asserts.TestOnlyType, headers, nil, checkParams)
+		as, err := asserts.AssembleBuiltinAssertion(asserts.TestOnlyType, t.headers, body, checkParams)
 		if t.error != "" {
 			c.Check(err, ErrorMatches, t.error, cmt)
 			c.Check(as, IsNil, cmt)
@@ -89,6 +97,68 @@ authority-id: canonical
 			c.Assert(err, IsNil, cmt)
 			c.Check(as.Type(), Equals, asserts.TestOnlyType, cmt)
 			c.Check(as.HeaderString("authority-id"), Equals, "canonical", cmt)
+			// injects timestamp and body-length if none is provided
+			c.Check(as.HeaderString("timestamp"), Not(Equals), "")
+			c.Check(as.HeaderString("body-length"), Not(Equals), "")
 		}
 	}
+}
+
+func (s *builtinSuite) TestBuiltinAssertionEncodeDecodeRoundTrip(c *C) {
+	headers := []byte(`type: test-only
+authority-id: canonical
+primary-key: primary-key-val
+`)
+	checkParams := asserts.BuiltinCheckParams{
+		Order:           []string{"authority-id"},
+		ExpectedHeaders: map[string]any{"authority-id": "canonical"},
+	}
+
+	original, err := asserts.AssembleBuiltinAssertion(asserts.TestOnlyType, headers, nil, checkParams)
+	c.Assert(err, IsNil)
+
+	encoded := asserts.Encode(original)
+	decoded, err := asserts.Decode(encoded)
+	c.Assert(err, IsNil)
+	c.Check(decoded.Type(), Equals, asserts.TestOnlyType)
+	c.Check(decoded.HeaderString("authority-id"), Equals, "canonical")
+	c.Check(decoded.HeaderString("primary-key"), Equals, "primary-key-val")
+
+	_, signature := decoded.Signature()
+	c.Check(string(signature), Equals, "$builtin")
+}
+
+func (s *builtinSuite) TestBuiltinAssertionStreamDecodeRoundTrip(c *C) {
+	headers := []byte(`type: test-only
+authority-id: canonical
+primary-key: primary-key-val
+`)
+	checkParams := asserts.BuiltinCheckParams{
+		Order:           []string{"authority-id"},
+		ExpectedHeaders: map[string]any{"authority-id": "canonical"},
+	}
+
+	original, err := asserts.AssembleBuiltinAssertion(asserts.TestOnlyType, headers, nil, checkParams)
+	c.Assert(err, IsNil)
+
+	// encode two copies into a stream
+	var buf bytes.Buffer
+	enc := asserts.NewEncoder(&buf)
+	c.Assert(enc.Encode(original), IsNil)
+	c.Assert(enc.Encode(original), IsNil)
+
+	// decode them back
+	dec := asserts.NewDecoder(&buf)
+	for i := 0; i < 2; i++ {
+		decoded, err := dec.Decode()
+		c.Assert(err, IsNil, Commentf("assertion %d", i))
+		c.Check(decoded.Type(), Equals, asserts.TestOnlyType)
+		c.Check(decoded.HeaderString("primary-key"), Equals, "primary-key-val")
+
+		_, signature := decoded.Signature()
+		c.Check(string(bytes.TrimRight(signature, "\n")), Equals, "$builtin")
+	}
+
+	_, err = dec.Decode()
+	c.Check(err, Equals, io.EOF)
 }

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -122,28 +122,29 @@ views:
         storage: v1.{account}.{set-name}.pinned-sequence
         access: read-write
 `),
+			// NOTE: JSON needs to be sorted, otherwise decoding validation would fail
 			"body": []byte(`{
   "storage": {
     "aliases": {
       "account-id": {
-        "type": "string",
-        "pattern": "^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28})$"
-      },
-      "set-name": {
-        "type": "string",
-        "pattern": "^[a-z0-9](?:-?[a-z0-9])*$"
+        "pattern": "^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28})$",
+        "type": "string"
       },
       "natural-number": {
-        "type": "int",
-        "min": 1
+        "min": 1,
+        "type": "int"
       },
       "presence": {
-        "type": "string",
         "choices": [
           "required",
           "optional",
           "invalid"
-        ]
+        ],
+        "type": "string"
+      },
+      "set-name": {
+        "pattern": "^[a-z0-9](?:-?[a-z0-9])*$",
+        "type": "string"
       }
     },
     "schema": {
@@ -157,11 +158,11 @@ views:
             ],
             "schema": {
               "mode": {
-                "type": "string",
                 "choices": [
                   "monitor",
                   "enforce"
-                ]
+                ],
+                "type": "string"
               },
               "pinned-sequence": "${natural-number}",
               "revision": "${natural-number}",
@@ -171,10 +172,6 @@ views:
                 "unique": true,
                 "values": {
                   "schema": {
-                    "id": "string",
-                    "name": "string",
-                    "presence": "${presence}",
-                    "revision": "${natural-number}",
                     "components": {
                       "values": {
                         "schema": {
@@ -182,16 +179,20 @@ views:
                           "revision": "${natural-number}"
                         }
                       }
-                    }
+                    },
+                    "id": "string",
+                    "name": "string",
+                    "presence": "${presence}",
+                    "revision": "${natural-number}"
                   }
                 }
               },
               "status": {
-                "type": "string",
                 "choices": [
                   "valid",
                   "invalid"
-                ]
+                ],
+                "type": "string"
               }
             }
           }

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -271,6 +271,26 @@ func (s *confdbSuite) TestAssembleAndSignChecksSchemaFormatFail(c *C) {
 	c.Assert(err, ErrorMatches, `assertion confdb-schema: JSON in body must be indented with 2 spaces and sort object entries by key`)
 }
 
+func (s *confdbSuite) TestBuiltinConfdbSchemaDecodeRoundTrip(c *C) {
+	var systemConfdbs []asserts.Assertion
+	for _, builtin := range asserts.Builtin() {
+		if builtin.Type() != asserts.ConfdbSchemaType {
+			continue
+		}
+		systemConfdbs = append(systemConfdbs, builtin)
+	}
+	c.Assert(systemConfdbs, Not(HasLen), 0)
+
+	for _, builtin := range systemConfdbs {
+		encoded := asserts.Encode(builtin)
+		decoded, err := asserts.Decode(encoded)
+		c.Assert(err, IsNil, Commentf("failed to decode builtin confdb-schema %q", builtin.HeaderString("name")))
+		c.Check(decoded.Type(), Equals, asserts.ConfdbSchemaType)
+		c.Check(decoded.HeaderString("name"), Equals, builtin.HeaderString("name"))
+		c.Check(decoded.HeaderString("account-id"), Equals, builtin.HeaderString("account-id"))
+	}
+}
+
 type confdbCtrlSuite struct {
 	db *asserts.Database
 }


### PR DESCRIPTION
Support encoding and decoding builtin assertions so users can run `snap known` for system assertions like the `base-declaration` and system `confdb-schema`.
https://warthogs.atlassian.net/browse/SNAPDENG-37046