### PR TITLE
o/certstate: guard the ensure check from running on classic

### DIFF
--- a/overlord/certstate/certmgr.go
+++ b/overlord/certstate/certmgr.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"gopkg.in/tomb.v2"
 )
 
@@ -85,7 +86,7 @@ func (m *CertManager) Ensure() error {
 	st.Lock()
 	defer st.Unlock()
 
-	if m.oneTimeChecksRan {
+	if m.oneTimeChecksRan || release.OnClassic {
 		return nil
 	}
 

--- a/overlord/certstate/certmgr.go
+++ b/overlord/certstate/certmgr.go
@@ -86,6 +86,8 @@ func (m *CertManager) Ensure() error {
 	st.Lock()
 	defer st.Unlock()
 
+	// Do not perform automatic db generation on classic, or if ensure
+	// has already run
 	if m.oneTimeChecksRan || release.OnClassic {
 		return nil
 	}

--- a/overlord/certstate/certmgr_test.go
+++ b/overlord/certstate/certmgr_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/certstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -47,6 +48,7 @@ type certMgrTestSuite struct {
 func (s *certMgrTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(release.MockOnClassic(false))
 
 	s.o = overlord.Mock()
 	s.state = s.o.State()
@@ -133,6 +135,35 @@ func (s *certMgrTestSuite) TestEnsureDoesNothingWhenNotSeeded(c *C) {
 		return nil
 	})
 	defer restore()
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(called, Equals, false)
+}
+
+func (s *certMgrTestSuite) TestEnsureSkipsOnClassic(c *C) {
+	defer release.MockOnClassic(true)()
+
+	var called bool
+	restore := certstate.MockRefreshCertificateDatabase(func() error {
+		called = true
+		return nil
+	})
+	defer restore()
+
+	restoreBootID := certstate.MockOsutilBootID(func() (string, error) {
+		return "", errors.New("boot id should not be queried on classic")
+	})
+	defer restoreBootID()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", true)
+	c.Assert(os.MkdirAll(dirs.SystemCertsDir, 0o755), IsNil)
+
+	s.state.Unlock()
+	defer s.state.Lock()
 
 	err := s.mgr.Ensure()
 	c.Assert(err, IsNil)

--- a/overlord/certstate/certmgr_test.go
+++ b/overlord/certstate/certmgr_test.go
@@ -48,7 +48,9 @@ type certMgrTestSuite struct {
 func (s *certMgrTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
-	s.AddCleanup(release.MockOnClassic(false))
+
+	restore := release.MockOnClassic(false)
+	s.AddCleanup(restore)
 
 	s.o = overlord.Mock()
 	s.state = s.o.State()
@@ -142,10 +144,11 @@ func (s *certMgrTestSuite) TestEnsureDoesNothingWhenNotSeeded(c *C) {
 }
 
 func (s *certMgrTestSuite) TestEnsureSkipsOnClassic(c *C) {
-	defer release.MockOnClassic(true)()
+	restore := release.MockOnClassic(true)
+	defer restore()
 
 	var called bool
-	restore := certstate.MockRefreshCertificateDatabase(func() error {
+	restore = certstate.MockRefreshCertificateDatabase(func() error {
 		called = true
 		return nil
 	})


### PR DESCRIPTION
The other invocations are already guarded as core only, but a guard was never introduced on the .Ensure() check.