### PR TITLE
cmd/snapd/tool/snap-gpio-helper: move snap-gpio-helper sources around

### DIFF
--- a/cmd/snap-gpio-helper/main.go
+++ b/cmd/snap-gpio-helper/main.go
@@ -20,46 +20,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/jessevdk/go-flags"
-
-	"github.com/snapcore/snapd/sandbox/gpio"
-	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-gpio-helper"
 )
 
-type options struct {
-	CmdExportChardev   cmdExportChardev   `command:"export-chardev"`
-	CmdUnexportChardev cmdUnexportChardev `command:"unexport-chardev"`
-}
-
-var gpioEnsureAggregatorDriver = gpio.EnsureAggregatorDriver
-
-func run(args []string) error {
-	// Make sure the gpio-aggregator module is loaded because the
-	// systemd security backend comes before the kmod security
-	// backend, there is an edge case on first connection where
-	// the helper service could be started before the gpio-aggregator
-	// module is loaded.
-	if err := gpioEnsureAggregatorDriver(); err != nil {
-		return nil
-	}
-
-	var opts options
-	p := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
-
-	if _, err := p.ParseArgs(args); err != nil {
-		return err
-	}
-	return nil
-}
-
 func main() {
-	snapdtool.ExecInSnapdOrCoreSnap()
-
-	if err := run(os.Args[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	snap_gpio_helper.Main()
 }

--- a/cmd/snapd/tool/snap-gpio-helper/cmd_export.go
+++ b/cmd/snapd/tool/snap-gpio-helper/cmd_export.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main
+package snap_gpio_helper
 
 import (
 	"context"

--- a/cmd/snapd/tool/snap-gpio-helper/cmd_export_test.go
+++ b/cmd/snapd/tool/snap-gpio-helper/cmd_export_test.go
@@ -17,27 +17,27 @@
  *
  */
 
-package main_test
+package snap_gpio_helper_test
 
 import (
 	"context"
 
 	. "gopkg.in/check.v1"
 
-	main "github.com/snapcore/snapd/cmd/snap-gpio-helper"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-gpio-helper"
 	"github.com/snapcore/snapd/strutil"
 )
 
 func (s *snapGpioHelperSuite) TestExportGpioChardevBadLine(c *C) {
 	exportCalled := 0
-	restore := main.MockGpioExportGadgetChardevChip(func(ctx context.Context, chipLabels []string, lines strutil.Range, gadgetName, slotName string) error {
+	restore := snap_gpio_helper.MockGpioExportGadgetChardevChip(func(ctx context.Context, chipLabels []string, lines strutil.Range, gadgetName, slotName string) error {
 		exportCalled++
 		return nil
 	})
 	defer restore()
 
 	ensureDriverCalled := 0
-	restore = main.MockGpioEnsureAggregatorDriver(func() error {
+	restore = snap_gpio_helper.MockGpioEnsureAggregatorDriver(func() error {
 		ensureDriverCalled++
 		return nil
 	})
@@ -49,7 +49,7 @@ func (s *snapGpioHelperSuite) TestExportGpioChardevBadLine(c *C) {
 		"0-":    `invalid lines argument: .*: invalid syntax`,
 		"a":     `invalid lines argument: .*: invalid syntax`,
 	} {
-		err := main.Run([]string{
+		err := snap_gpio_helper.Run([]string{
 			"export-chardev", "label-0", lines, "gadget-name", "slot-name",
 		})
 		c.Check(err, ErrorMatches, expectedErr)
@@ -61,7 +61,7 @@ func (s *snapGpioHelperSuite) TestExportGpioChardevBadLine(c *C) {
 
 func (s *snapGpioHelperSuite) TestExportGpioChardev(c *C) {
 	exportCalled := 0
-	restore := main.MockGpioExportGadgetChardevChip(func(ctx context.Context, chipLabels []string, lines strutil.Range, gadgetName, slotName string) error {
+	restore := snap_gpio_helper.MockGpioExportGadgetChardevChip(func(ctx context.Context, chipLabels []string, lines strutil.Range, gadgetName, slotName string) error {
 		exportCalled++
 		c.Check(chipLabels, DeepEquals, []string{"label-0", "label-1"})
 		c.Check(lines, DeepEquals, strutil.Range{
@@ -76,13 +76,13 @@ func (s *snapGpioHelperSuite) TestExportGpioChardev(c *C) {
 	defer restore()
 
 	ensureDriverCalled := 0
-	restore = main.MockGpioEnsureAggregatorDriver(func() error {
+	restore = snap_gpio_helper.MockGpioEnsureAggregatorDriver(func() error {
 		ensureDriverCalled++
 		return nil
 	})
 	defer restore()
 
-	err := main.Run([]string{
+	err := snap_gpio_helper.Run([]string{
 		"export-chardev", "label-0,label-1", "7,0-6,8-100", "gadget-name", "slot-name",
 	})
 	c.Check(err, IsNil)

--- a/cmd/snapd/tool/snap-gpio-helper/cmd_unexport.go
+++ b/cmd/snapd/tool/snap-gpio-helper/cmd_unexport.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main
+package snap_gpio_helper
 
 import "github.com/snapcore/snapd/sandbox/gpio"
 

--- a/cmd/snapd/tool/snap-gpio-helper/cmd_unexport_test.go
+++ b/cmd/snapd/tool/snap-gpio-helper/cmd_unexport_test.go
@@ -17,17 +17,17 @@
  *
  */
 
-package main_test
+package snap_gpio_helper_test
 
 import (
 	. "gopkg.in/check.v1"
 
-	main "github.com/snapcore/snapd/cmd/snap-gpio-helper"
+	"github.com/snapcore/snapd/cmd/snapd/tool/snap-gpio-helper"
 )
 
 func (s *snapGpioHelperSuite) TestUnexportGpioChardev(c *C) {
 	unexportCalled := 0
-	restore := main.MockGpioUnxportGadgetChardevChip(func(gadgetName, slotName string) error {
+	restore := snap_gpio_helper.MockGpioUnxportGadgetChardevChip(func(gadgetName, slotName string) error {
 		unexportCalled++
 		c.Check(gadgetName, Equals, "gadget-name")
 		c.Check(slotName, Equals, "slot-name")
@@ -36,13 +36,13 @@ func (s *snapGpioHelperSuite) TestUnexportGpioChardev(c *C) {
 	defer restore()
 
 	ensureDriverCalled := 0
-	restore = main.MockGpioEnsureAggregatorDriver(func() error {
+	restore = snap_gpio_helper.MockGpioEnsureAggregatorDriver(func() error {
 		ensureDriverCalled++
 		return nil
 	})
 	defer restore()
 
-	err := main.Run([]string{
+	err := snap_gpio_helper.Run([]string{
 		"unexport-chardev", "label-0,label-1", "7,0-6,8-100", "gadget-name", "slot-name",
 	})
 	c.Check(err, IsNil)

--- a/cmd/snapd/tool/snap-gpio-helper/export_test.go
+++ b/cmd/snapd/tool/snap-gpio-helper/export_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-package main
+package snap_gpio_helper
 
 import (
 	"context"

--- a/cmd/snapd/tool/snap-gpio-helper/main.go
+++ b/cmd/snapd/tool/snap-gpio-helper/main.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_gpio_helper
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/sandbox/gpio"
+	"github.com/snapcore/snapd/snapdtool"
+)
+
+type options struct {
+	CmdExportChardev   cmdExportChardev   `command:"export-chardev"`
+	CmdUnexportChardev cmdUnexportChardev `command:"unexport-chardev"`
+}
+
+var gpioEnsureAggregatorDriver = gpio.EnsureAggregatorDriver
+
+func run(args []string) error {
+	// Make sure the gpio-aggregator module is loaded because the
+	// systemd security backend comes before the kmod security
+	// backend, there is an edge case on first connection where
+	// the helper service could be started before the gpio-aggregator
+	// module is loaded.
+	if err := gpioEnsureAggregatorDriver(); err != nil {
+		return nil
+	}
+
+	var opts options
+	p := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+
+	if _, err := p.ParseArgs(args); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Main() {
+	snapdtool.ExecInSnapdOrCoreSnap()
+
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/snapd/tool/snap-gpio-helper/main_test.go
+++ b/cmd/snapd/tool/snap-gpio-helper/main_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main_test
+package snap_gpio_helper_test
 
 import (
 	"testing"

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -366,6 +366,7 @@ Provides:      golang(%{import_path}/cmd/snapctl) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/cli) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snapd/daemon) = %{version}-%{release}
+Provides:      golang(%{import_path}/cmd/snapd/tool/snap-gpio-helper) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snaplock) = %{version}-%{release}
 Provides:      golang(%{import_path}/cmd/snaplock/runinhibit) = %{version}-%{release}
 Provides:      golang(%{import_path}/daemon) = %{version}-%{release}


### PR DESCRIPTION
Move snap-gpio-helper sources around before transitioning to multi entry dispatch mechanism.

Related: SNAPDENG-37215

Similar approach as in https://github.com/canonical/snapd/pull/17341 and https://github.com/canonical/snapd/pull/17343

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
