### PR TITLE
fix(interfaces): IBus portal related desktop interface fixes

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -442,6 +442,14 @@ dbus (send)
       member=CreateInputContext
       peer=(name=org.freedesktop.portal.IBus),
 
+# Allow IBus to verify that the portal is responsive before connecting
+dbus (send)
+      bus=session
+      path=/org/freedesktop/IBus
+      interface=org.freedesktop.DBus.Peer
+      member=Ping
+      peer=(name=org.freedesktop.portal.IBus),
+
 dbus (send, receive)
       bus=session
       path=/org/freedesktop/IBus/InputContext_[0-9]*

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -456,6 +456,14 @@ dbus (send, receive)
       interface=org.freedesktop.IBus.InputContext
       peer=(label=unconfined),
 
+# Allow IBus to initialize and update input context properties
+dbus (send)
+      bus=session
+      path=/org/freedesktop/IBus/InputContext_[0-9]*
+      interface=org.freedesktop.DBus.Properties
+      member={Get,GetAll,Set}
+      peer=(label=unconfined),
+
 # Allow access to the Fcitx portal, supported by fcitx/fcitx5
 dbus (send)
       bus=session

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -147,6 +147,7 @@ func (s *DesktopInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.config/gtk-4.0/{*.css,**/*.css} r,")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow access to xdg-desktop-portal and xdg-document-portal")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=org.freedesktop.DBus.Peer\n      member=Ping\n      peer=(name=org.freedesktop.portal.IBus),")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=org.freedesktop.DBus.Properties\n      member={Get,GetAll,Set}\n      peer=(label=unconfined),")
 
 	// check desktop interface uses correct label for Mutter when provided
 	// by the system

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -146,6 +146,7 @@ func (s *DesktopInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.config/gtk-3.0/{*.css,**/*.css} r,")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.config/gtk-4.0/{*.css,**/*.css} r,")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow access to xdg-desktop-portal and xdg-document-portal")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=org.freedesktop.DBus.Peer\n      member=Ping\n      peer=(name=org.freedesktop.portal.IBus),")
 
 	// check desktop interface uses correct label for Mutter when provided
 	// by the system


### PR DESCRIPTION
**Content warning:** Most of this pull request is AI-generated.  While I did test the code works in my use case I am not competent enough to fully-endorse this change at the moment.  _Feel free to drop it if it isn't salvageable._

IBus [sends org.freedesktop.DBus.Peer.Ping before completing a portal connection](https://github.com/ibus/ibus/blob/81ac95ed70b2fe02d41c7735c6788a4c6ab47bcc/src/ibusbus.c#L453):

    g_dbus_connection_call (
            bus->priv->connection,
            IBUS_SERVICE_PORTAL,
            IBUS_PATH_IBUS,
            "org.freedesktop.DBus.Peer",
            "Ping",
            ...
            _bus_connect_start_portal_cb,
            g_object_ref (bus));

The desktop interface currently denies that call, preventing the input context from becoming ready and causing key events to queue and eventually be dropped(appear to the user that the input method doesn't work).

Allow Ping specifically for org.freedesktop.portal.IBus and verify the permission in the desktop interface AppArmor test.

Assisted-by: Codex:gpt-5.6-sol context7

---

Without this patch the following warning is emitted during application launch:

```text
(iscan:1159583): IBUS-WARNING **: 17:02:11.075: Create input context failed: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy p
revents this sender from sending this message to this recipient; type="method_call", sender=":1.11474" (uid=1000 pid=1159583 comm="/snap/iscan/x2/usr/
bin/iscan" label="snap.iscan.iscan (enforce)") interface="org.freedesktop.IBus" member="CreateInputContext" error name="(unset)" requested_reply="0" d
estination="org.freedesktop.IBus" (uid=1000 pid=10045 comm="/usr/bin/fcitx5" label="unconfined")
```

and the following error is emitted when the user is entering keystrokes when the input method is active:

```text
(iscan:1159583): IBUS-CRITICAL **: 17:02:39.166: ibus_im_context_filter_keypress: assertion 'ibusimcontext->cancellable != NULL || ibus_bus_is_connect
ed (_bus) == FALSE' failed
```

