### PR TITLE
Only run user services for regular users

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -450,6 +450,22 @@ snap-mgmt/snap-mgmt-selinux: snap-mgmt/snap-mgmt-selinux.sh.in Makefile snap-mgm
 endif
 
 ##
+## snap-user-exec-condition
+##
+
+libexec_SCRIPTS += snap-user-exec-condition/snap-user-exec-condition
+CLEANFILES += snap-user-exec-condition/$(am__dirstamp) snap-user-exec-condition/snap-user-exec-condition
+
+snap-user-exec-condition/$(am__dirstamp):
+	mkdir -p $$(dirname $@)
+	touch $@
+
+EXTRA_DIST += snap-user-exec-condition/main.py
+
+snap-user-exec-condition/snap-user-exec-condition: snap-user-exec-condition/main.py Makefile snap-user-exec-condition/$(am__dirstamp)
+	install -m 755 $< $@
+
+##
 ## snap-device-helper
 ##
 

--- a/cmd/snap-user-exec-condition/main.py
+++ b/cmd/snap-user-exec-condition/main.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+
+LOGIN1_BUS_NAME = "org.freedesktop.login1"
+LOGIN1_MANAGER_PATH = "/org/freedesktop/login1"
+LOGIN1_MANAGER_IFACE = "org.freedesktop.login1.Manager"
+LOGIN1_SESSION_IFACE = "org.freedesktop.login1.Session"
+DBUS_PROPERTIES_IFACE = "org.freedesktop.DBus.Properties"
+
+TARGET_SESSION_CLASS = "user"
+
+def get_session_class(bus, session_path):
+    result = bus.call_sync(
+        LOGIN1_BUS_NAME,
+        session_path,
+        DBUS_PROPERTIES_IFACE,
+        "Get",
+        GLib.Variant("(ss)", (LOGIN1_SESSION_IFACE, "Class")),
+        GLib.VariantType.new("(v)"),
+        Gio.DBusCallFlags.NONE,
+        -1,
+        None,
+    )
+
+    return result.unpack()[0]
+
+
+def main():
+    current_uid = os.getuid()
+
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+
+        result = bus.call_sync(
+            LOGIN1_BUS_NAME,
+            LOGIN1_MANAGER_PATH,
+            LOGIN1_MANAGER_IFACE,
+            "ListSessions",
+            None,
+            GLib.VariantType.new("(a(susso))"),
+            Gio.DBusCallFlags.NONE,
+            -1,
+            None,
+        )
+
+        sessions = result.unpack()[0]
+        for session_id, uid, username, seat, session_path in sessions:
+            if uid != current_uid:
+                continue
+
+            session_class = get_session_class(bus, session_path)
+            if session_class == TARGET_SESSION_CLASS:
+                print(f"found {TARGET_SESSION_CLASS} session: {session_id} ({username})")
+                return 0
+
+        print(f"no current-user sessions with class '{TARGET_SESSION_CLASS}' found")
+        return 77
+
+    except GLib.Error as error:
+        print(f"failed to query logind: {error.message}", file=sys.stderr)
+        return -1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/ubuntu-26.04/snapd.install.in
+++ b/packaging/ubuntu-26.04/snapd.install.in
@@ -47,3 +47,5 @@ NEWS.md /usr/share/doc/snapd/
 usr/lib/systemd/system-environment-generators
 # system generators use <systemdutildir>/system-generators (resolved via pkg-config)
 @systemd-lib@/system-generators
+
+usr/lib/snapd/snap-user-exec-condition

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -161,6 +161,9 @@ EnvironmentFile=-/etc/environment
 {{- if .LogNamespace}}
 Environment=SNAPD_LOG_NAMESPACE={{.LogNamespace}}
 {{- end}}
+{{- if .ExecCondition}}
+ExecCondition={{.ExecCondition}}
+{{- end}}
 ExecStart={{.App.LauncherCommand}}
 SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
 Restart={{.Restart}}
@@ -289,6 +292,7 @@ WantedBy={{.ServicesTarget}}
 		InterfaceUnitSnippets    string
 		SliceUnit                string
 		LogNamespace             string
+		ExecCondition            string
 
 		Home    string
 		EnvVars string
@@ -338,6 +342,7 @@ WantedBy={{.ServicesTarget}}
 		// FIXME: ideally use UserDataDir("%h"), but then the
 		// unit fails if the directory doesn't exist.
 		wrapperData.WorkingDir = appInfo.Snap.DataDir()
+		wrapperData.ExecCondition = "/usr/lib/snapd/snap-user-exec-condition"
 	default:
 		panic("unknown snap.DaemonScope")
 	}

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -83,6 +83,7 @@ X-Snappy=yes
 
 [Service]
 EnvironmentFile=-/etc/environment
+ExecCondition=/usr/lib/snapd/snap-user-exec-condition
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=%s


### PR DESCRIPTION
@olivercalder here's a draft on how to prevent user daemons from running on non-regular user sessions.

I've found a way to make the XDG_SESSION_CLASS check work, so that's what I implemented. It could be paired or replaced with a `uid >= 1000 && (uid < 60578 || uid > 60705)` check if that seems appropriate.

Ultimately this shouldn't be a python script, and actually it will probably have to be a `snap` CLI command so that it can be executed also when snapd is running as a snap.

I intend to keep this MR as just a draft, you can take it on from here.