### PR TITLE
i/b/browser_support: Allow access to WebHID.

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -154,6 +154,9 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /run/udev/data/+hid:* r,
 /run/udev/data/+input:input[0-9]* r,
 
+# Allow access to WebHID devices (LP: #2148141).
+/dev/hidraw[0-9]* rwk,
+
 # screen
 /run/udev/data/c29:[0-9]* r,  # /dev/fb*
 /run/udev/data/+backlight:* r,


### PR DESCRIPTION
Bug: https://bugs.launchpad.net/snapd/+bug/2148141.

This was [discussed in the internal ~security-engineering channel](https://chat.canonical.com/canonical/pl/nzdtdmxqjtrgdf6oxah38h61iw).