### PR TITLE
tests: accout for syscalls missing on arm64

### DIFF
--- a/tests/main/snap-seccomp-blocks-certain-creat/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-creat/test.c
@@ -5,6 +5,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifdef SYS_creat
 static const char *errno_name(int e)
 {
     switch (e) {
@@ -18,6 +19,7 @@ static const char *errno_name(int e)
     default:         return strerror(e);
     }
 }
+#endif
 
 static void test_creat(const char *dir, const char *name, int mode, const char *label)
 {

--- a/tests/main/snap-seccomp-blocks-certain-mknod/task.yaml
+++ b/tests/main/snap-seccomp-blocks-certain-mknod/task.yaml
@@ -23,14 +23,18 @@ execute: |
     snap run test-snapd-sh.sh -c "\$SNAP_COMMON/test-mknod \$SNAP_COMMON" > output.txt
     cat output.txt
 
-    # mknod with setuid bit (mode S_IFIFO|4644) must be denied
-    MATCH 'mknod setuid: EACCES' < output.txt
-
-    # mknod with setgid bit (mode S_IFIFO|2644) must be denied
-    MATCH 'mknod setgid: EACCES' < output.txt
-
-    # mknod with normal mode (mode S_IFIFO|0644) must succeed
-    MATCH 'mknod normal: succeeded' < output.txt
+    # mknod setuid/setgid must be denied; sticky and normal must succeed
+    # (skipped gracefully on architectures that don't have SYS_mknod, e.g. arm64)
+    if grep -qE 'mknod setuid: skipped' output.txt; then
+        echo "SYS_mknod is not available, all mknod tests should be skipped"
+        MATCH 'mknod setuid: skipped' < output.txt
+        MATCH 'mknod setgid: skipped' < output.txt
+        MATCH 'mknod normal: skipped' < output.txt
+    else
+        MATCH 'mknod setuid: EACCES' < output.txt
+        MATCH 'mknod setgid: EACCES' < output.txt
+        MATCH 'mknod normal: succeeded' < output.txt
+    fi
 
     # mknodat with setuid bit must be denied
     MATCH 'mknodat setuid: EACCES' < output.txt

--- a/tests/main/snap-seccomp-blocks-certain-mknod/test.c
+++ b/tests/main/snap-seccomp-blocks-certain-mknod/test.c
@@ -26,6 +26,7 @@ static void test_mknod(const char *dir, const char *name, mode_t mode, const cha
     snprintf(path, sizeof(path), "%s/%s", dir, name);
     unlink(path);
 
+#ifdef SYS_mknod
     /* Use S_IFIFO (named pipe) as the file type: creating FIFOs does not
      * require CAP_MKNOD, so it works in a confined snap without extra
      * privileges.
@@ -37,6 +38,11 @@ static void test_mknod(const char *dir, const char *name, mode_t mode, const cha
         printf("mknod %s: succeeded\n", label);
         unlink(path);
     }
+#else
+    /* mknod is not available on this architecture (e.g. arm64); skip. */
+    (void)mode;
+    printf("mknod %s: skipped (no SYS_mknod)\n", label);
+#endif
 }
 
 static void test_mknodat(const char *dir, const char *name, mode_t mode, const char *label)


### PR DESCRIPTION
Both mknod and creat are missing on younger architectures.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37197
