### PR TITLE
cmd/snap-preseed: move the sources around

### DIFF
--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,145 +20,9 @@
 package main
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-
-	"github.com/jessevdk/go-flags"
-
-	"github.com/snapcore/snapd/image/preseed"
-
-	// for SanitizePlugsSlots
-	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-preseed"
 )
-
-const (
-	shortHelp = "Prerun the first boot seeding of snaps in an image filesystem chroot with a snapd seed."
-	longHelp  = `
-The snap-preseed command takes a directory containing an image, including seed
-snaps (at /var/lib/snapd/seed), and runs through the snapd first-boot process
-up to hook execution. No boot actions unrelated to snapd are performed.
-It creates systemd units for seeded snaps, makes any connections, and generates
-security profiles. The image is updated and consequently optimised to reduce
-first-boot startup time`
-)
-
-type options struct {
-	Reset               bool   `long:"reset"`
-	ResetChroot         bool   `long:"reset-chroot" hidden:"1"`
-	Hybrid              bool   `long:"hybrid"`
-	SystemLabel         string `long:"system-label"`
-	PreseedSignKey      string `long:"preseed-sign-key"`
-	AppArmorFeaturesDir string `long:"apparmor-features-dir"`
-	SysfsOverlay        string `long:"sysfs-overlay"`
-}
-
-var (
-	osGetuid = os.Getuid
-	// unused currently, left in place for consistency for when it is needed
-	// Stdout   io.Writer = os.Stdout
-	Stderr io.Writer = os.Stderr
-
-	preseedCore20               = preseed.Core20
-	preseedClassic              = preseed.Classic
-	preseedClassicReset         = preseed.ClassicReset
-	preseedHybrid               = preseed.Hybrid
-	preseedHybridReset          = preseed.HybridReset
-	preseedResetPreseededChroot = preseed.ResetPreseededChroot
-
-	opts options
-)
-
-func Parser() *flags.Parser {
-	opts = options{}
-	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
-	parser.ShortDescription = shortHelp
-	parser.LongDescription = longHelp
-	return parser
-}
-
-func probeCore20ImageDir(dir string) bool {
-	sysDir := filepath.Join(dir, "system-seed")
-	_, isDir, _ := osutil.DirExists(sysDir)
-	return isDir
-}
 
 func main() {
-	parser := Parser()
-	if err := run(parser, os.Args[1:]); err != nil {
-		fmt.Fprintf(Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-func run(parser *flags.Parser, args []string) (err error) {
-	// real validation of plugs and slots; needs to be set
-	// for processing of seeds with gadget because of readInfo().
-	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
-
-	rest, err := parser.ParseArgs(args)
-	if err != nil {
-		return err
-	}
-
-	if osGetuid() != 0 {
-		return fmt.Errorf("must be run as root")
-	}
-
-	var chrootDir string
-	if opts.ResetChroot {
-		chrootDir = "/"
-	} else {
-		if len(rest) == 0 {
-			return fmt.Errorf("need chroot path as argument")
-		}
-
-		chrootDir, err = filepath.Abs(rest[0])
-		if err != nil {
-			return err
-		}
-
-		// safety check
-		if chrootDir == "/" {
-			return fmt.Errorf("cannot run snap-preseed against /")
-		}
-	}
-
-	if opts.SystemLabel != "" && !opts.Hybrid {
-		return fmt.Errorf("cannot use --system-label without --hybrid")
-	}
-
-	if opts.Hybrid {
-		if opts.SystemLabel == "" {
-			return fmt.Errorf("cannot use --hybrid without --system-label")
-		}
-		if opts.Reset {
-			return preseedHybridReset(chrootDir, opts.SystemLabel)
-		}
-		return preseedHybrid(chrootDir, opts.SystemLabel)
-	}
-
-	if probeCore20ImageDir(chrootDir) {
-		if opts.Reset || opts.ResetChroot {
-			return fmt.Errorf("cannot snap-preseed --reset for Ubuntu Core")
-		}
-
-		coreOpts := &preseed.CoreOptions{
-			PrepareImageDir:           chrootDir,
-			PreseedSignKey:            opts.PreseedSignKey,
-			AppArmorKernelFeaturesDir: opts.AppArmorFeaturesDir,
-			SysfsOverlay:              opts.SysfsOverlay,
-		}
-		return preseedCore20(coreOpts)
-	}
-	if opts.ResetChroot {
-		return preseedResetPreseededChroot(chrootDir)
-	}
-	if opts.Reset {
-		return preseedClassicReset(chrootDir)
-	}
-	return preseedClassic(chrootDir)
+	snap_preseed.Main()
 }

--- a/cmd/snapd/tool/snap-preseed/export_test.go
+++ b/cmd/snapd/tool/snap-preseed/export_test.go
@@ -17,15 +17,11 @@
  *
  */
 
-package main
+package snap_preseed
 
 import (
 	"github.com/snapcore/snapd/image/preseed"
 	"github.com/snapcore/snapd/testutil"
-)
-
-var (
-	Run = run
 )
 
 func MockOsGetuid(f func() int) (restore func()) {

--- a/cmd/snapd/tool/snap-preseed/export_test.go
+++ b/cmd/snapd/tool/snap-preseed/export_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+var (
+	Run = run
+)
+
 func MockOsGetuid(f func() int) (restore func()) {
 	r := testutil.Backup(&osGetuid)
 	osGetuid = f

--- a/cmd/snapd/tool/snap-preseed/main.go
+++ b/cmd/snapd/tool/snap-preseed/main.go
@@ -18,7 +18,6 @@
  */
 
 // Package snap_preseed implements the snap-preseed command entry point.
-// It is used by cmd/snap when invoked as "snap-preseed".
 package snap_preseed
 
 import (
@@ -88,7 +87,7 @@ func probeCore20ImageDir(dir string) bool {
 }
 
 // Run executes the snap-preseed logic with the given parser and args.
-func Run(parser *flags.Parser, args []string) (err error) {
+func run(parser *flags.Parser, args []string) (err error) {
 	// real validation of plugs and slots; needs to be set
 	// for processing of seeds with gadget because of readInfo().
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
@@ -160,7 +159,7 @@ func Run(parser *flags.Parser, args []string) (err error) {
 // Main is the entry point for snap-preseed. It exits the process on error.
 func Main() {
 	parser := Parser()
-	if err := Run(parser, os.Args[1:]); err != nil {
+	if err := run(parser, os.Args[1:]); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/snapd/tool/snap-preseed/main.go
+++ b/cmd/snapd/tool/snap-preseed/main.go
@@ -1,0 +1,167 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package snap_preseed implements the snap-preseed command entry point.
+// It is used by cmd/snap when invoked as "snap-preseed".
+package snap_preseed
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/image/preseed"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+const (
+	shortHelp = "Prerun the first boot seeding of snaps in an image filesystem chroot with a snapd seed."
+	longHelp  = `
+The snap-preseed command takes a directory containing an image, including seed
+snaps (at /var/lib/snapd/seed), and runs through the snapd first-boot process
+up to hook execution. No boot actions unrelated to snapd are performed.
+It creates systemd units for seeded snaps, makes any connections, and generates
+security profiles. The image is updated and consequently optimised to reduce
+first-boot startup time`
+)
+
+// Options holds the command line options for snap-preseed.
+type Options struct {
+	Reset               bool   `long:"reset"`
+	ResetChroot         bool   `long:"reset-chroot" hidden:"1"`
+	Hybrid              bool   `long:"hybrid"`
+	SystemLabel         string `long:"system-label"`
+	PreseedSignKey      string `long:"preseed-sign-key"`
+	AppArmorFeaturesDir string `long:"apparmor-features-dir"`
+	SysfsOverlay        string `long:"sysfs-overlay"`
+}
+
+var (
+	osGetuid = os.Getuid
+	// Stderr is the writer for error output, exported for testing.
+	Stderr io.Writer = os.Stderr
+
+	preseedCore20               = preseed.Core20
+	preseedClassic              = preseed.Classic
+	preseedClassicReset         = preseed.ClassicReset
+	preseedHybrid               = preseed.Hybrid
+	preseedHybridReset          = preseed.HybridReset
+	preseedResetPreseededChroot = preseed.ResetPreseededChroot
+
+	opts Options
+)
+
+// Parser creates and returns a go-flags parser for snap-preseed.
+func Parser() *flags.Parser {
+	opts = Options{}
+	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
+	parser.ShortDescription = shortHelp
+	parser.LongDescription = longHelp
+	return parser
+}
+
+func probeCore20ImageDir(dir string) bool {
+	sysDir := filepath.Join(dir, "system-seed")
+	_, isDir, _ := osutil.DirExists(sysDir)
+	return isDir
+}
+
+// Run executes the snap-preseed logic with the given parser and args.
+func Run(parser *flags.Parser, args []string) (err error) {
+	// real validation of plugs and slots; needs to be set
+	// for processing of seeds with gadget because of readInfo().
+	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
+
+	rest, err := parser.ParseArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if osGetuid() != 0 {
+		return fmt.Errorf("must be run as root")
+	}
+
+	var chrootDir string
+	if opts.ResetChroot {
+		chrootDir = "/"
+	} else {
+		if len(rest) == 0 {
+			return fmt.Errorf("need chroot path as argument")
+		}
+
+		chrootDir, err = filepath.Abs(rest[0])
+		if err != nil {
+			return err
+		}
+
+		// safety check
+		if chrootDir == "/" {
+			return fmt.Errorf("cannot run snap-preseed against /")
+		}
+	}
+
+	if opts.SystemLabel != "" && !opts.Hybrid {
+		return fmt.Errorf("cannot use --system-label without --hybrid")
+	}
+
+	if opts.Hybrid {
+		if opts.SystemLabel == "" {
+			return fmt.Errorf("cannot use --hybrid without --system-label")
+		}
+		if opts.Reset {
+			return preseedHybridReset(chrootDir, opts.SystemLabel)
+		}
+		return preseedHybrid(chrootDir, opts.SystemLabel)
+	}
+
+	if probeCore20ImageDir(chrootDir) {
+		if opts.Reset || opts.ResetChroot {
+			return fmt.Errorf("cannot snap-preseed --reset for Ubuntu Core")
+		}
+
+		coreOpts := &preseed.CoreOptions{
+			PrepareImageDir:           chrootDir,
+			PreseedSignKey:            opts.PreseedSignKey,
+			AppArmorKernelFeaturesDir: opts.AppArmorFeaturesDir,
+			SysfsOverlay:              opts.SysfsOverlay,
+		}
+		return preseedCore20(coreOpts)
+	}
+	if opts.ResetChroot {
+		return preseedResetPreseededChroot(chrootDir)
+	}
+	if opts.Reset {
+		return preseedClassicReset(chrootDir)
+	}
+	return preseedClassic(chrootDir)
+}
+
+// Main is the entry point for snap-preseed. It exits the process on error.
+func Main() {
+	parser := Parser()
+	if err := Run(parser, os.Args[1:]); err != nil {
+		fmt.Fprintf(Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/snapd/tool/snap-preseed/main.go
+++ b/cmd/snapd/tool/snap-preseed/main.go
@@ -46,8 +46,8 @@ security profiles. The image is updated and consequently optimised to reduce
 first-boot startup time`
 )
 
-// Options holds the command line options for snap-preseed.
-type Options struct {
+// options holds the command line options for snap-preseed.
+type options struct {
 	Reset               bool   `long:"reset"`
 	ResetChroot         bool   `long:"reset-chroot" hidden:"1"`
 	Hybrid              bool   `long:"hybrid"`
@@ -69,12 +69,12 @@ var (
 	preseedHybridReset          = preseed.HybridReset
 	preseedResetPreseededChroot = preseed.ResetPreseededChroot
 
-	opts Options
+	opts options
 )
 
 // Parser creates and returns a go-flags parser for snap-preseed.
 func Parser() *flags.Parser {
-	opts = Options{}
+	opts = options{}
 	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
 	parser.ShortDescription = shortHelp
 	parser.LongDescription = longHelp

--- a/cmd/snapd/tool/snap-preseed/preseed_classic_test.go
+++ b/cmd/snapd/tool/snap-preseed/preseed_classic_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main_test
+package snap_preseed_test
 
 import (
 	"testing"
@@ -25,7 +25,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/cmd/snap-preseed"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-preseed"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/snap"
@@ -52,48 +52,48 @@ func (s *startPreseedSuite) TearDownTest(c *C) {
 }
 
 func testParser(c *C) *flags.Parser {
-	parser := main.Parser()
+	parser := snap_preseed.Parser()
 	_, err := parser.ParseArgs([]string{})
 	c.Assert(err, IsNil)
 	return parser
 }
 
 func (s *startPreseedSuite) TestRequiresRoot(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 1000
 	})
 	defer restore()
 
 	parser := testParser(c)
-	c.Check(main.Run(parser, []string{"/"}), ErrorMatches, `must be run as root`)
+	c.Check(snap_preseed.Run(parser, []string{"/"}), ErrorMatches, `must be run as root`)
 }
 
 func (s *startPreseedSuite) TestMissingArg(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	parser := testParser(c)
-	c.Check(main.Run(parser, nil), ErrorMatches, `need chroot path as argument`)
+	c.Check(snap_preseed.Run(parser, nil), ErrorMatches, `need chroot path as argument`)
 }
 
 func (s *startPreseedSuite) TestRunPreseedAgainstFilesystemRoot(c *C) {
-	restore := main.MockOsGetuid(func() int { return 0 })
+	restore := snap_preseed.MockOsGetuid(func() int { return 0 })
 	defer restore()
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"/"}), ErrorMatches, `cannot run snap-preseed against /`)
+	c.Assert(snap_preseed.Run(parser, []string{"/"}), ErrorMatches, `cannot run snap-preseed against /`)
 }
 
 func (s *startPreseedSuite) TestRunPreseedClassicHappy(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	var called bool
-	restorePreseed := main.MockPreseedClassic(func(dir string) error {
+	restorePreseed := snap_preseed.MockPreseedClassic(func(dir string) error {
 		c.Check(dir, Equals, "/a/dir")
 		called = true
 		return nil
@@ -101,54 +101,54 @@ func (s *startPreseedSuite) TestRunPreseedClassicHappy(c *C) {
 	defer restorePreseed()
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"/a/dir"}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"/a/dir"}), IsNil)
 	c.Check(called, Equals, true)
 }
 
 func (s *startPreseedSuite) TestResetReexeced(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	var called bool
-	main.MockResetPreseededChroot(func(dir string) error {
+	snap_preseed.MockResetPreseededChroot(func(dir string) error {
 		c.Check(dir, Equals, "/")
 		called = true
 		return nil
 	})
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--reset-chroot"}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"--reset-chroot"}), IsNil)
 	c.Check(called, Equals, true)
 }
 
 func (s *startPreseedSuite) TestReset(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	var called bool
-	main.MockPreseedClassicReset(func(dir string) error {
+	snap_preseed.MockPreseedClassicReset(func(dir string) error {
 		c.Check(dir, Equals, "/a/dir")
 		called = true
 		return nil
 	})
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--reset", "/a/dir"}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"--reset", "/a/dir"}), IsNil)
 	c.Check(called, Equals, true)
 }
 
 func (s *startPreseedSuite) TestHybridHappy(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	var called bool
-	main.MockPreseedHybrid(func(dir, label string) error {
+	snap_preseed.MockPreseedHybrid(func(dir, label string) error {
 		c.Check(dir, Equals, "/a/dir")
 		c.Check(label, Equals, "system-label")
 		called = true
@@ -156,18 +156,18 @@ func (s *startPreseedSuite) TestHybridHappy(c *C) {
 	})
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--hybrid", "--system-label", "system-label", "/a/dir"}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"--hybrid", "--system-label", "system-label", "/a/dir"}), IsNil)
 	c.Check(called, Equals, true)
 }
 
 func (s *startPreseedSuite) TestHybridReset(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	var called bool
-	main.MockPreseedHybridReset(func(dir, label string) error {
+	snap_preseed.MockPreseedHybridReset(func(dir, label string) error {
 		c.Check(dir, Equals, "/a/dir")
 		c.Check(label, Equals, "system-label")
 		called = true
@@ -175,28 +175,28 @@ func (s *startPreseedSuite) TestHybridReset(c *C) {
 	})
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--hybrid", "--system-label", "system-label", "--reset", "/a/dir"}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"--hybrid", "--system-label", "system-label", "--reset", "/a/dir"}), IsNil)
 	c.Check(called, Equals, true)
 }
 
 func (s *startPreseedSuite) TestHybridMissingLabel(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	parser := testParser(c)
-	c.Check(main.Run(parser, []string{"--hybrid", "/a/dir"}), ErrorMatches, `cannot use --hybrid without --system-label`)
+	c.Check(snap_preseed.Run(parser, []string{"--hybrid", "/a/dir"}), ErrorMatches, `cannot use --hybrid without --system-label`)
 }
 
 func (s *startPreseedSuite) TestLabelWithoutHybrid(c *C) {
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
 
 	parser := testParser(c)
-	c.Check(main.Run(parser, []string{"--system-label", "label", "/a/dir"}), ErrorMatches, `cannot use --system-label without --hybrid`)
+	c.Check(snap_preseed.Run(parser, []string{"--system-label", "label", "/a/dir"}), ErrorMatches, `cannot use --system-label without --hybrid`)
 }
 
 func (s *startPreseedSuite) TestReadInfoValidity(c *C) {
@@ -214,7 +214,7 @@ func (s *startPreseedSuite) TestReadInfoValidity(c *C) {
 
 	parser := testParser(c)
 	tmpDir := c.MkDir()
-	_ = main.Run(parser, []string{tmpDir})
+	_ = snap_preseed.Run(parser, []string{tmpDir})
 
 	// real sanitize method should be set after Run()
 	snap.SanitizePlugsSlots(inf)

--- a/cmd/snapd/tool/snap-preseed/preseed_uc20_test.go
+++ b/cmd/snapd/tool/snap-preseed/preseed_uc20_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main_test
+package snap_preseed_test
 
 import (
 	"os"
@@ -25,7 +25,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/cmd/snap-preseed"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-preseed"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/image/preseed"
 )
@@ -34,7 +34,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
 
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
@@ -45,7 +45,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
-	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
+	restorePreseed := snap_preseed.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
 		c.Check(opts.PrepareImageDir, Equals, tmpDir)
 		c.Check(opts.PreseedSignKey, Equals, "key")
 		c.Check(opts.AppArmorKernelFeaturesDir, Equals, "/custom/aa/features")
@@ -56,7 +56,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	defer restorePreseed()
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--preseed-sign-key", "key", "--apparmor-features-dir", "/custom/aa/features", "--sysfs-overlay", "/sysfs-overlay", tmpDir}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{"--preseed-sign-key", "key", "--apparmor-features-dir", "/custom/aa/features", "--sysfs-overlay", "/sysfs-overlay", tmpDir}), IsNil)
 	c.Check(called, Equals, true)
 }
 
@@ -64,7 +64,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20HappyNoArgs(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
 
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
@@ -74,7 +74,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20HappyNoArgs(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
-	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
+	restorePreseed := snap_preseed.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
 		c.Check(opts.PrepareImageDir, Equals, tmpDir)
 		c.Check(opts.PreseedSignKey, Equals, "")
 		c.Check(opts.AppArmorKernelFeaturesDir, Equals, "")
@@ -85,7 +85,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20HappyNoArgs(c *C) {
 	defer restorePreseed()
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{tmpDir}), IsNil)
+	c.Assert(snap_preseed.Run(parser, []string{tmpDir}), IsNil)
 	c.Check(called, Equals, true)
 }
 
@@ -93,7 +93,7 @@ func (s *startPreseedSuite) TestResetUC20(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
 
-	restore := main.MockOsGetuid(func() int {
+	restore := snap_preseed.MockOsGetuid(func() int {
 		return 0
 	})
 	defer restore()
@@ -104,14 +104,14 @@ func (s *startPreseedSuite) TestResetUC20(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
-	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
+	restorePreseed := snap_preseed.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
 		called = true
 		return nil
 	})
 	defer restorePreseed()
 
 	parser := testParser(c)
-	res := main.Run(parser, []string{"--reset", tmpDir})
+	res := snap_preseed.Run(parser, []string{"--reset", tmpDir})
 	c.Assert(res, Not(IsNil))
 	c.Check(res, ErrorMatches, "cannot snap-preseed --reset for Ubuntu Core")
 	c.Check(called, Equals, false)

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -366,6 +366,7 @@ Provides:      golang(%{import_path}/cmd/snapctl) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/cli) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/daemon) = %{version}-%{release}
+Provides:      golang(%{import_path}/cmd/snapd/tool/snap-preseed) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/tool/snap-gpio-helper) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/tool/snapd-apparmor) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snaplock) = %{version}-%{release}


### PR DESCRIPTION
Move the sources around in preparation for merging of snap-preseed into snapd.

Related: SNAPDENG-37053

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
