### PR TITLE
o/ifacestate, tests: ensure profiles are setup before running prepare-{slot, plug}* hooks

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -158,6 +158,15 @@ func delayedEffectsTask(chg *state.Change) *state.Task {
 	return nil
 }
 
+func hasPrepareConnectionHook(snapInfo *snap.Info) bool {
+	for hookName := range snapInfo.Hooks {
+		if strings.HasPrefix(hookName, "prepare-plug-") || strings.HasPrefix(hookName, "prepare-slot-") {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
 	st.Lock()
@@ -229,15 +238,31 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 	}
 
 	if prepareProfiles {
-		// In prepare mode we only refresh repository state and run backend
-		// preparation; full profile setup is deferred to the later
-		// setup-profiles task after auto-connect.
+		// In prepare mode we refresh repository state and run backend
+		// preparation. Full connection-aware regeneration is deferred to the
+		// later setup-profiles task after auto-connect, but snaps that declare
+		// prepare connection hooks still need baseline setup now so those hooks
+		// can execute under confinement.
 		if _, _, err = m.refreshAppSetConnections(task, appSet); err != nil {
 			return err
 		}
 
 		for _, backend := range m.repo.Backends() {
 			if err := backend.Prepare(appSet); err != nil {
+				return err
+			}
+		}
+		if hasPrepareConnectionHook(snapInfo) {
+			// prepare-{plug,slot}- hooks run before the later full setup-profiles
+			// task, so their hook context still needs baseline confinement and
+			// backend artifacts such as snap device cgroup policy files.
+			sctxs := map[string]interfaces.SetupContext{
+				appSet.InstanceName(): {
+					Reason:          interfaces.SnapSetupReasonOwnUpdate,
+					CanDelayEffects: false,
+				},
+			}
+			if err := m.setupSecurityByBackend(task, []*interfaces.SnapAppSet{appSet}, []interfaces.ConfinementOptions{opts}, sctxs, perfTimings); err != nil {
 				return err
 			}
 		}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3642,10 +3642,12 @@ slots:
 }
 
 // This covers the split setup-profiles flow where one setup-profiles task runs
-// in "prepare-profiles" mode (minimal work before auto-connect) and a later
-// setup-profiles task does full profile generation. The producer's final
-// setup must observe the connection created by the consumer path and regenerate
-// both snaps accordingly.
+// in "prepare-profiles" mode before auto-connect and a later setup-profiles
+// task does full profile generation. Snaps with prepare interface hooks now
+// receive a baseline single-snap setup in the prepare phase so those hooks can
+// execute under confinement. The producer's final setup must still observe the
+// connection created by the consumer path and regenerate both snaps
+// accordingly.
 func (s *interfaceManagerSuite) TestProducerSetupProfilesWaitsForConsumerSetupProfilesAndConnectionIsMade(c *C) {
 	s.MockModel(c, nil)
 
@@ -3726,7 +3728,7 @@ slots:
 	consumerSetup := snapstate.FindTaskMatchingKindAndSnap(consumerChange.Tasks(), "setup-profiles", "consumer")
 	c.Assert(consumerSetup, Not(IsNil))
 
-	c.Assert(secBackend.SetupManyCalls, HasLen, 3)
+	c.Assert(secBackend.SetupManyCalls, HasLen, 5)
 
 	// order the appsets so that the checks are deterministic
 	for i := range secBackend.SetupManyCalls {
@@ -3740,15 +3742,21 @@ slots:
 	c.Check(secBackend.SetupManyCalls[0].AppSets[0].InstanceName(), Equals, "consumer")
 	c.Check(secBackend.SetupManyCalls[0].AppSets[1].InstanceName(), Equals, "producer")
 
-	// doSetupProfiles for consumer
-	c.Assert(secBackend.SetupManyCalls[1].AppSets, HasLen, 1)
-	c.Check(secBackend.SetupManyCalls[1].AppSets[0].InstanceName(), Equals, "consumer")
+	// The prepare phase now sets up the individual snaps that declare
+	// prepare-{plug,slot}- hooks before those hooks can run.
+	singleSnapCalls := make([]string, 0, 3)
+	for _, call := range secBackend.SetupManyCalls[1:4] {
+		c.Assert(call.AppSets, HasLen, 1)
+		singleSnapCalls = append(singleSnapCalls, call.AppSets[0].InstanceName())
+	}
+	sort.Strings(singleSnapCalls)
+	c.Check(singleSnapCalls, DeepEquals, []string{"consumer", "consumer", "producer"})
 
 	// doSetupProfiles for the producer, and here the important thing is that
 	// setup-profiles marks both producer and consumer for setting up
-	c.Assert(secBackend.SetupManyCalls[2].AppSets, HasLen, 2)
-	c.Check(secBackend.SetupManyCalls[2].AppSets[0].InstanceName(), Equals, "consumer")
-	c.Check(secBackend.SetupManyCalls[2].AppSets[1].InstanceName(), Equals, "producer")
+	c.Assert(secBackend.SetupManyCalls[4].AppSets, HasLen, 2)
+	c.Check(secBackend.SetupManyCalls[4].AppSets[0].InstanceName(), Equals, "consumer")
+	c.Check(secBackend.SetupManyCalls[4].AppSets[1].InstanceName(), Equals, "producer")
 }
 
 // The auto-connect task will check snap declarations providing the
@@ -6896,6 +6904,70 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.PendingSecurity.SideInfo.Revision, Equals, snapInfo.Revision)
+}
+
+func (s *interfaceManagerSuite) TestPrepareProfilesSetsUpSecurityForPrepareConnectionHooks(c *C) {
+	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
+
+	const producerV1 = `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: test
+hooks:
+ prepare-slot-slot:
+`
+	const producerV2 = `
+name: producer
+version: 2
+slots:
+ slot:
+  interface: test
+hooks:
+ prepare-slot-slot:
+`
+
+	producerInfo := s.mockSnap(c, producerV1)
+	updatedInfo := s.mockUpdatedSnap(c, producerV2, producerInfo.Revision.N+1)
+
+	_ = s.manager(c)
+
+	s.state.Lock()
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, producerInfo.InstanceName(), &snapst), IsNil)
+	snapst.Active = false
+	snapstate.Set(s.state, producerInfo.InstanceName(), &snapst)
+
+	change := s.state.NewChange("test", "")
+	task := s.state.NewTask("setup-profiles", "")
+	task.Set("prepare-profiles", true)
+	task.Set("snap-setup", &snapstate.SnapSetup{SideInfo: &snap.SideInfo{
+		RealName: updatedInfo.SnapName(),
+		Revision: updatedInfo.Revision,
+	}})
+	change.AddTask(task)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+	c.Assert(change.Err(), IsNil)
+	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
+	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, producerInfo.InstanceName())
+	c.Check(s.secBackend.SetupCalls[0].AppSet.Info().Revision, Equals, updatedInfo.Revision)
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[0].SetupContext, DeepEquals, interfaces.SetupContext{
+		Reason:          interfaces.SnapSetupReasonOwnUpdate,
+		CanDelayEffects: false,
+	})
+
+	c.Assert(snapstate.Get(s.state, producerInfo.InstanceName(), &snapst), IsNil)
+	c.Assert(snapst.PendingSecurity, NotNil)
+	c.Check(snapst.PendingSecurity.SideInfo.Revision, Equals, updatedInfo.Revision)
 }
 
 func (s *interfaceManagerSuite) TestFailedRefreshRestoresAutoConnectionPrunedFromIncomingRevision(c *C) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4704,13 +4704,16 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	s.testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c, snapInfo.InstanceName(), snapInfo.Revision)
 
 	// Ensure that the backend was used to setup security of both snaps
