### PR TITLE
packaging/ubuntu-26.04, tests: fix service startup during install, account for dh-systemd in tests

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -116,7 +116,7 @@
         "runs-on": "['self-hosted', 'spread-enabled']",
         "group": "ubuntu-deb",
         "backend": "openstack",
-        "systems": "ubuntu-24.04-64",
+        "systems": "ubuntu-24.04-64 ubuntu-26.04-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/packaging/ubuntu-26.04/rules
+++ b/packaging/ubuntu-26.04/rules
@@ -155,9 +155,12 @@ override_dh_installsystemd:
 	dh_installsystemd -psnapd $(DH_SYSTEMD_START_OPTS) \
 	$(filter-out snapd.socket snapd.service snapd.mounts-pre.target, \
 	$(notdir $(wildcard debian/snapd$(SYSTEMD_UNITS_DESTDIR)/*)))
-	# TODO: call dh_installsystemduser if it becomes idempotent and stops
-	# making the symlink state sticky
-	# dh_installsystemduser -psnapd
+	# Handle user units (e.g. snapd.session-agent.socket). This must be
+	# called explicitly because override_dh_installsystemd suppresses the
+	# automatic dh_installsystemduser invocation. The deb-systemd-helper
+	# state files are cleared in the spread test suite prepare to ensure
+	# idempotent behaviour across VM reuse.
+	dh_installsystemduser -psnapd
 
 override_dh_clean:
 	dh_clean

--- a/packaging/ubuntu-26.04/rules
+++ b/packaging/ubuntu-26.04/rules
@@ -147,6 +147,10 @@ override_dh_installsystemd:
 	# Due to https://github.com/systemd/systemd/issues/8102 
 	# debhelper supporting --remaining like behaviour here would
 	# have been useful
+	# Enable snapd.apparmor first so that it is enabled before snapd.service
+	# is started; snapd checks whether snapd.apparmor is enabled at startup
+	# and emits a warning if it is not.
+	dh_installsystemd -psnapd --no-start snapd.apparmor.service
 	# (Re-)start socket first
 	dh_installsystemd -psnapd $(DH_SYSTEMD_START_OPTS) snapd.socket
 	# Then service

--- a/packaging/ubuntu-26.04/snapd.install.in
+++ b/packaging/ubuntu-26.04/snapd.install.in
@@ -10,6 +10,7 @@ usr/bin/snap-preseed /usr/lib/snapd/
 usr/bin/snap-recovery-chooser /usr/lib/snapd/
 usr/bin/snap-fde-keymgr /usr/lib/snapd/
 usr/bin/snapd-apparmor /usr/lib/snapd/
+usr/bin/snap-gpio-helper /usr/lib/snapd/
 
 # bash completion
 data/completion/bash/snap /usr/share/bash-completion/completions

--- a/packaging/ubuntu-26.04/snapd.links
+++ b/packaging/ubuntu-26.04/snapd.links
@@ -1,10 +1,3 @@
 /usr/lib/snapd/snap-device-helper  /usr/lib/udev/snappy-app-dev
-# The symlink below must be shipped directly in the deb rather than relying on
-# dh_installsystemduser. Although dh_installsystemduser would call
-# deb-systemd-helper --user enable in the postinst (which creates the symlink in
-# /etc/systemd/user/sockets.target.wants/ at install time), deb-systemd-helper
-# skips re-creating the symlink on disk if its state file already exists from a
-# prior install, even if the actual symlink was removed.
-/usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
 usr/lib/snapd/snapd usr/bin/snap

--- a/packaging/ubuntu-26.04/snapd.postinst
+++ b/packaging/ubuntu-26.04/snapd.postinst
@@ -10,6 +10,14 @@ case "$1" in
         # Ensure that the void directory has correct permissions.
         chmod 111 /var/lib/snapd/void
 
+        # Ensure that the seed is valid, otherwise disable it
+        if [ -e /var/lib/snapd/seed/seed.yaml ] && [ "$(snap debug state --is-seeded /var/lib/snapd/state.json)" = "false" ]; then
+            if ! snap debug validate-seed /var/lib/snapd/seed/seed.yaml; then
+                echo "Found incorrect seed, disabling it"
+                mv /var/lib/snapd/seed /var/lib/snapd/seed.disabled
+            fi
+        fi
+
         # ensure required caps on snap-confine
         setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.caps
         ;;

--- a/packaging/ubuntu-26.04/snapd.postrm
+++ b/packaging/ubuntu-26.04/snapd.postrm
@@ -122,11 +122,6 @@ if [ "$1" = "purge" ]; then
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 
-    # snapd session-agent
-    rm -f /etc/systemd/user/snapd.session-agent.socket
-    rm -f /etc/systemd/user/snapd.session-agent.service
-    rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
-
     # dbus activation configuration
     rm -f /etc/dbus-1/session.d/snapd.session-services.conf
     rm -f /etc/dbus-1/system.d/snapd.system-services.conf

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -376,6 +376,8 @@ prepare_project() {
         # no packaging setup for 14.04, we're no longer building the packages in
         # CI
         :
+    elif os.query is-ubuntu-ge 26.04; then
+        ln -sf packaging/ubuntu-26.04 debian
     elif os.query is-ubuntu; then
         # TODO generate packaging appropriate for a given ubuntu release
         ln -sf packaging/ubuntu-16.04 debian

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -438,6 +438,20 @@ prepare_project() {
 
             # now we can attempt to purge the actual distro package via apt
             distro_purge_package snapd
+            # On ubuntu-26.04+ the snapd deb uses dh_installsystemd and
+            # dh_installsystemduser to enable units. The underlying
+            # deb-systemd-helper tool skips re-creating enable symlinks when
+            # its state files already exist from a prior install, even if the
+            # actual symlinks were removed. Clear the state so that the CI deb
+            # install behaves as a clean first installation and all snapd units
+            # (including snapd.apparmor.service and snapd.session-agent.socket)
+            # are properly enabled.
+            if os.query is-ubuntu-ge 26.04; then
+                find /var/lib/systemd/deb-systemd-helper-enabled \
+                    -name 'snapd*' -delete || true
+                find /var/lib/systemd/deb-systemd-user-helper-enabled \
+                    -name 'snapd*' -delete || true
+            fi
             # XXX: the original package's purge may have left socket units behind
             find /etc/systemd/system -name "snap.*.socket" | while read -r f; do
                 systemctl stop "$(basename "$f")" || true
@@ -866,6 +880,12 @@ restore_suite() {
         # shellcheck source=tests/lib/pkgdb.sh
         . "$TESTSLIB"/pkgdb.sh
         distro_purge_package snapd
+        if os.query is-ubuntu-ge 26.04; then
+            find /var/lib/systemd/deb-systemd-helper-enabled \
+                -name 'snapd*' -delete || true
+            find /var/lib/systemd/deb-systemd-user-helper-enabled \
+                -name 'snapd*' -delete || true
+        fi
         if [[ "$SPREAD_SYSTEM" != opensuse-* && "$SPREAD_SYSTEM" != arch-* ]]; then
             # A snap-confine package never existed on openSUSE or Arch
             distro_purge_package snap-confine

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -480,6 +480,16 @@ prepare_classic() {
         exit 1
     fi
 
+    if os.query is-ubuntu 26.04; then
+        # there was a known packaing problem on Ubuntu 26.04 where snapd would
+        # generate warnings right from the start
+        if dpkg -l snapd | MATCH '\s+2\.76\+ubuntu'; then
+            # clear known warnings
+            snap warnings
+            snap okay
+        fi
+    fi
+
     # Some systems (google:ubuntu-16.04-64) ship with a broken sshguard
     # unit. Stop the broken unit to not confuse the "degraded-boot" test.
     #

--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -16,6 +16,9 @@ skip:
     - reason: This test needs test keys to be trusted
       if: |
         [ "$TRUST_TEST_KEYS" = "false" ]
+    - reason: Known packaging bug in snapd 2.76+ubuntu26.04
+      if: |
+        os.query is-ubuntu 26.04 && ( dpkg -l snapd | MATCH '\s+2\.76\+ubuntu' )
 
 prepare: |
     snap pack "$TESTSLIB/snaps/basic18"

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -5,9 +5,11 @@ details: |
     the snapd code from the local branch.
 
     This test verifies that the debs have the 'built-using' header. It also
-    checks that Apparmor & Seccomp are compiled (only in Ubuntu), that
-    the snapd.session-agent.socket symlink is part of the deb and that
-    it has the right (relative) target.
+    checks that Apparmor & Seccomp are compiled (only in Ubuntu), and that
+    the snapd.session-agent.socket is properly enabled. On Ubuntu >= 26.04
+    this is done via dh_installsystemduser (postinst calls deb-systemd-helper
+    --user enable, creating the symlink in /etc/systemd/user/). On older
+    distros a static symlink is shipped in the deb via snapd.links.
 
 systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
@@ -27,9 +29,15 @@ execute: |
 
     # not running on 14.04 because we don't have user sessions there
     if not os.query is-trusty; then
-        echo "Ensure that the snapd.session-agent.socket symlink is part of the deb and has the right (relative) target"
-        dpkg -c "$GOHOME"/snapd_*.deb | MATCH -- '-> \.\./snapd.session-agent.socket'
+        if os.query is-ubuntu-ge 26.04; then
+            # deb-systemd-helper invokes systemctl and 'enable' symlinks are created under /etc
+            echo "Ensure the symlink exists in /etc/systemd/user/sockets.target.wants/"
+            test -L /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
+        else
+            echo "Ensure the snapd.session-agent.socket symlink is shipped in the deb"
+            dpkg -c "$GOHOME"/snapd_*.deb | MATCH -- '-> \.\./snapd.session-agent.socket'
 
-        echo "Ensure that the snapd.session-agent.socket symlink exists on the filesystem"
-        test -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+            echo "Ensure the symlink exists in /usr/lib/systemd/user/sockets.target.wants/"
+            test -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+        fi
     fi

--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -111,6 +111,15 @@ execute: |
             continue
         fi
 
+        # The native AppArmor 5.0.0 parser on 26.04 has a regression and cannot compile the profile
+        if [ "$plug_iface" = "$CONSUMER_SNAP:nfs-mount" ] && ! tests.info is-reexec-in-use && os.query is-ubuntu-ge 26.04; then
+            if apparmor_parser --version | MATCH '5\.0\.0~beta1' ; then
+                snap connect "$plug_iface" "$slot_iface" 2>&1 | \
+                    MATCH 'cannot setup profiles.*cannot load apparmor profiles'
+                continue
+            fi
+        fi
+
         echo "When slot $slot_iface is connected"
         if snap interfaces | grep -E -q "$DISCONNECTED_PATTERN"; then
             if [ "$slot_iface" = ":broadcom-asic-control" ] || [ "$slot_iface" = ":firewall-control" ] || [ "$slot_iface" = ":kubernetes-support" ] || [ "$slot_iface" = ":microstack-support" ] || [ "$slot_iface" = ":openvswitch-support" ] || [ "$slot_iface" = ":ppp" ]; then

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -34,8 +34,9 @@ execute: |
     not test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10
 
     # TODO: remove this check once distro apparmor fixes the issue
+    # TODO: make the check host apparmor version specific
     # When re-exec is not used, the distro apparmor allows to stat /dev/mqueue
-    if tests.info is-reexec-in-use; then
+    if tests.info is-reexec-in-use || os.query is-ubuntu-ge 26.04; then
         # We cannot probe /dev/mqueue
         not snap run --shell test-snapd-posix-mq.mqctl -c 'stat /dev/mqueue'
     else


### PR DESCRIPTION
This branch is a follow-up to #17390 reverted to using snapd.links for snap.session-agent.socket unit. It fixes a couple of issues discovered when running the spread test suite against the ubuntu-26.04 packaging.

First, revert to the original `dh_installsystemduser` instead of snapd.links hack. but account for dh-systemd-helper lack of idempotency and forcefully clear its state when restoring/preparing/resetting the test suite.

Ensure that postinst generated by `dh_installsystemd` processes units in the right order, such that snapd.apparmor is enabled **before** starting snapd.service. Otherwise, snapd would issue a warning about snapd.apparmor not being enabled right when it starts up.

Ensure that we run the 'deb' suite on 26.04 and that the correct packaging is used in the process.

Related: SNAPDENG-37263