### PR TITLE
strutil/quantity: make "ages!" duration-overflow string translatable

### DIFF
--- a/strutil/quantity/quantity.go
+++ b/strutil/quantity/quantity.go
@@ -195,7 +195,7 @@ func FormatDuration(dt float64) string {
 
 	if dt > math.MaxUint64 || uint64(dt) == 0 {
 		// TODO: figure out exactly what overflow causes the ==0
-		return "ages!"
+		return i18n.G("ages!")
 	}
 
 	return FormatAmount(uint64(dt), 4) + years


### PR DESCRIPTION
The overflow fallback in FormatDuration returns the bare string "ages!" instead of running it through i18n.G like every other unit suffix in this file, so it can never be translated.

Fixes: LP#1986413