### PR TITLE
cmd/snapd/cli: make arguments of debug mount-namespace consistent with other debug commands

### DIFF
--- a/cmd/snapd/cli/cmd_debug_mount_namespace.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace.go
@@ -20,7 +20,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -29,81 +28,79 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/snapdtool"
 )
 
-var (
-	osGetuid = os.Getuid
-)
+var shortDebugMountNamespaceHelp = i18n.G("Debug and inspect snap mount namespaces")
 
-type cmdDebugMountNamespace struct{}
+var longDebugMountNamespaceHelp = i18n.G(`
+Run a command or start a shell inside the mount namespace of the given snap.
+
+When used with --discard, discard the mount namespace of a snap if one exists.
+
+The command may require root privileges.
+`)
+
+type cmdDebugMountNamespace struct {
+	Shell      bool `long:"shell"`
+	Discard    bool `long:"discard"`
+	Positional struct {
+		Snap string `positional-arg-name:"<snap>" required:"yes"`
+	} `positional-args:"yes"`
+}
 
 func init() {
-	cmd := addDebugCommand("mount-namespace",
-		"Debugging of snap mount namespaces",
-		"Commands to aid debugging of snap mount namespaces.",
+	addDebugCommand("mount-namespace",
+		shortDebugMountNamespaceHelp,
+		longDebugMountNamespaceHelp,
 		func() flags.Commander { return &cmdDebugMountNamespace{} },
-		nil,
-		nil,
+		map[string]string{
+			"shell":   i18n.G("Open a shell or execute a command within the mount namespace"),
+			"discard": i18n.G("Discard the mount namespace"),
+		},
+		[]argDesc{
+			{"<snap>", "Snap name"},
+		},
 	)
-	cmd.extra = func(c *flags.Command) {
-		c.AddCommand("discard", "Discard a snap mount namespace",
-			"Discard the mount namespace of the given snap by invoking snap-discard-ns.",
-			&cmdDebugMountNsDiscard{})
-		c.AddCommand("shell", "Start a shell or run a command in a snap mount namespace",
-			`Run a command inside the mount namespace of the given snap using nsenter.
-If no command is specified, an interactive shell (/bin/bash) is started.`,
-			&cmdDebugMountNsShell{})
-	}
 }
 
 func (x *cmdDebugMountNamespace) Execute(args []string) error {
-	return flag.ErrHelp
-}
-
-type cmdDebugMountNsDiscard struct {
-	Positionals struct {
-		SnapName string `required:"yes" positional-arg-name:"<snap-name>"`
-	} `positional-args:"true"`
-}
-
-func (x *cmdDebugMountNsDiscard) Execute(args []string) error {
-	if osGetuid() != 0 {
-		return fmt.Errorf("this command requires root privileges")
+	if x.Shell && x.Discard {
+		return fmt.Errorf("--shell and --discard cannot be used together")
 	}
 
+	if x.Discard {
+		return x.discard(x.Positional.Snap)
+	}
+
+	// --shell is default
+	return x.shell(x.Positional.Snap, args)
+}
+
+func (x *cmdDebugMountNamespace) discard(snapName string) error {
 	toolPath, err := snapdtool.InternalToolPath("snap-discard-ns")
 	if err != nil {
 		return fmt.Errorf("cannot find snap-discard-ns: %v", err)
 	}
 
-	cmd := exec.Command(toolPath, x.Positionals.SnapName)
+	cmd := exec.Command(toolPath, snapName)
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cannot discard mount namespace of snap %q: %v",
-			x.Positionals.SnapName, err)
+		return fmt.Errorf("cannot discard mount namespace of snap %q: %w",
+			snapName, err)
 	}
 	return nil
 }
 
