### PR TITLE
interfaces: allow connecting to system-wide docker on classic

### DIFF
--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -30,7 +30,8 @@ const dockerBaseDeclarationSlots = `
     deny-installation:
       slot-snap-type:
         - app
-    deny-connection: true
+    deny-connection:
+      on-classic: false
     deny-auto-connection: true
 `
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1184,7 +1184,6 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"cups":                      true,
 		"custom-device":             true,
 		"desktop":                   true,
-		"docker":                    true,
 		"fwupd":                     true,
 		"location-control":          true,
 		"location-observe":          true,


### PR DESCRIPTION
This will allow connecting to docker running as a non-snap package, when running on classic. On core one still has to use docker snap.

The non-classic docker snap package allows anyone to connect to its slot, but not auto-connect. This allows a user to make an informed decision to allow connecting to docker without docker snap being aware of this at the assertion level. This change is making this property apply to the implicit system slot of docker.

Related: https://warthogs.atlassian.net/browse/SNAPDENG-37212