### PR TITLE
i/builtin: fix mountinfo denial for steam/docker interfaces

### DIFF
--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -250,6 +250,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -118,6 +118,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -843,6 +843,10 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 		}
 	}
 
+	// we need to override the base denial of /proc/self/mountinfo otherwise that
+	// denial would take priority over the broad `@{PROC}/** r,`
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
+
 	spec.SetUsesPtraceTrace()
 	return nil
 }

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -230,8 +230,8 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }
 
 func (s *DockerSupportInterfaceSuite) TestAppArmorSpec(c *C) {

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -206,6 +206,34 @@ func (s *DockerSupportInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
+func (s *DockerSupportInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	restore := apparmor_sandbox.MockFeatures(nil, nil, nil, nil)
+	defer restore()
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.docker.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	snippet = spec.SnippetForTag("snap.docker.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}
+
 func (s *DockerSupportInterfaceSuite) TestAppArmorSpec(c *C) {
 	// no features so should not support userns
 	restore := apparmor_sandbox.MockFeatures(nil, nil, nil, nil)

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -328,6 +328,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -296,6 +296,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, `owner @{PROC}/@{pid}/mountinfo r,`)
 	c.Assert(snippet, testutil.Contains, `owner @{PROC}/self/mountinfo r,`)
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -518,6 +518,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -106,6 +106,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -400,7 +400,7 @@ func (iface *steamSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 	}
 
 	// we need to override the base denial of /proc/self/mountinfo otherwise that
-	// denial would take priority over the allow all/file
+	// denial would take priority over the "allow all," / "allow file,"
 	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
 
 	spec.SetUsesPtraceTrace()

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -399,6 +399,10 @@ func (iface *steamSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 		}
 	}
 
+	// we need to override the base denial of /proc/self/mountinfo otherwise that
+	// denial would take priority over the allow all/file
+	spec.AddPrioritizedSnippet(mountInfoSnippet, apparmor.MountInfoKey, mountInfoPriority)
+
 	spec.SetUsesPtraceTrace()
 	return nil
 }

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -124,8 +124,8 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }
 
 func (s *SteamSupportInterfaceSuite) TestSecCompSpec(c *C) {

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -100,6 +100,34 @@ func (s *SteamSupportInterfaceSuite) TestAppArmorSpecWithoutAllowAll(c *C) {
 	c.Check(snippet, testutil.Contains, "Mimic allow all")
 }
 
+func (s *SteamSupportInterfaceSuite) TestPrioritizedSnippetMountInfo(c *C) {
+	restore := apparmor_sandbox.MockFeatures(nil, nil, []string{"allow-all"}, nil)
+	defer restore()
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	spec.AddBasePrioritizedSnippet(`
+deny @{PROC}/self/mountinfo r,
+deny @{PROC}/@{pid}/mountinfo r,
+`, apparmor.MountInfoKey)
+
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	// contains the denials but not the allows
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "owner @{PROC}/self/mountinfo r,")
+
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	snippet = spec.SnippetForTag("snap.consumer.app")
+	// contains the allows but not the denials
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
+	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+}
+
 func (s *SteamSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/usb_gadget_test.go
+++ b/interfaces/builtin/usb_gadget_test.go
@@ -220,6 +220,6 @@ deny @{PROC}/@{pid}/mountinfo r,
 	// contains the allows but not the denials
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/@{pid}/mountinfo r,")
 	c.Assert(snippet, testutil.Contains, "owner @{PROC}/self/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/@{pid}/mountinfo r,")
-	c.Assert(snippet, Not(testutil.Contains), "deny @{PROC}/self/mountinfo r,")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
+	c.Assert(snippet, Not(Matches), "(?s).*\ndeny [^\n]*/mountinfo [^\n]*.*")
 }


### PR DESCRIPTION
https://github.com/canonical/snapd/pull/16982 added a default denial for /proc/self/mountinfo due to recent changes to the Go runtime. It missed adding overrides for the docker and steam support interfaces since those granted more broad accesses (e.g., /proc/** or allow all).
Tested locally with both the steam and docker snaps.

https://warthogs.atlassian.net/browse/SNAPDENG-37182