-type cmdDebugMountNsShell struct {
-	Positionals struct {
-		SnapName string `required:"yes" positional-arg-name:"<snap-name>"`
-	} `positional-args:"true"`
-}
-
-func (x *cmdDebugMountNsShell) Execute(args []string) error {
-	if osGetuid() != 0 {
-		return fmt.Errorf("this command requires root privileges")
-	}
-
-	mntPath := filepath.Join(dirs.SnapRunNsDir, x.Positionals.SnapName+".mnt")
+func (x *cmdDebugMountNamespace) shell(snapName string, args []string) error {
+	mntPath := filepath.Join(dirs.SnapRunNsDir, snapName+".mnt")
 	if _, err := os.Stat(mntPath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("cannot enter mount namespace of snap %q: "+
 				"the mount namespace is not bound to a file (%s does not exist)",
-				x.Positionals.SnapName, mntPath)
+				snapName, mntPath)
 		}
 		return fmt.Errorf("cannot stat mount namespace file: %w", err)
 	}

--- a/cmd/snapd/cli/cmd_debug_mount_namespace.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace.go
@@ -35,9 +35,10 @@ import (
 var shortDebugMountNamespaceHelp = i18n.G("Debug and inspect snap mount namespaces")
 
 var longDebugMountNamespaceHelp = i18n.G(`
-Run a command or start a shell inside the mount namespace of the given snap.
-
-When used with --discard, discard the mount namespace of a snap if one exists.
+The debug mount-namespace command displays information about the mount namespace
+of a given snap when invoked with no flags. Use --shell to start a shell or run
+a command inside the mount namespace. Use --discard to discard the mount
+namespace of a snap if one exists.
 
 The command may require root privileges.
 `)
@@ -65,6 +66,17 @@ func init() {
 	)
 }
 
+func snapMountNamespacePath(snapName string) (string, error) {
+	mntPath := filepath.Join(dirs.SnapRunNsDir, snapName+".mnt")
+	if _, err := os.Stat(mntPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("cannot stat mount namespace file: %w", err)
+	}
+	return mntPath, nil
+}
+
 func (x *cmdDebugMountNamespace) Execute(args []string) error {
 	if x.Shell && x.Discard {
 		return fmt.Errorf("--shell and --discard cannot be used together")
@@ -74,8 +86,22 @@ func (x *cmdDebugMountNamespace) Execute(args []string) error {
 		return x.discard(x.Positional.Snap)
 	}
 
-	// --shell is default
-	return x.shell(x.Positional.Snap, args)
+	if x.Shell {
+		return x.shell(x.Positional.Snap, args)
+	}
+
+	mntPath, err := snapMountNamespacePath(x.Positional.Snap)
+	if err != nil {
+		return err
+	}
+	if mntPath != "" {
+		fmt.Fprintf(Stdout, "mount namespace of snap %q bound to %s\n",
+			x.Positional.Snap, mntPath)
+	} else {
+		fmt.Fprintf(Stdout, "no mount namespace of snap %q found\n",
+			x.Positional.Snap)
+	}
+	return nil
 }
 
 func (x *cmdDebugMountNamespace) discard(snapName string) error {
@@ -95,14 +121,14 @@ func (x *cmdDebugMountNamespace) discard(snapName string) error {
 }
 
 func (x *cmdDebugMountNamespace) shell(snapName string, args []string) error {
-	mntPath := filepath.Join(dirs.SnapRunNsDir, snapName+".mnt")
-	if _, err := os.Stat(mntPath); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("cannot enter mount namespace of snap %q: "+
-				"the mount namespace is not bound to a file (%s does not exist)",
-				snapName, mntPath)
-		}
-		return fmt.Errorf("cannot stat mount namespace file: %w", err)
+	mntPath, err := snapMountNamespacePath(snapName)
+	if err != nil {
+		return err
+	}
+	if mntPath == "" {
+		return fmt.Errorf("cannot enter mount namespace of snap %q: "+
+			"the mount namespace is not bound to a file (%s does not exist)",
+			snapName, filepath.Join(dirs.SnapRunNsDir, snapName+".mnt"))
 	}
 
 	nsenterPath, err := exec.LookPath("nsenter")
@@ -114,12 +140,9 @@ func (x *cmdDebugMountNamespace) shell(snapName string, args []string) error {
 	if len(args) > 0 {
 		argv = append(argv, args...)
 	} else {
-		// We know that /bin/bash is in the core* snaps. If a given uses
-		// bare, then the user can always invoke '/bin/busybox sh'.
 		argv = append(argv, "/bin/bash")
 	}
 
-	// Override the environment and set a safe PATH.
 	env := []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"}
 	return syscallExec(nsenterPath, argv, env)
 }

--- a/cmd/snapd/cli/cmd_debug_mount_namespace.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace.go
@@ -95,7 +95,7 @@ func (x *cmdDebugMountNamespace) Execute(args []string) error {
 		return err
 	}
 	if mntPath != "" {
-		fmt.Fprintf(Stdout, "mount namespace of snap %q bound to %s\n",
+		fmt.Fprintf(Stdout, "mount namespace of snap %q bound to %s, use --shell to enter\n",
 			x.Positional.Snap, mntPath)
 	} else {
 		fmt.Fprintf(Stdout, "no mount namespace of snap %q found\n",
@@ -144,5 +144,10 @@ func (x *cmdDebugMountNamespace) shell(snapName string, args []string) error {
 	}
 
 	env := []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"}
+
+	if len(args) == 0 {
+		env = append(env, fmt.Sprintf("PS1=(%s) [\\u@\\h \\W]\\$ ", snapName))
+	}
+
 	return syscallExec(nsenterPath, argv, env)
 }

--- a/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
@@ -30,37 +30,15 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func (s *SnapSuite) TestDebugMountNamespaceDiscardRequiresRoot(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 1000 })
-	defer restore()
-
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
-	c.Assert(err, ErrorMatches, "this command requires root privileges")
-}
-
-func (s *SnapSuite) TestDebugMountNamespaceShellRequiresRoot(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 1000 })
-	defer restore()
-
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
-	c.Assert(err, ErrorMatches, "this command requires root privileges")
-}
-
 func (s *SnapSuite) TestDebugMountNamespaceShellFailsIfMntFileNotExist(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
 	c.Assert(err, ErrorMatches, `cannot enter mount namespace of snap "test-snap": the mount namespace is not bound to a file \(.*/run/snapd/ns/test-snap.mnt does not exist\)`)
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	rootDir := c.MkDir()
 	dirs.SetRootDir(rootDir)
 	defer dirs.SetRootDir("/")
@@ -90,7 +68,7 @@ func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
 	})
 	defer restoreExec()
 