-	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
+	// consumer is set up twice (prepare and main phase), producer once
+	c.Assert(s.secBackend.SetupCalls, HasLen, 3)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "producer")
+	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
+	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, "producer")
 
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInvokedOnSlotSide(c *C) {
@@ -4722,17 +4725,26 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	s.testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c, snapInfo.InstanceName(), snapInfo.Revision)
 
 	// Ensure that the backend was used to setup security of both snaps
-	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
+	// producer is set up twice (prepare and main phase), consumer once
+	c.Assert(s.secBackend.SetupCalls, HasLen, 3)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "producer")
-	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
+	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "producer")
+	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, "consumer")
 
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+
+	// Verify the reasons for each Setup call
 	c.Check(s.secBackend.SetupCalls[0].SetupContext, DeepEquals, interfaces.SetupContext{
 		Reason: interfaces.SnapSetupReasonOwnUpdate,
 	})
 	c.Check(s.secBackend.SetupCalls[1].SetupContext, DeepEquals, interfaces.SetupContext{
+		Reason: interfaces.SnapSetupReasonOwnUpdate,
+	})
+	// Consumer is affected because it's connected to the producer's slot
+	c.Check(s.secBackend.SetupCalls[2].SetupContext, DeepEquals, interfaces.SetupContext{
 		Reason: interfaces.SnapSetupReasonConnectedSlotProviderUpdate,
 	})
 }
