### PR TITLE
boot/makebootable.go: make reprovision only seal

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -474,6 +474,46 @@ func isSealModeenvLocked() bool {
 	return atomic.LoadInt32(&sealModeenvLocked) == 1
 }
 
+func makeRunnableSystemSeal(modeenv *Modeenv, model *asserts.Model, protector secboot.KeyProtectorFactory, encryption *EncryptionSetup, makeOpts makeRunnableOptions) error {
+	tokens := UseTokens(model)
+	if tokens {
+		logger.Debugf("key data will be stored in tokens")
+	} else {
+		logger.Debugf("key data will be stored in files")
+	}
+
+	flags := sealKeyToModeenvFlags{
+		HookKeyProtectorFactory:   protector,
+		LegacyFactoryResetKeyPath: makeOpts.LegacyFactoryResetKeyPath,
+		Reprovision:               makeOpts.Reprovision,
+		SeedDir:                   makeOpts.SeedDir,
+		StateUnlocker:             makeOpts.StateUnlocker,
+		UseTokens:                 tokens,
+	}
+
+	if makeOpts.Standalone {
+		flags.SnapsDir = dirs.SnapBlobDirUnder(InstallHostWritableDir(model))
+	}
+
+	// seal the encryption key to the parameters specified in
+	// modeenv as well as optimum PCR configuration specified in the
+	// check result (when available)
+	if err := sealKeyToModeenv(
+		encryption.dataBootstrappedContainer,
+		encryption.saveBootstrappedContainer,
+		encryption.primaryKey,
+		encryption.volumesAuth,
+		encryption.checkResult,
+		model,
+		modeenv,
+		flags,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup, makeOpts makeRunnableOptions) error {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return fmt.Errorf("internal error: cannot make pre-UC20 system runnable")
@@ -668,37 +708,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, bootAssets 
 			return fmt.Errorf("cannot check for fde-setup hook key protector: %v", err)
 		}
 
-		tokens := UseTokens(model)
-		if tokens {
-			logger.Debugf("key data will be stored in tokens")
-		} else {
-			logger.Debugf("key data will be stored in files")
-		}
-
-		flags := sealKeyToModeenvFlags{
-			HookKeyProtectorFactory:   protector,
-			LegacyFactoryResetKeyPath: makeOpts.LegacyFactoryResetKeyPath,
-			Reprovision:               makeOpts.Reprovision,
-			SeedDir:                   makeOpts.SeedDir,
-			StateUnlocker:             makeOpts.StateUnlocker,
-			UseTokens:                 tokens,
-		}
-		if makeOpts.Standalone {
-			flags.SnapsDir = snapBlobDir
-		}
-		// seal the encryption key to the parameters specified in
-		// modeenv as well as optimum PCR configuration specified in the
-		// check result (when available)
-		if err := sealKeyToModeenv(
-			encryption.dataBootstrappedContainer,
-			encryption.saveBootstrappedContainer,
-			encryption.primaryKey,
-			encryption.volumesAuth,
-			encryption.checkResult,
-			model,
-			modeenv,
-			flags,
-		); err != nil {
+		if err := makeRunnableSystemSeal(modeenv, model, protector, encryption, makeOpts); err != nil {
 			return err
 		}
 	}
@@ -813,8 +823,16 @@ func MakeRunnableSystemAfterDataReset(model *asserts.Model, bootWith *BootableSe
 // MakeRunnableSystemReprovision make the systems currently running bootable again.
 // This is intended to repair the boot of a system that was booted for example
 // with a recovery key.
-func MakeRunnableSystemReprovision(model *asserts.Model, bootWith *BootableSet, bootAssets BootAssets, encryption *EncryptionSetup) error {
-	return makeRunnableSystem(model, bootWith, bootAssets, encryption, makeRunnableOptions{
+func MakeRunnableSystemReprovision(model *asserts.Model, protector secboot.KeyProtectorFactory, encryption *EncryptionSetup) error {
+	sealModeenvLock()
+	defer sealModeenvUnlock()
+
+	modeenv, err := ReadModeenv("")
+	if err != nil {
+		return err
+	}
+
+	return makeRunnableSystemSeal(modeenv, model, protector, encryption, makeRunnableOptions{
 		Reprovision: true,
 		SeedDir:     dirs.SnapSeedDir,
 	})

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -580,7 +580,6 @@ func (s *makeBootable20Suite) TestMakeSystemRunnableSealWithHookKeyProtector(c *
 type testMakeSystemRunnable20Opts struct {
 	standalone           bool
 	factoryReset         bool
-	reprovision          bool
 	classic              bool
 	fromInitrd           bool
 	withKComps           bool
@@ -822,7 +821,7 @@ version: 5.0
 		c.Assert(recoveryGrub.Hashes, HasLen, 1)
 		c.Check(recoveryGrub.Hashes[0], Equals, "aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5")
 
-		c.Check(params.Reprovision, Equals, opts.reprovision || opts.factoryReset)
+		c.Check(params.Reprovision, Equals, opts.factoryReset)
 		c.Check(params.LegacyFactoryResetKeyPath, Equals, opts.factoryReset)
 		if opts.classic {
 			c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data"))
@@ -870,8 +869,6 @@ version: 5.0
 		c.Check(u.unlocked, Equals, 1)
 	case opts.factoryReset && !opts.fromInitrd:
 		err = boot.MakeRunnableSystemAfterDataReset(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
-	case opts.reprovision && !opts.fromInitrd:
-		err = boot.MakeRunnableSystemReprovision(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	default:
 		err = boot.MakeRunnableSystem(model, bootWith, obs.BootAssets(), obs.EncryptionSetup())
 	}
@@ -1047,16 +1044,6 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20FactoryResetOnClassic(c *C
 		classic:      true,
 		fromInitrd:   false,
 		withKComps:   true,
-	})
-}
-
-func (s *makeBootable20Suite) TestMakeSystemRunnable20Reprovision(c *C) {
-	s.testMakeSystemRunnable20(c, testMakeSystemRunnable20Opts{
-		standalone:  false,
-		reprovision: true,
-		classic:     false,
-		fromInitrd:  false,
-		withKComps:  true,
 	})
 }
 
@@ -2607,4 +2594,184 @@ func (s *makeBootable20Suite) TestMakeBootableImageOptionalKernelArgsSignedAndDa
 	}
 	// The option is ignored if non-dangerous model
 	s.testMakeBootableImageOptionalKernelArgs(c, model, options, "", "")
+}
+
+func (s *makeBootable20Suite) TestMakeSystemRunnableReprovision(c *C) {
+	/* baseName := "core26" */
+	fakeProc := c.MkDir()
+	fakeCmdline := filepath.Join(fakeProc, "cmdline")
+	defer kcmdline.MockProcCmdline(fakeCmdline)()
+	err := os.WriteFile(fakeCmdline, []byte(fmt.Sprintf("some ubuntu-core.force-experimental-tokens=1 args")), 0644)
+	c.Assert(err, IsNil)
+
+	restore := release.MockOnClassic(true)
+	defer restore()
+	dirs.SetRootDir(dirs.GlobalRootDir)
+
+	bootloader.Force(nil)
+
+	var model *asserts.Model
+	model = boottest.MakeMockUC20Model(map[string]any{
+		"classic":      "true",
+		"distribution": "ubuntu",
+	})
+	/*seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)*/
+
+	mockSeedGrubDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI", "ubuntu")
+	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
+	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	c.Assert(err, IsNil)
+	genv := grubenv.NewEnv(filepath.Join(mockSeedGrubDir, "grubenv"))
+	c.Assert(genv.Save(), IsNil)
+
+	mockBootGrubDir := filepath.Join(boot.InitramfsUbuntuBootDir, "EFI", "ubuntu")
+	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
+	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
+	c.Assert(err, IsNil)
+
+	myKey := secboot.CreateMockBootstrappedContainer()
+	myKey2 := secboot.CreateMockBootstrappedContainer()
+	chosenPrimaryKey := []byte("primarykey!")
+	myVolumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
+	myCheckResult := &secboot.PreinstallCheckResult{}
+
+	encryptionSetup := boot.NewEncryptionSetup(
+		myKey, myKey2,
+		chosenPrimaryKey,
+		myVolumesAuth,
+		myCheckResult,
+	)
+
+	var readSystemEssentialCalls []string
+	restore = boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
+		readSystemEssentialCalls = append(readSystemEssentialCalls, label)
+		c.Check(seedDir, Equals, dirs.SnapSeedDir)
+		if label == "test" {
+			return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
+		} else {
+			return model, []*seed.Snap{mockKernelSeedSnap(snap.R(2)), mockGadgetSeedSnap(c, nil)}, nil
+		}
+	})
+	defer restore()
+
+	kernel2, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_2.snap")
+	c.Assert(err, IsNil)
+
+	kernel3, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_3.snap")
+	c.Assert(err, IsNil)
+
+	sealKeyForBootChainsCalled := 0
+	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, checkResult *secboot.PreinstallCheckResult, params *boot.SealKeyForBootChainsParams) error {
+		sealKeyForBootChainsCalled++
+		c.Check(method, Equals, device.SealingMethodTPM)
+		c.Check(key, Equals, myKey)
+		c.Check(saveKey, Equals, myKey2)
+		c.Check(primaryKey, DeepEquals, chosenPrimaryKey)
+		c.Check(volumesAuth, Equals, myVolumesAuth)
+		c.Check(checkResult, Equals, myCheckResult)
+
+		recoveryBootLoader, hasRecovery := params.RoleToBlName[bootloader.RoleRecovery]
+		c.Assert(hasRecovery, Equals, true)
+		c.Check(recoveryBootLoader, Equals, "grub")
+		runBootLoader, hasRun := params.RoleToBlName[bootloader.RoleRunMode]
+		c.Assert(hasRun, Equals, true)
+		c.Check(runBootLoader, Equals, "grub")
+
+		c.Assert(params.RunModeBootChains, HasLen, 2)
+		for n, runBootChain := range params.RunModeBootChains {
+			c.Check(runBootChain.Model, Equals, model.Model())
+			c.Check(runBootChain.KernelCmdlines, DeepEquals, []string{"foo", "bar"})
+			c.Check(runBootChain.KernelBootFile.Path, Equals, "kernel.efi")
+			switch n {
+			case 0:
+				c.Check(runBootChain.KernelBootFile.Snap, Equals, filepath.Join(dirs.SnapBlobDir, "pc-kernel_2.snap"))
+			case 1:
+				c.Check(runBootChain.KernelBootFile.Snap, Equals, filepath.Join(dirs.SnapBlobDir, "pc-kernel_3.snap"))
+			}
+			c.Check(runBootChain.KernelBootFile.Role, Equals, bootloader.RoleRunMode)
+			c.Assert(runBootChain.AssetChain, HasLen, 3)
+			runShim := runBootChain.AssetChain[0]
+			runGrub := runBootChain.AssetChain[1]
+			runGrubRun := runBootChain.AssetChain[2]
+			c.Check(runShim.Name, Equals, "bootx64.efi")
+			c.Check(runShim.Hashes, DeepEquals, []string{"shimhash1", "shimhash2"})
+			c.Check(runGrub.Name, Equals, "grubx64.efi")
+			c.Check(runGrub.Hashes, DeepEquals, []string{"recovery-hash1"})
+			c.Check(runGrubRun.Name, Equals, "grubx64.efi")
+			c.Check(runGrubRun.Hashes, DeepEquals, []string{"hash1", "hash2"})
+		}
+
+		c.Check(params.RecoveryBootChainsForRunKey, HasLen, 0)
+		c.Assert(params.RecoveryBootChains, HasLen, 2)
+		for n, recoveryBootChain := range params.RecoveryBootChains {
+			c.Check(recoveryBootChain.KernelBootFile.Path, Equals, "kernel.efi")
+			switch n {
+			case 0:
+				c.Check(recoveryBootChain.KernelBootFile.Snap, Equals, "/var/lib/snapd/seed/snaps/pc-kernel_1.snap")
+			case 1:
+				c.Check(recoveryBootChain.KernelBootFile.Snap, Equals, "/var/lib/snapd/seed/snaps/pc-kernel_2.snap")
+			}
+			c.Check(recoveryBootChain.KernelBootFile.Role, Equals, bootloader.RoleRecovery)
+			c.Check(recoveryBootChain.Model, Equals, model.Model())
+			c.Assert(recoveryBootChain.AssetChain, HasLen, 2)
+			recoveryShim := recoveryBootChain.AssetChain[0]
+			recoveryGrub := recoveryBootChain.AssetChain[1]
+			c.Check(recoveryShim.Name, Equals, "bootx64.efi")
+			c.Check(recoveryShim.Hashes, DeepEquals, []string{"shimhash1", "shimhash2"})
+			c.Check(recoveryGrub.Name, Equals, "grubx64.efi")
+			c.Check(recoveryGrub.Hashes, DeepEquals, []string{"recovery-hash1"})
+		}
+
+		c.Check(params.Reprovision, Equals, true)
+		c.Check(params.LegacyFactoryResetKeyPath, Equals, false)
+		c.Check(params.InstallHostWritableDir, Equals, filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data"))
+
+		c.Check(params.UseTokens, Equals, true)
+
+		return nil
+	})
+	defer restore()
+
+	restore = boot.MockCryptsetupSupportsTokenReplace(true)
+	defer restore()
+
+	modeenv := &boot.Modeenv{
+		Mode:                   "run",
+		RecoverySystem:         "test",
+		CurrentRecoverySystems: []string{"test", "other"},
+		GoodRecoverySystems:    []string{"test", "other"},
+
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"grubx64.efi": []string{"hash1", "hash2"},
+		},
+		CurrentTrustedRecoveryBootAssets: boot.BootAssetsMap{
+			"bootx64.efi": []string{"shimhash1", "shimhash2"},
+			"grubx64.efi": []string{"recovery-hash1"},
+		},
+		CurrentKernelCommandLines: boot.BootCommandLines{
+			"foo", "bar",
+		},
+
+		CurrentKernels: []string{kernel2.Filename(), kernel3.Filename()},
+
+		Model:          "my-model-uc20",
+		BrandID:        "my-brand",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		Grade:          "dangerous",
+	}
+	c.Assert(modeenv.WriteTo(""), IsNil)
+
+	var protector secboot.KeyProtectorFactory
+
+	err = boot.MakeRunnableSystemReprovision(model, protector, encryptionSetup)
+	c.Assert(err, IsNil)
+
+	c.Check(sealKeyForBootChainsCalled, Equals, 1)
+	c.Check(readSystemEssentialCalls, DeepEquals, []string{"test", "other"})
 }

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -242,10 +242,15 @@ func sealKeyToModeenvForMethod(
 		}
 	}
 
-	// When installing or reprovsion, we expect there is no try system
+	// When installing or reprovsioning, we expect there is no try
+	// system.
 	includeTryModel := false
+	// When provisioning we keep all good recovery systems.
 	systems := modeenv.GoodRecoverySystems
 	if len(systems) == 0 {
+		// The main recovery system is set only when installing.
+		// And there is no system marked as good.
+		// We use that installation recovery system.
 		systems = []string{modeenv.RecoverySystem}
 	}
 	modes := map[string][]string{}

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -242,13 +242,23 @@ func sealKeyToModeenvForMethod(
 		}
 	}
 
