### PR TITLE
interfaces/builtin: allow gtk css in subdirectories

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -237,9 +237,9 @@ const desktopConnectedPlugAppArmorClassic = `
 # subset of gnome abstraction
 /etc/gtk-3.0/settings.ini r,
 owner @{HOME}/.config/gtk-3.0/settings.ini r,
-owner @{HOME}/.config/gtk-3.0/*.css r,
+owner @{HOME}/.config/gtk-3.0/{*.css,**/*.css} r,
 owner @{HOME}/.config/gtk-4.0/settings.ini r,
-owner @{HOME}/.config/gtk-4.0/*.css r,
+owner @{HOME}/.config/gtk-4.0/{*.css,**/*.css} r,
 # Note: this leaks directory names that wouldn't otherwise be known to the snap
 owner @{HOME}/.config/gtk-3.0/bookmarks r,
 owner @{HOME}/.config/gtk-4.0/bookmarks r,

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -143,6 +143,8 @@ func (s *DesktopInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access basic graphical desktop resources")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/etc/gtk-3.0/settings.ini r,")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.config/gtk-3.0/{*.css,**/*.css} r,")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.config/gtk-4.0/{*.css,**/*.css} r,")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow access to xdg-desktop-portal and xdg-document-portal")
 
 	// check desktop interface uses correct label for Mutter when provided


### PR DESCRIPTION
## Summary
- allow gtk css files under subdirectories of `~/.config/gtk-3.0` and `~/.config/gtk-4.0`
- keep the rule limited to `*.css` rather than broadening access to arbitrary files
- extend the desktop interface test to cover the new AppArmor snippet

## Testing
- `go test ./interfaces/builtin -check.f Desktop`

## Context
- Jira: SNAPDENG-37221
- Forum: https://forum.snapcraft.io/t/snapd-desktop-integration-permissions-for-gtk-3-4-0-apparmor/52097
