### PR TITLE
tests: fix lxd-mount-units in ubuntu jammy

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -24,7 +24,7 @@ execute: |
 
     # Define the core snap for the current system
     core_snap=core20
-    if os.query is-ubuntu-gt 22.04; then
+    if os.query is-ubuntu-ge 22.04; then
         core_snap=core22
     fi
 


### PR DESCRIPTION
The lxd image used in jammy is seeded with core22 snap.