+	// When installing or reprovsion, we expect there is no try system
 	includeTryModel := false
-	systems := []string{modeenv.RecoverySystem}
-	modes := map[string][]string{
-		// the system we are installing from is considered current and
-		// tested, hence allow both recover and factory reset modes
-		modeenv.RecoverySystem: {ModeRecover, ModeFactoryReset},
+	systems := modeenv.GoodRecoverySystems
+	if len(systems) == 0 {
+		systems = []string{modeenv.RecoverySystem}
 	}
+	modes := map[string][]string{}
+	for _, system := range systems {
+		logger.Debugf("sealing for system %q", system)
+		modes[system] = []string{ModeRecover, ModeFactoryReset}
+	}
+	for _, system := range modeenv.CurrentRecoverySystems {
+		if _, has := modes[system]; !has {
+			return fmt.Errorf("trying to install or reprovision with a try system %q", system)
+		}
+	}
+
 	var err error
 	params.RecoveryBootChains, err = recoveryBootChainsForSystems(systems, modes, tbl, modeenv, includeTryModel, flags.SeedDir)
 	if err != nil {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -79,19 +79,39 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 	defer boot.MockSealModeenvLocked()()
 
 	for idx, tc := range []struct {
-		sealErr       error
-		provisionErr  error
-		factoryReset  bool
-		reprovision   bool
-		shimId        string
-		grubId        string
-		runGrubId     string
-		expErr        string
-		expSealCalls  int
-		disableTokens bool
+		sealErr                error
+		provisionErr           error
+		factoryReset           bool
+		reprovision            bool
+		shimId                 string
+		grubId                 string
+		runGrubId              string
+		goodRecoverySystems    []string
+		currentRecoverySystems []string
+		expErr                 string
+		expSealCalls           int
+		disableTokens          bool
 	}{
 		{
 			expSealCalls: 1,
+		},
+		{
+			currentRecoverySystems: []string{"20200825"},
+			expSealCalls:           1,
+		},
+		{
+			currentRecoverySystems: []string{"20200825"},
+			goodRecoverySystems:    []string{"20200825"},
+			expSealCalls:           1,
+		},
+		{
+			currentRecoverySystems: []string{"20260702"},
+			expErr:                 `trying to install or reprovision with a try system "20260702"`,
+		},
+		{
+			currentRecoverySystems: []string{"20260702"},
+			goodRecoverySystems:    []string{"20200825"},
+			expErr:                 `trying to install or reprovision with a try system "20260702"`,
 		},
 		{
 			expSealCalls:  1,
@@ -158,6 +178,13 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 			BrandID:        model.BrandID(),
 			Grade:          string(model.Grade()),
 			ModelSignKeyID: model.SignKeyID(),
+		}
+
+		if tc.currentRecoverySystems != nil {
+			modeenv.CurrentRecoverySystems = tc.currentRecoverySystems
+		}
+		if tc.goodRecoverySystems != nil {
+			modeenv.GoodRecoverySystems = tc.goodRecoverySystems
 		}
 
 		// mock asset cache


### PR DESCRIPTION
There are lots of things that makebootable does that is not needed or should not be done on a running system. For now we split it to only do the sealing part. Later we could look at doing more repairs.
