### PR TITLE
many: update apparmor to 5.0.2

### DIFF
--- a/build-aux/snap/local/apparmor/af_names.h
+++ b/build-aux/snap/local/apparmor/af_names.h
@@ -1,8 +1,8 @@
 /*
   this file was generated on a Ubuntu noble install from the upstream
-  apparmor-5.0.1 release tarball as follows:
+  apparmor-5.0.2 release tarball as follows:
 
-  AA_VER=5.0.1
+  AA_VER=5.0.2
   TARBALL_NAME="apparmor-v${AA_VER}"
   wget \
   "https://gitlab.com/apparmor/apparmor/-/archive/v${AA_VER}/${TARBALL_NAME}.tar.gz"
@@ -240,4 +240,3 @@ AA_GEN_NET_ENT("mctp", AF_MCTP)
 
 
 #define AA_AF_MAX 46
-

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -161,8 +161,8 @@ parts:
       - pkg-config
       - wget
       - libzstd-dev
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.1/apparmor-v5.0.1.tar.gz
-    source-checksum: sha256/cea1fc638dccea42a0a972bfe6ee2a34cbf52ed98526c25a49bbed39450d2dcc
+    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.2/apparmor-v5.0.2.tar.gz
+    source-checksum: sha256/bef45f228c0bde2f80d9630084e56bd8020b3fc4dfa7ee48a6aca585bb5ea0ed
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 AS_IF([test "x$enable_apparmor" = "xyes"], [
     # Expect AppArmor 5 when building as a snap under snapcraft
     AS_IF([test "x$SNAPCRAFT_PROJECT_NAME" = "xsnapd"], [
-        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.1], [
+        PKG_CHECK_MODULES([APPARMOR], [libapparmor = 5.0.2], [
             AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor 5 support])], [
             AC_MSG_ERROR([unable to find apparmor 5 for snap build of snapd])])], [
         PKG_CHECK_MODULES([APPARMOR], [libapparmor], [

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -641,7 +641,7 @@ func (s *parserFeatureTestSuite) TestProbeFeature(c *C) {
 	probeOneParserFeature(c, &knownProbes, parserPath, "xdp", `profile snap-test { network xdp,}`)
 
 	// Pretend we have all the features.
-	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.1")), 0o755)
+	err := os.WriteFile(parserPath, []byte(fakeParserScript("5.0.2")), 0o755)
 	c.Assert(err, IsNil)
 
 	// Did any feature probes got added to non-test code?


### PR DESCRIPTION
This fixes the nested hybrid remodel test case. The upstream fix is the same pair of patches we've investigated when updating to apparmor 4.0.x a while ago. The patches that were a part of the 4.x release somehow never made it into 5.x branch, thus causing this regression.

I've also brought a skill that can be useful for updating apparmor in the future.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37185

unskip:
- openstack-ext:ubuntu-22.04-64:tests/nested/manual/hybrid-remodel