### PR TITLE
o/snapstate, o/devicestate: rework how SnapSetup.SnapPath is used

### DIFF
--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1858,17 +1858,19 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	s.setupSnapRevisionForFileAndID(c, fooSnap, s.ss.AssertedSnapID("foo"), "canonical", snap.R(99))
 	snapsupBar := snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "bar", SnapID: s.ss.AssertedSnapID("bar"), Revision: snap.R(100)},
-		SnapPath: barSnap,
 	}
 	s.setupSnapDeclForNameAndID(c, "bar", s.ss.AssertedSnapID("bar"), "canonical")
 	s.setupSnapRevisionForFileAndID(c, barSnap, s.ss.AssertedSnapID("bar"), "canonical", snap.R(100))
-	// when download completes, the files will be at /var/lib/snapd/snap
-	c.Assert(os.MkdirAll(filepath.Dir(snapsupFoo.BlobPath()), 0755), IsNil)
-	c.Assert(os.Rename(fooSnap, snapsupFoo.BlobPath()), IsNil)
-	c.Assert(os.MkdirAll(filepath.Dir(snapsupBar.BlobPath()), 0755), IsNil)
-	c.Assert(os.Rename(barSnap, snapsupBar.BlobPath()), IsNil)
-	tSnapsup1.Set("snap-setup", snapsupFoo)
+
+	// bar represents a downloaded snap setup at its canonical blob path.
+	barBlob := snapsupBar.BlobPath()
+	c.Assert(os.MkdirAll(filepath.Dir(barBlob), 0755), IsNil)
+	c.Assert(os.Rename(barSnap, barBlob), IsNil)
 	tSnapsup2.Set("snap-setup", snapsupBar)
+
+	// foo represents a local-path setup before mount-snap has consumed
+	// SnapPath.
+	tSnapsup1.Set("snap-setup", snapsupFoo)
 
 	tss, err := devicestate.CreateRecoverySystemTasks(s.state, "1234", []string{tSnapsup1.ID(), tSnapsup2.ID()}, nil, devicestate.CreateRecoverySystemOptions{
 		TestSystem: true,

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -357,9 +357,13 @@ func (ig *setupInfoGetter) SnapInfo(st *state.State, name string) (info *snap.In
 		if snapsup.SnapName() != name {
 			continue
 		}
-		// by the time this task runs, the file has already been
-		// downloaded and validated
-		snapFile, err := snapfile.Open(snapsup.BlobPath())
+		// local path tasks carry SnapPath until mount-snap consumes it; otherwise
+		// use the canonical blob path prepared by download-snap or mount-snap.
+		snapPath := snapsup.SnapPath
+		if snapPath == "" {
+			snapPath = snapsup.BlobPath()
+		}
+		snapFile, err := snapfile.Open(snapPath)
 		if err != nil {
 			return nil, "", false, err
 		}
@@ -368,7 +372,7 @@ func (ig *setupInfoGetter) SnapInfo(st *state.State, name string) (info *snap.In
 			return nil, "", false, err
 		}
 
-		return info, info.MountFile(), true, nil
+		return info, snapPath, true, nil
 	}
 
 	// either a remodel scenario, in which case the snap is not

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -916,20 +916,18 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	st.Lock()
+	defer st.Unlock()
+
+	perfTimings.Save(st)
 
 	// nothing else should use SnapPath anymore, since that path might not even
 	// exist, in the case that the file was removed above. to prevent this, we
 	// clear it out
 	snapsup.SnapPath = ""
 	if err := SetTaskSnapSetup(t, snapsup); err != nil {
-		st.Unlock()
 		return err
 	}
 	t.SetStatus(state.DoneStatus)
-
-	perfTimings.Save(st)
-
-	st.Unlock()
 
 	return nil
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -916,7 +916,19 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	st.Lock()
+
+	// nothing else should use SnapPath anymore, since that path might not even
+	// exist, in the case that the file was removed above. to prevent this, we
+	// clear it out
+	snapsup.SnapPath = ""
+	if err := SetTaskSnapSetup(t, snapsup); err != nil {
+		st.Unlock()
+		return err
+	}
+	t.SetStatus(state.DoneStatus)
+
 	perfTimings.Save(st)
+
 	st.Unlock()
 
 	return nil

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -69,6 +69,40 @@ func (s *mountSnapSuite) TestDoMountSnapDoesNotRemovesSnaps(c *C) {
 	c.Assert(osutil.FileExists(testSnap), Equals, true)
 }
 
+func (s *mountSnapSuite) TestDoMountSnapRemoveSnapPathClearsSnapSetup(c *C) {
+	v1 := "name: foo\nversion: 1.0\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+
+	t := s.state.NewTask("mount-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+		},
+		SnapPath: testSnap,
+		Flags:    snapstate.Flags{RemoveSnapPath: true},
+	})
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(osutil.FileExists(testSnap), Equals, false)
+
+	snapsup, err := snapstate.TaskSnapSetup(t)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.SnapPath, Equals, "")
+}
+
 func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 	v1 := "name: core\nversion: 1.0\nepoch: 1\n"
 	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)

