### PR TITLE
o/snapshotstate: mock systemd for snapshotSuite as Restore now uses it to list mounts

### DIFF
--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -53,6 +53,8 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -78,6 +80,9 @@ func (s *snapshotSuite) SetUpTest(c *check.C) {
 		return nil, nil
 	}
 	s.AddCleanup(osutil.MockMountInfo(""))
+	s.AddCleanup(systemd.MockNewSystemd(func(_ systemd.Backend, _ string, _ systemd.InstanceMode, _ systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	}))
 }
 
 func (s *snapshotSuite) TearDownTest(c *check.C) {


### PR DESCRIPTION
This fixes a flaky unit test for the changes introduced in https://github.com/canonical/snapd/pull/17224.

```
FAIL: <autogenerated>:1: snapshotSuite.TestRestoreIntegrationFails

snapshotstate_test.go:1398:
    c.Check(strings.TrimSpace(string(out)), check.Equals, filepath.Join(homedir, "snap"))
... obtained string = "" +
...     "/tmp/check-1545068906/85/home/a-user/snap\n" +
...     "/tmp/check-1545068906/85/home/a-user/snap/tri-snap\n" +
...     "/tmp/check-1545068906/85/home/a-user/snap/one-snap"
... expected string = "/tmp/check-1545068906/85/home/a-user/snap"

OOPS: 106 passed, 1 FAILED
--- FAIL: TestSnapshot (1.38s)
```