### PR TITLE
tests/main/preseed: fix base snap expectation on ubuntu 22.04

### DIFF
--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -48,7 +48,7 @@ restore: |
 
 execute: |
   LXD_BASE_SNAP=core20
-  if os.query is-ubuntu-gt 22.04; then
+  if os.query is-ubuntu-gt 20.04; then
       LXD_BASE_SNAP=core22
   fi
 


### PR DESCRIPTION
The test selected core20 for Ubuntu 22.04, but current cloud images seed core22. This caused the task-log assertion to fail while matching preseed tasks.

Observed failure excerpt:
  MATCH 'Done .+ prerequisites +Ensure prerequisites for "core20" are available'
  grep error: pattern not found, got:
  ...
  Done ... prerequisites ... Ensure prerequisites for "core22" are available

Fix the selection logic to use core22 for Ubuntu > 20.04 so the test expects the seeded base snap reported by the image.
