### PR TITLE
interfaces/builtin: make polkit interface assert implicit core slot on Core systems only

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -150,19 +150,6 @@ func MockDirsToEnsure(fn func(paths []string) ([]*interfaces.EnsureDirSpec, erro
 	return restore
 }
 
-func MockPolkitDaemonPaths(path1, path2 string) (restore func()) {
-	oldDaemonPath1 := polkitDaemonPath1
-	oldDaemonPath2 := polkitDaemonPath2
-
-	polkitDaemonPath1 = path1
-	polkitDaemonPath2 = path2
-
-	return func() {
-		polkitDaemonPath1 = oldDaemonPath1
-		polkitDaemonPath2 = oldDaemonPath2
-	}
-}
-
 func MockApparmorGenerateAAREExclusionPatterns(fn func(excludePatterns []string, opts *apparmor.AAREExclusionPatternsOptions) (string, error)) (restore func()) {
 	return testutil.Mock(&apparmorGenerateAAREExclusionPatterns, fn)
 }

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -335,7 +335,8 @@ var (
 // the polkit daemon executable. This function can be shortened but keep it like
 // this for readability.
 func hasPolkitDaemonExecutableOnCore() bool {
-	return osutil.IsExecutable(polkitDaemonPath1) || osutil.IsExecutable(polkitDaemonPath2)
+	return osutil.IsExecutable(filepath.Join(dirs.GlobalRootDir, polkitDaemonPath1)) ||
+		osutil.IsExecutable(filepath.Join(dirs.GlobalRootDir, polkitDaemonPath2))
 }
 
 func canWriteToDir(dir string) bool {
@@ -346,7 +347,9 @@ func (iface *polkitInterface) StaticInfo() interfaces.StaticInfo {
 	info := iface.commonInterface.StaticInfo()
 	// We must have the polkit daemon present on the system and be able to write
 	// to either the polkit actions directory or the polkit rules directory.
-	info.ImplicitOnCore = !release.OnClassic && hasPolkitDaemonExecutableOnCore() && (canWriteToDir(dirs.SnapPolkitPolicyDir) || canWriteToDir(dirs.SnapPolkitRuleDir))
+	info.ImplicitOnCore = !release.OnClassic &&
+		hasPolkitDaemonExecutableOnCore() &&
+		(canWriteToDir(dirs.SnapPolkitPolicyDir) || canWriteToDir(dirs.SnapPolkitRuleDir))
 	return info
 }
 

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/polkit"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/polkit/validate"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -345,7 +346,7 @@ func (iface *polkitInterface) StaticInfo() interfaces.StaticInfo {
 	info := iface.commonInterface.StaticInfo()
 	// We must have the polkit daemon present on the system and be able to write
 	// to either the polkit actions directory or the polkit rules directory.
-	info.ImplicitOnCore = hasPolkitDaemonExecutableOnCore() && (canWriteToDir(dirs.SnapPolkitPolicyDir) || canWriteToDir(dirs.SnapPolkitRuleDir))
+	info.ImplicitOnCore = !release.OnClassic && hasPolkitDaemonExecutableOnCore() && (canWriteToDir(dirs.SnapPolkitPolicyDir) || canWriteToDir(dirs.SnapPolkitRuleDir))
 	return info
 }
 

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/polkit"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -74,6 +75,8 @@ func (s *polkitInterfaceSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() {
 		dirs.SetRootDir("/")
 	})
+
+	s.AddCleanup(release.MockOnClassic(false))
 
 	const mockSlotSnapInfoYaml = `name: core
 version: 1.0
@@ -542,10 +545,24 @@ slots:
 	c.Assert(err, ErrorMatches, `snap "other" has interface "polkit" with invalid value type bool for "action-prefix" attribute: \*string`)
 }
 
-func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
+func (s *polkitInterfaceSuite) TestStaticInfoCore(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	// ImplicitOnCore is only tested in TestPolkitPoliciesSupported and TestPolkitRulesSupported.
 	c.Check(si.ImplicitOnClassic, Equals, true)
+	// ImplicitOnCore is only tested in TestPolkitPoliciesSupported and TestPolkitRulesSupported.
+	// though the suite already mocks writable directories, which already implies an implicit interface slot.
+	c.Check(si.ImplicitOnCore, Equals, true)
+	c.Check(si.Summary, Equals, "allows installing polkit rules and/or access to polkitd to check authorisation")
+	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "polkit")
+}
+
+func (s *polkitInterfaceSuite) TestStaticInfoClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.ImplicitOnCore, Equals, false)
 	c.Check(si.Summary, Equals, "allows installing polkit rules and/or access to polkitd to check authorisation")
 	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")
 	c.Check(si.BaseDeclarationSlots, testutil.Contains, "polkit")

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -49,29 +49,20 @@ type polkitInterfaceSuite struct {
 	slot     *interfaces.ConnectedSlot
 	slotInfo *snap.SlotInfo
 
-	daemonPath1  string
-	daemonPath2  string
-	restorePaths func()
+	root        string
+	daemonPath1 string
+	daemonPath2 string
 }
 
 var _ = Suite(&polkitInterfaceSuite{
 	iface: builtin.MustInterface("polkit"),
 })
 
-func (s *polkitInterfaceSuite) SetUpSuite(c *C) {
-	d := c.MkDir()
-	s.daemonPath1 = filepath.Join(d, "polkitd-1")
-	s.daemonPath2 = filepath.Join(d, "polkitd-2")
-	s.restorePaths = builtin.MockPolkitDaemonPaths(s.daemonPath1, s.daemonPath2)
-}
-
-func (s *polkitInterfaceSuite) TearDownSuite(c *C) {
-	s.restorePaths()
-}
-
 func (s *polkitInterfaceSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
+
+	s.root = c.MkDir()
+	dirs.SetRootDir(s.root)
 	s.AddCleanup(func() {
 		dirs.SetRootDir("/")
 	})
@@ -88,8 +79,13 @@ slots:
 
 	s.slot, s.slotInfo = MockConnectedSlot(c, mockSlotSnapInfoYaml, nil, "polkit")
 
+	s.daemonPath1 = filepath.Join(dirs.GlobalRootDir, "/usr/libexec/polkitd")
+	s.daemonPath2 = filepath.Join(dirs.GlobalRootDir, "/usr/lib/polkit-1/polkitd")
+
+	c.Assert(os.MkdirAll(filepath.Dir(s.daemonPath1), 0o700), IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(s.daemonPath2), 0o700), IsNil)
 	c.Assert(os.WriteFile(s.daemonPath1, nil, 0o600), IsNil)
-	c.Assert(os.WriteFile(s.daemonPath2, nil, 0o600), IsNil)
+	c.Assert(os.WriteFile(s.daemonPath2, nil, 0o700), IsNil) // core24 and later
 	c.Assert(os.MkdirAll(dirs.SnapPolkitPolicyDir, 0o700), IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapPolkitRuleDir, 0o700), IsNil)
 }
@@ -548,7 +544,7 @@ slots:
 func (s *polkitInterfaceSuite) TestStaticInfoCore(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Check(si.ImplicitOnClassic, Equals, true)
-	// ImplicitOnCore is only tested in TestPolkitPoliciesSupported and TestPolkitRulesSupported.
+	// ImplicitOnCore is also tested in TestPolkitPoliciesSupported and TestPolkitRulesSupported.
 	// though the suite already mocks writable directories, which already implies an implicit interface slot.
 	c.Check(si.ImplicitOnCore, Equals, true)
 	c.Check(si.Summary, Equals, "allows installing polkit rules and/or access to polkitd to check authorisation")


### PR DESCRIPTION
Make the implicit core slot presence be asserted only on Core systems.

Cherry picked from #17208 

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
