### PR TITLE
interfaces/builtin: make upower implicit on core observe check execute on Core systems only

### DIFF
--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -20,13 +20,16 @@
 package builtin
 
 import (
+	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -224,7 +227,7 @@ func (iface *upowerObserveInterface) Name() string {
 func (iface *upowerObserveInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              upowerObserveSummary,
-		ImplicitOnCore:       osutil.IsExecutable("/usr/libexec/upowerd"),
+		ImplicitOnCore:       !release.OnClassic && osutil.IsExecutable(filepath.Join(dirs.GlobalRootDir, "/usr/libexec/upowerd")),
 		ImplicitOnClassic:    true,
 		BaseDeclarationSlots: upowerObserveBaseDeclarationSlots,
 	}

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -244,10 +244,10 @@ func (s *UPowerObserveInterfaceSuite) TestStaticInfoCoreWithUpower(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	cmd := testutil.MockCommand(c, filepath.Join(s.rootdir, "usr/libexec/upower"), "")
+	cmd := testutil.MockCommand(c, filepath.Join(s.rootdir, "usr/libexec/upowerd"), "")
 	defer cmd.Restore()
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnCore, Equals, true)
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.BaseDeclarationSlots, testutil.Contains, "upower-observe")
 

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -20,18 +20,23 @@
 package builtin_test
 
 import (
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type UPowerObserveInterfaceSuite struct {
+	testutil.BaseTest
+
 	iface           interfaces.Interface
 	coreSlotInfo    *snap.SlotInfo
 	coreSlot        *interfaces.ConnectedSlot
@@ -39,6 +44,7 @@ type UPowerObserveInterfaceSuite struct {
 	classicSlot     *interfaces.ConnectedSlot
 	plugInfo        *snap.PlugInfo
 	plug            *interfaces.ConnectedPlug
+	rootdir         string
 }
 
 var _ = Suite(&UPowerObserveInterfaceSuite{
@@ -78,6 +84,11 @@ apps:
 
 	// snap with the upower-observe plug
 	s.plug, s.plugInfo = MockConnectedPlug(c, mockPlugSnapInfoYaml, nil, "upower-observe")
+
+	s.rootdir = c.MkDir()
+	dirs.SetRootDir(s.rootdir)
+
+	s.AddCleanup(func() { dirs.SetRootDir("") })
 }
 
 func (s *UPowerObserveInterfaceSuite) TestName(c *C) {
@@ -219,11 +230,39 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c
 	c.Assert(apparmorSpec.SnippetForTag("snap.upowerd.app"), testutil.Contains, `peer=(label="snap.upower.app"),`)
 }
 
-func (s *UPowerObserveInterfaceSuite) TestStaticInfo(c *C) {
+func (s *UPowerObserveInterfaceSuite) TestStaticInfoClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/upowerd"))
+	c.Check(si.ImplicitOnCore, Equals, false)
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.Summary, Equals, "allows operating as or reading from the UPower service")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "upower-observe")
+}
+
+func (s *UPowerObserveInterfaceSuite) TestStaticInfoCoreWithUpower(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	cmd := testutil.MockCommand(c, filepath.Join(s.rootdir, "usr/libexec/upower"), "")
+	defer cmd.Restore()
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "upower-observe")
+
+	// double check the command hasn't been called
+	c.Check(cmd.Calls(), HasLen, 0)
+}
+
+func (s *UPowerObserveInterfaceSuite) TestStaticInfoCoreWithoutUpower(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	// no mocked usr/libexec/upowerd
+
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.BaseDeclarationSlots, testutil.Contains, "upower-observe")
 }
 


### PR DESCRIPTION
This avoids probing on classic systems.

Cherry picked from https://github.com/canonical/snapd/pull/17208

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
