### PR TITLE
packaging: use stonking image instead of resolute for 26.10

### DIFF
--- a/packaging/ubuntu-26.10/README.md
+++ b/packaging/ubuntu-26.10/README.md
@@ -55,7 +55,7 @@ podman run \
     -v "snapd-ubuntu-apt-lists:/var/lib/apt/lists" \
     -v "snapd-gomod-cache:/var/cache/gomod" \
     -w /build \
-    docker.io/ubuntu:resolute \
+    docker.io/ubuntu:stonking \
     /bin/bash -x -e -u
 ```
 


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
