### PR TITLE
sandbox/apparmor: accept apparmor 5.0 ABI from host when running as deb

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -952,14 +952,13 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 		if _, err := os.Stat(path); err == nil {
 			logger.Debugf("checking distro apparmor_parser at %v", path)
 
-			// Detect but ignore apparmor 5.0 ABI support.
-			// There's no known, diagnosed issue with ABI 5 yet but given that
-			// we also ignore host ABI 4.0, it's sensible to ignore this one explicitly too.
+			// Detect apparmor 5.0 ABI support from the host distribution and use it if available.
 			if fi, err := os.Lstat(hostAbi50File); err == nil && !fi.IsDir() {
-				logger.Debugf("apparmor 5.0 ABI detected but ignored")
+				logger.Debugf("apparmor 5.0 ABI detected")
+				return exec.Command(path, "--policy-features", hostAbi50File), false, nil
 			}
 
-			// Detect but ignore apparmor 4.0 ABI support.
+			// Detect but ignore apparmor 4.0 ABI support from the host distribution.
 			//
 			// At present this causes some bugs with mqueue mediation that can
 			// be avoided by pinning to 3.0 (which is also supported on

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -104,25 +104,24 @@ func (s *apparmorSuite) TestAppArmorParserDistroAbiIgnored(c *C) {
 			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0")},
 		},
 		{
-			name:     "only abi 5.0 ignored",
+			name:     "only abi 5.0",
 			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
-			expected: []string{mockParserCmd.Exe()},
-			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored`,
+			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0")},
 		},
 		{
-			name:     "abi 4.0 and 5.0 ignored",
+			name:     "abi 4.0 and 5.0 - uses 5.0",
 			abi40:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/4.0"),
 			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
-			expected: []string{mockParserCmd.Exe()},
-			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored.* DEBUG: apparmor 4.0 ABI detected but ignored`,
+			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0")},
+			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected`,
 		},
 		{
-			name:     "all three abis - pins to 3.0, ignores 4 and 5",
+			name:     "all three abis - uses 5.0",
 			abi30:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0"),
 			abi40:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/4.0"),
 			abi50:    filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0"),
-			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/3.0")},
-			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected but ignored.* DEBUG: apparmor 4.0 ABI detected but ignored`,
+			expected: []string{mockParserCmd.Exe(), "--policy-features", filepath.Join(s.fakeroot, "/etc/apparmor.d/abi/5.0")},
+			logMatch: `(?ms).* DEBUG: apparmor 5.0 ABI detected`,
 		},
 	}
 
@@ -155,8 +154,8 @@ func (s *apparmorSuite) TestAppArmorParserDistroAbiIgnored(c *C) {
 		c.Check(internal, Equals, false)
 		if tc.logMatch != "" {
 			c.Check(log.String(), Matches, tc.logMatch)
-		} else if tc.name == "no abi files" || tc.name == "only abi 3.0" {
-			// No ABI-5/ABI-4 ignore messages expected; the generic
+		} else if tc.name == "no abi files" || tc.name == "only abi 3.0" || tc.name == "only abi 5.0" {
+			// No ABI-4/ABI-5 ignore messages expected; the generic
 			// "checking distro apparmor_parser" message is still present.
 			c.Check(log.String(), Matches, `(?ms).* DEBUG: checking distro apparmor_parser .*\n`)
 		}


### PR DESCRIPTION
When snapd runs as a deb on Ubuntu systems with apparmor_parser 5.x, the host distribution's ABI 5.0 file was previously detected but ignored, causing snapd to fall back to ABI 3.0 even though ABI 5.0 is available. This caused odd behavior when new snapd deb packages arrived on development releases of Ubuntu where apparmor_parser carries a +ubuntu suffix in its version string.

Stop ignoring ABI 5.0: detect it via /etc/apparmor.d/abi/5.0 and pass it to the host parser as --policy-features, matching what the internal (snapd-as-snap) path already does for its bundled apparmor_parser.

The existing ABI 4.0 mqueue mediation pin remains in place — ABI 4.0 is still detected but ignored on the distro path.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37231