--- a/overlord/snapstate/snap.go
+++ b/overlord/snapstate/snap.go
@@ -115,6 +115,20 @@ func (sc *snapInstallChoreographer) runRefreshHooks() bool {
 }
 
 func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *taskChainSpan, ic installContext) ([]*state.Task, error) {
+	if sc.revisionIsPresent() && sc.snapsup.RemoveSnapPath {
+		// If the revision is local, we will not need the temporary snap. This
+		// can happen when e.g. side-loading a local revision again. The
+		// SnapPath is only needed in the "mount-snap" handler and that is
+		// skipped for local revisions.
+		if err := os.Remove(sc.snapsup.SnapPath); err != nil {
+			return nil, err
+		}
+
+		// before snapsup is attached to the tasks, clear it out. a path that
+		// points to nothing isn't useful any more.
+		sc.snapsup.SnapPath = ""
+	}
+
 	prereq := st.NewTask("prerequisites", fmt.Sprintf(
 		i18n.G("Ensure prerequisites for %q are available"), sc.snapsup.InstanceName()))
 	prereq.Set("snap-setup", sc.snapsup)
@@ -131,6 +145,7 @@ func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *tas
 			i18n.G("Download snap %q%s from channel %q"),
 			sc.snapsup.InstanceName(), sc.revisionString(), sc.snapsup.Channel))
 	}
+
 	prepare.Set("snap-setup", sc.snapsup)
 	prepare.WaitFor(prereq)
 	s.AppendWithoutData(prepare)
