### PR TITLE
seclog: strip trailing whitespace from audit netlink message payload

### DIFF
--- a/seclog/audit_linux.go
+++ b/seclog/audit_linux.go
@@ -20,6 +20,7 @@
 package seclog
 
 import (
+	"bytes"
 	"fmt"
 	"sync/atomic"
 	"syscall"
@@ -78,13 +79,20 @@ func OpenAuditWriter() (*AuditWriter, error) {
 	return &AuditWriter{fd: fd, opened: true}, nil
 }
 
-// Write sends payload as an AUDIT_TRUSTED_APP netlink message.
-// The returned byte count reflects only the original payload length.
-// Concurrent use requires external synchronization.
+// Write sends payload as an AUDIT_TRUSTED_APP netlink message. Each call must
+// carry a complete, well-formed message; partial writes are not supported.
+// Trailing whitespace is stripped before the payload is sent. The returned
+// byte count reflects the original payload length. Concurrent use requires
+// external synchronization.
 func (aw *AuditWriter) Write(payload []byte) (int, error) {
 	if !aw.opened {
 		return 0, fmt.Errorf("cannot send audit message: not open")
 	}
+	n := len(payload)
+	// Strip trailing whitespace; should the payload be constructed by a logger
+	// that appends a newline (e.g. slog), we remove it here since the audit
+	// subsystem does not expect it.
+	payload = bytes.TrimRight(payload, " \t\r\n")
 	msg := aw.buildMessage(payload)
 	addr := &syscall.SockaddrNetlink{
 		Family: syscall.AF_NETLINK,
@@ -94,7 +102,7 @@ func (aw *AuditWriter) Write(payload []byte) (int, error) {
 	if err := sys.Sendto(aw.fd, msg, 0, addr); err != nil {
 		return 0, fmt.Errorf("cannot send audit message: %v", err)
 	}
-	return len(payload), nil
+	return n, nil
 }
 
 // Close closes the underlying netlink socket.

--- a/seclog/audit_linux_test.go
+++ b/seclog/audit_linux_test.go
@@ -258,6 +258,32 @@ func (s *AuditSuite) TestBuildMessageEmptyPayload(c *C) {
 	c.Check(totalLen, Equals, uint32(20))
 }
 
+func (s *AuditSuite) TestWriteStripsTrailingWhitespace(c *C) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{"{\"foo\":\"bar\"}\n", "{\"foo\":\"bar\"}"},
+		{"{\"foo\":\"bar\"} \t\r\n", "{\"foo\":\"bar\"}"},
+		{"{\"foo\":\"bar\"}", "{\"foo\":\"bar\"}"},
+	} {
+		mock := &mockSyscallOps{socketFD: 7}
+		restore := seclog.MockSyscallOps(mock)
+		defer restore()
+
+		writer, err := seclog.OpenAuditWriter()
+		c.Assert(err, IsNil)
+
+		n, err := writer.Write([]byte(tc.input))
+		c.Assert(err, IsNil)
+		c.Check(n, Equals, len(tc.input))
+
+		payload := mock.sendtoData[syscall.SizeofNlMsghdr:]
+		c.Check(string(payload[:len(tc.want)]), Equals, tc.want)
+		c.Check(payload[len(tc.want)], Equals, byte(0))
+	}
+}
+
 func (s *AuditSuite) TestNlmsgAlignAlreadyAligned(c *C) {
 	c.Check(seclog.NlmsgAlign(0), Equals, uint32(0))
 	c.Check(seclog.NlmsgAlign(4), Equals, uint32(4))


### PR DESCRIPTION
Should the payload be constructed using a logger that appends a newline (e.g. slog), the newline would be embedded verbatim in the netlink message and appear in journald output as a trailing newline inside the quoted message field (LP: #2160691).

Strip all trailing whitespace in AuditWriter.Write before building the netlink message. The returned byte count still reflects the original input length to satisfy the io.Writer contract.

Related: SNAPDENG-37246
Fixes: LP#2160691
