### PR TITLE
data/selinux, packaging: assign a default label for /tmp/snap-private-tmp, set it during installation

### DIFF
--- a/data/selinux/snappy.fc
+++ b/data/selinux/snappy.fc
@@ -44,6 +44,8 @@ ifdef(`distro_debian',`
 /lib/systemd/system/snapd.* 	--	gen_context(system_u:object_r:snappy_unit_file_t,s0)
 ')
 
+/tmp/snap-private-tmp		-d	gen_context(system_u:object_r:snappy_tmp_t,s0)
+
 /var/run/snapd(/.*)?	        gen_context(system_u:object_r:snappy_var_run_t,s0)
 /var/run/snapd\.socket 		-s	gen_context(system_u:object_r:snappy_var_run_t,s0)
 /var/run/snapd-snap\.socket 	-s	gen_context(system_u:object_r:snappy_var_run_t,s0)

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -873,6 +873,8 @@ snappy_stream_connect(snappy_cli_t)
 userdom_search_user_tmp_dirs(snappy_cli_t)
 # create /run/user/<uid>/snap.<name> directories
 userdom_manage_tmp_dirs(snappy_cli_t)
+# the snap command probes for /tmp/snap-private-tmp presence
+allow snappy_cli_t snappy_tmp_t:dir getattr;
 
 # allow snappy_cli_t to exec() into the snapd binary which implements
 # snap CLI handler and other internal snapd tools

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -1009,6 +1009,10 @@ fi
 %post selinux
 %selinux_modules_install %{_datadir}/selinux/packages/snappy.pp.bz2
 %selinux_relabel_post
+# Ensure the private tmp directory for snap-confine exists and has the correct
+# SELinux label now that the policy module is loaded
+install -d -m 0700 /tmp/snap-private-tmp
+restorecon /tmp/snap-private-tmp || :
 
 %posttrans selinux
 %selinux_relabel_post

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -514,6 +514,10 @@ fi
 
 %post selinux
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/snappy.pp.bz2
+# Ensure the private tmp directory for snap-confine exists and has the correct
+# SELinux label now that the policy module is loaded
+install -d -m 0700 /tmp/snap-private-tmp
+restorecon /tmp/snap-private-tmp || :
 
 %preun selinux
 %selinux_relabel_pre -s %{selinuxtype}


### PR DESCRIPTION
The recently merged changes from 2.76.3 added a line creating `/tmp/snap-private-tmp` in `%post`. However, since we have no default label assigned for that path and the `%post` script is executed by rpm, the path got incorrect label:
```
garden:fedora-44-64 .../tests/main/selinux-clean# ls -lZ /tmp/
total 1728
drwxr-xr-x. 2 root root unconfined_u:object_r:user_tmp_t:s0           120 Jul 23 16:23 fs-initial
-rw-------. 1 root root unconfined_u:object_r:user_tmp_t:s0       1759910 Jul 23 16:19 gojq.tar.gz
drwx------. 4 root root unconfined_u:object_r:rpm_script_tmp_t:s0      80 Jul 23 16:23 snap-private-tmp
```

The branch updates the default file labels so that we get `snappy_tmp_t`, ensures we get the right label during installation and allows the `snap` command to probe for the directory.