### PR TITLE
tests/utils/features: remove ending slash on suite if present

### DIFF
--- a/tests/utils/features/runtimeadder.py
+++ b/tests/utils/features/runtimeadder.py
@@ -86,6 +86,8 @@ def build_runtime_lookup(results_dir: str) -> dict[tuple, float]:
             try:
                 system = f"{item['backend']}:{item['system']}"
                 name = item["name"]
+                if name.endswith('/'):
+                    name = name[:-1]
                 variant = item.get("variant") or ""
                 runtime = _parse_runtime_seconds(item["start"], item["end"])
             except (KeyError, ValueError):


### PR DESCRIPTION
commit https://github.com/canonical/snapd/pull/17221/changes/2fc4334e7e4b7ba3330f001745a7443d7a03e9cb removed the ending slash for suite names. `runtimeadder` needs to also be updated