### PR TITLE
packaging/ubuntu-26.04: fix session-agent socket handling, update tests

### DIFF
--- a/packaging/ubuntu-26.04/rules
+++ b/packaging/ubuntu-26.04/rules
@@ -155,6 +155,9 @@ override_dh_installsystemd:
 	dh_installsystemd -psnapd $(DH_SYSTEMD_START_OPTS) \
 	$(filter-out snapd.socket snapd.service snapd.mounts-pre.target, \
 	$(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR)/*)))
+	# TODO: call dh_installsystemduser if it becomes idempotent and stops
+	# making the symlink state sticky
+	# dh_installsystemduser -psnapd
 
 override_dh_clean:
 	dh_clean

--- a/packaging/ubuntu-26.04/snapd.links
+++ b/packaging/ubuntu-26.04/snapd.links
@@ -1,3 +1,10 @@
 /usr/lib/snapd/snap-device-helper  /usr/lib/udev/snappy-app-dev
+# The symlink below must be shipped directly in the deb rather than relying on
+# dh_installsystemduser. Although dh_installsystemduser would call
+# deb-systemd-helper --user enable in the postinst (which creates the symlink in
+# /etc/systemd/user/sockets.target.wants/ at install time), deb-systemd-helper
+# skips re-creating the symlink on disk if its state file already exists from a
+# prior install, even if the actual symlink was removed.
+/usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
 usr/lib/snapd/snapd usr/bin/snap

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -11,6 +11,10 @@ details: |
 
 systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
+skip:
+    - reason: This test checks the locally-built deb content, which is not available when snapd is from the archive
+      if: tests.info is-snapd-from-archive
+
 execute: |
     echo "Ensure that our debs have the 'built-using' header"
     out=$(dpkg -I "$GOHOME"/snapd_*.deb)
@@ -23,6 +27,9 @@ execute: |
 
     # not running on 14.04 because we don't have user sessions there
     if not os.query is-trusty; then
-        echo "Ensure that the snapd.session-agent.socket symlinks is part of the deb and that it has the right (relative) target"
-        dpkg -c "$GOHOME"/snapd_*.deb |MATCH -- '-> \.\./snapd.session-agent.socket'
+        echo "Ensure that the snapd.session-agent.socket symlink is part of the deb and has the right (relative) target"
+        dpkg -c "$GOHOME"/snapd_*.deb | MATCH -- '-> \.\./snapd.session-agent.socket'
+
+        echo "Ensure that the snapd.session-agent.socket symlink exists on the filesystem"
+        test -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
     fi


### PR DESCRIPTION
The override_dh_installsystemd target suppresses the automatic invocation of dh_installsystemduser by debhelper. As a result, no postinst/prerm snippets were generated for user units, so snapd.session-agent.socket was never enabled on package install.

Add an explicit dh_installsystemduser call so that the generated postinst calls deb-systemd-helper --user enable, which creates the sockets.target.wants/snapd.session-agent.socket symlink in /etc/systemd/user/ at install time.

Update spread test checking deb contents to account for differences in handling of the session-agent units.

Add Ubuntu 26.04 to the ubuntu-deb suite so that we exercise the relevant spread tests in CI