### PR TITLE
interfaces/apparmor: allow reading of /proc/self/smaps_rollup

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -279,6 +279,7 @@ var templateCommon = `
   owner @{PROC}/@{pid}/loginuid r,
   owner @{PROC}/@{pid}/sessionid r,
   @{PROC}/@{pid}/smaps r,
+  @{PROC}/@{pid}/smaps_rollup r,
   @{PROC}/@{pid}/stat r,
   @{PROC}/@{pid}/statm r,
   @{PROC}/@{pid}/status r,


### PR DESCRIPTION
Allow read of /proc/self/smaps_rollup.

Related: SNAPDENG-37261, LP#2110510

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