-	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
 	c.Assert(err, IsNil)
 	c.Assert(execCalled, Equals, true)
 	c.Assert(execPath, Equals, nsenterCmd.Exe())
@@ -99,9 +77,6 @@ func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceShellWithCommand(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	rootDir := c.MkDir()
 	dirs.SetRootDir(rootDir)
 	defer dirs.SetRootDir("/")
@@ -127,16 +102,13 @@ func (s *SnapSuite) TestDebugMountNamespaceShellWithCommand(c *C) {
 	})
 	defer restoreExec()
 
-	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap", "--", "/usr/bin/findmnt", "-l"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "test-snap", "--", "/usr/bin/findmnt", "-l"})
 	c.Assert(err, IsNil)
 	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/usr/bin/findmnt", "-l"})
 	c.Assert(execEnv, DeepEquals, []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"})
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceShellWithCommandNoDash(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	rootDir := c.MkDir()
 	dirs.SetRootDir(rootDir)
 	defer dirs.SetRootDir("/")
@@ -161,20 +133,17 @@ func (s *SnapSuite) TestDebugMountNamespaceShellWithCommandNoDash(c *C) {
 	defer restoreExec()
 
 	// Without --, positional arguments that don't look like flags work fine
-	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "shell", "test-snap", "/usr/bin/findmnt"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "test-snap", "/usr/bin/findmnt"})
 	c.Assert(err, IsNil)
 	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/usr/bin/findmnt"})
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceDiscardRunsTool(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
 	dirs.DistroLibExecDir = cmd.BinDir()
 	defer cmd.Restore()
 
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--discard", "test-snap"})
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"snap-discard-ns", "test-snap"},
@@ -182,13 +151,15 @@ func (s *SnapSuite) TestDebugMountNamespaceDiscardRunsTool(c *C) {
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceDiscardReportsError(c *C) {
-	restore := snap.MockOsGetuid(func() int { return 0 })
-	defer restore()
-
 	cmd := testutil.MockCommand(c, "snap-discard-ns", "echo 'namespace error'; exit 1")
 	dirs.DistroLibExecDir = cmd.BinDir()
 	defer cmd.Restore()
 
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "discard", "test-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--discard", "test-snap"})
 	c.Assert(err, ErrorMatches, `cannot discard mount namespace of snap "test-snap": .*`)
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceShellAndDiscardMutuallyExclusive(c *C) {
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "--discard", "test-snap"})
+	c.Assert(err, ErrorMatches, `--shell and --discard cannot be used together`)
 }

