### PR TITLE
tests: build snap-bootstrap with netgo

### DIFF
--- a/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
+++ b/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
@@ -152,7 +152,10 @@ prepare: |
     ./get-deps.sh --skip-unused-check
     ./mkversion.sh "2.67.1"
     CGO_ENABLED=1 go build -mod=vendor -tags withtestkeys -o ../snapd_old/usr/lib/snapd/snapd github.com/snapcore/snapd/cmd/snapd
-    CGO_ENABLED=1 go build -mod=vendor -tags withtestkeys,nomanagers -o ../snap-bootstrap ./cmd/snap-bootstrap
+    # Use the pure-Go net/user resolvers (netgo,osusergo) so the binary does
+    # not link libresolv.so.2, which on 20.04 (glibc 2.31) is a separate
+    # library not present in the initramfs we inject snap-bootstrap into.
+    CGO_ENABLED=1 go build -mod=vendor -tags withtestkeys,nomanagers,netgo -o ../snap-bootstrap ./cmd/snap-bootstrap
     popd
     rm -rf snapd_old_source
     snap pack snapd_old --filename="${extra}/snapd_old.snap"


### PR DESCRIPTION
Fix tests/nested/manual/update-snapd-seed-and-factory-reset by building snap-bootstrap with the netgo resolver tag to avoid a runtime dependency on libresolv.so.2.

On Ubuntu 20.04, libresolv is separate from libc and not present in the injected initramfs, which caused snap-bootstrap to fail during early boot.

This was likely broken by https://github.com/canonical/snapd/pull/17067 which didn't run nested tests.

JIRA: SNAPDENG-37248
