### PR TITLE
tests: fix how timesyncd is configured for ubuntu-core

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1706,7 +1706,9 @@ EOF
                         echo "File timesyncd.conf not found in core image"
                         exit 1
                     fi
-                    cp /etc/systemd/timesyncd.conf "$TARGET_TIME_CONF"
+                    while IFS= read -r target; do
+                        cp /etc/systemd/timesyncd.conf "$target"
+                    done <<< "$TARGET_TIME_CONF"
                 fi
                 if [ -e "${BASE}-snap/usr/lib/tmpfiles.d/core-writable.conf" ]; then
                     echo "C /etc/chrony/sources.d/ci-proxy.sources" >>"${BASE}-snap/usr/lib/tmpfiles.d/core-writable.conf"


### PR DESCRIPTION
This is needed in order to fix uc26 when there are more than timesyncd.conf files in the core base snap.

This fix solves the issues related to refreshes in uc26

See the error:
```
+ cp /etc/systemd/timesyncd.conf $'core26-snap/etc/systemd/timesyncd.conf\ncore26-snap/usr/share/factory/writable/system-data/etc/systemd/timesyncd.conf'
cp: cannot create regular file 'core26-snap/etc/systemd/timesyncd.conf'$'\n''core26-snap/usr/share/factory/writable/system-data/etc/systemd/timesyncd.conf': No such file or directory
-----
.
```