### PR TITLE
tests: fix nvidia-driver:535 on ubuntu 22.04 and 24.04

### DIFF
--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -97,6 +97,8 @@ prepare: |
     skip["ubuntu-24.04-64/515-server"]="transitional-driver"
     skip["ubuntu-24.04-64/525"]="transitional-driver"
     skip["ubuntu-24.04-64/530"]="transitional-driver"
+    skip["ubuntu-24.04-64/535"]="transitional-driver"
+    skip["ubuntu-24.04-64/535-server"]="transitional-driver"
     skip["ubuntu-24.04-64/550"]="transitional-driver"
     skip["ubuntu-24.04-64/550-server"]="transitional-driver"
     skip["ubuntu-24.04-64/560"]="no-driver"

--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -81,6 +81,8 @@ prepare: |
     skip["ubuntu-22.04-64/515-server"]="transitional-driver"
     skip["ubuntu-22.04-64/525"]="transitional-driver"
     skip["ubuntu-22.04-64/530"]="transitional-driver"
+    skip["ubuntu-22.04-64/535"]="transitional-driver"
+    skip["ubuntu-22.04-64/535-server"]="transitional-driver"
     skip["ubuntu-22.04-64/550"]="transitional-driver"
     skip["ubuntu-22.04-64/550-server"]="transitional-driver"
     skip["ubuntu-22.04-64/560"]="no-driver"


### PR DESCRIPTION
I see apt-cache show nvidia-driver-535 now reports a transitional metapackage on 22.04 and 24.04. 

The test expects every known transitional package to already be listed in skip[...].

ubuntu-22.04-64/535 was missing, so we saw an unbound-variable failure in tests executions.

This is an example of the error:
```
+ echo 'Transitional driver is in use, expecting: skip["ubuntu-22.04-64/535"]="transitional-driver"'
Transitional driver is in use, expecting: skip["ubuntu-22.04-64/535"]="transitional-driver"
/bin/bash: line 186: skip[$combi_key]: unbound variable
```

