### PR TITLE
release: 2.77

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,48 @@
+# New in snapd 2.77
+* FDE: add reseal check after snapd refresh
+* FDE: allow reprovision without factory reset
+* FDE: make reprovision only seal
+* FDE: add reprovision recovery key generation API
+* FDE: extend /v2/system-info/storage-encrypted to show install-time decisions
+* Interfaces: kernel-sched-ext-control | add the kernel sched-ext control interface implementation
+* Interfaces: allow reading of /proc/self/smaps_rollup
+* Interfaces: allow Wine to execute files accessed via the Document Portal
+* Interfaces: allow gtk css in subdirectories
+* Interfaces: docker | allow connecting to system-wide docker on classic
+* Interfaces: allow the systemd networkctl command
+* Interfaces: allow systemd networkd link property changes via D-Bus
+* Interfaces: grant default access to memory.high in a snap's cgroup
+* Interfaces: fix mountinfo denial for steam and docker interfaces
+* Interfaces: add xdg-portal-permission-store interface
+* Interfaces: add atkey pid and 7 relative vid support
+* Interfaces: make polkit and upower implicit on Core systems only
+* Confdb: add validation-sets handler and fix data loss when writing to new schemas or accounts
+* Confdb: fix bug on reading uneven lists
+* Confdb: support sign-only external keypair backends
+* Confdb: support Encode/Decode for builtins
+* Remote device management: add post install actions API, apply messages, queue response messages, and sequencing for dispatch of management messages
+* Packaging: assign a default label for /tmp/snap-private-tmp and set it during installation
+* Packaging: fix service startup during install and session-agent socket handling on Ubuntu 26.04+
+* Packaging: update bundled AppArmor to 5.0.2 and accept the 5.0 ABI when running as deb
+* Packaging: use a relative symlink for snapctl and update steam-support udev rules
+* Packaging: add back gbp.conf output directory for Ubuntu 26.04 builds
+* Packaging: build deb with Go 1.23 for noble and jammy, Go 1.22 for focal
+* Cross-distro: update SELinux policy to allow snapd socket activation
+* Cross-distro: update SELinux policy to support /etc/ld.so.cache mounting
+* Snap: add run-inhibit hints, better component reporting, snap delta support, and improved install handling
+* snap-confine: work around kernel mnt_ns_loop() ordering bug on 6.18.x
+* Snap-confine: allow inheriting unix sockets from snaps, link to libm, and harden bpffs mounts
+* Snap-confine: fix mountinfo parsing, set FD_CLOEXEC on BPF helper fds, and support transparent huge pages
+* Snap-update-ns: switch to a multi-pass process for constructing and updating mount namespaces
+* Core-initrd: add missing libbpf and systemd dlopen dependencies, and increase mount burst
+* Security logging: add seclog API for administrative actions and token create/remove events
+* Prompting: re-enable the prompting notice backend and improve validation and error handling
+* Cmd/snap: report hidden file access for paths allowed by home when prompting is active
+* Cmd/snap: report read-only file access for paths allowed by system-package-doc
+* Cmd/snap: fix self-managed cgroup support checks
+* Experimental features: graduate layouts, classic-preserves-xdg-runtime-dir, refresh-app-awareness, and dbus-activation features
+* Experimental features: warn when setting graduated or default-enabled experimental features and do not store settings for graduated features
+
 # New in snapd 2.76.3
 * FDE: support keyboard configuration at install-time for first-boot
 * FDE: re-enable passphrases/PINs at install-time

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'libcap' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.76.3
+pkgver=2.77
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,79 @@
+snapd (2.77-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2158102
+    - FDE: add reseal check after snapd refresh
+    - FDE: allow reprovision without factory reset
+    - FDE: make reprovision only seal
+    - FDE: add reprovision recovery key generation API
+    - FDE: extend /v2/system-info/storage-encrypted to show install-time decisions
+    - Interfaces: kernel-sched-ext-control | add the kernel sched-ext
+      control interface implementation
+    - Interfaces: allow reading of /proc/self/smaps_rollup
+    - Interfaces: allow Wine to execute files accessed via the Document
+      Portal
+    - Interfaces: allow gtk css in subdirectories
+    - Interfaces: docker | allow connecting to system-wide docker on
+      classic
+    - Interfaces: allow the systemd networkctl command
+    - Interfaces: allow systemd networkd link property changes via D-Bus
+    - Interfaces: grant default access to memory.high in a snap's cgroup
+    - Interfaces: fix mountinfo denial for steam and docker interfaces
+    - Interfaces: add xdg-portal-permission-store interface
+    - Interfaces: add atkey pid and 7 relative vid support
+    - Interfaces: make polkit and upower implicit on Core systems only
+    - Confdb: add validation-sets handler and fix data loss when writing
+      to new schemas or accounts
+    - Confdb: fix bug on reading uneven lists
+    - Confdb: support sign-only external keypair backends
+    - Confdb: support Encode/Decode for builtins
+    - Remote device management: add post install actions API, apply
+      messages, queue response messages, and sequencing for dispatch of
+      management messages
+    - Packaging: assign a default label for /tmp/snap-private-tmp and
+      set it during installation
+    - Packaging: fix service startup during install and session-agent
+      socket handling on Ubuntu 26.04+
+    - Packaging: update bundled AppArmor to 5.0.2 and accept the 5.0 ABI
+      when running as deb
+    - Packaging: use a relative symlink for snapctl and update steam-
+      support udev rules
+    - Packaging: add back gbp.conf output directory for Ubuntu 26.04
+      builds
+    - Packaging: build deb with Go 1.23 for noble and jammy, Go 1.22 for
+      focal
+    - Cross-distro: update SELinux policy to allow snapd socket
+      activation
+    - Cross-distro: update SELinux policy to support /etc/ld.so.cache
+      mounting
+    - Snap: add run-inhibit hints, better component reporting, snap
+      delta support, and improved install handling
+    - snap-confine: work around kernel mnt_ns_loop() ordering bug on
+      6.18.x
+    - Snap-confine: allow inheriting unix sockets from snaps, link to
+      libm, and harden bpffs mounts
+    - Snap-confine: fix mountinfo parsing, set FD_CLOEXEC on BPF helper
+      fds, and support transparent huge pages
+    - Snap-update-ns: switch to a multi-pass process for constructing
+      and updating mount namespaces
+    - Core-initrd: add missing libbpf and systemd dlopen dependencies,
+      and increase mount burst
+    - Security logging: add seclog API for administrative actions and
+      token create/remove events
+    - Prompting: re-enable the prompting notice backend and improve
+      validation and error handling
+    - Cmd/snap: report hidden file access for paths allowed by home when
+      prompting is active
+    - Cmd/snap: report read-only file access for paths allowed by
+      system-package-doc
+    - Cmd/snap: fix self-managed cgroup support checks
+    - Experimental features: graduate layouts, classic-preserves-xdg-
+      runtime-dir, refresh-app-awareness, and dbus-activation features
+    - Experimental features: warn when setting graduated or default-
+      enabled experimental features and do not store settings for
+      graduated features
+
+ -- Sergio Cazzolato <sergio.cazzolato@canonical.com>  Fri, 24 Jul 2026 20:45:05 -0300
+
 snapd (2.76.3-1) unstable; urgency=medium
 
   * New upstream release, LP: #2158301

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -114,7 +114,7 @@
 %endif
 
 Name:           snapd
-Version:        2.76.3
+Version:        2.77
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1025,6 +1025,79 @@ fi
 %endif
 
 %changelog
+* Fri Jul 24 2026 Sergio Cazzolato <sergio.cazzolato@canonical.com>
+- New upstream release 2.77
+ - FDE: add reseal check after snapd refresh
+ - FDE: allow reprovision without factory reset
+ - FDE: make reprovision only seal
+ - FDE: add reprovision recovery key generation API
+ - FDE: extend /v2/system-info/storage-encrypted to show install-time decisions
+ - Interfaces: kernel-sched-ext-control | add the kernel sched-ext
+   control interface implementation
+ - Interfaces: allow reading of /proc/self/smaps_rollup
+ - Interfaces: allow Wine to execute files accessed via the Document
+   Portal
+ - Interfaces: allow gtk css in subdirectories
+ - Interfaces: docker | allow connecting to system-wide docker on
+   classic
+ - Interfaces: allow the systemd networkctl command
+ - Interfaces: allow systemd networkd link property changes via D-Bus
+ - Interfaces: grant default access to memory.high in a snap's cgroup
+ - Interfaces: fix mountinfo denial for steam and docker interfaces
+ - Interfaces: add xdg-portal-permission-store interface
+ - Interfaces: add atkey pid and 7 relative vid support
+ - Interfaces: make polkit and upower implicit on Core systems only
+ - Confdb: add validation-sets handler and fix data loss when writing
+   to new schemas or accounts
+ - Confdb: fix bug on reading uneven lists
+ - Confdb: support sign-only external keypair backends
+ - Confdb: support Encode/Decode for builtins
+ - Remote device management: add post install actions API, apply
+   messages, queue response messages, and sequencing for dispatch of
+   management messages
+ - Packaging: assign a default label for /tmp/snap-private-tmp and
+   set it during installation
+ - Packaging: fix service startup during install and session-agent
+   socket handling on Ubuntu 26.04+
+ - Packaging: update bundled AppArmor to 5.0.2 and accept the 5.0 ABI
+   when running as deb
+ - Packaging: use a relative symlink for snapctl and update steam-
+   support udev rules
+ - Packaging: add back gbp.conf output directory for Ubuntu 26.04
+   builds
+ - Packaging: build deb with Go 1.23 for noble and jammy, Go 1.22 for
+   focal
+ - Cross-distro: update SELinux policy to allow snapd socket
+   activation
+ - Cross-distro: update SELinux policy to support /etc/ld.so.cache
+   mounting
+ - Snap: add run-inhibit hints, better component reporting, snap
+   delta support, and improved install handling
+ - snap-confine: work around kernel mnt_ns_loop() ordering bug on
+   6.18.x
+ - Snap-confine: allow inheriting unix sockets from snaps, link to
+   libm, and harden bpffs mounts
+ - Snap-confine: fix mountinfo parsing, set FD_CLOEXEC on BPF helper
+   fds, and support transparent huge pages
+ - Snap-update-ns: switch to a multi-pass process for constructing
+   and updating mount namespaces
+ - Core-initrd: add missing libbpf and systemd dlopen dependencies,
+   and increase mount burst
+ - Security logging: add seclog API for administrative actions and
+   token create/remove events
+ - Prompting: re-enable the prompting notice backend and improve
+   validation and error handling
+ - Cmd/snap: report hidden file access for paths allowed by home when
+   prompting is active
+ - Cmd/snap: report read-only file access for paths allowed by
+   system-package-doc
+ - Cmd/snap: fix self-managed cgroup support checks
+ - Experimental features: graduate layouts, classic-preserves-xdg-
+   runtime-dir, refresh-app-awareness, and dbus-activation features
+ - Experimental features: warn when setting graduated or default-
+   enabled experimental features and do not store settings for
+   graduated features
+
 * Tue Jul 07 2026 Katie May <katie.may@canonical.com>
 - New upstream release 2.76.3
  - FDE: support keyboard configuration at install-time for first-boot

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul 24 23:45:05 UTC 2026 - sergio.cazzolato@canonical.com
+
+- Update to upstream release 2.77
+
+-------------------------------------------------------------------
 Tue Jul 07 08:06:48 UTC 2026 - katie.may@canonical.com
 
 - Update to upstream release 2.76.3

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -115,7 +115,7 @@
 
 
 Name:           snapd
-Version:        2.76.3
+Version:        2.77
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,79 @@
+snapd (2.77) xenial; urgency=medium
+
+  * New upstream release, LP: #2158102
+    - FDE: add reseal check after snapd refresh
+    - FDE: allow reprovision without factory reset
+    - FDE: make reprovision only seal
+    - FDE: add reprovision recovery key generation API
+    - FDE: extend /v2/system-info/storage-encrypted to show install-time decisions
+    - Interfaces: kernel-sched-ext-control | add the kernel sched-ext
+      control interface implementation
+    - Interfaces: allow reading of /proc/self/smaps_rollup
+    - Interfaces: allow Wine to execute files accessed via the Document
+      Portal
+    - Interfaces: allow gtk css in subdirectories
+    - Interfaces: docker | allow connecting to system-wide docker on
+      classic
+    - Interfaces: allow the systemd networkctl command
+    - Interfaces: allow systemd networkd link property changes via D-Bus
+    - Interfaces: grant default access to memory.high in a snap's cgroup
+    - Interfaces: fix mountinfo denial for steam and docker interfaces
+    - Interfaces: add xdg-portal-permission-store interface
+    - Interfaces: add atkey pid and 7 relative vid support
+    - Interfaces: make polkit and upower implicit on Core systems only
+    - Confdb: add validation-sets handler and fix data loss when writing
+      to new schemas or accounts
+    - Confdb: fix bug on reading uneven lists
+    - Confdb: support sign-only external keypair backends
+    - Confdb: support Encode/Decode for builtins
+    - Remote device management: add post install actions API, apply
+      messages, queue response messages, and sequencing for dispatch of
+      management messages
+    - Packaging: assign a default label for /tmp/snap-private-tmp and
+      set it during installation
+    - Packaging: fix service startup during install and session-agent
+      socket handling on Ubuntu 26.04+
+    - Packaging: update bundled AppArmor to 5.0.2 and accept the 5.0 ABI
+      when running as deb
+    - Packaging: use a relative symlink for snapctl and update steam-
+      support udev rules
+    - Packaging: add back gbp.conf output directory for Ubuntu 26.04
+      builds
+    - Packaging: build deb with Go 1.23 for noble and jammy, Go 1.22 for
+      focal
+    - Cross-distro: update SELinux policy to allow snapd socket
+      activation
+    - Cross-distro: update SELinux policy to support /etc/ld.so.cache
+      mounting
+    - Snap: add run-inhibit hints, better component reporting, snap
+      delta support, and improved install handling
+    - snap-confine: work around kernel mnt_ns_loop() ordering bug on
+      6.18.x
+    - Snap-confine: allow inheriting unix sockets from snaps, link to
+      libm, and harden bpffs mounts
+    - Snap-confine: fix mountinfo parsing, set FD_CLOEXEC on BPF helper
+      fds, and support transparent huge pages
+    - Snap-update-ns: switch to a multi-pass process for constructing
+      and updating mount namespaces
+    - Core-initrd: add missing libbpf and systemd dlopen dependencies,
+      and increase mount burst
+    - Security logging: add seclog API for administrative actions and
+      token create/remove events
+    - Prompting: re-enable the prompting notice backend and improve
+      validation and error handling
+    - Cmd/snap: report hidden file access for paths allowed by home when
+      prompting is active
+    - Cmd/snap: report read-only file access for paths allowed by
+      system-package-doc
+    - Cmd/snap: fix self-managed cgroup support checks
+    - Experimental features: graduate layouts, classic-preserves-xdg-
+      runtime-dir, refresh-app-awareness, and dbus-activation features
+    - Experimental features: warn when setting graduated or default-
+      enabled experimental features and do not store settings for
+      graduated features
+
+ -- Sergio Cazzolato <sergio.cazzolato@canonical.com>  Fri, 24 Jul 2026 20:45:05 -0300
+
 snapd (2.76.3) xenial; urgency=medium
 
   * New upstream release, LP: #2158301

--- a/packaging/ubuntu-26.04/changelog
+++ b/packaging/ubuntu-26.04/changelog
@@ -1,3 +1,79 @@
+snapd (2.77) resolute; urgency=medium
+
+  * New upstream release, LP: #2158102
+    - FDE: add reseal check after snapd refresh
+    - FDE: allow reprovision without factory reset
+    - FDE: make reprovision only seal
+    - FDE: add reprovision recovery key generation API
+    - FDE: extend /v2/system-info/storage-encrypted to show install-time decisions
+    - Interfaces: kernel-sched-ext-control | add the kernel sched-ext
+      control interface implementation
+    - Interfaces: allow reading of /proc/self/smaps_rollup
+    - Interfaces: allow Wine to execute files accessed via the Document
+      Portal
+    - Interfaces: allow gtk css in subdirectories
+    - Interfaces: docker | allow connecting to system-wide docker on
+      classic
+    - Interfaces: allow the systemd networkctl command
+    - Interfaces: allow systemd networkd link property changes via D-Bus
+    - Interfaces: grant default access to memory.high in a snap's cgroup
+    - Interfaces: fix mountinfo denial for steam and docker interfaces
+    - Interfaces: add xdg-portal-permission-store interface
+    - Interfaces: add atkey pid and 7 relative vid support
+    - Interfaces: make polkit and upower implicit on Core systems only
+    - Confdb: add validation-sets handler and fix data loss when writing
+      to new schemas or accounts
+    - Confdb: fix bug on reading uneven lists
+    - Confdb: support sign-only external keypair backends
+    - Confdb: support Encode/Decode for builtins
+    - Remote device management: add post install actions API, apply
+      messages, queue response messages, and sequencing for dispatch of
+      management messages
+    - Packaging: assign a default label for /tmp/snap-private-tmp and
+      set it during installation
+    - Packaging: fix service startup during install and session-agent
+      socket handling on Ubuntu 26.04+
+    - Packaging: update bundled AppArmor to 5.0.2 and accept the 5.0 ABI
+      when running as deb
+    - Packaging: use a relative symlink for snapctl and update steam-
+      support udev rules
+    - Packaging: add back gbp.conf output directory for Ubuntu 26.04
+      builds
+    - Packaging: build deb with Go 1.23 for noble and jammy, Go 1.22 for
+      focal
+    - Cross-distro: update SELinux policy to allow snapd socket
+      activation
+    - Cross-distro: update SELinux policy to support /etc/ld.so.cache
+      mounting
+    - Snap: add run-inhibit hints, better component reporting, snap
+      delta support, and improved install handling
+    - snap-confine: work around kernel mnt_ns_loop() ordering bug on
+      6.18.x
+    - Snap-confine: allow inheriting unix sockets from snaps, link to
+      libm, and harden bpffs mounts
+    - Snap-confine: fix mountinfo parsing, set FD_CLOEXEC on BPF helper
+      fds, and support transparent huge pages
+    - Snap-update-ns: switch to a multi-pass process for constructing
+      and updating mount namespaces
+    - Core-initrd: add missing libbpf and systemd dlopen dependencies,
+      and increase mount burst
+    - Security logging: add seclog API for administrative actions and
+      token create/remove events
+    - Prompting: re-enable the prompting notice backend and improve
+      validation and error handling
+    - Cmd/snap: report hidden file access for paths allowed by home when
+      prompting is active
+    - Cmd/snap: report read-only file access for paths allowed by
+      system-package-doc
+    - Cmd/snap: fix self-managed cgroup support checks
+    - Experimental features: graduate layouts, classic-preserves-xdg-
+      runtime-dir, refresh-app-awareness, and dbus-activation features
+    - Experimental features: warn when setting graduated or default-
+      enabled experimental features and do not store settings for
+      graduated features
+
+ -- Sergio Cazzolato <sergio.cazzolato@canonical.com>  Fri, 24 Jul 2026 20:45:05 -0300
+
 snapd (2.76.3) resolute; urgency=medium
 
   * New upstream release, LP: #2158301


### PR DESCRIPTION
DEBEMAIL="Sergio Cazzolato <sergio.cazzolato@canonical.com>" release-tools/changelog.py 2.77 2158102 NEWS.md

LP bugs: https://launchpad.net/snapd/+milestone/2.77
SRU bug: https://bugs.launchpad.net/snapd/+bug/2158102
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-36858

Test fixes:
- tests: accout for syscalls missing on arm64
- tests: fix lxd-mount-units in ubuntu jammy
- tests: remove support ubuntu 25.10 add support ubuntu 26.10
- tests: fix nvidia-driver:535 on ubuntu 22.04 and 24.04
- tests: fix service startup during install, account for dh-systemd in tests
- tests: fix how timesyncd is configured for ubuntu-core
- tests: build snap-bootstrap with netgo
- tests: verify that a wrongly signed shim cannot get installed
- tests: cleanup redundant tests.cleanup restore
- tests: add back printer-driver-cups-pdf as a dependency
- tests: move trusty to openstack and remove alternative-backend from workflows
- tests: rename views, plugs and paths per SD247 spec
- tests: add commands for debugging or accessing snap mount namespaces
- tests: add request counting, add debug-api command, use it in tests
- tests: migrate fips and secboot from google to openstack
- tests: retry when gh client fails and check last change time in auto-rerun workflow
- tests: fix security-logging test in opensuse
- tests: fix spread filter to allow more specific rules than tasks
- tests: update main/nvidia-files
- tests: fix interfaces-kernel-module-control on core 18
- tests: create a new auto trigger workflow for prs
- tests: stabilize rpm package tracking in fedora/opensuse spread cleanup

Requires rebase merge
