### PR TITLE
many: extend /v2/system-info/storage-encrypted to show install-time decisions

### DIFF
--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -1250,6 +1251,10 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithoutModel(c *check.C) {
 		expectedStatus = status
 		expectedResponse["status"] = status
 		expectedResponse["auto-repair-result"] = "not-initialized"
+		expectedResponse["preinstall"] = map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		}
 	}
 
 	defer daemon.MockFdestateSystemState(func(s *state.State, model *asserts.Model) (*fdestate.FDESystemState, error) {
@@ -1258,12 +1263,20 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithoutModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusActive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
+				Preinstall: fdestate.FDEPreinstallState{
+					Requirements:   []install.EncryptionSupportRequirement{},
+					AcceptedErrors: map[string]any{},
+				},
 			}, nil
 
 		case "inactive":
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusInactive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
+				Preinstall: fdestate.FDEPreinstallState{
+					Requirements:   []install.EncryptionSupportRequirement{},
+					AcceptedErrors: map[string]any{},
+				},
 			}, nil
 		}
 
@@ -1325,6 +1338,12 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithModel(c *check.C) {
 		expectedStatus = status
 		expectedResponse["status"] = status
 		expectedResponse["auto-repair-result"] = "not-initialized"
+		expectedResponse["preinstall"] = map[string]any{
+			"requirements": []any{"volumes-auth"},
+			"accepted-errors": map[string]any{
+				"no-hardware-root-of-trust": nil,
+			},
+		}
 	}
 
 	defer daemon.MockFdestateSystemState(func(s *state.State, model *asserts.Model) (*fdestate.FDESystemState, error) {
@@ -1333,12 +1352,24 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusActive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
+				Preinstall: fdestate.FDEPreinstallState{
+					Requirements: []install.EncryptionSupportRequirement{"volumes-auth"},
+					AcceptedErrors: map[string]any{
+						"no-hardware-root-of-trust": nil,
+					},
+				},
 			}, nil
 
 		case "inactive":
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusInactive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
+				Preinstall: fdestate.FDEPreinstallState{
+					Requirements: []install.EncryptionSupportRequirement{"volumes-auth"},
+					AcceptedErrors: map[string]any{
+						"no-hardware-root-of-trust": nil,
+					},
+				},
 			}, nil
 		}
 

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -1263,7 +1263,7 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithoutModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusActive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
-				Preinstall: fdestate.FDEPreinstallState{
+				Preinstall: fdestate.FDEPreinstallInfo{
 					Requirements:   []install.EncryptionSupportRequirement{},
 					AcceptedErrors: map[string]any{},
 				},
@@ -1273,7 +1273,7 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithoutModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusInactive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
-				Preinstall: fdestate.FDEPreinstallState{
+				Preinstall: fdestate.FDEPreinstallInfo{
 					Requirements:   []install.EncryptionSupportRequirement{},
 					AcceptedErrors: map[string]any{},
 				},
@@ -1352,7 +1352,7 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusActive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
-				Preinstall: fdestate.FDEPreinstallState{
+				Preinstall: fdestate.FDEPreinstallInfo{
 					Requirements: []install.EncryptionSupportRequirement{"volumes-auth"},
 					AcceptedErrors: map[string]any{
 						"no-hardware-root-of-trust": nil,
@@ -1364,7 +1364,7 @@ func (s *generalSuite) TestSysInfoStorageEncHappyWithModel(c *check.C) {
 			return &fdestate.FDESystemState{
 				Status:           fdestate.FDEStatusInactive,
 				AutoRepairResult: fdestate.AutoRepairNotInitialized,
-				Preinstall: fdestate.FDEPreinstallState{
+				Preinstall: fdestate.FDEPreinstallInfo{
 					Requirements: []install.EncryptionSupportRequirement{"volumes-auth"},
 					AcceptedErrors: map[string]any{
 						"no-hardware-root-of-trust": nil,

--- a/overlord/fdestate/activate_state.go
+++ b/overlord/fdestate/activate_state.go
@@ -89,8 +89,8 @@ func RunningWithPlatformKeys(status FDEStatus) bool {
 	return status == FDEStatusDegraded || status == FDEStatusActive
 }
 
-// FDEPreinstallState is json serializable data captured at install time.
-type FDEPreinstallState struct {
+// FDEPreinstallInfo is json serializable data captured at install time.
+type FDEPreinstallInfo struct {
 	// Requirements lists encryption support requirements detected at install-time.
 	Requirements []install.EncryptionSupportRequirement `json:"requirements"`
 
@@ -111,14 +111,14 @@ type FDESystemState struct {
 	AutoRepairResult AutoRepairResult `json:"auto-repair-result"`
 
 	// Preinstall provides information captured during install-time checks.
-	Preinstall FDEPreinstallState `json:"preinstall"`
+	Preinstall FDEPreinstallInfo `json:"preinstall"`
 }
 
 // SystemState returns a json serializable FDE state of the booted
 // system.
 func SystemState(st *state.State, model *asserts.Model) (*FDESystemState, error) {
 	ret := &FDESystemState{
-		Preinstall: FDEPreinstallState{
+		Preinstall: FDEPreinstallInfo{
 			Requirements:   []install.EncryptionSupportRequirement{},
 			AcceptedErrors: map[string]any{},
 		},

--- a/overlord/fdestate/activate_state.go
+++ b/overlord/fdestate/activate_state.go
@@ -25,12 +25,14 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 )
 
 var (
-	bootLoadDiskUnlockState = boot.LoadDiskUnlockState
+	bootLoadDiskUnlockState   = boot.LoadDiskUnlockState
+	installLoadPreinstallInfo = install.LoadPreinstallInfo
 )
 
 var errNoActivateState = errors.New("snap-bootstrap did not provide an activation state")
@@ -87,6 +89,17 @@ func RunningWithPlatformKeys(status FDEStatus) bool {
 	return status == FDEStatusDegraded || status == FDEStatusActive
 }
 
+// FDEPreinstallState is json serializable data captured at install time.
+type FDEPreinstallState struct {
+	// Requirements lists encryption support requirements detected at install-time.
+	Requirements []install.EncryptionSupportRequirement `json:"requirements"`
+
+	// AcceptedErrors maps accepted preinstall check error kinds to optional metadata.
+	// Values are currently nil with but can be extended later with arguments for
+	// future proofing.
+	AcceptedErrors map[string]any `json:"accepted-errors"`
+}
+
 // FDESystemState is json serializable disk encryption state for the
 // current boot.
 type FDESystemState struct {
@@ -96,12 +109,32 @@ type FDESystemState struct {
 
 	// AutoRepairResult is the status of the auto-repair attempt
 	AutoRepairResult AutoRepairResult `json:"auto-repair-result"`
+
+	// Preinstall provides information captured during install-time checks.
+	Preinstall FDEPreinstallState `json:"preinstall"`
 }
 
 // SystemState returns a json serializable FDE state of the booted
 // system.
 func SystemState(st *state.State, model *asserts.Model) (*FDESystemState, error) {
-	ret := &FDESystemState{}
+	ret := &FDESystemState{
+		Preinstall: FDEPreinstallState{
+			Requirements:   []install.EncryptionSupportRequirement{},
+			AcceptedErrors: map[string]any{},
+		},
+	}
+
+	preinstallInfo, err := installLoadPreinstallInfo()
+	if err != nil {
+		return nil, err
+	}
+	requirements := preinstallInfo.Requirements()
+	if len(requirements) != 0 {
+		ret.Preinstall.Requirements = requirements
+	}
+	for _, errKind := range preinstallInfo.AcceptedErrors {
+		ret.Preinstall.AcceptedErrors[errKind] = nil
+	}
 
 	repairResult, err := getRepairAttemptResult(st)
 	if err != nil {

--- a/overlord/fdestate/activate_state.go
+++ b/overlord/fdestate/activate_state.go
@@ -95,7 +95,7 @@ type FDEPreinstallState struct {
 	Requirements []install.EncryptionSupportRequirement `json:"requirements"`
 
 	// AcceptedErrors maps accepted preinstall check error kinds to optional metadata.
-	// Values are currently nil with but can be extended later with arguments for
+	// Values are currently nil but can be extended later with arguments for
 	// future proofing.
 	AcceptedErrors map[string]any `json:"accepted-errors"`
 }

--- a/overlord/fdestate/activate_state_test.go
+++ b/overlord/fdestate/activate_state_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/testutil"
@@ -100,6 +101,10 @@ func (s *activateStateSuite) TestActivateStateHappy(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "active",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 
 	// Let's check the file is cached
@@ -140,6 +145,10 @@ func (s *activateStateSuite) TestActivateStateHappyWithAutoRepairState(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "active",
 		"auto-repair-result": "success",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 
 	// Let's check the file is cached
@@ -181,6 +190,10 @@ func (s *activateStateSuite) TestActivateStateDegraded(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "degraded",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 
 	// Let's check the file is cached
@@ -210,6 +223,10 @@ func (s *activateStateSuite) TestActivateStateInactive(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "inactive",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 }
 
@@ -241,6 +258,10 @@ func (s *activateStateSuite) TestActivateStateRecovery(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "recovery",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 }
 
@@ -260,6 +281,10 @@ func (s *activateStateSuite) TestActivateStateNoActivateState(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "indeterminate",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 }
 
@@ -310,6 +335,10 @@ func (s *activateStateSuite) TestActivateStateNoUnlockedJSONStateHybridModel(c *
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "indeterminate",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 }
 
@@ -338,6 +367,10 @@ func (s *activateStateSuite) TestActivateStateNoUnlockedJSONClassicModel(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "inactive",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
 }
 
@@ -357,7 +390,76 @@ func (s *activateStateSuite) TestActivateStateNoUnlockedJSONNoModel(c *C) {
 	c.Check(systemState, SerializesTo, map[string]any{
 		"status":             "indeterminate",
 		"auto-repair-result": "not-initialized",
+		"preinstall": map[string]any{
+			"requirements":    []any{},
+			"accepted-errors": map[string]any{},
+		},
 	})
+}
+
+func (s *activateStateSuite) testActivateStateIncludesPreinstallRequirements(c *C, noHWROT bool) {
+	defer fdestate.MockBootLoadDiskUnlockState(func(name string) (*boot.DiskUnlockState, error) {
+		c.Check(name, Equals, "unlocked.json")
+
+		s := &secboot.ActivateState{}
+		s.Activations = map[string]*sb.ContainerActivateState{
+			"data-cred-id": {
+				Status: sb.ActivationSucceededWithPlatformKey,
+			},
+			"save-cred-id": {
+				Status: sb.ActivationSucceededWithPlatformKey,
+			},
+		}
+		return &boot.DiskUnlockState{State: s}, nil
+	})()
+
+	defer fdestate.MockInstallLoadPreinstallInfo(func() (*install.PreinstallInfo, error) {
+		if noHWROT {
+			return &install.PreinstallInfo{
+				AcceptedErrors: []string{secboot.ErrorKindNoHardwareRootOfTrust},
+			}, nil
+		}
+		return &install.PreinstallInfo{
+			AcceptedErrors: []string{"running-in-vm"},
+		}, nil
+	})()
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	systemState, err := fdestate.SystemState(st, nil)
+	c.Assert(err, IsNil)
+
+	if noHWROT {
+		c.Check(systemState, SerializesTo, map[string]any{
+			"status":             "active",
+			"auto-repair-result": "not-initialized",
+			"preinstall": map[string]any{
+				"requirements":    []any{"volumes-auth"},
+				"accepted-errors": map[string]any{secboot.ErrorKindNoHardwareRootOfTrust: nil},
+			},
+		})
+	} else {
+		c.Check(systemState, SerializesTo, map[string]any{
+			"status":             "active",
+			"auto-repair-result": "not-initialized",
+			"preinstall": map[string]any{
+				"requirements":    []any{},
+				"accepted-errors": map[string]any{"running-in-vm": nil},
+			},
+		})
+	}
+}
+
+func (s *activateStateSuite) TestActivateStateIncludesPreinstallRequirements(c *C) {
+	const noHWROT = false
+	s.testActivateStateIncludesPreinstallRequirements(c, noHWROT)
+}
+
+func (s *activateStateSuite) TestActivateStateIncludesPreinstallRequirementsNoHWROT(c *C) {
+	const noHWROT = true
+	s.testActivateStateIncludesPreinstallRequirements(c, noHWROT)
 }
 
 func (s *activateStateSuite) TestActivateStateErrorUnlockedJSON(c *C) {

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -174,6 +175,10 @@ func VolumesAuthOptionsKey() volumesAuthOptionsKey {
 
 func MockBootLoadDiskUnlockState(f func(name string) (*boot.DiskUnlockState, error)) (restore func()) {
 	return testutil.Mock(&bootLoadDiskUnlockState, f)
+}
+
+func MockInstallLoadPreinstallInfo(f func() (*install.PreinstallInfo, error)) (restore func()) {
+	return testutil.Mock(&installLoadPreinstallInfo, f)
 }
 
 type CachedActivateStateKey = cachedActivateStateKey

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -75,9 +75,5 @@ func MockSecbootFDEOpteeTAPresent(fn func() bool) (restore func()) {
 }
 
 func MockSecbootLoadCheckResult(f func(filename string) (*secboot.PreinstallCheckResult, error)) (restore func()) {
-	old := secbootLoadCheckResult
-	secbootLoadCheckResult = f
-	return func() {
-		secbootLoadCheckResult = old
-	}
+	return testutil.Mock(&secbootLoadCheckResult, f)
 }

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -71,4 +72,12 @@ func MockSecbootFDEOpteeTAPresent(fn func() bool) (restore func()) {
 	restore = testutil.Backup(&secbootFDEOpteeTAPresent)
 	secbootFDEOpteeTAPresent = fn
 	return restore
+}
+
+func MockSecbootLoadCheckResult(f func(filename string) (*secboot.PreinstallCheckResult, error)) (restore func()) {
+	old := secbootLoadCheckResult
+	secbootLoadCheckResult = f
+	return func() {
+		secbootLoadCheckResult = old
+	}
 }

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -1123,10 +1123,12 @@ func (p *preseedSnapHandler) HandleAndDigestAssertedContainer(cpi snap.Container
 	return targetPath, sha3_384, uint64(size), nil
 }
 
+// PreinstallInfo holds preinstall check information persisted during install.
 type PreinstallInfo struct {
 	AcceptedErrors []string
 }
 
+// LoadPreinstallInfo loads persisted preinstall check information.
 func LoadPreinstallInfo() (*PreinstallInfo, error) {
 	checkResultPath := device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir)
 	checkResult, err := secbootLoadCheckResult(checkResultPath)
@@ -1143,6 +1145,7 @@ func LoadPreinstallInfo() (*PreinstallInfo, error) {
 	}, nil
 }
 
+// Requirements returns the encryption support requirements implied by the accepted errors.
 func (info *PreinstallInfo) Requirements() []EncryptionSupportRequirement {
 	acceptedErrors := make(map[string]bool, len(info.AcceptedErrors))
 	for _, err := range info.AcceptedErrors {

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -122,8 +122,12 @@ const (
 
 // Requirements returns the list of encryption support requirements.
 func (esi *EncryptionSupportInfo) Requirements() []EncryptionSupportRequirement {
+	return encryptionSupportRequirements(esi.seenAvailabilityCheckErrorKinds)
+}
+
+func encryptionSupportRequirements(preinstallErrors map[string]bool) []EncryptionSupportRequirement {
 	var requirements []EncryptionSupportRequirement
-	if esi.seenAvailabilityCheckErrorKinds[secboot.ErrorKindNoHardwareRootOfTrust] {
+	if preinstallErrors[secboot.ErrorKindNoHardwareRootOfTrust] {
 		requirements = append(requirements, EncryptionSupportRequirementVolumesAuth)
 	}
 	return requirements
@@ -159,6 +163,7 @@ var (
 	secbootPreinstallCheckAction       = (*secboot.PreinstallCheckContext).PreinstallCheckAction
 	secbootSaveCheckResult             = (*secboot.PreinstallCheckContext).SaveCheckResult
 	secbootCheckResult                 = (*secboot.PreinstallCheckContext).CheckResult
+	secbootLoadCheckResult             = secboot.LoadCheckResult
 	secbootFDEOpteeTAPresent           = secboot.FDEOpteeTAPresent
 	preinstallCheckTimeout             = 2 * time.Minute
 
@@ -1116,4 +1121,32 @@ func (p *preseedSnapHandler) HandleAndDigestAssertedContainer(cpi snap.Container
 		return "", "", 0, fmt.Errorf("cannot encode snap %q digest: %v", path, err)
 	}
 	return targetPath, sha3_384, uint64(size), nil
+}
+
+type PreinstallInfo struct {
+	AcceptedErrors []string
+}
+
+func LoadPreinstallInfo() (*PreinstallInfo, error) {
+	checkResultPath := device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir)
+	checkResult, err := secbootLoadCheckResult(checkResultPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// no preinstall info was saved.
+			return &PreinstallInfo{}, nil
+		}
+		return nil, err
+	}
+
+	return &PreinstallInfo{
+		AcceptedErrors: checkResult.AcceptedErrors(),
+	}, nil
+}
+
+func (info *PreinstallInfo) Requirements() []EncryptionSupportRequirement {
+	acceptedErrors := make(map[string]bool, len(info.AcceptedErrors))
+	for _, err := range info.AcceptedErrors {
+		acceptedErrors[err] = true
+	}
+	return encryptionSupportRequirements(acceptedErrors)
 }

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -433,6 +433,78 @@ func (s *installSuite) TestEncryptionSupportRequirements(c *C) {
 	c.Assert(encSupportInfo.Requirements()[0], Equals, install.EncryptionSupportRequirementVolumesAuth)
 }
 
+func (s *installSuite) TestPreinstallInfoRequirements(c *C) {
+	preinstallInfo := install.PreinstallInfo{}
+
+	// nil accepted-errors list should not require volumes auth
+	c.Assert(preinstallInfo.Requirements(), HasLen, 0)
+
+	preinstallInfo.AcceptedErrors = []string{}
+	c.Assert(preinstallInfo.Requirements(), HasLen, 0)
+
+	preinstallInfo.AcceptedErrors = []string{"some-other-kind"}
+	c.Assert(preinstallInfo.Requirements(), HasLen, 0)
+
+	preinstallInfo.AcceptedErrors = []string{secboot.ErrorKindNoHardwareRootOfTrust}
+	c.Assert(preinstallInfo.Requirements(), HasLen, 1)
+	c.Assert(preinstallInfo.Requirements()[0], Equals, install.EncryptionSupportRequirementVolumesAuth)
+}
+
+func (s *installSuite) TestLoadPreinstallInfo(c *C) {
+	restore := install.MockSecbootLoadCheckResult(func(filename string) (*secboot.PreinstallCheckResult, error) {
+		checkResultJSON := `{
+			"result": {
+				"accepted-errors": {
+					"no-hardware-root-of-trust": null,
+					"running-in-vm": null
+				}
+			}
+		}`
+		var checkResult secboot.PreinstallCheckResult
+		err := json.Unmarshal([]byte(checkResultJSON), &checkResult)
+		c.Assert(err, IsNil)
+		return &checkResult, nil
+	})
+	defer restore()
+
+	info, err := install.LoadPreinstallInfo()
+	c.Assert(err, IsNil)
+	c.Assert(info, DeepEquals, &install.PreinstallInfo{
+		AcceptedErrors: []string{
+			secboot.ErrorKindNoHardwareRootOfTrust,
+			"running-in-vm",
+		},
+	})
+	c.Assert(info.Requirements(), DeepEquals, []install.EncryptionSupportRequirement{"volumes-auth"})
+}
+
+func (s *installSuite) TestLoadPreinstallInfoNotExist(c *C) {
+	checkResultPath := device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir)
+
+	restore := install.MockSecbootLoadCheckResult(func(filename string) (*secboot.PreinstallCheckResult, error) {
+		c.Check(filename, Equals, checkResultPath)
+		return nil, os.ErrNotExist
+	})
+	defer restore()
+
+	info, err := install.LoadPreinstallInfo()
+	c.Assert(err, IsNil)
+	c.Assert(info, DeepEquals, &install.PreinstallInfo{})
+}
+
+func (s *installSuite) TestLoadPreinstallInfoLoadError(c *C) {
+	expectedErr := errors.New("boom")
+
+	restore := install.MockSecbootLoadCheckResult(func(filename string) (*secboot.PreinstallCheckResult, error) {
+		return nil, expectedErr
+	})
+	defer restore()
+
+	info, err := install.LoadPreinstallInfo()
+	c.Assert(info, IsNil)
+	c.Assert(err, Equals, expectedErr)
+}
+
 func (s *installSuite) TestPreinstallCheckSupported(c *C) {
 	logbuf, restore := logger.MockLogger()
 	s.AddCleanup(restore)

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -451,6 +451,10 @@ func (s *installSuite) TestPreinstallInfoRequirements(c *C) {
 }
 
 func (s *installSuite) TestLoadPreinstallInfo(c *C) {
+	if !secboot.WithSecbootSupport {
+		c.Skip("secboot is not available")
+	}
+
 	restore := install.MockSecbootLoadCheckResult(func(filename string) (*secboot.PreinstallCheckResult, error) {
 		checkResultJSON := `{
 			"result": {

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -59,7 +59,6 @@ func (cc *PreinstallCheckContext) CheckResult() (*PreinstallCheckResult, error) 
 	return nil, errBuildWithoutSecboot
 }
 
-// AcceptedErrors returns nil because preinstall checks are unavailable without secboot.
 func (cr *PreinstallCheckResult) AcceptedErrors() []string {
 	return nil
 }

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -59,6 +59,7 @@ func (cc *PreinstallCheckContext) CheckResult() (*PreinstallCheckResult, error) 
 	return nil, errBuildWithoutSecboot
 }
 
+// AcceptedErrors returns nil because preinstall checks are unavailable without secboot.
 func (cr *PreinstallCheckResult) AcceptedErrors() []string {
 	return nil
 }

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -58,3 +58,7 @@ func (c *PreinstallCheckContext) SaveCheckResult(filename string) error {
 func (cc *PreinstallCheckContext) CheckResult() (*PreinstallCheckResult, error) {
 	return nil, errBuildWithoutSecboot
 }
+
+func (cr *PreinstallCheckResult) AcceptedErrors() []string {
+	return nil
+}

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -211,6 +211,7 @@ func (cc *PreinstallCheckContext) CheckResult() (*PreinstallCheckResult, error) 
 	return &PreinstallCheckResult{sbCheckResult: result, sbPCRProfileOpts: pcrProfileOpts}, nil
 }
 
+// AcceptedErrors returns accepted preinstall check error kinds in stable order.
 func (cr *PreinstallCheckResult) AcceptedErrors() []string {
 	if cr.sbCheckResult == nil || len(cr.sbCheckResult.AcceptedErrors) == 0 {
 		return nil

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	sb_efi "github.com/snapcore/secboot/efi"
 	sb_preinstall "github.com/snapcore/secboot/efi/preinstall"
@@ -208,6 +209,19 @@ func (cc *PreinstallCheckContext) CheckResult() (*PreinstallCheckResult, error) 
 	pcrProfileOpts := cc.sbRunChecksContext.ProfileOpts()
 
 	return &PreinstallCheckResult{sbCheckResult: result, sbPCRProfileOpts: pcrProfileOpts}, nil
+}
+
+func (cr *PreinstallCheckResult) AcceptedErrors() []string {
+	if cr.sbCheckResult == nil || len(cr.sbCheckResult.AcceptedErrors) == 0 {
+		return nil
+	}
+
+	acceptedErrors := make([]string, 0, len(cr.sbCheckResult.AcceptedErrors))
+	for err := range cr.sbCheckResult.AcceptedErrors {
+		acceptedErrors = append(acceptedErrors, string(err))
+	}
+	sort.Strings(acceptedErrors)
+	return acceptedErrors
 }
 
 func (cr *PreinstallCheckResult) save(filename string) error {

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -579,3 +579,50 @@ func (s *preinstallSuite) TestLoadCheckResultInvalidJSON(c *C) {
 	c.Assert(checkResult, IsNil)
 	c.Assert(err, ErrorMatches, "cannot deserialize preinstall check result: .*")
 }
+
+func (s *preinstallSuite) TestAcceptedErrors(c *C) {
+	testCases := []struct {
+		name        string
+		checkResult *secboot.PreinstallCheckResult
+		expected    []string
+	}{
+		{
+			name:        "nil secboot check result",
+			checkResult: secboot.NewPreinstallCheckResult(nil, sb_preinstall.PCRProfileOptionsDefault),
+			expected:    nil,
+		},
+		{
+			name: "empty accepted errors",
+			checkResult: secboot.NewPreinstallCheckResult(
+				&sb_preinstall.CheckResult{AcceptedErrors: map[sb_preinstall.ErrorKind]json.RawMessage{}},
+				sb_preinstall.PCRProfileOptionsDefault,
+			),
+			expected: nil,
+		},
+		{
+			name: "accepted errors are returned as strings",
+			checkResult: secboot.NewPreinstallCheckResult(
+				&sb_preinstall.CheckResult{AcceptedErrors: map[sb_preinstall.ErrorKind]json.RawMessage{
+					sb_preinstall.ErrorKindNoHardwareRootOfTrust: nil,
+					sb_preinstall.ErrorKindTPMDeviceDisabled:     nil,
+				}},
+				sb_preinstall.PCRProfileOptionsDefault,
+			),
+			expected: []string{
+				secboot.ErrorKindNoHardwareRootOfTrust,
+				string(sb_preinstall.ErrorKindTPMDeviceDisabled),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		acceptedErrors := tc.checkResult.AcceptedErrors()
+		if acceptedErrors == nil {
+			c.Check(acceptedErrors, DeepEquals, tc.expected, Commentf(tc.name))
+			continue
+		}
+
+		expected := append([]string(nil), tc.expected...)
+		c.Check(acceptedErrors, DeepEquals, expected, Commentf(tc.name))
+	}
+}


### PR DESCRIPTION
Extend "/v2/system-info/storage-encrypted" with a new "preinstall" stanza that shows install-time decisions, currently only "requirements" and "accepted-errors" are exposed.

The use case is to give the security-center context on install-time decisions (e.g. accepting HWROT error or that PIN/passphrase was required) to influence the messaging to user.

Relevant spec: SD201
JIRA: [SNAPDENG-37104](https://warthogs.atlassian.net/browse/SNAPDENG-37104)


[SNAPDENG-37104]: https://warthogs.atlassian.net/browse/SNAPDENG-37104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