### PR TITLE
asserts, i/builtin: ensure that compatibility labels are strings

### DIFF
--- a/asserts/constraint.go
+++ b/asserts/constraint.go
@@ -228,8 +228,16 @@ var (
 func matchCompatLabels(v1, v2 any) bool {
 	// Note that decoding errors should not happen as interfaces are
 	// expected to check the format of the labels before this can even be
-	// called.
-	return compatibility.CheckCompatibility(v1.(string), v2.(string))
+	// called. Still, avoid panicking if malformed values reach this layer.
+	s1, ok := v1.(string)
+	if !ok {
+		return false
+	}
+	s2, ok := v2.(string)
+	if !ok {
+		return false
+	}
+	return compatibility.CheckCompatibility(s1, s2)
 }
 
 func compileEvalOrRefAttrMatcher(cc compileContext, s string) (attrMatcher, error) {

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -381,6 +381,23 @@ func (s *attrConstraintsSuite) TestEvalCheckPlugCompat(c *C) {
 	s.testEvalCheckCompat(c, "PLUG_COMPAT")
 }
 
+func (s *attrConstraintsSuite) TestEvalCheckCompatNonString(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  compatibility: $SLOT_COMPAT(compatibility)`))
+	c.Assert(err, IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
+	c.Assert(err, IsNil)
+
+	comp := func(op string, arg string) (any, error) {
+		return "foo-1", nil
+	}
+	err = cstrs.Check(attrs(`
+compatibility: 1
+`), testEvalAttr{comp: comp, compatLabels: true})
+	c.Check(err, ErrorMatches, `attribute "compatibility" does not match \$SLOT_COMPAT\(compatibility\): 1 != foo-1`)
+}
+
 func (s *attrConstraintsSuite) testEvalCheckCompat(c *C, compatOper string) {
 	m, err := asserts.ParseHeaders([]byte(fmt.Sprintf(`attrs:
   foo: $%s(foo)`, compatOper)))

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -96,7 +96,16 @@ func checkLabelAttributes(attrs map[string]any, nameDef string) error {
 	// here we allow the compatibility labels to exist in any case as it
 	// has no further side effect.
 	content, okContent := attrs["content"].(string)
+
+	// TODO: consider asserting that "content" is a string. right now, a
+	// non-string "content" attribute will result in us using the plug's name as
+	// the "content" attribute.
+
 	compat, okCompat := attrs["compatibility"].(string)
+	if _, ok := attrs["compatibility"]; ok && !okCompat {
+		return errors.New("compatibility label must be a string")
+	}
+
 	hasContent := okContent && len(content) > 0
 	hasCompat := okCompat && len(compat) > 0
 	if hasCompat && hasContent {

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -112,6 +112,22 @@ slots:
 	c.Assert(slot.Attrs["content"], IsNil)
 }
 
+func (s *ContentSuite) TestSanitizeSlotBadCompatibilityType(c *C) {
+	const mockSnapYaml = `name: content-slot-snap
+version: 1.0
+slots:
+ content-slot:
+  interface: content
+  compatibility: 1
+  read:
+   - shared/read
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`compatibility label must be a string`)
+}
+
 func (s *ContentSuite) TestSanitizeSlotBothContentAndCompatLabels(c *C) {
 	const mockSnapYaml = `name: content-slot-snap
 version: 1.0
@@ -250,6 +266,21 @@ plugs:
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), ErrorMatches,
 		`compatibility label "foo@-0": while parsing: unexpected rune: @`)
 	c.Assert(plug.Attrs["content"], IsNil)
+}
+
+func (s *ContentSuite) TestSanitizePlugBadCompatibilityType(c *C) {
+	const mockSnapYaml = `name: content-slot-snap
+version: 1.0
+plugs:
+ content-plug:
+  interface: content
+  compatibility: 1
+  target: import
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := info.Plugs["content-plug"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), ErrorMatches,
+		`compatibility label must be a string`)
 }
 
 func (s *ContentSuite) TestSanitizePlugBothContentAndCompatLabels(c *C) {


### PR DESCRIPTION
This fixes a panic during auto-connection when installing a snap with an invalid compatibility label.