### PR TITLE
tests/main/desktop-file-ids: fix stale local test snap

### DIFF
--- a/tests/main/desktop-file-ids/task.yaml
+++ b/tests/main/desktop-file-ids/task.yaml
@@ -14,7 +14,12 @@ environment:
     DIR: /var/lib/snapd/desktop/applications
 
 prepare: |
-    cat > "$TESTSLIB"/snaps/test-snapd-desktop-file-ids/meta/gui/'bad. ,?**[]{}^\$#.desktop' << EOF
+    cp -a "$TESTSLIB"/snaps/test-snapd-desktop-file-ids .
+    # The shared fixture may contain a cached packed snap. Remove it from the
+    # local copy so install-local packs the desktop file added below.
+    rm -f test-snapd-desktop-file-ids/*.snap
+
+    cat > test-snapd-desktop-file-ids/meta/gui/'bad. ,?**[]{}^\$#.desktop' << EOF
     [Desktop Entry]
     Name=test-snapd-desktop-file-ids.cmd
     Comment=A desktop file for test-snapd-desktop-file-ids.cmd


### PR DESCRIPTION
When another test packed the test snap first, install-local reused the cached snap from the shared fixture. The desktop file added by this test was therefore missing from the installed snap, causing the expected desktop-file check to fail.

This PR fixes this by copying the fixture locally and removing any cached snap so install-local packs the test-specific contents without modifying shared state.

JIRA: SNAPDENG-37109