### PR TITLE
o/snapstate/backend: list dir contents on failure to remove snap base data dir

### DIFF
--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -100,13 +100,15 @@ func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts
 				if !errors.Is(firstRemoveErr, unix.ENOTEMPTY) {
 					return ""
 				}
-				entries, err := os.ReadDir(firstErrDir)
+				d, err := os.Open(firstErrDir)
 				if err != nil {
 					return ""
 				}
-				names := make([]string, len(entries))
-				for i, e := range entries {
-					names[i] = e.Name()
+				defer d.Close()
+				const maxEntries = 10
+				names, err := d.Readdirnames(maxEntries)
+				if err != nil {
+					return ""
 				}
 				return "\ndir contents: [" + strings.Join(names, ", ") + "]"
 			}()

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	unix "syscall"
 
 	"github.com/snapcore/snapd/dirs"
@@ -70,56 +71,62 @@ func (b Backend) RemoveSnapSaveData(snapInfo *snap.Info, dev snap.Device) error 
 
 // RemoveSnapDataDir removes base snap data directories
 func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error {
-	if info.InstanceKey != "" {
-		// data directories of snaps with instance key are never used by
-		// other instances
-		dirs, err := snapBaseDataDirs(info.InstanceName(), opts)
+	removeBaseDataDirsFor := func(snapName string) error {
+		dirs, err := snapBaseDataDirs(snapName, opts)
 		if err != nil {
 			return err
 		}
 		var firstRemoveErr error
+		var firstErrDir string
 		for _, dir := range dirs {
 			// remove data symlink that could have been created by snap-run
 			// https://bugs.launchpad.net/snapd/+bug/2009617
 			if err := os.Remove(filepath.Join(dir, "current")); err != nil && !os.IsNotExist(err) {
 				if firstRemoveErr == nil {
+					// firstErrDir is not set here: it is needed only
+					// to list dir contents in case of ENOTEMPTY error
 					firstRemoveErr = err
 				}
 			}
 			if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
 				if firstRemoveErr == nil {
 					firstRemoveErr = err
+					firstErrDir = dir
 				}
 			}
 		}
 		if firstRemoveErr != nil {
-			return fmt.Errorf("failed to remove snap %q base directory: %v", info.InstanceName(), firstRemoveErr)
+			dirContents := func() string {
+				if !errors.Is(firstRemoveErr, unix.ENOTEMPTY) {
+					return ""
+				}
+				entries, err := os.ReadDir(firstErrDir)
+				if err != nil {
+					return ""
+				}
+				names := make([]string, len(entries))
+				for i, e := range entries {
+					names[i] = e.Name()
+				}
+				return "\ndir contents: [" + strings.Join(names, ", ") + "]"
+			}()
+			return fmt.Errorf("failed to remove snap %q base directory: %v%s", snapName, firstRemoveErr, dirContents)
+		}
+		return nil
+	}
+
+	if info.InstanceKey != "" {
+		// data directories of snaps with instance key are never used by
+		// other instances
+		if err := removeBaseDataDirsFor(info.InstanceName()); err != nil {
+			return err
 		}
 	}
 	if !hasOtherInstances {
 		// remove the snap base directory only if there are no other
 		// snap instances using it
-		dirs, err := snapBaseDataDirs(info.SnapName(), opts)
-		if err != nil {
+		if err := removeBaseDataDirsFor(info.SnapName()); err != nil {
 			return err
-		}
-		var firstRemoveErr error
-		for _, dir := range dirs {
-			// remove data symlink that could have been created by snap-run
-			// https://bugs.launchpad.net/snapd/+bug/2009617
-			if err := os.Remove(filepath.Join(dir, "current")); err != nil && !os.IsNotExist(err) {
-				if firstRemoveErr == nil {
-					firstRemoveErr = err
-				}
-			}
-			if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
-				if firstRemoveErr == nil {
-					firstRemoveErr = err
-				}
-			}
-		}
-		if firstRemoveErr != nil {
-			return fmt.Errorf("failed to remove snap %q base directory: %v", info.SnapName(), firstRemoveErr)
 		}
 	}
 

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -312,7 +312,7 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// unexpected folder to make removal fail with ENOTEMPTY
 	c.Assert(os.Mkdir(filepath.Join(baseDataDir, "unexpected"), 0755), IsNil)
-	// make the dir non-readable so ReadDir fails; dir contents should not
+	// make the dir non-readable so Readdirnames fails; dir contents should not
 	// be appended to the error message in this case
 	c.Assert(os.Chmod(baseDataDir, 0111), IsNil)
 	defer os.Chmod(baseDataDir, 0755)

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -304,5 +304,49 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err := s.be.RemoveSnapDataDir(info, false, nil)
+	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello: directory not empty\ndir contents: \[unexpected\]`)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
+	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
+	// unexpected folder to make removal fail with ENOTEMPTY
+	c.Assert(os.Mkdir(filepath.Join(baseDataDir, "unexpected"), 0755), IsNil)
+	// make the dir non-readable so ReadDir fails; dir contents should not
+	// be appended to the error message in this case
+	c.Assert(os.Chmod(baseDataDir, 0111), IsNil)
+	defer os.Chmod(baseDataDir, 0755)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapDataDir(info, false, nil)
 	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello: directory not empty`)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
+	parentDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap")
+	baseDataDir := filepath.Join(parentDir, "hello")
+	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
+	// make parent non-writable so removal fails with EACCES, not ENOTEMPTY;
+	// dir contents should not be appended to the error message in this case
+	c.Assert(os.Chmod(parentDir, 0555), IsNil)
+	defer os.Chmod(parentDir, 0755)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapDataDir(info, false, nil)
+	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello: permission denied`)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
+	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
+	// create the current symlink
+	c.Assert(os.Symlink("10", filepath.Join(baseDataDir, "current")), IsNil)
+	// make the dir non-writable so unlinking current fails with EACCES;
+	// dir contents should not be appended since the error is not ENOTEMPTY
+	c.Assert(os.Chmod(baseDataDir, 0555), IsNil)
+	defer os.Chmod(baseDataDir, 0755)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapDataDir(info, false, nil)
+	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello/current: permission denied`)
 }


### PR DESCRIPTION
Helps with the analysis of a failure to remove a snap