### PR TITLE
tests/main/snap-cli-no-managers: skip the test if snaps is from archive

### DIFF
--- a/tests/main/snap-cli-no-managers/task.yaml
+++ b/tests/main/snap-cli-no-managers/task.yaml
@@ -6,6 +6,10 @@ details: |
 
 systems: [-ubuntu-core-*]
 
+skip:
+    - reason: needs snapd package built in tests
+      if: tests.info is-snapd-from-archive
+
 execute: |
   check_imports() {
     local BINFILE="$1"


### PR DESCRIPTION
The test is supposed to check the native packaging provided in snapd source tree. It makes no sense to run it if the suite is using snapd installed from a given distro's archive.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