@@ -168,16 +183,6 @@ func (sc *snapInstallChoreographer) BeforeLocalSystemMod(st *state.State, s *tas
 }
 
 func (sc *snapInstallChoreographer) UpToLinkSnapAndBeforeReboot(st *state.State, s *taskChainSpan, ic installContext) ([]*state.Task, error) {
-	if sc.revisionIsPresent() && sc.snapsup.Flags.RemoveSnapPath {
-		// If the revision is local, we will not need the temporary snap. This
-		// can happen when e.g. side-loading a local revision again. The
-		// SnapPath is only needed in the "mount-snap" handler and that is
-		// skipped for local revisions.
-		if err := os.Remove(sc.snapsup.SnapPath); err != nil {
-			return nil, err
-		}
-	}
-
 	removeExtraComps, discardExtraComps, err := removeExtraComponentsTasks(st, sc.snapst, sc.snapsup.Revision(), sc.compsups)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1009,9 +1009,15 @@ func (s *snapmgrTestSuite) TestInstallRemovesSnapPathWhenRevisionPresent(c *C) {
 		Flags:    snapstate.Flags{RemoveSnapPath: true},
 	}
 
-	_, err := snapstate.DoInstallOrPreDownload(s.state, snapst, snapsup, nil, snapstate.InstallContext{})
+	installTS, err := snapstate.DoInstallOrPreDownload(s.state, snapst, snapsup, nil, snapstate.InstallContext{})
 	c.Assert(err, IsNil)
 	c.Check(snapPath, testutil.FileAbsent)
+
+	setupTask, err := installTS.TaskSet().Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	updated, err := snapstate.TaskSnapSetup(setupTask)
+	c.Assert(err, IsNil)
+	c.Check(updated.SnapPath, Equals, "")
 }
 
 func (s *snapmgrTestSuite) TestInstallSnapdConflictExclusiveKind(c *C) {
@@ -1539,7 +1545,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 
 	c.Assert(snapsup.Channel, Equals, "channel-for-media")
 	c.Assert(snapsup.UserID, Equals, s.user.ID)
-	c.Assert(snapsup.SnapPath, Matches, `.*some-snap_11.snap`)
+	c.Assert(snapsup.SnapPath, Equals, "")
 	c.Assert(snapsup.DownloadInfo, DeepEquals, &snap.DownloadInfo{
 		DownloadURL: "https://some-server.com/some/path.snap",
 		Size:        5,
@@ -1893,9 +1899,8 @@ func (s *snapmgrTestSuite) testParallelInstanceInstallRunThrough(c *C, inputFlag
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel:  "some-channel",
-		UserID:   s.user.ID,
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_instance_11.snap"),
+		Channel: "some-channel",
+		UserID:  s.user.ID,
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -2268,9 +2273,8 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel:  "some-channel",
-		UserID:   s.user.ID,
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_666.snap"),
+		Channel: "some-channel",
+		UserID:  s.user.ID,
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -2485,9 +2489,8 @@ func (s *snapmgrTestSuite) testInstallWithRevisionRunThrough(c *C, snapName, req
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel:  setupChannel,
-		UserID:   s.user.ID,
-		SnapPath: filepath.Join(dirs.SnapBlobDir, snapFileName),
+		Channel: setupChannel,
+		UserID:  s.user.ID,
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -2661,7 +2664,6 @@ version: 1.0`)
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath:  mockSnap,
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeApp,
 		Version:   "1.0",
@@ -2801,7 +2803,6 @@ epoch: 1*
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath:                        mockSnap,
 		SideInfo:                        snapsup.SideInfo,
 		Type:                            snap.TypeApp,
 		Version:                         "1.0",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1348,7 +1348,6 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		Channel: "channel-for-components",
 		UserID:  s.user.ID,
 
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-kernel_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -1630,7 +1629,6 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 		CohortKey: "some-cohort",
 		UserID:    s.user.ID,
 
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "services-snap_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -2022,7 +2020,6 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 		Channel: "some-channel",
 		UserID:  s.user.ID,
 
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "services-snap_instance_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -2383,7 +2380,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 		Channel: "18/edge",
 		UserID:  s.user.ID,
 
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "kernel_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -17815,7 +17811,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		Channel: channel,
 		UserID:  s.user.ID,
 
-		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, newSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      opts.snapType,
 		Version:   snapName + "Ver",
@@ -17832,6 +17827,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
 		}
+	} else {
+		expectedSnapsup.SnapPath = filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, newSnapRev))
 	}
 
 	c.Assert(snapsup, DeepEquals, expectedSnapsup)
@@ -18312,7 +18309,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 		Channel: channel,
 		UserID:  s.user.ID,
 
-		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, newSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
 		Version:   "kernelVer",
@@ -19023,7 +19019,6 @@ components:
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel:   channel,
-		SnapPath:  snapPath,
 		SideInfo:  snapsup.SideInfo,
 		Type:      snapType,
 		Version:   "some-snapVer",

--- a/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
+++ b/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
@@ -3,7 +3,8 @@ summary: refresh seed when a model snap moves back to an existing revision
 details: |
   Verify that moving a model snap back to an existing revision triggers a
   seed-refresh on Ubuntu Core. Covers snap refresh --revision, snap install from
-  a local path, and revert for kernel, gadget, base, and app snaps.
+  a local path, snap install from a local path after removing the target
+  revision, and revert for kernel, gadget, base, and app snaps.
 
 systems:
   - -ubuntu-1*
@@ -44,6 +45,8 @@ environment:
 
   BACK_TO_REVISION_METHOD/install_path_kernel: install-path
   SNAP_UNDER_TEST/install_path_kernel: kernel
+  BACK_TO_REVISION_METHOD/install_path_removed_app: install-path-removed
+  SNAP_UNDER_TEST/install_path_removed_app: app
 
 skip:
   - reason: This test needs test keys to be trusted
@@ -201,8 +204,6 @@ execute: |
 
   run_seed_refresh_change() {
     local command="$1"
-    local local_revision="${2:-}"
-    local source_kind="${3:-store-or-existing}"
     local change_id boot_id
 
     boot_id="$(tests.nested boot-id)"
@@ -212,14 +213,6 @@ execute: |
     retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\\s+(Done|Undone|Error)'"
     remote.exec 'sudo snap changes' | MATCH "^${change_id}\\s+Done"
     remote.exec "sudo snap tasks ${change_id}" | MATCH 'Create recovery system with label'
-    if [ -n "${local_revision}" ]; then
-      remote.exec "sudo snap tasks ${change_id}" | NOMATCH "Download snap \"${snap_name}\""
-      if [ "${source_kind}" = install-path ]; then
-        remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .+ \(${local_revision}\)"
-      else
-        remote.exec "sudo snap tasks ${change_id}" | MATCH "Prepare snap .*/${snap_name}_${local_revision}.snap"
-      fi
-    fi
   }
 
   case "${SNAP_UNDER_TEST}" in
@@ -278,12 +271,19 @@ execute: |
       ;;
     refresh)
       assert_snap_revision_in_sequence "${snap_name}" 2
-      run_seed_refresh_change "sudo snap refresh --revision=2 --no-wait ${snap_name}" 2
+      run_seed_refresh_change "sudo snap refresh --revision=2 --no-wait ${snap_name}"
       ;;
     install-path)
       assert_snap_revision_in_sequence "${snap_name}" 2
       remote.push "./${snap_name}-rev2.snap"
-      run_seed_refresh_change "sudo snap install --no-wait ./${snap_name}-rev2.snap" 2 install-path
+      run_seed_refresh_change "sudo snap install --no-wait ./${snap_name}-rev2.snap"
+      ;;
+    install-path-removed)
+      assert_snap_revision_in_sequence "${snap_name}" 2
+      remote.exec "sudo snap remove --revision=2 ${snap_name}"
+      remote.push "./${snap_name}-rev2.snap"
+      remote.exec "test ! -e /var/lib/snapd/snaps/${snap_name}_2.snap"
+      run_seed_refresh_change "sudo snap install --no-wait ./${snap_name}-rev2.snap"
       ;;
     *)
       echo "unexpected BACK_TO_REVISION_METHOD: ${BACK_TO_REVISION_METHOD}"


### PR DESCRIPTION
If we can make a non-empty `SnapSetup.SnapPath` imply that the file should exist on disk, then we can use that assumption during seed creation.