### PR TITLE
cmd: exclude Georgian from translation linting

### DIFF
--- a/cmd/snapd/cli/main.go
+++ b/cmd/snapd/cli/main.go
@@ -168,7 +168,8 @@ func lintDesc(cmdName, optName, desc, origDesc string) {
 		// decode the first rune instead of converting all of desc into []rune
 		r, _ := utf8.DecodeRuneInString(desc)
 		// note IsLower != !IsUpper for runes with no upper/lower.
-		if unicode.IsLower(r) && !strings.HasPrefix(desc, "login.ubuntu.com") && !strings.HasPrefix(desc, cmdName) {
+		// Note: exclude Georgian text which doesn't start sentences with uppercase
+		if unicode.IsLower(r) && !unicode.Is(unicode.Georgian, r) && !strings.HasPrefix(desc, "login.ubuntu.com") && !strings.HasPrefix(desc, cmdName) {
 			panicOnDebug("description of %s's %q is lowercase in locale %q: %q", cmdName, optName, i18n.CurrentLocale(), desc)
 		}
 	}

--- a/cmd/snapd/cli/main_test.go
+++ b/cmd/snapd/cli/main_test.go
@@ -393,6 +393,12 @@ func (s *SnapSuite) TestLintDesc(c *C) {
 	c.Check(fn, PanicMatches, `description of command's "<option>" is lowercase in locale "en_US": "description"`)
 	log.Reset()
 
+	os.Setenv("LC_MESSAGES", "ka_GE")
+	snap.LintDesc("command", "<option>", "ფაილის ბილიკი", "")
+	c.Check(log.String(), HasLen, 0)
+	log.Reset()
+	os.Setenv("LC_MESSAGES", "en_US")
+
 	// LintDesc does not complain about lowercase description starting with login.ubuntu.com
 	snap.LintDesc("command", "<option>", "login.ubuntu.com description", "")
 	c.Check(log.String(), HasLen, 0)


### PR DESCRIPTION
The i18n spread test was failing with:
```
main.go:683: PANIC description of file-access's "<ბილიკი>" is lowercase in locale "ka_GE": "ფაილის ბილიკი"
panic: description of file-access's "<ბილიკი>" is lowercase in locale "ka_GE": "ფაილის ბილიკი" [recovered]
panic: description of file-access's "<ბილიკი>" is lowercase in locale "ka_GE": "ფაილის ბილიკი"
```

This happened because, although Georgian Mkhedruli text is lowercase, Georgian sentences don't usually start with uppercase. So this excludes Georgian from the linting check.
