### PR TITLE
i/builtin: allow access to /var/lib/iscsi/nodes

### DIFF
--- a/interfaces/builtin/iscsi_initiator.go
+++ b/interfaces/builtin/iscsi_initiator.go
@@ -19,6 +19,18 @@
 
 package builtin
 
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/strutil"
+)
+
 /*
  * The iscsi-initiator interface allows snaps to act as iSCSI initiators,
  * enabling them to discover, connect to, and manage iSCSI targets for
@@ -60,8 +72,8 @@ const iscsiInitiatorConnectedPlugAppArmor = `
 /etc/iscsi/isns/ rwk,
 /etc/iscsi/isns/** rw,
 # iSCSI target node information for persistent connections
-/etc/iscsi/nodes/ rwk,
-/etc/iscsi/nodes/** rw,
+/{etc,var/lib}/iscsi/nodes/ rwk,
+/{etc,var/lib}/iscsi/nodes/** rw,
 
 # Runtime files and locks for iSCSI daemon operation
 /run/lock/iscsi/ rw,
@@ -103,7 +115,66 @@ func init() {
 		implicitOnClassic:        true,
 		baseDeclarationSlots:     iscsiInitiatorBaseDeclarationSlots,
 		baseDeclarationPlugs:     iscsiInitiatorBaseDeclarationPlugs,
-		connectedPlugAppArmor:    iscsiInitiatorConnectedPlugAppArmor,
 		connectedPlugKModModules: iscsiInitiatorConnectedPlugKmod,
 	}})
+}
+
+const nodesDBDebianPath = "/var/lib/iscsi/nodes"
+
+// shouldMountVarLibNodesDB returns true if we're running in a distro that uses
+// /var/lib/iscsi/nodes as the nodes DB path, in which case it must be
+// bind-mounted from /var/lib/snapd/hostfs/... to the expected location.
+func shouldMountVarLibNodesDB() (bool, error) {
+	if !release.DistroLike("debian", "ubuntu") {
+		return false, nil
+	}
+
+	if release.ReleaseInfo.ID == "ubuntu" {
+		const minVersion = "24.04"
+		cmp, err := strutil.VersionCompare(release.ReleaseInfo.VersionID, minVersion)
+		if err != nil {
+			return false, err
+		}
+		if cmp < 0 {
+			return false, nil
+		}
+	}
+
+	srcDir := dirs.GlobalRootDir + nodesDBDebianPath
+	return osutil.IsDirectory(srcDir), nil
+}
+
+// MountConnectedPlug exposes the host's iSCSI persistent node database at
+// /var/lib/iscsi/nodes inside the snap mount namespace.
+func (iface *iscsiInitiatorInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	ok, err := shouldMountVarLibNodesDB()
+	if err != nil || !ok {
+		return err
+	}
+
+	return spec.AddMountEntry(osutil.MountEntry{
+		Name:    filepath.Join("/var/lib/snapd/hostfs", nodesDBDebianPath),
+		Dir:     nodesDBDebianPath,
+		Options: []string{"bind", "rw"},
+	})
+}
+
+// AppArmorConnectedPlug updates the snap-update-ns rules to allow the bind
+// mount of the iscsi node DB to the correct location.
+func (iface *iscsiInitiatorInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(iscsiInitiatorConnectedPlugAppArmor)
+
+	ok, err := shouldMountVarLibNodesDB()
+	if err != nil || !ok {
+		return err
+	}
+
+	emit := spec.AddUpdateNSf
+	emit("  # Bind-mount host's iSCSI persistent node database\n")
+	emit("  mount options=(bind, rw) /var/lib/snapd/hostfs%s/ -> %s/,\n", nodesDBDebianPath, nodesDBDebianPath)
+	emit("  umount %s/,\n", nodesDBDebianPath)
+	// /var/lib/iscsi/nodes/ does not exist in the snap's base, so we need to
+	// add writable-mimic rules for snap-update-ns create it
+	apparmor.GenWritableProfile(emit, nodesDBDebianPath, 1)
+	return nil
 }

--- a/interfaces/builtin/iscsi_initiator.go
+++ b/interfaces/builtin/iscsi_initiator.go
@@ -22,13 +22,9 @@ package builtin
 import (
 	"path/filepath"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/strutil"
 )
 
 /*
@@ -116,65 +112,29 @@ func init() {
 		baseDeclarationSlots:     iscsiInitiatorBaseDeclarationSlots,
 		baseDeclarationPlugs:     iscsiInitiatorBaseDeclarationPlugs,
 		connectedPlugKModModules: iscsiInitiatorConnectedPlugKmod,
+		// expose the host's iSCSI persistent node database at /var/lib/iscsi/nodes,
+		// if one exists
+		connectedPlugMount: []osutil.MountEntry{{
+			Name:    filepath.Join("/var/lib/snapd/hostfs", nodesDBDebianPath),
+			Dir:     nodesDBDebianPath,
+			Options: []string{"bind", "rw"},
+		}},
 	}})
 }
 
 const nodesDBDebianPath = "/var/lib/iscsi/nodes"
-
-// shouldMountVarLibNodesDB returns true if we're running in a distro that uses
-// /var/lib/iscsi/nodes as the nodes DB path, in which case it must be
-// bind-mounted from /var/lib/snapd/hostfs/... to the expected location.
-func shouldMountVarLibNodesDB() (bool, error) {
-	if !release.DistroLike("debian", "ubuntu") {
-		return false, nil
-	}
-
-	if release.ReleaseInfo.ID == "ubuntu" {
-		const minVersion = "24.04"
-		cmp, err := strutil.VersionCompare(release.ReleaseInfo.VersionID, minVersion)
-		if err != nil {
-			return false, err
-		}
-		if cmp < 0 {
-			return false, nil
-		}
-	}
-
-	srcDir := dirs.GlobalRootDir + nodesDBDebianPath
-	return osutil.IsDirectory(srcDir), nil
-}
-
-// MountConnectedPlug exposes the host's iSCSI persistent node database at
-// /var/lib/iscsi/nodes inside the snap mount namespace.
-func (iface *iscsiInitiatorInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	ok, err := shouldMountVarLibNodesDB()
-	if err != nil || !ok {
-		return err
-	}
-
-	return spec.AddMountEntry(osutil.MountEntry{
-		Name:    filepath.Join("/var/lib/snapd/hostfs", nodesDBDebianPath),
-		Dir:     nodesDBDebianPath,
-		Options: []string{"bind", "rw"},
-	})
-}
 
 // AppArmorConnectedPlug updates the snap-update-ns rules to allow the bind
 // mount of the iscsi node DB to the correct location.
 func (iface *iscsiInitiatorInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.AddSnippet(iscsiInitiatorConnectedPlugAppArmor)
 
-	ok, err := shouldMountVarLibNodesDB()
-	if err != nil || !ok {
-		return err
-	}
-
 	emit := spec.AddUpdateNSf
 	emit("  # Bind-mount host's iSCSI persistent node database\n")
-	emit("  mount options=(bind, rw) /var/lib/snapd/hostfs%s/ -> %s/,\n", nodesDBDebianPath, nodesDBDebianPath)
+	emit("  mount options=(bind, rw) /var/lib/snapd/hostfs%[1]s/ -> %[1]s/,\n", nodesDBDebianPath)
 	emit("  umount %s/,\n", nodesDBDebianPath)
 	// /var/lib/iscsi/nodes/ does not exist in the snap's base, so we need to
-	// add writable-mimic rules for snap-update-ns create it
+	// add writable-mimic rules for snap-update-ns to create it.
 	apparmor.GenWritableProfile(emit, nodesDBDebianPath, 1)
 	return nil
 }

--- a/interfaces/builtin/iscsi_initiator_test.go
+++ b/interfaces/builtin/iscsi_initiator_test.go
@@ -20,13 +20,20 @@
 package builtin_test
 
 import (
+	"os"
+	"strings"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/kmod"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -94,8 +101,8 @@ func (s *iscsiInitiatorInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/iscsi/static/** rw,")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/iscsi/isns/ rwk,")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/iscsi/isns/** rw,")
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/iscsi/nodes/ rwk,")
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/iscsi/nodes/** rw,")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/{etc,var/lib}/iscsi/nodes/ rwk,")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/{etc,var/lib}/iscsi/nodes/** rw,")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/run/lock/iscsi/** rwlk,")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/sys/class/iscsi_session/** rw,")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/sys/class/iscsi_host/** r,")
@@ -132,4 +139,78 @@ func (s *iscsiInitiatorInterfaceSuite) TestUDevConnectedPlug(c *C) {
 
 func (s *iscsiInitiatorInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *iscsiInitiatorInterfaceSuite) TestMountConnectedPlugSourceMissing(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	restore := release.MockReleaseInfo(&release.OS{ID: "debian"})
+	defer restore()
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	// no source directory so we don't create the mount entry
+	c.Check(spec.MountEntries(), HasLen, 0)
+}
+
+func (s *iscsiInitiatorInterfaceSuite) TestUpdateNSAppArmor(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+	c.Assert(os.MkdirAll(dirs.GlobalRootDir+"/var/lib/iscsi/nodes", 0o755), IsNil)
+
+	const nsSnippet = "mount options=(bind, rw) /var/lib/snapd/hostfs/var/lib/iscsi/nodes/ -> /var/lib/iscsi/nodes/,"
+
+	for _, tc := range []struct {
+		releaseInfo *release.OS
+		expectMount bool
+	}{{
+		releaseInfo: &release.OS{ID: "debian"},
+		expectMount: true,
+	}, {
+		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "24.04"},
+		expectMount: true,
+	}, {
+		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "26.04"},
+		expectMount: true,
+	}, {
+		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "22.04"},
+		expectMount: false,
+	}, {
+		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "20.04"},
+		expectMount: false,
+	}, {
+		releaseInfo: &release.OS{ID: "fedora"},
+		expectMount: false,
+	}, {
+		releaseInfo: &release.OS{ID: "arch"},
+		expectMount: false,
+	},
+	} {
+		restore := release.MockReleaseInfo(tc.releaseInfo)
+		cmt := Commentf("distro %s %s", tc.releaseInfo.ID, tc.releaseInfo.VersionID)
+
+		mountSpec := &mount.Specification{}
+		c.Assert(mountSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil, cmt)
+
+		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+		c.Assert(err, IsNil, cmt)
+		apparmorSpec := apparmor.NewSpecification(appSet)
+		c.Assert(apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil, cmt)
+
+		mountNs := strings.Join(apparmorSpec.UpdateNS(), "\n")
+		if tc.expectMount {
+			c.Check(mountSpec.MountEntries(), DeepEquals, []osutil.MountEntry{{
+				Name:    "/var/lib/snapd/hostfs/var/lib/iscsi/nodes",
+				Dir:     "/var/lib/iscsi/nodes",
+				Options: []string{"bind", "rw"},
+			}}, cmt)
+			c.Check(mountNs, testutil.Contains, nsSnippet, cmt)
+		} else {
+			c.Check(mountSpec.MountEntries(), HasLen, 0, cmt)
+			c.Check(mountNs, Not(testutil.Contains), "/var/lib/iscsi/nodes", cmt)
+		}
+
+		restore()
+	}
 }

--- a/interfaces/builtin/iscsi_initiator_test.go
+++ b/interfaces/builtin/iscsi_initiator_test.go
@@ -20,12 +20,10 @@
 package builtin_test
 
 import (
-	"os"
 	"strings"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -33,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -141,76 +138,21 @@ func (s *iscsiInitiatorInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
-func (s *iscsiInitiatorInterfaceSuite) TestMountConnectedPlugSourceMissing(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("")
-
-	restore := release.MockReleaseInfo(&release.OS{ID: "debian"})
-	defer restore()
-
-	spec := &mount.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	// no source directory so we don't create the mount entry
-	c.Check(spec.MountEntries(), HasLen, 0)
-}
-
-func (s *iscsiInitiatorInterfaceSuite) TestUpdateNSAppArmor(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("")
-	c.Assert(os.MkdirAll(dirs.GlobalRootDir+"/var/lib/iscsi/nodes", 0o755), IsNil)
-
+func (s *iscsiInitiatorInterfaceSuite) TestMountEntryAndNsRule(c *C) {
 	const nsSnippet = "mount options=(bind, rw) /var/lib/snapd/hostfs/var/lib/iscsi/nodes/ -> /var/lib/iscsi/nodes/,"
 
-	for _, tc := range []struct {
-		releaseInfo *release.OS
-		expectMount bool
-	}{{
-		releaseInfo: &release.OS{ID: "debian"},
-		expectMount: true,
-	}, {
-		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "24.04"},
-		expectMount: true,
-	}, {
-		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "26.04"},
-		expectMount: true,
-	}, {
-		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "22.04"},
-		expectMount: false,
-	}, {
-		releaseInfo: &release.OS{ID: "ubuntu", VersionID: "20.04"},
-		expectMount: false,
-	}, {
-		releaseInfo: &release.OS{ID: "fedora"},
-		expectMount: false,
-	}, {
-		releaseInfo: &release.OS{ID: "arch"},
-		expectMount: false,
-	},
-	} {
-		restore := release.MockReleaseInfo(tc.releaseInfo)
-		cmt := Commentf("distro %s %s", tc.releaseInfo.ID, tc.releaseInfo.VersionID)
+	mountSpec := &mount.Specification{}
+	c.Assert(mountSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(mountSpec.MountEntries(), DeepEquals, []osutil.MountEntry{{
+		Name:    "/var/lib/snapd/hostfs/var/lib/iscsi/nodes",
+		Dir:     "/var/lib/iscsi/nodes",
+		Options: []string{"bind", "rw"},
+	}})
 
-		mountSpec := &mount.Specification{}
-		c.Assert(mountSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil, cmt)
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	aaSpec := apparmor.NewSpecification(appSet)
+	c.Assert(aaSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
-		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
-		c.Assert(err, IsNil, cmt)
-		apparmorSpec := apparmor.NewSpecification(appSet)
-		c.Assert(apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil, cmt)
-
-		mountNs := strings.Join(apparmorSpec.UpdateNS(), "\n")
-		if tc.expectMount {
-			c.Check(mountSpec.MountEntries(), DeepEquals, []osutil.MountEntry{{
-				Name:    "/var/lib/snapd/hostfs/var/lib/iscsi/nodes",
-				Dir:     "/var/lib/iscsi/nodes",
-				Options: []string{"bind", "rw"},
-			}}, cmt)
-			c.Check(mountNs, testutil.Contains, nsSnippet, cmt)
-		} else {
-			c.Check(mountSpec.MountEntries(), HasLen, 0, cmt)
-			c.Check(mountNs, Not(testutil.Contains), "/var/lib/iscsi/nodes", cmt)
-		}
-
-		restore()
-	}
+	c.Check(strings.Join(aaSpec.UpdateNS(), "\n"), testutil.Contains, nsSnippet)
 }

--- a/tests/main/interfaces-iscsi-initiator/task.yaml
+++ b/tests/main/interfaces-iscsi-initiator/task.yaml
@@ -35,20 +35,16 @@ prepare: |
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/static
   "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/isns
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/isns
+  "$TESTSTOOLS"/fs-state mock-dir /var/lib/iscsi/nodes
+  tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /var/lib/iscsi/nodes
+  "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/nodes
+  tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/nodes
   "$TESTSTOOLS"/fs-state mock-file /etc/iscsi/initiatorname.iscsi
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-file /etc/iscsi/initiatorname.iscsi
   "$TESTSTOOLS"/fs-state mock-file /etc/iscsi/iscsid.conf
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-file /etc/iscsi/iscsid.conf
   echo "InitiatorName=iqn.1993-08.org.debian:01:abcdef123" > /etc/iscsi/initiatorname.iscsi
   echo "node.startup = automatic" > /etc/iscsi/iscsid.conf
-
-  if os.query is-debian || os.query is-ubuntu-ge 24.04; then
-    "$TESTSTOOLS"/fs-state mock-dir /var/lib/iscsi/nodes
-    tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /var/lib/iscsi/nodes
-  else
-    "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/nodes
-    tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/nodes
-  fi
 
   snap install "$TEST_SNAP" --channel=latest/edge
 
@@ -74,13 +70,8 @@ execute: |
   "$TEST_SNAP".client -c "cat /etc/iscsi/iscsid.conf"
 
   echo "And the snap is able to access iSCSI nodes directory"
-  NODE_DIR=""
-  if os.query is-debian || os.query is-ubuntu-ge 24.04; then
-    NODE_DIR="/var/lib/iscsi/nodes"
-  else
-    NODE_DIR="/etc/iscsi/nodes"
-  fi
-  "$TEST_SNAP".client -c "ls $NODE_DIR"
+  "$TEST_SNAP".client -c "ls /etc/iscsi/nodes"
+  "$TEST_SNAP".client -c "ls /var/lib/iscsi/nodes"
 
   echo "And the snap is able to access additional Open-iSCSI persistent state"
   "$TEST_SNAP".client -c "ls /etc/iscsi/ifaces"

--- a/tests/main/interfaces-iscsi-initiator/task.yaml
+++ b/tests/main/interfaces-iscsi-initiator/task.yaml
@@ -35,14 +35,20 @@ prepare: |
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/static
   "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/isns
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/isns
-  "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/nodes
-  tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/nodes
   "$TESTSTOOLS"/fs-state mock-file /etc/iscsi/initiatorname.iscsi
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-file /etc/iscsi/initiatorname.iscsi
   "$TESTSTOOLS"/fs-state mock-file /etc/iscsi/iscsid.conf
   tests.cleanup defer "$TESTSTOOLS"/fs-state restore-file /etc/iscsi/iscsid.conf
   echo "InitiatorName=iqn.1993-08.org.debian:01:abcdef123" > /etc/iscsi/initiatorname.iscsi
   echo "node.startup = automatic" > /etc/iscsi/iscsid.conf
+
+  if os.query is-debian || os.query is-ubuntu-ge 24.04; then
+    "$TESTSTOOLS"/fs-state mock-dir /var/lib/iscsi/nodes
+    tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /var/lib/iscsi/nodes
+  else
+    "$TESTSTOOLS"/fs-state mock-dir /etc/iscsi/nodes
+    tests.cleanup defer "$TESTSTOOLS"/fs-state restore-dir /etc/iscsi/nodes
+  fi
 
   snap install "$TEST_SNAP" --channel=latest/edge
 
@@ -68,7 +74,13 @@ execute: |
   "$TEST_SNAP".client -c "cat /etc/iscsi/iscsid.conf"
 
   echo "And the snap is able to access iSCSI nodes directory"
-  "$TEST_SNAP".client -c "ls /etc/iscsi/nodes"
+  NODE_DIR=""
+  if os.query is-debian || os.query is-ubuntu-ge 24.04; then
+    NODE_DIR="/var/lib/iscsi/nodes"
+  else
+    NODE_DIR="/etc/iscsi/nodes"
+  fi
+  "$TEST_SNAP".client -c "ls $NODE_DIR"
 
   echo "And the snap is able to access additional Open-iSCSI persistent state"
   "$TEST_SNAP".client -c "ls /etc/iscsi/ifaces"


### PR DESCRIPTION
Newer openiSCSI stores its persistent node database in /var/lib/iscsi/nodes (https://salsa.debian.org/linux-blocks-team/open-iscsi/-/commit/74f7df689b2c53f9509bc2959804b30887038db9). This adapts the iscsi-initiator to allow access to that path and binds mounts the existing path /var/lib/snapd/hostfs/iscsi/nodes to the expected location.
The rules are added unconditionally but the bind mounting (and related snap-update-ns rule) is gated on the distro (we also check if the dir exists so the distro gating might be redundant).
Follow-up to https://github.com/canonical/snapd/pull/16768#discussion_r3378176433

https://warthogs.atlassian.net/browse/SNAPDENG-37035