--- a/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
@@ -34,7 +34,7 @@ func (s *SnapSuite) TestDebugMountNamespaceShellFailsIfMntFileNotExist(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "test-snap"})
 	c.Assert(err, ErrorMatches, `cannot enter mount namespace of snap "test-snap": the mount namespace is not bound to a file \(.*/run/snapd/ns/test-snap.mnt does not exist\)`)
 }
 
@@ -55,23 +55,16 @@ func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
 	nsenterCmd := testutil.MockCommand(c, "nsenter", "")
 	defer nsenterCmd.Restore()
 
-	var execCalled bool
-	var execPath string
 	var execArgv []string
 	var execEnv []string
 	restoreExec := snap.MockSyscallExec(func(path string, argv []string, env []string) error {
-		execCalled = true
-		execPath = path
 		execArgv = argv
 		execEnv = env
 		return nil
 	})
 	defer restoreExec()
 
-	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
-	c.Assert(err, IsNil)
-	c.Assert(execCalled, Equals, true)
-	c.Assert(execPath, Equals, nsenterCmd.Exe())
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "test-snap"})
 	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/bin/bash"})
 	c.Assert(execEnv, DeepEquals, []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"})
 }
@@ -157,6 +150,34 @@ func (s *SnapSuite) TestDebugMountNamespaceDiscardReportsError(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--discard", "test-snap"})
 	c.Assert(err, ErrorMatches, `cannot discard mount namespace of snap "test-snap": .*`)
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceInfoMessageFound(c *C) {
+	rootDir := c.MkDir()
+	dirs.SetRootDir(rootDir)
+	defer dirs.SetRootDir("/")
+
+	nsDir := filepath.Join(rootDir, "/run/snapd/ns")
+	err := os.MkdirAll(nsDir, 0755)
+	c.Assert(err, IsNil)
+	mntFile := filepath.Join(nsDir, "test-snap.mnt")
+	err = os.WriteFile(mntFile, nil, 0600)
+	c.Assert(err, IsNil)
+
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, "mount namespace of snap \"test-snap\" bound to "+mntFile+"\n")
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestDebugMountNamespaceInfoMessageNotFound(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, "no mount namespace of snap \"test-snap\" found\n")
+	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceShellAndDiscardMutuallyExclusive(c *C) {

--- a/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
+++ b/cmd/snapd/cli/cmd_debug_mount_namespace_test.go
@@ -65,8 +65,12 @@ func (s *SnapSuite) TestDebugMountNamespaceShellDefaultBash(c *C) {
 	defer restoreExec()
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "--shell", "test-snap"})
+	c.Assert(err, IsNil)
 	c.Assert(execArgv, DeepEquals, []string{"nsenter", "-m" + mntFile, "/bin/bash"})
-	c.Assert(execEnv, DeepEquals, []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"})
+	c.Assert(execEnv, DeepEquals, []string{
+		"PATH=/usr/bin:/bin:/usr/sbin:/sbin",
+		"PS1=(test-snap) [\\u@\\h \\W]\\$ ",
+	})
 }
 
 func (s *SnapSuite) TestDebugMountNamespaceShellWithCommand(c *C) {
@@ -166,7 +170,7 @@ func (s *SnapSuite) TestDebugMountNamespaceInfoMessageFound(c *C) {
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "mount-namespace", "test-snap"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "mount namespace of snap \"test-snap\" bound to "+mntFile+"\n")
+	c.Assert(s.Stdout(), Equals, "mount namespace of snap \"test-snap\" bound to "+mntFile+", use --shell to enter\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 

--- a/cmd/snapd/cli/export_test.go
+++ b/cmd/snapd/cli/export_test.go
@@ -504,7 +504,3 @@ func MockSquashfsGenerateDelta(f func(context.Context, string, string, string, s
 func MockSquashfsApplyDelta(f func(context.Context, string, string, string) error) (restore func()) {
 	return testutil.Mock(&squashfsApplyDelta, f)
 }
-
-func MockOsGetuid(f func() int) (restore func()) {
-	return testutil.Mock(&osGetuid, f)
-}

--- a/tests/main/interfaces-fuse-support/task.yaml
+++ b/tests/main/interfaces-fuse-support/task.yaml
@@ -40,10 +40,10 @@ prepare: |
 
 restore: |
     # remove the mount point
-    mounts=$(snap debug mount-namespace shell "$NAME" -- cat /proc/mounts | \
+    mounts=$(snap debug mount-namespace --shell "$NAME" -- cat /proc/mounts | \
              grep "$(basename "$MOUNT_POINT") fuse" | cut -f2 -d' ')
     for m in $mounts; do
-        snap debug mount-namespace shell "$NAME" -- umount "$m"
+        snap debug mount-namespace --shell "$NAME" -- umount "$m"
     done
     rm -rf "$MOUNT_POINT_OUTSIDE"
 
@@ -103,6 +103,6 @@ execute: |
     wait $createpid || test "$?" = "159"
 
     # verify that the mount_point was not removed from mount namespace of the snap
-    mountpath=$(snap debug mount-namespace shell "$NAME" -- cat /proc/mounts | \
+    mountpath=$(snap debug mount-namespace --shell "$NAME" -- cat /proc/mounts | \
                 grep "$(basename "$MOUNT_POINT") fuse" | cut -f2 -d' ')
     test -n "$mountpath"

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -27,17 +27,17 @@ execute: |
     snap connect app:runtime runtime:runtime
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per the layout, there is a symlink
-    snap debug mount-namespace app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace --shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
 
     echo "The application is refreshed with another layout"
     snap install --dangerous ./app_2_all.snap
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per new layout, there is a bind mount
-    snap debug mount-namespace app -- /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
+    snap debug mount-namespace --shell app -- /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
 
     echo "The application is reverted"
     snap revert app 2>&1 | MATCH 'app reverted to 1'
     # Back to symlink
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # And we still have a bind mount
-    snap debug mount-namespace app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace --shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -27,17 +27,17 @@ execute: |
     snap connect app:runtime runtime:runtime
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per the layout, there is a symlink
-    snap debug mount-namespace shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
 
     echo "The application is refreshed with another layout"
     snap install --dangerous ./app_2_all.snap
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # As per new layout, there is a bind mount
-    snap debug mount-namespace shell app -- /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
+    snap debug mount-namespace app -- /bin/grep /opt/runtime /proc/self/mountinfo | MATCH '/runtime /opt/runtime .* /dev/loop'
 
     echo "The application is reverted"
     snap revert app 2>&1 | MATCH 'app reverted to 1'
     # Back to symlink
     app 2>&1 | MATCH "RUNTIME: Hello from the app"
     # And we still have a bind mount
-    snap debug mount-namespace shell app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'
+    snap debug mount-namespace app -- /bin/ls -l /opt | MATCH 'runtime -> /snap/app/x1/runtime'

--- a/tests/main/ld-cache-from-base/task.yaml
+++ b/tests/main/ld-cache-from-base/task.yaml
@@ -16,7 +16,7 @@ execute: |
   test-snapd-sh-core"$base".sh -c pwd
 
   # Check ld cache related paths are mounted from the base
-  snap debug mount-namespace shell "$test_snap" -- mount > mounts.txt
+  snap debug mount-namespace --shell "$test_snap" -- mount > mounts.txt
   SNAP_MOUNT_DIR=$(os.paths snap-mount-dir)
   currBaseRev=$(readlink "$SNAP_MOUNT_DIR"/core"$base"/current)
   basePath=/var/lib/snapd/snaps/core"$base"_"$currBaseRev".snap

--- a/tests/regression/lp-1884849/task.yaml
+++ b/tests/regression/lp-1884849/task.yaml
@@ -19,9 +19,9 @@ prepare: |
   sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.test-snapd-desktop.fstab
   # Having manually altered the mount namespace, so that fontconfig cache is not mounted
   touch /var/cache/fontconfig/.canary
-  snap debug mount-namespace shell test-snapd-desktop -- test -e /var/cache/fontconfig/.canary
-  snap debug mount-namespace shell test-snapd-desktop -- umount /var/cache/fontconfig
-  snap debug mount-namespace shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace test-snapd-desktop -- test -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace test-snapd-desktop -- umount /var/cache/fontconfig
+  snap debug mount-namespace test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
   # Having confirmed that snap-update-ns manifest assumes it still is.
   grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
 
@@ -35,4 +35,4 @@ execute: |
   MATCH 'DEBUG:?.*ignoring EINVAL from unmount, [\]?"/var/cache/fontconfig[\]?" is not mounted' <snap-update-ns.log
   # And confirm snap-update-ns fixed the situation
   not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
-  snap debug mount-namespace shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary

--- a/tests/regression/lp-1884849/task.yaml
+++ b/tests/regression/lp-1884849/task.yaml
@@ -19,9 +19,9 @@ prepare: |
   sed -i -e 's@^/var/lib/snapd/hostfs/var/cache/fontconfig@#/var/lib/snapd/hostfs/var/cache/fontconfig@' /var/lib/snapd/mount/snap.test-snapd-desktop.fstab
   # Having manually altered the mount namespace, so that fontconfig cache is not mounted
   touch /var/cache/fontconfig/.canary
-  snap debug mount-namespace test-snapd-desktop -- test -e /var/cache/fontconfig/.canary
-  snap debug mount-namespace test-snapd-desktop -- umount /var/cache/fontconfig
-  snap debug mount-namespace test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace --shell test-snapd-desktop -- test -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace --shell test-snapd-desktop -- umount /var/cache/fontconfig
+  snap debug mount-namespace --shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
   # Having confirmed that snap-update-ns manifest assumes it still is.
   grep -qFx '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
 
@@ -35,4 +35,4 @@ execute: |
   MATCH 'DEBUG:?.*ignoring EINVAL from unmount, [\]?"/var/cache/fontconfig[\]?" is not mounted' <snap-update-ns.log
   # And confirm snap-update-ns fixed the situation
   not grep -qF '/var/lib/snapd/hostfs/var/cache/fontconfig /var/cache/fontconfig none bind,ro 0 0' < /run/snapd/ns/snap.test-snapd-desktop.fstab
-  snap debug mount-namespace test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary
+  snap debug mount-namespace --shell test-snapd-desktop -- test ! -e /var/cache/fontconfig/.canary

--- a/tests/regression/lp-1898038/task.yaml
+++ b/tests/regression/lp-1898038/task.yaml
@@ -44,9 +44,9 @@ execute: |
     # now connect it and verify profile can be compiled
     test-snapd-docker-support-app.test-snapd-docker-support
     # check that within the snap mount namespace /etc/apparmor is mounted and comes from a snap
-    test "$(snap debug mount-namespace shell test-snapd-docker-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace test-snapd-docker-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 
     # and do the same for multipass-support
     test-snapd-multipass-support-app.test-snapd-multipass-support
-    test "$(snap debug mount-namespace shell test-snapd-multipass-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace test-snapd-multipass-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 

--- a/tests/regression/lp-1898038/task.yaml
+++ b/tests/regression/lp-1898038/task.yaml
@@ -44,9 +44,9 @@ execute: |
     # now connect it and verify profile can be compiled
     test-snapd-docker-support-app.test-snapd-docker-support
     # check that within the snap mount namespace /etc/apparmor is mounted and comes from a snap
-    test "$(snap debug mount-namespace test-snapd-docker-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace --shell test-snapd-docker-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 
     # and do the same for multipass-support
     test-snapd-multipass-support-app.test-snapd-multipass-support
-    test "$(snap debug mount-namespace test-snapd-multipass-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
+    test "$(snap debug mount-namespace --shell test-snapd-multipass-support-app -- mount | grep -c '/etc/apparmor\(.d\)\? type squashfs')" -eq 2
 


### PR DESCRIPTION
Other debug commands do not use nested subcommands but instead take
--param style parameters. Update the 'snap debug mount-namespace'
command to follow the same style.