### PR TITLE
tests/main/selinux-clean: filter out more unrelated denials

### DIFF
--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -39,12 +39,19 @@ restore: |
     rm -rf /home/test/foo
 
 execute: |
-    filter_out_dbus_broker() {
+    # The following SELinux denials are not related to snapd; they stem from
+    # the systemd / SELinux / ssh session startup interactions on the test
+    # systems. The comm and name fields are quoted in raw ausearch output but
+    # unquoted when -i (interpreted) is used, so quotes are made optional.
+    filter_out_unrelated() {
+        grep -v -E 'avc:  denied  { (setattr|read) } .* name="?linger"? .* scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0' | \
+        grep -v -E 'avc:  denied  { write } .* comm="?systemd"? .* scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t' | \
+        grep -v -E 'avc:  denied  { ioctl } .* comm="?\(runuser\)"? .* scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t' | \
         grep -v -E 'avc:  denied  { write } .* comm="?dbus-broker"? .* scontext=system_u:system_r:system_dbusd_t.* tcontext=system_u:system_r:sshd_session_t'
     }
 
     systemctl restart snapd.socket
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop
     test-snapd-desktop.sh -c echo 'hello world'
@@ -68,22 +75,18 @@ execute: |
     # were logged, they it will show up now, but not for subsequent checkpoints.
     # XXX ausearch exits with 1 when there are denials
     ausearch --checkpoint stamp --start checkpoint -m AVC > avc-after 2>&1 || true
-    grep -v -E 'avc:  denied  { (setattr|read) } .* name=linger .* scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:systemd_logind_var_lib_t:s0' < avc-after | \
-        grep -v -E 'avc:  denied  { write } .* comm="systemd" .* scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t' | \
-        grep -v -E 'avc:  denied  { ioctl } .* comm="\(runuser\)" .* scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t' | \
-        filter_out_dbus_broker | \
-        NOMATCH 'type=AVC'
+    filter_out_unrelated < avc-after | NOMATCH 'type=AVC'
 
     # another revision triggers copy of snap data
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
     # removal triggers cleanups
     snap remove test-snapd-desktop
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     "$TESTSTOOLS"/snaps-state install-local test-snapd-appstream-metadata
     snap connect test-snapd-appstream-metadata:appstream-metadata
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     snap stop test-snapd-service
@@ -91,18 +94,18 @@ execute: |
     # TODO: enable once there is a workaround for denials caused by journalctl
     # snap logs test-snapd-service
     snap remove test-snapd-service
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
     test-snapd-layout.sh -c 'ls /'
     su test -c "test-snapd-layout.sh -c 'ls /'"
     snap remove test-snapd-layout
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     "$TESTSTOOLS"/snaps-state install-local socket-activation
     [ -S /var/snap/socket-activation/common/socket ]
     snap remove socket-activation
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     # snaps with bases are special in the way that $(libexecdir)/snapd form host
     # is bind mounted into the mount namespace of a snap, thus the SELinux
@@ -111,13 +114,13 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-snapctl-core18
     snap restart test-snapd-snapctl-core18
     snap remove test-snapd-snapctl-core18
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
 
     snap install snap-store
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'
     # we are likely running without a display, so this will likely fail,
     # hopefully triggering enough of earlier setup to catch any relevant denials
     tests.session -u test exec snap run snap-store || true
     # removal triggers cleanups
     snap remove snap-store
-    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_dbus_broker | NOMATCH 'type=AVC'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | filter_out_unrelated | NOMATCH 'type=AVC'


### PR DESCRIPTION
Update the test to filter out denials that match the following pattern:

```
avc: denied { write } ... comm=systemd ... scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t ... tclass=fifo_file
avc: denied { ioctl } ... comm=(runuser) ... scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:sshd_session_t ... tclass=fifo_file
```

Which are caused by systemctl talking to the dbus-broker and init_t (systemd) writing things back to the SSH session pipe.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
