### PR TITLE
bootloader: make the logging less verbose

### DIFF
--- a/bootloader/withbootassettesting.go
+++ b/bootloader/withbootassettesting.go
@@ -50,7 +50,7 @@ func MaybeInjectTestingBootloaderAssets() {
 	}
 
 	// log an info level message, it is a testing build of snapd anyway
-	logger.Noticef("maybe inject boot assets?")
+	logger.Debugf("maybe inject boot assets?")
 
 	// is there a marker file at /usr/lib/snapd/ in the snap?
 	selfExe, err := maybeInjectOsReadlink("/proc/self/exe")
@@ -60,7 +60,7 @@ func MaybeInjectTestingBootloaderAssets() {
 
 	injectPieceRaw, err := os.ReadFile(filepath.Join(filepath.Dir(selfExe), "bootassetstesting"))
 	if os.IsNotExist(err) {
-		logger.Noticef("no boot asset testing marker")
+		logger.Debugf("no boot asset testing marker")
 		return
 	}
 	if len(injectPieceRaw) == 0 {


### PR DESCRIPTION
Only log at notice level when conditions for injecting boot assets are met.

Cherry picked from https://github.com/canonical/snapd/pull/17145

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