@@ -6428,13 +6440,15 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	c.Check(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
-	// The first snap is setup in devmode, the second is not
-	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
+	// The consumer is set up twice in devmode (prepare and main), the producer is set up not in devmode
+	c.Assert(s.secBackend.SetupCalls, HasLen, 3)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, siC.InstanceName())
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true, KernelSnap: "krnl"})
-	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, siP.InstanceName())
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, siC.InstanceName())
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true, KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, siP.InstanceName())
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeny(c *C) {
@@ -13406,14 +13420,16 @@ func (s *interfaceManagerSuite) testDelayedEffectsSetupProfilesRunThrough(c *C, 
 	// call parameters verified in callback
 	if opts.AlreadyConnected {
 		c.Check(setupCalls, DeepEquals, []string{
-			"producer", // 1st call to the producer
-			"consumer", // 2nd call to an affected snap
+			"producer", // 1st call to the producer (prepare phase)
+			"producer", // 2nd call to the producer (final phase)
+			"consumer", // 3rd call to an affected snap
 		})
 	} else {
 		// new connection through auto-connect
 		c.Check(setupCalls, DeepEquals, []string{
-			"producer", // 1st setup-profiles triggered by auto-connect
-			"consumer", // 2nd call to an affected snap
+			"producer", // 1st setup-profiles triggered by auto-connect (prepare phase)
+			"producer", // 2nd call to the producer (final phase)
+			"consumer", // 3rd call to an affected snap
 		})
 	}
 
@@ -13652,7 +13668,8 @@ func (s *interfaceManagerSuite) TestDelayedEffectsSetupProfilesRunThroughMultipl
 	c.Check(chg.Err(), IsNil)
 	// call parameters verified in callback
 	c.Check(setupCalls, DeepEquals, []string{
-		"producer",  // 1st call to the producer
+		"producer",  // 1st call to the producer (prepare phase)
+		"producer",  // 2nd call to the producer (final phase)
 		"consumer1", // affected snap
 		"consumer2", // affected snap
 		"consumer3", // affected snap

--- a/tests/main/layout-content-prepare-hook/task.yaml
+++ b/tests/main/layout-content-prepare-hook/task.yaml
@@ -1,0 +1,66 @@
+summary: Verify interaction with content created in slot prepare hook
+
+details: |
+    Verify that the content created by slot prepare hook is visible in the slot
+    consumer.
+
+environment:
+    STORE_DIR: $(pwd)/fake-store-blobdir
+    STORE_ADDR: localhost:11028
+
+skip:
+    - reason: "Test keys need to be trusted"
+      if: |
+          [ "$TRUST_TEST_KEYS" = "false" ]
+
+prepare: |
+    snap install core24
+
+    "$TESTSTOOLS"/store-state setup-fake-store "$STORE_DIR"
+    tests.cleanup defer "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
+
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    snap ack "$TESTSLIB/assertions/developer1.account"
+    snap ack "$TESTSLIB/assertions/developer1.account-key"
+
+    cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$STORE_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+
+    # provider snaps
+    snap pack test-snapd-content-provider
+
+    "$TESTSTOOLS"/store-state make-snap-installable --revision 1 "$STORE_DIR" \
+        test-snapd-content-provider_1*.snap provider-id
+
+    # consumer snap
+    snap pack test-snapd-content-consumer
+    "$TESTSTOOLS"/store-state make-snap-installable --revision 1 "$STORE_DIR" \
+        test-snapd-content-consumer_1.*.snap consumer-id
+
+debug: |
+    cat /var/snap/test-snapd-content-provider/common/hook.log || true
+    cat /var/snap/test-snapd-content-consumer/common/hook.log || true
+
+execute: |
+    # Install the consumer snap before the provider to ensure
+    # provider profiles are not yet set up. They will get set up
+    # before running prepare-slot* hooks.
+    snap install test-snapd-content-consumer
+
+    snap install test-snapd-content-provider
+
+    snap connections test-snapd-content-consumer | MATCH "test-snapd-content-provider:content-basic"
+    # the prepare slot hook created the target
+    test -e /var/snap/test-snapd-content-provider/common/basic/content
+    MATCH "content slot prepare hook" < /var/snap/test-snapd-content-provider/common/hook.log
+
+    test-snapd-content-consumer.app |& tee output.log
+    MATCH 'app running' < output.log
+    MATCH 'content basic' < output.log
+
+    MATCH 'content basic' < /var/snap/test-snapd-content-provider/common/basic/content
+
+    # shellcheck disable=SC2016
+    snap run --shell test-snapd-content-consumer.app -c 'echo foo > $SNAP_COMMON/content-basic/bar'
+    MATCH 'foo' < /var/snap/test-snapd-content-provider/common/basic/bar

--- a/tests/main/layout-content-prepare-hook/test-snapd-content-consumer/bin/app
+++ b/tests/main/layout-content-prepare-hook/test-snapd-content-consumer/bin/app
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "app running"
+cat "$SNAP_COMMON/content-basic/content"

--- a/tests/main/layout-content-prepare-hook/test-snapd-content-consumer/meta/snap.yaml
+++ b/tests/main/layout-content-prepare-hook/test-snapd-content-consumer/meta/snap.yaml
@@ -1,0 +1,14 @@
+name: test-snapd-content-consumer
+version: 1.0.0
+base: core24
+
+apps:
+    app:
+        command: bin/app
+        plugs:
+            - content-basic
+
+plugs:
+  content-basic:
+    interface: content
+    target: $SNAP_COMMON/content-basic

--- a/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/hooks/connect-slot-content-basic
+++ b/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/hooks/connect-slot-content-basic
@@ -1,0 +1,6 @@
+#!/bin/sh
+exec >> "$SNAP_COMMON/hook.log" 2>&1
+
+date
+echo "=== provider"
+echo "connecting slot special-content basic"

--- a/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/hooks/prepare-slot-content-basic
+++ b/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/hooks/prepare-slot-content-basic
@@ -1,0 +1,9 @@
+#!/bin/sh
+exec >> "$SNAP_COMMON/hook.log" 2>&1
+
+date
+echo "=== provider"
+echo "content slot prepare hook"
+
+mkdir -p "$SNAP_COMMON"/basic
+echo "content basic" > "$SNAP_COMMON"/basic/content

--- a/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/snap.yaml
+++ b/tests/main/layout-content-prepare-hook/test-snapd-content-provider/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-content-provider
+version: 1.0.0
+base: core24
+
+slots:
+    content-basic:
+        interface: content
+        write:
+            - $SNAP_COMMON/basic


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/SNAPDENG-37152

proposed fix from @Meulengracht
spread test modified to show the failure from @bboozzoo's PR https://github.com/canonical/snapd/pull/17300