### PR TITLE
run-checks: check priority override on ifaces w/ mountinfo rules

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -190,13 +190,16 @@ check_mountinfo_override() {
     #   * specific mountinfo paths under /proc or @{PROC} in various forms
     #   * broad access to /proc/**
     #   * unconditional "allow file," or "allow all," rules
+    # It also looks for references to mountInfoSnippet. These are likely used
+    # in an AddPrioritizedSnippet call but let's be sure.
 
     local prefix='^[[:space:]]*(owner[[:space:]]+)?'
     # perms must include 'r' since the base deny only blocks reads
     local perms='[[:space:]][a-z]*r[a-z]*,'
     local rules="(${prefix}(/proc|@\\{PROC\\})/(self|@\\{pid\\}|[0-9]+)/mountinfo${perms}"
     rules+="|${prefix}(/proc|@\\{PROC\\})/\\*\\*${perms}"
-    rules+='|^[[:space:]]*allow[[:space:]]+(file|all),[[:space:]]*$)'
+    rules+='|^[[:space:]]*allow[[:space:]]+(file|all),[[:space:]]*$'
+    rules+='|mountInfoSnippet)'
 
     local -a missing_override=()
     local f
@@ -207,25 +210,25 @@ check_mountinfo_override() {
 
         local matches
         matches=$(grep -nE "$rules" "$f" || true)
-        if [ -n "$matches" ] || grep -q '\bmountInfoSnippet\b' "$f"; then
-            if ! grep -q '\bapparmor\.MountInfoKey\b' "$f"; then
-                local lines
-                lines=$(echo "$matches" | cut -d: -f1 | paste -sd, -)
-                if [ -z "$lines" ]; then
-                    lines=$(grep -n '\bmountInfoSnippet\b' "$f" | cut -d: -f1 | paste -sd, -)
-                fi
-                missing_override+=("$f:$lines")
+        if [ -n "$matches" ]; then
+            if ! grep -qE 'AddPrioritizedSnippet\(.* apparmor\.MountInfoKey' "$f"; then
+                missing_override+=("$f")
+                missing_override+=("$matches")
             fi
         fi
     done
 
     if [ "${#missing_override[@]}" -gt 0 ]; then
         echo "" >&2
-        echo "These interfaces allow access to /proc/*/mountinfo (explicitly or not)" >&2
+        echo "These interfaces allow access to /proc/*/mountinfo (specifically or not)" >&2
         echo "without adding the allow rule as a prioritized snippet" >&2
         echo "(see basePrioritizedSnippets in interfaces/apparmor/template.go):" >&2
-        for f in "${missing_override[@]}"; do
-            echo "  - ${f%%:*} (lines: ${f#*:})" >&2
+        local i
+        for ((i=0; i<${#missing_override[@]}; i+=2)); do
+            echo "  - ${missing_override[i]}:" >&2
+            while IFS= read -r line; do
+                echo "      ${line}" >&2
+            done <<< "${missing_override[i+1]}"
         done
         return 1
     fi

--- a/run-checks
+++ b/run-checks
@@ -184,52 +184,52 @@ missing_interface_spread_test() {
 
 check_mountinfo_override() {
     # This check verifies that interfaces that grant access to /proc/self/mountinfo
-    # (directly or not) also add a matching prioritized override for the base
-    # "deny" rule (see basePrioritizedSnippets in interfaces/apparmor/template.go).
-    # This looks for the following rules:
-    #   * specific mountinfo paths under /proc or @{PROC} in various forms
-    #   * broad access to /proc/**
-    #   * unconditional "allow file," or "allow all," rules
-    # It also looks for references to mountInfoSnippet. These are likely used
-    # in an AddPrioritizedSnippet call but let's be sure.
+    # (directly or not) also have a prioritized override (see basePrioritizedSnippets
+    # in interfaces/apparmor/template.go for why this is necessary). We do this
+    # by looking for a "AddPrioritizedSnippet(*, apparmor.MountInfoKey, ...)" call
+    # for any such interfaces.
 
-    local prefix='^[[:space:]]*(owner[[:space:]]+)?'
-    # perms must include 'r' since the base deny only blocks reads
-    local perms='[[:space:]][a-z]*r[a-z]*,'
-    local rules="(${prefix}(/proc|@\\{PROC\\})/(self|@\\{pid\\}|[0-9]+)/mountinfo${perms}"
-    rules+="|${prefix}(/proc|@\\{PROC\\})/\\*\\*${perms}"
-    rules+='|^[[:space:]]*allow[[:space:]]+(file|all),[[:space:]]*$'
-    rules+='|mountInfoSnippet)'
-
-    local -a missing_override=()
+    local missing_override=""
     local f
     for f in interfaces/builtin/*.go; do
         if [[ "$f" == *"_test.go" ]]; then
             continue
         fi
 
-        local matches
-        matches=$(grep -nE "$rules" "$f" || true)
-        if [ -n "$matches" ]; then
-            if ! grep -qE 'AddPrioritizedSnippet\(.* apparmor\.MountInfoKey' "$f"; then
-                missing_override+=("$f")
-                missing_override+=("$matches")
-            fi
-        fi
+        local out
+        out=$(awk '
+            # if a prioritized override is present, we can stop early
+            /AddPrioritizedSnippet\(.* apparmor\.MountInfoKey/ { m=""; exit }
+
+            # We look for the following types of rules:
+            #   * Explicit mountinfo rules. For example, any combination of:
+            #      owner /proc/self/mountinfo r,
+            #      @{PROC}/@{pid} rw,
+            #      /proc/1234/mountinfo
+            #   * References to the "mountInfoSnippet" variable which contains
+            #      the same rules as the previous item
+            #   * Broad /proc grants:
+            #      owner @{PROC}/** r,
+            #      /proc/** rw,
+            #   * Relevant "allow" rules:
+            #      allow file
+            #      allow all
+
+            /^[[:space:]]*(owner[[:space:]]+)?(\/proc|@\{PROC\})\/(self|@\{pid\}|[0-9]+)\/mountinfo[[:space:]][a-z]*r[a-z]*,/ ||
+            /^[[:space:]]*(owner[[:space:]]+)?(\/proc|@\{PROC\})\/\*\*[[:space:]][a-z]*r[a-z]*,/ ||
+            /^[[:space:]]*allow[[:space:]]+(file|all),[[:space:]]*$/ ||
+            /mountInfoSnippet/ { m = m "      " NR ":" $0 ORS }
+            END { if (m != "") printf "  - %s:\n%s", FILENAME, m }
+        ' "$f")
+        [ -n "$out" ] && missing_override+="${out}"$'\n'
     done
 
-    if [ "${#missing_override[@]}" -gt 0 ]; then
+    if [ -n "$missing_override" ]; then
         echo "" >&2
         echo "These interfaces allow access to /proc/*/mountinfo (specifically or not)" >&2
         echo "without adding the allow rule as a prioritized snippet" >&2
         echo "(see basePrioritizedSnippets in interfaces/apparmor/template.go):" >&2
-        local i
-        for ((i=0; i<${#missing_override[@]}; i+=2)); do
-            echo "  - ${missing_override[i]}:" >&2
-            while IFS= read -r line; do
-                echo "      ${line}" >&2
-            done <<< "${missing_override[i+1]}"
-        done
+        printf "%s" "$missing_override" >&2
         return 1
     fi
 }

--- a/run-checks
+++ b/run-checks
@@ -182,6 +182,55 @@ missing_interface_spread_test() {
     done
 }
 
+check_mountinfo_override() {
+    # This check verifies that interfaces that grant access to /proc/self/mountinfo
+    # (directly or not) also add a matching prioritized override for the base
+    # "deny" rule (see basePrioritizedSnippets in interfaces/apparmor/template.go).
+    # This looks for the following rules:
+    #   * specific mountinfo paths under /proc or @{PROC} in various forms
+    #   * broad access to /proc/**
+    #   * unconditional "allow file," or "allow all," rules
+
+    local prefix='^[[:space:]]*(owner[[:space:]]+)?'
+    # perms must include 'r' since the base deny only blocks reads
+    local perms='[[:space:]][a-z]*r[a-z]*,'
+    local rules="(${prefix}(/proc|@\\{PROC\\})/(self|@\\{pid\\}|[0-9]+)/mountinfo${perms}"
+    rules+="|${prefix}(/proc|@\\{PROC\\})/\\*\\*${perms}"
+    rules+='|^[[:space:]]*allow[[:space:]]+(file|all),[[:space:]]*$)'
+
+    local -a missing_override=()
+    local f
+    for f in interfaces/builtin/*.go; do
+        if [[ "$f" == *"_test.go" ]]; then
+            continue
+        fi
+
+        local matches
+        matches=$(grep -nE "$rules" "$f" || true)
+        if [ -n "$matches" ] || grep -q '\bmountInfoSnippet\b' "$f"; then
+            if ! grep -q '\bapparmor\.MountInfoKey\b' "$f"; then
+                local lines
+                lines=$(echo "$matches" | cut -d: -f1 | paste -sd, -)
+                if [ -z "$lines" ]; then
+                    lines=$(grep -n '\bmountInfoSnippet\b' "$f" | cut -d: -f1 | paste -sd, -)
+                fi
+                missing_override+=("$f:$lines")
+            fi
+        fi
+    done
+
+    if [ "${#missing_override[@]}" -gt 0 ]; then
+        echo "" >&2
+        echo "These interfaces allow access to /proc/*/mountinfo (explicitly or not)" >&2
+        echo "without adding the allow rule as a prioritized snippet" >&2
+        echo "(see basePrioritizedSnippets in interfaces/apparmor/template.go):" >&2
+        for f in "${missing_override[@]}"; do
+            echo "  - ${f%%:*} (lines: ${f#*:})" >&2
+        done
+        return 1
+    fi
+}
+
 forbidden_cmd_go_deps() {
     local -a forbidden_deps=(
         "github.com/snapcore/snapd/testutil"
@@ -388,6 +437,9 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] Checking cmd binaries for forbidden dependencies"
     forbidden_cmd_go_deps
+
+    echo ">> [Go] Checking interfaces that grant mountinfo access use a prioritized override"
+    check_mountinfo_override
 
     if command -v shellcheck >/dev/null; then
         exclude_tools_path=tests/lib/external/snapd-testing-tools


### PR DESCRIPTION
Interfaces that grant access to /proc/self/mountinfo (explicitly or not) must have a prioritized override (see basePrioritizedSnippets in interfaces/apparmor/template.go) which swaps out the deny rule. Otherwise, the deny rule wins out and the interface does not work as intended, as was the case here: https://github.com/canonical/snapd/pull/17321.
This adds a static check to run-checks that tries to maintain this invariant by looking for interfaces that grant /proc/self/mountinfo, even if by granting broader access (/proc/**, allow file, etc), and checking whether the file also contains the corresponding override.

https://warthogs.atlassian.net/browse/SNAPDENG-37188
