### PR TITLE
o/certstate: garbage check should run after symlink migration

### DIFF
--- a/overlord/certstate/certmgr.go
+++ b/overlord/certstate/certmgr.go
@@ -109,19 +109,14 @@ func (m *CertManager) Ensure() error {
 		return nil
 	}
 
-	// Run garbage collection for the cert generations
-	if err := m.ensureGarbageCollectionRun(); err != nil {
-		return err
-	}
-
 	// If the CA certificate database is already present, nothing to do.
 	// Remove the old style merged folder if it exists. If the merged folder exists, and
 	// it's not a symlink, we remove the folder and regenerate the database
 	mergedDir := CurrentCertificateDir()
 	if osutil.IsSymlink(mergedDir) {
 		// The merged directory is already a symlink, we assume it's correctly set up and skip generation.
-		logger.Debugf("merged certificate database exists, skipping generation")
-		return nil
+		logger.Debugf("merged certificate database exists, running garbage collection")
+		return m.ensureGarbageCollectionRun()
 	} else {
 		if err := os.RemoveAll(mergedDir); err != nil {
 			// In case of weird errors in this case, log it and skip generation. If it was
@@ -129,6 +124,11 @@ func (m *CertManager) Ensure() error {
 			logger.Noticef("error checking merged certificate database: %v", err)
 			return nil
 		}
+	}
+
+	// Run garbage collection for the cert generations, but only after the symlink check.
+	if err := m.ensureGarbageCollectionRun(); err != nil {
+		return err
 	}
 
 	// Create the update CA certificate database, this is likely a first

--- a/overlord/certstate/certmgr_test.go
+++ b/overlord/certstate/certmgr_test.go
@@ -163,6 +163,35 @@ func (s *certMgrTestSuite) TestEnsureSkipsWhenCertDbExists(c *C) {
 	c.Check(called, Equals, false)
 }
 
+func (s *certMgrTestSuite) TestEnsureRegeneratesWhenMergedIsPlainDirectory(c *C) {
+	var called bool
+	restore := certstate.MockRefreshCertificateDatabase(func() error {
+		called = true
+		return nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", true)
+	c.Assert(os.MkdirAll(dirs.SystemCertsDir, 0o755), IsNil)
+
+	mergedDir := filepath.Join(dirs.SnapdPKIV1Dir, "merged")
+	c.Assert(os.MkdirAll(mergedDir, 0o755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(mergedDir, "leftover"), []byte("stale"), 0o644), IsNil)
+
+	s.state.Unlock()
+	defer s.state.Lock()
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(called, Equals, true)
+
+	_, err = os.Stat(mergedDir)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
 func (s *certMgrTestSuite) TestEnsureSkipsWhenNoBaseCertsDir(c *C) {
 	var called bool
 	restore := certstate.MockRefreshCertificateDatabase(func() error {


### PR DESCRIPTION
This fixes the error:

```
stateengine.go:171: state ensure error: readlink /var/lib/snapd/pki/v1/merged: invalid argument
```

Which is due to the fact that the GC expects the merged to be a symlink, as it was introduced after the change. Ensure we do the migration before.