### PR TITLE
packaging/debian-sid: make sure that usr/bin/snap is built with correct build tags

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -170,8 +170,10 @@ override_dh_auto_build: snapd.defines.mk
 	# dependencies from the distro, and this would require further updates to the
 	# go.mod file
 	GO111MODULE=off dh_auto_build -- $(BUILDFLAGS) -tags "$(TAGS)" $(GCCGOFLAGS)
-
-	GO111MODULE=off $(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snap SNAPD_DEFINES_DIR=$(CURDIR)
+	# remove snap built by dh_auto_build and build it again using the right tags
+	rm -v $(CURDIR)/_build/bin/snap
+	GO111MODULE=off GOPATH=$(CURDIR)/_build \
+		$(MAKE) -f packaging/snapd.mk $(CURDIR)/_build/bin/snap SNAPD_DEFINES_DIR=$(CURDIR)
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)


### PR DESCRIPTION
Make sure that usr/bin/snap is built with correct build tags.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
