### PR TITLE
tests: fix compilation error in snap-seccomp-blocks-certain tests

### DIFF
--- a/tests/main/snap-seccomp-blocks-certain-chmod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-chmod/test.c
@@ -27,7 +27,7 @@ static int make_file(const char *path)
     unlink(path);
     int fd = open(path, O_CREAT | O_WRONLY, 0644);
     if (fd < 0) {
-        fprintf(stderr, "open %s: %s\n", path, errno_name(errno));
+        fprintf(stderr, "open %s: %s\n", path, strerror(errno));
     }
     return fd;
 }

--- a/tests/main/snap-seccomp-blocks-certain-chmod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-chmod/test.c
@@ -6,20 +6,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-static const char *errno_name(int e)
-{
-    switch (e) {
-    case EACCES:     return "EACCES";
-    case EPERM:      return "EPERM";
-    case ENOSYS:     return "ENOSYS";
-    case EOPNOTSUPP: return "EOPNOTSUPP";
-    case EINVAL:     return "EINVAL";
-    case ENOENT:     return "ENOENT";
-    case EEXIST:     return "EEXIST";
-    default:         return strerror(e);
-    }
-}
-
 /* Create a plain file at path and return an open fd, or -1 on error. */
 static int make_file(const char *path)
 {
@@ -36,7 +22,7 @@ static void test_chmod(const char *path, mode_t mode, const char *label)
 #ifdef SYS_chmod
     int ret = (int)syscall(SYS_chmod, path, mode);
     if (ret < 0) {
-        printf("chmod %s: %s\n", label, errno_name(errno));
+        printf("chmod %s: %s\n", label, strerror(errno));
     } else {
         printf("chmod %s: succeeded\n", label);
     }
@@ -51,7 +37,7 @@ static void test_fchmod(int fd, mode_t mode, const char *label)
 {
     int ret = (int)syscall(SYS_fchmod, fd, mode);
     if (ret < 0) {
-        printf("fchmod %s: %s\n", label, errno_name(errno));
+        printf("fchmod %s: %s\n", label, strerror(errno));
     } else {
         printf("fchmod %s: succeeded\n", label);
     }
@@ -61,7 +47,7 @@ static void test_fchmodat(const char *path, mode_t mode, const char *label)
 {
     int ret = (int)syscall(SYS_fchmodat, AT_FDCWD, path, mode, 0);
     if (ret < 0) {
-        printf("fchmodat %s: %s\n", label, errno_name(errno));
+        printf("fchmodat %s: %s\n", label, strerror(errno));
     } else {
         printf("fchmodat %s: succeeded\n", label);
     }
@@ -72,7 +58,7 @@ static void test_fchmodat2(const char *path, mode_t mode, const char *label)
 #ifdef SYS_fchmodat2
     int ret = (int)syscall(SYS_fchmodat2, AT_FDCWD, path, mode, 0);
     if (ret < 0) {
-        printf("fchmodat2 %s: %s\n", label, errno_name(errno));
+        printf("fchmodat2 %s: %s\n", label, strerror(errno));
     } else {
         printf("fchmodat2 %s: succeeded\n", label);
     }

--- a/tests/main/snap-seccomp-blocks-certain-chmod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-chmod/test.c
@@ -6,13 +6,28 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+static const char *errno_name(int e) __attribute__((unused));
+static const char *errno_name(int e)
+{
+    switch (e) {
+    case EACCES:     return "EACCES";
+    case EPERM:      return "EPERM";
+    case ENOSYS:     return "ENOSYS";
+    case EOPNOTSUPP: return "EOPNOTSUPP";
+    case EINVAL:     return "EINVAL";
+    case ENOENT:     return "ENOENT";
+    case EEXIST:     return "EEXIST";
+    default:         return strerror(e);
+    }
+}
+
 /* Create a plain file at path and return an open fd, or -1 on error. */
 static int make_file(const char *path)
 {
     unlink(path);
     int fd = open(path, O_CREAT | O_WRONLY, 0644);
     if (fd < 0) {
-        fprintf(stderr, "open %s: %s\n", path, strerror(errno));
+        fprintf(stderr, "open %s: %s\n", path, errno_name(errno));
     }
     return fd;
 }
@@ -22,7 +37,7 @@ static void test_chmod(const char *path, mode_t mode, const char *label)
 #ifdef SYS_chmod
     int ret = (int)syscall(SYS_chmod, path, mode);
     if (ret < 0) {
-        printf("chmod %s: %s\n", label, strerror(errno));
+        printf("chmod %s: %s\n", label, errno_name(errno));
     } else {
         printf("chmod %s: succeeded\n", label);
     }
@@ -37,7 +52,7 @@ static void test_fchmod(int fd, mode_t mode, const char *label)
 {
     int ret = (int)syscall(SYS_fchmod, fd, mode);
     if (ret < 0) {
-        printf("fchmod %s: %s\n", label, strerror(errno));
+        printf("fchmod %s: %s\n", label, errno_name(errno));
     } else {
         printf("fchmod %s: succeeded\n", label);
     }
@@ -47,7 +62,7 @@ static void test_fchmodat(const char *path, mode_t mode, const char *label)
 {
     int ret = (int)syscall(SYS_fchmodat, AT_FDCWD, path, mode, 0);
     if (ret < 0) {
-        printf("fchmodat %s: %s\n", label, strerror(errno));
+        printf("fchmodat %s: %s\n", label, errno_name(errno));
     } else {
         printf("fchmodat %s: succeeded\n", label);
     }
@@ -58,7 +73,7 @@ static void test_fchmodat2(const char *path, mode_t mode, const char *label)
 #ifdef SYS_fchmodat2
     int ret = (int)syscall(SYS_fchmodat2, AT_FDCWD, path, mode, 0);
     if (ret < 0) {
-        printf("fchmodat2 %s: %s\n", label, strerror(errno));
+        printf("fchmodat2 %s: %s\n", label, errno_name(errno));
     } else {
         printf("fchmodat2 %s: succeeded\n", label);
     }

--- a/tests/main/snap-seccomp-blocks-certain-creat/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-creat/test.c
@@ -5,20 +5,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-static const char *errno_name(int e)
-{
-    switch (e) {
-    case EACCES:     return "EACCES";
-    case EPERM:      return "EPERM";
-    case ENOSYS:     return "ENOSYS";
-    case EOPNOTSUPP: return "EOPNOTSUPP";
-    case EINVAL:     return "EINVAL";
-    case ENOENT:     return "ENOENT";
-    case EEXIST:     return "EEXIST";
-    default:         return strerror(e);
-    }
-}
-
 static void test_creat(const char *dir, const char *name, int mode, const char *label)
 {
     char path[4096];
@@ -28,7 +14,7 @@ static void test_creat(const char *dir, const char *name, int mode, const char *
 #ifdef SYS_creat
     int fd = (int)syscall(SYS_creat, path, mode);
     if (fd < 0) {
-        printf("creat %s: %s\n", label, errno_name(errno));
+        printf("creat %s: %s\n", label, strerror(errno));
     } else {
         printf("creat %s: succeeded\n", label);
         close(fd);

--- a/tests/main/snap-seccomp-blocks-certain-creat/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-creat/test.c
@@ -5,6 +5,21 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+static const char *errno_name(int e) __attribute__((unused));
+static const char *errno_name(int e)
+{
+    switch (e) {
+    case EACCES:     return "EACCES";
+    case EPERM:      return "EPERM";
+    case ENOSYS:     return "ENOSYS";
+    case EOPNOTSUPP: return "EOPNOTSUPP";
+    case EINVAL:     return "EINVAL";
+    case ENOENT:     return "ENOENT";
+    case EEXIST:     return "EEXIST";
+    default:         return strerror(e);
+    }
+}
+
 static void test_creat(const char *dir, const char *name, int mode, const char *label)
 {
     char path[4096];
@@ -14,7 +29,7 @@ static void test_creat(const char *dir, const char *name, int mode, const char *
 #ifdef SYS_creat
     int fd = (int)syscall(SYS_creat, path, mode);
     if (fd < 0) {
-        printf("creat %s: %s\n", label, strerror(errno));
+        printf("creat %s: %s\n", label, errno_name(errno));
     } else {
         printf("creat %s: succeeded\n", label);
         close(fd);

--- a/tests/main/snap-seccomp-blocks-certain-mknod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-mknod/test.c
@@ -6,6 +6,21 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+static const char *errno_name(int e) __attribute__((unused));
+static const char *errno_name(int e)
+{
+    switch (e) {
+    case EACCES:     return "EACCES";
+    case EPERM:      return "EPERM";
+    case ENOSYS:     return "ENOSYS";
+    case EOPNOTSUPP: return "EOPNOTSUPP";
+    case EINVAL:     return "EINVAL";
+    case ENOENT:     return "ENOENT";
+    case EEXIST:     return "EEXIST";
+    default:         return strerror(e);
+    }
+}
+
 static void test_mknod(const char *dir, const char *name, mode_t mode, const char *label)
 {
     char path[4096];
@@ -18,7 +33,7 @@ static void test_mknod(const char *dir, const char *name, mode_t mode, const cha
      * Call the raw mknod syscall directly to bypass any libc wrapper. */
     int ret = (int)syscall(SYS_mknod, path, S_IFIFO | mode, 0);
     if (ret < 0) {
-        printf("mknod %s: %s\n", label, strerror(errno));
+        printf("mknod %s: %s\n", label, errno_name(errno));
     } else {
         printf("mknod %s: succeeded\n", label);
         unlink(path);
@@ -34,7 +49,7 @@ static void test_mknodat(const char *dir, const char *name, mode_t mode, const c
     /* Same as test_mknod but exercises the mknodat syscall. */
     int ret = (int)syscall(SYS_mknodat, AT_FDCWD, path, S_IFIFO | mode, 0);
     if (ret < 0) {
-        printf("mknodat %s: %s\n", label, strerror(errno));
+        printf("mknodat %s: %s\n", label, errno_name(errno));
     } else {
         printf("mknodat %s: succeeded\n", label);
         unlink(path);

--- a/tests/main/snap-seccomp-blocks-certain-mknod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-mknod/test.c
@@ -6,20 +6,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-static const char *errno_name(int e)
-{
-    switch (e) {
-    case EACCES:     return "EACCES";
-    case EPERM:      return "EPERM";
-    case ENOSYS:     return "ENOSYS";
-    case EOPNOTSUPP: return "EOPNOTSUPP";
-    case EINVAL:     return "EINVAL";
-    case ENOENT:     return "ENOENT";
-    case EEXIST:     return "EEXIST";
-    default:         return strerror(e);
-    }
-}
-
 static void test_mknod(const char *dir, const char *name, mode_t mode, const char *label)
 {
     char path[4096];
@@ -32,7 +18,7 @@ static void test_mknod(const char *dir, const char *name, mode_t mode, const cha
      * Call the raw mknod syscall directly to bypass any libc wrapper. */
     int ret = (int)syscall(SYS_mknod, path, S_IFIFO | mode, 0);
     if (ret < 0) {
-        printf("mknod %s: %s\n", label, errno_name(errno));
+        printf("mknod %s: %s\n", label, strerror(errno));
     } else {
         printf("mknod %s: succeeded\n", label);
         unlink(path);
@@ -48,7 +34,7 @@ static void test_mknodat(const char *dir, const char *name, mode_t mode, const c
     /* Same as test_mknod but exercises the mknodat syscall. */
     int ret = (int)syscall(SYS_mknodat, AT_FDCWD, path, S_IFIFO | mode, 0);
     if (ret < 0) {
-        printf("mknodat %s: %s\n", label, errno_name(errno));
+        printf("mknodat %s: %s\n", label, strerror(errno));
     } else {
         printf("mknodat %s: succeeded\n", label);
         unlink(path);

--- a/tests/main/snap-seccomp-blocks-certain-open/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-open/test.c
@@ -8,20 +8,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-static const char *errno_name(int e)
-{
-    switch (e) {
-    case EACCES:     return "EACCES";
-    case EPERM:      return "EPERM";
-    case ENOSYS:     return "ENOSYS";
-    case EOPNOTSUPP: return "EOPNOTSUPP";
-    case EINVAL:     return "EINVAL";
-    case ENOENT:     return "ENOENT";
-    case EEXIST:     return "EEXIST";
-    default:         return strerror(e);
-    }
-}
-
 /* Test SYS_open with O_CREAT.  On architectures without SYS_open (e.g. arm64)
  * the test is skipped; SYS_openat (always present) provides the coverage
  * for those architectures via test_openat() below. */
@@ -34,7 +20,7 @@ static void test_open(const char *dir, const char *name, int mode, const char *l
 #ifdef SYS_open
     int fd = (int)syscall(SYS_open, path, O_CREAT | O_WRONLY, mode);
     if (fd < 0) {
-        printf("open %s: %s\n", label, errno_name(errno));
+        printf("open %s: %s\n", label, strerror(errno));
     } else {
         printf("open %s: succeeded\n", label);
         close(fd);
@@ -56,7 +42,7 @@ static void test_openat(const char *dir, const char *name, int mode, const char 
 
     int fd = (int)syscall(SYS_openat, AT_FDCWD, path, O_CREAT | O_WRONLY, mode);
     if (fd < 0) {
-        printf("openat %s: %s\n", label, errno_name(errno));
+        printf("openat %s: %s\n", label, strerror(errno));
     } else {
         printf("openat %s: succeeded\n", label);
         close(fd);
@@ -75,11 +61,11 @@ static void finish_tmpfile(int fd, const char *dir, const char *name, const char
     snprintf(destpath, sizeof(destpath), "%s/tmpfile-%s-%s", dir, name, label);
 
     if (linkat(AT_FDCWD, procpath, AT_FDCWD, destpath, AT_SYMLINK_FOLLOW) < 0) {
-        printf("%s tmpfile %s: linkat: %s\n", name, label, errno_name(errno));
+        printf("%s tmpfile %s: linkat: %s\n", name, label, strerror(errno));
     } else {
         struct stat st;
         if (stat(destpath, &st) < 0) {
-            printf("%s tmpfile %s: stat: %s\n", name, label, errno_name(errno));
+            printf("%s tmpfile %s: stat: %s\n", name, label, strerror(errno));
             unlink(destpath);
             close(fd);
             return;
@@ -102,7 +88,7 @@ static void test_open_tmpfile(const char *dir, int mode, const char *label)
         if (errno == EOPNOTSUPP || errno == EINVAL) {
             printf("open tmpfile %s: skipped (O_TMPFILE not supported)\n", label);
         } else {
-            printf("open tmpfile %s: %s\n", label, errno_name(errno));
+            printf("open tmpfile %s: %s\n", label, strerror(errno));
         }
         return;
     }
@@ -142,7 +128,7 @@ static void test_openat2(const char *dir, const char *name, int mode, const char
         if (errno == ENOSYS) {
             printf("openat2 %s: skipped (no SYS_openat2)\n", label);
         } else {
-            printf("openat2 %s: %s\n", label, errno_name(errno));
+            printf("openat2 %s: %s\n", label, strerror(errno));
         }
         return;
     }
@@ -163,7 +149,7 @@ static void test_openat_tmpfile(const char *dir, int mode, const char *label)
         if (errno == EOPNOTSUPP || errno == EINVAL) {
             printf("openat tmpfile %s: skipped (O_TMPFILE not supported)\n", label);
         } else {
-            printf("openat tmpfile %s: %s\n", label, errno_name(errno));
+            printf("openat tmpfile %s: %s\n", label, strerror(errno));
         }
         return;
     }

--- a/tests/main/snap-seccomp-blocks-certain-open/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-open/test.c
@@ -8,6 +8,21 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+static const char *errno_name(int e) __attribute__((unused));
+static const char *errno_name(int e)
+{
+    switch (e) {
+    case EACCES:     return "EACCES";
+    case EPERM:      return "EPERM";
+    case ENOSYS:     return "ENOSYS";
+    case EOPNOTSUPP: return "EOPNOTSUPP";
+    case EINVAL:     return "EINVAL";
+    case ENOENT:     return "ENOENT";
+    case EEXIST:     return "EEXIST";
+    default:         return strerror(e);
+    }
+}
+
 /* Test SYS_open with O_CREAT.  On architectures without SYS_open (e.g. arm64)
  * the test is skipped; SYS_openat (always present) provides the coverage
  * for those architectures via test_openat() below. */
@@ -20,7 +35,7 @@ static void test_open(const char *dir, const char *name, int mode, const char *l
 #ifdef SYS_open
     int fd = (int)syscall(SYS_open, path, O_CREAT | O_WRONLY, mode);
     if (fd < 0) {
-        printf("open %s: %s\n", label, strerror(errno));
+        printf("open %s: %s\n", label, errno_name(errno));
     } else {
         printf("open %s: succeeded\n", label);
         close(fd);
@@ -42,7 +57,7 @@ static void test_openat(const char *dir, const char *name, int mode, const char 
 
     int fd = (int)syscall(SYS_openat, AT_FDCWD, path, O_CREAT | O_WRONLY, mode);
     if (fd < 0) {
-        printf("openat %s: %s\n", label, strerror(errno));
+        printf("openat %s: %s\n", label, errno_name(errno));
     } else {
         printf("openat %s: succeeded\n", label);
         close(fd);
@@ -61,11 +76,11 @@ static void finish_tmpfile(int fd, const char *dir, const char *name, const char
     snprintf(destpath, sizeof(destpath), "%s/tmpfile-%s-%s", dir, name, label);
 
     if (linkat(AT_FDCWD, procpath, AT_FDCWD, destpath, AT_SYMLINK_FOLLOW) < 0) {
-        printf("%s tmpfile %s: linkat: %s\n", name, label, strerror(errno));
+        printf("%s tmpfile %s: linkat: %s\n", name, label, errno_name(errno));
     } else {
         struct stat st;
         if (stat(destpath, &st) < 0) {
-            printf("%s tmpfile %s: stat: %s\n", name, label, strerror(errno));
+            printf("%s tmpfile %s: stat: %s\n", name, label, errno_name(errno));
             unlink(destpath);
             close(fd);
             return;
@@ -88,7 +103,7 @@ static void test_open_tmpfile(const char *dir, int mode, const char *label)
         if (errno == EOPNOTSUPP || errno == EINVAL) {
             printf("open tmpfile %s: skipped (O_TMPFILE not supported)\n", label);
         } else {
-            printf("open tmpfile %s: %s\n", label, strerror(errno));
+            printf("open tmpfile %s: %s\n", label, errno_name(errno));
         }
         return;
     }
@@ -128,7 +143,7 @@ static void test_openat2(const char *dir, const char *name, int mode, const char
         if (errno == ENOSYS) {
             printf("openat2 %s: skipped (no SYS_openat2)\n", label);
         } else {
-            printf("openat2 %s: %s\n", label, strerror(errno));
+            printf("openat2 %s: %s\n", label, errno_name(errno));
         }
         return;
     }
@@ -149,7 +164,7 @@ static void test_openat_tmpfile(const char *dir, int mode, const char *label)
         if (errno == EOPNOTSUPP || errno == EINVAL) {
             printf("openat tmpfile %s: skipped (O_TMPFILE not supported)\n", label);
         } else {
-            printf("openat tmpfile %s: %s\n", label, strerror(errno));
+            printf("openat tmpfile %s: %s\n", label, errno_name(errno));
         }
         return;
     }


### PR DESCRIPTION
This change is fixing the compilation error we see in ubuntu-arm editions.
```
Compile and prepare the test program
+ gcc -static -Wall -Wextra -Werror ./test.c -o /var/snap/test-snapd-sh/common/test-creat
./test.c:8:20: error: ‘errno_name’ defined but not used [-Werror=unused-function]
8 | static const char *errno_name(int e)
|                    ^~~~~~~~~~
cc1: all warnings being treated as errors
```


